### PR TITLE
Add option to zpool status to print guids

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -405,7 +405,7 @@ struct zfs_cmd;
 extern const char *zfs_history_event_names[];
 
 extern char *zpool_vdev_name(libzfs_handle_t *, zpool_handle_t *, nvlist_t *,
-    boolean_t verbose);
+    nvlist_t *display_args);
 extern int zpool_upgrade(zpool_handle_t *, uint64_t);
 extern int zpool_get_history(zpool_handle_t *, nvlist_t **);
 extern int zpool_history_unpack(char *, uint64_t, uint64_t *,

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -150,7 +150,7 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
-\fBzpool status\fR [\fB-xvD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
+\fBzpool status\fR [\fB-gxvD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
 .fi
 
 .LP
@@ -1848,13 +1848,24 @@ Sets the specified property for \fInewpool\fR. See the “Properties” section 
 .ne 2
 .mk
 .na
-\fBzpool status\fR [\fB-xvD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
+\fBzpool status\fR [\fB-gxvD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
 .ad
 .sp .6
 .RS 4n
 Displays the detailed health status for the given pools. If no \fIpool\fR is specified, then the status of each pool in the system is displayed. For more information on pool and device health, see the "Device Failure and Recovery" section.
 .sp
 If a scrub or resilver is in progress, this command reports the percentage done and the estimated time to completion. Both of these are only approximate, because the amount of data in the pool and the other workloads on the system can change.
+.sp
+.ne 2
+.mk
+.na
+\fB\fB-g\fR\fR
+.ad
+.RS 12n
+.rt
+Display vdev GUIDs instead of the normal short/long device names. These GUIDs can be used in-place of device names for the zpool detach/offline/remove/replace commands.
+.RE
+
 .sp
 .ne 2
 .mk


### PR DESCRIPTION
The use of vdev GUIDs are a necessary workaround in edge cases where the
names provided by `zpool status` are not accepted by the zpool
detach/offline/remove/replace commands. The current method of obtaining
them uses zdb, but this does not work in all cases (see
zfsonlinux/zfs#1530).

This provides a method of obtaining vdev GUIDs that is more reliable and
straightforward than zdb. It would be better to fix all edge cases that
require the use of GUIDs as a workaround, but Linux's /dev design makes
it difficult to anticipate such edge cases, which makes this option
necessary.

Note that this adds a new boolean parameter to `zpool_vdev_name`, which
changes the libzfs interface.

Closes zfsonlinux/zfs#2011

Signed-off-by: Richard Yao <ryao@gentoo.org>