### PR TITLE
Make sure 'everyone' knows about changes to the sharetab.

### DIFF
--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -167,9 +167,7 @@ static void
 update_sharetab(sa_handle_impl_t impl_handle)
 {
 	sa_share_impl_t impl_share;
-	int temp_fd;
 	FILE *temp_fp;
-	char tempfile[] = "/etc/dfs/sharetab.XXXXXX";
 	sa_fstype_t *fstype;
 	const char *resource;
 
@@ -177,12 +175,11 @@ update_sharetab(sa_handle_impl_t impl_handle)
 		return;
 	}
 
-	temp_fd = mkstemp(tempfile);
-
-	if (temp_fd < 0)
-		return;
-
-	temp_fp = fdopen(temp_fd, "w");
+	if (impl_handle->zfs_libhandle->libzfs_sharetab)
+		temp_fp = freopen("/etc/dfs/sharetab", "w",
+				impl_handle->zfs_libhandle->libzfs_sharetab);
+	else
+		temp_fp = fopen("/etc/dfs/sharetab", "w");
 
 	if (temp_fp == NULL)
 		return;
@@ -211,10 +208,7 @@ update_sharetab(sa_handle_impl_t impl_handle)
 	}
 
 	fflush(temp_fp);
-	fsync(temp_fd);
-	fclose(temp_fp);
-
-	rename(tempfile, "/etc/dfs/sharetab");
+	impl_handle->zfs_libhandle->libzfs_sharetab = temp_fp;
 }
 
 typedef struct update_cookie_s {

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <libzfs_impl.h>
 #include <libzfs.h>
 #include <libshare.h>
 #include "libshare_impl.h"
@@ -109,16 +110,16 @@ libshare_init(void)
 
 static void
 parse_sharetab(sa_handle_impl_t impl_handle) {
-	FILE *fp;
 	char line[512];
 	char *eol, *pathname, *resource, *fstype, *options, *description;
+	libzfs_handle_t *hdl = impl_handle->zfs_libhandle;
 
-	fp = fopen("/etc/dfs/sharetab", "r");
-
-	if (fp == NULL)
+	if (hdl->libzfs_sharetab == NULL)
 		return;
 
-	while (fgets(line, sizeof (line), fp) != NULL) {
+	(void) fseek(hdl->libzfs_sharetab, 0, SEEK_SET);
+
+	while (fgets(line, sizeof (line), hdl->libzfs_sharetab) != NULL) {
 		eol = line + strlen(line) - 1;
 
 		while (eol >= line) {
@@ -160,8 +161,6 @@ parse_sharetab(sa_handle_impl_t impl_handle) {
 		(void) process_share(impl_handle, NULL, pathname, resource,
 		    fstype, options, description, NULL, B_TRUE);
 	}
-
-	fclose(fp);
 }
 
 static void


### PR DESCRIPTION
+ Instead of opening a temporary sharetab and then renaming it, just open it with freopen() writeable and write the info.
+ If sharetab isn't opened, open it with fopen() instead of freopen() to avoid segfault if it doesn't exist.
+ Don't open sharetab in parse_sharetab() - it's already open!
+ Reuse the handle, fseek to beginning and read...

This might help (somewhat!) with #821, #845 and #1484, but it is no way close enough to fix the issues completely. Most it can do is cut the amount of time used with a few minutes in total. But it's still a worthy enough pull request to consider (until such time we can remove or redesign/rewrite libshare completely).

This was part of my SMB rewrites patch (#1476), but it's better served as a separate pull request.

Signed-off-by: Turbo Fredriksson <turbo@bayour.com>