### PR TITLE
Tautological Compare warning fixes

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -148,7 +148,8 @@ typedef enum {
 	ZFS_PROP_SELINUX_DEFCONTEXT,
 	ZFS_PROP_SELINUX_ROOTCONTEXT,
 	ZFS_PROP_RELATIME,
-	ZFS_NUM_PROPS
+	ZFS_NUM_PROPS,
+	ZFS_PROP_INVALID = -1           /* used as error return value */
 } zfs_prop_t;
 
 typedef enum {
@@ -191,7 +192,8 @@ typedef enum {
 	ZPOOL_PROP_COMMENT,
 	ZPOOL_PROP_EXPANDSZ,
 	ZPOOL_PROP_FREEING,
-	ZPOOL_NUM_PROPS
+	ZPOOL_NUM_PROPS,
+	ZPOOL_PROP_INVALID = -1         /* used as error return value */
 } zpool_prop_t;
 
 /* Small enough to not hog a whole line of printout in zpool(1M). */

--- a/include/zpios-ctl.h
+++ b/include/zpios-ctl.h
@@ -145,10 +145,6 @@ zpios_timespec_normalize(zpios_timespec_t *ts, uint32_t sec, uint32_t nsec)
 		nsec -= NSEC_PER_SEC;
 		sec++;
 	}
-	while (nsec < 0) {
-		nsec += NSEC_PER_SEC;
-		sec--;
-	}
 	ts->ts_sec = sec;
 	ts->ts_nsec = nsec;
 }

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3076,7 +3076,7 @@ zfs_receive_impl(libzfs_handle_t *hdl, const char *tosnap, recvflags_t *flags,
 	    &zcksum)))
 		return (err);
 
-	if (drr.drr_type == DRR_END || drr.drr_type == BSWAP_32(DRR_END)) {
+	if (drr.drr_type == DRR_END || (uint32_t)drr.drr_type == BSWAP_32(DRR_END)) {
 		/* It's the double end record at the end of a package */
 		return (ENODATA);
 	}

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -110,7 +110,7 @@ zio_checksum_dedup_select(spa_t *spa, enum zio_checksum child,
 	if (child == ZIO_CHECKSUM_ON)
 		return (spa_dedup_checksum(spa));
 
-	if (child == (ZIO_CHECKSUM_ON | ZIO_CHECKSUM_VERIFY))
+	if (child == (enum zio_checksum)(ZIO_CHECKSUM_ON | ZIO_CHECKSUM_VERIFY))
 		return (spa_dedup_checksum(spa) | ZIO_CHECKSUM_VERIFY);
 
 	ASSERT(zio_checksum_table[child & ZIO_CHECKSUM_MASK].ci_dedup ||


### PR DESCRIPTION
Since unsigned integers can never be negative, some code can never
be reached and can safely be removed as dead code.
Since enum values are known at compile time, some comparisons are
flagged as always true/false. Special invalid enum values and explicit
casts prevent those warnings.

None of this changes should alter behavior of the resulting binary.