### PR TITLE
Added checks for NULL returns by calloc

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -114,9 +114,7 @@ parse_option(char *mntopt, unsigned long *mntflags,
 	char *ptr, *name, *value = NULL;
 	int error = 0;
 
-	name = strdup(mntopt);
-	if (name == NULL)
-		return (ENOMEM);
+	name = safe_strdup(mntopt);
 
 	for (ptr = name; ptr && *ptr; ptr++) {
 		if (*ptr == '=') {
@@ -156,9 +154,7 @@ parse_options(char *mntopts, unsigned long *mntflags, unsigned long *zfsflags,
 	int error = 0, quote = 0, flag = 0, count = 0;
 	char *ptr, *opt, *opts;
 
-	opts = strdup(mntopts);
-	if (opts == NULL)
-		return (ENOMEM);
+	opts = safe_strdup(mntopts);
 
 	*mntflags = 0;
 	opt = NULL;
@@ -249,7 +245,7 @@ parse_dataset(char *dataset)
 		if (error) {
 			nvlist_free(config);
 		} else {
-			dataset = strdup(name);
+			dataset = safe_strdup(name);
 			nvlist_free(config);
 			return (dataset);
 		}

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1410,9 +1410,7 @@ dump_znode_sa_xattr(sa_handle_t *hdl)
 	if (error || sa_xattr_size == 0)
 		return;
 
-	sa_xattr_packed = malloc(sa_xattr_size);
-	if (sa_xattr_packed == NULL)
-		return;
+	sa_xattr_packed = safe_malloc(sa_xattr_size);
 
 	error = sa_lookup(hdl, sa_attr_table[ZPL_DXATTR],
 	    sa_xattr_packed, sa_xattr_size);
@@ -1906,11 +1904,7 @@ dump_cachefile(const char *cachefile)
 		exit(1);
 	}
 
-	if ((buf = malloc(statbuf.st_size)) == NULL) {
-		(void) fprintf(stderr, "failed to allocate %llu bytes\n",
-		    (u_longlong_t)statbuf.st_size);
-		exit(1);
-	}
+	buf = safe_malloc(statbuf.st_size);
 
 	if (read(fd, buf, statbuf.st_size) != statbuf.st_size) {
 		(void) fprintf(stderr, "failed to read %llu bytes\n",
@@ -1971,7 +1965,7 @@ dump_label(const char *dev)
 
 	if (strncmp(dev, "/dev/dsk/", 9) == 0) {
 		len++;
-		path = malloc(len);
+		path = safe_malloc(len);
 		(void) snprintf(path, len, "%s%s", "/dev/rdsk/", dev + 9);
 	} else {
 		path = strdup(dev);
@@ -3386,7 +3380,7 @@ main(int argc, char **argv)
 	if (!dump_opt['R']) {
 		if (argc > 0) {
 			zopt_objects = argc;
-			zopt_object = calloc(zopt_objects, sizeof (uint64_t));
+			zopt_object = safe_malloc(zopt_objects * sizeof (uint64_t));
 			for (i = 0; i < zopt_objects; i++) {
 				errno = 0;
 				zopt_object[i] = strtoull(argv[i], NULL, 0);

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1968,7 +1968,7 @@ dump_label(const char *dev)
 		path = safe_malloc(len);
 		(void) snprintf(path, len, "%s%s", "/dev/rdsk/", dev + 9);
 	} else {
-		path = strdup(dev);
+		path = safe_strdup(dev);
 	}
 
 	if ((fd = open64(path, O_RDONLY)) < 0) {
@@ -2900,7 +2900,7 @@ zdb_read_block(char *thing, spa_t *spa)
 	char *s, *p, *dup, *vdev, *flagstr;
 	int i, error;
 
-	dup = strdup(thing);
+	dup = safe_strdup(thing);
 	s = strtok(dup, ":");
 	vdev = s ? s : "";
 	s = strtok(NULL, ":");

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -51,9 +51,7 @@ zed_conf_create(void)
 {
 	struct zed_conf *zcp;
 
-	zcp = malloc(sizeof (*zcp));
-	if (!zcp)
-		goto nomem;
+	zcp = safe_malloc(sizeof (*zcp));
 
 	memset(zcp, 0, sizeof (*zcp));
 

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -63,23 +63,12 @@ zed_conf_create(void)
 	zcp->zfs_hdl = NULL;		/* opened via zed_event_init() */
 	zcp->zevent_fd = -1;		/* opened via zed_event_init() */
 
-	if (!(zcp->conf_file = strdup(ZED_CONF_FILE)))
-		goto nomem;
-
-	if (!(zcp->pid_file = strdup(ZED_PID_FILE)))
-		goto nomem;
-
-	if (!(zcp->script_dir = strdup(ZED_SCRIPT_DIR)))
-		goto nomem;
-
-	if (!(zcp->state_file = strdup(ZED_STATE_FILE)))
-		goto nomem;
+	zcp->conf_file = safe_strdup(ZED_CONF_FILE);
+	zcp->pid_file = safe_strdup(ZED_PID_FILE);
+	zcp->script_dir = safe_strdup(ZED_SCRIPT_DIR);
+	zcp->state_file = safe_strdup(ZED_STATE_FILE);
 
 	return (zcp);
-
-nomem:
-	zed_log_die("Failed to create conf: %s", strerror(errno));
-	return (NULL);
 }
 
 /*
@@ -223,7 +212,7 @@ _zed_conf_parse_path(char **resultp, const char *path)
 		free(*resultp);
 
 	if (path[0] == '/') {
-		*resultp = strdup(path);
+		*resultp = safe_strdup(path);
 	} else if (!getcwd(buf, sizeof (buf))) {
 		zed_log_die("Failed to get current working dir: %s",
 		    strerror(errno));
@@ -232,10 +221,8 @@ _zed_conf_parse_path(char **resultp, const char *path)
 	} else if (strlcat(buf, path, sizeof (buf)) >= sizeof (buf)) {
 		zed_log_die("Failed to copy path: %s", strerror(ENAMETOOLONG));
 	} else {
-		*resultp = strdup(buf);
+		*resultp = safe_strdup(buf);
 	}
-	if (!*resultp)
-		zed_log_die("Failed to copy path: %s", strerror(ENOMEM));
 }
 
 /*

--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -36,6 +36,7 @@
 #include "zed_file.h"
 #include "zed_log.h"
 #include "zed_strings.h"
+#include <libzfs.h>
 
 #define	ZEVENT_FILENO	3
 
@@ -61,9 +62,7 @@ _zed_exec_create_env(zed_strings_t *zsp)
 	for (q = zed_strings_first(zsp); q; q = zed_strings_next(zsp))
 		buflen += strlen(q) + 1;
 
-	buf = malloc(buflen);
-	if (!buf)
-		return (NULL);
+	buf = safe_malloc(buflen);
 
 	pp = (char **) buf;
 	p = buf + (num_ptrs * sizeof (char *));

--- a/cmd/zed/zed_strings.c
+++ b/cmd/zed/zed_strings.c
@@ -32,6 +32,7 @@
 #include <sys/avl.h>
 #include <sys/sysmacros.h>
 #include "zed_strings.h"
+#include <libzfs.h>
 
 struct zed_strings {
 	avl_tree_t tree;
@@ -83,7 +84,7 @@ zed_strings_create(void)
 {
 	zed_strings_t *zsp;
 
-	zsp = malloc(sizeof (*zsp));
+	zsp = safe_malloc(sizeof (*zsp));
 	if (!zsp)
 		return (NULL);
 
@@ -131,7 +132,7 @@ zed_strings_add(zed_strings_t *zsp, const char *s)
 		return (-1);
 	}
 	len = sizeof (zed_strings_node_t) + strlen(s) + 1;
-	np = malloc(len);
+	np = safe_malloc(len);
 	if (!np)
 		return (-1);
 

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -320,21 +320,6 @@ nomem(void)
 	exit(1);
 }
 
-/*
- * Utility function to guarantee malloc() success.
- */
-
-void *
-safe_malloc(size_t size)
-{
-	void *data;
-
-	if ((data = calloc(1, size)) == NULL)
-		nomem();
-
-	return (data);
-}
-
 static char *
 safe_strdup(char *str)
 {

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -320,17 +320,6 @@ nomem(void)
 	exit(1);
 }
 
-static char *
-safe_strdup(char *str)
-{
-	char *dupstr = strdup(str);
-
-	if (dupstr == NULL)
-		nomem();
-
-	return (dupstr);
-}
-
 /*
  * Callback routine that will print out information for each of
  * the properties.
@@ -1035,11 +1024,11 @@ destroy_print_cb(zfs_handle_t *zhp, void *arg)
 
 	if (nvlist_exists(cb->cb_nvl, name)) {
 		if (cb->cb_firstsnap == NULL)
-			cb->cb_firstsnap = strdup(name);
+			cb->cb_firstsnap = safe_strdup(name);
 		if (cb->cb_prevsnap != NULL)
 			free(cb->cb_prevsnap);
 		/* this snap continues the current range */
-		cb->cb_prevsnap = strdup(name);
+		cb->cb_prevsnap = safe_strdup(name);
 		if (cb->cb_firstsnap == NULL || cb->cb_prevsnap == NULL)
 			nomem();
 		if (cb->cb_verbose) {
@@ -6398,12 +6387,9 @@ zfs_do_diff(int argc, char **argv)
 
 	copy = NULL;
 	if (*fromsnap != '@')
-		copy = strdup(fromsnap);
+		copy = safe_strdup(fromsnap);
 	else if (tosnap)
-		copy = strdup(tosnap);
-	if (copy == NULL)
-		usage(B_FALSE);
-
+		copy = safe_strdup(tosnap);
 	if ((atp = strchr(copy, '@')))
 		*atp = '\0';
 

--- a/cmd/zfs/zfs_util.h
+++ b/cmd/zfs/zfs_util.h
@@ -31,7 +31,6 @@
 extern "C" {
 #endif
 
-void * safe_malloc(size_t size);
 void nomem(void);
 libzfs_handle_t *g_zfs;
 

--- a/cmd/zhack/zhack.c
+++ b/cmd/zhack/zhack.c
@@ -147,7 +147,7 @@ import_pool(const char *target, boolean_t readonly)
 
 	g_importargs.unique = B_TRUE;
 	g_importargs.can_be_active = readonly;
-	g_pool = strdup(target);
+	g_pool = safe_strdup(target);
 	if ((sepp = strpbrk(g_pool, "/@")) != NULL)
 		*sepp = '\0';
 	g_importargs.poolname = g_pool;
@@ -313,7 +313,7 @@ zhack_do_feature_enable(int argc, char **argv)
 			feature.fi_can_readonly = B_TRUE;
 			break;
 		case 'd':
-			desc = strdup(optarg);
+			desc = safe_strdup(optarg);
 			break;
 		default:
 			usage();
@@ -322,7 +322,7 @@ zhack_do_feature_enable(int argc, char **argv)
 	}
 
 	if (desc == NULL)
-		desc = strdup("zhack injected");
+		desc = safe_strdup("zhack injected");
 	feature.fi_desc = desc;
 
 	argc -= optind;

--- a/cmd/zpios/Makefile.am
+++ b/cmd/zpios/Makefile.am
@@ -1,7 +1,9 @@
 include $(top_srcdir)/config/Rules.am
 
 DEFAULT_INCLUDES += \
-	-I$(top_srcdir)/include
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/lib/libspl/include
+
 
 sbin_PROGRAMS = zpios
 
@@ -9,4 +11,10 @@ zpios_SOURCES = \
 	$(top_srcdir)/cmd/zpios/zpios_main.c \
 	$(top_srcdir)/cmd/zpios/zpios_util.c \
 	$(top_srcdir)/cmd/zpios/zpios.h
+zpios_LDADD = \
+	$(top_builddir)/lib/libnvpair/libnvpair.la \
+	$(top_builddir)/lib/libuutil/libuutil.la \
+	$(top_builddir)/lib/libzpool/libzpool.la \
+	$(top_builddir)/lib/libzfs/libzfs.la \
+	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 

--- a/cmd/zpios/zpios_util.c
+++ b/cmd/zpios/zpios_util.c
@@ -37,6 +37,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <regex.h>
+#include "libzfs.h"
 #include "zpios.h"
 
 /* extracts an unsigned int (64) and K,M,G,T from the string */
@@ -158,9 +159,7 @@ split_string(const char *optarg, char *pattern, range_repeat_t *range)
 	if ((rc = regex_match(optarg, pattern)))
 		return (rc);
 
-	cp = strdup(optarg);
-	if (cp == NULL)
-		return (ENOMEM);
+	cp = safe_strdup(optarg);
 
 	do {
 		/*
@@ -256,9 +255,7 @@ set_load_params(cmd_args_t *args, char *optarg)
 	char *param, *search, comma[] = ",";
 	int rc = 0;
 
-	search = strdup(optarg);
-	if (search == NULL)
-		return (ENOMEM);
+	search = safe_strdup(optarg);
 
 	while ((param = strtok(search, comma)) != NULL) {
 		search = NULL;

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2196,7 +2196,7 @@ zpool_do_import(int argc, char **argv)
 	if ((searchdirs == NULL) && (env = getenv("ZPOOL_IMPORT_PATH"))) {
 		char *dir;
 
-		envdup = strdup(env);
+		envdup = safe_strdup(env);
 
 		dir = strtok(envdup, ":");
 		while (dir != NULL) {

--- a/cmd/zpool/zpool_util.c
+++ b/cmd/zpool/zpool_util.c
@@ -33,22 +33,6 @@
 #include "zpool_util.h"
 
 /*
- * Utility function to guarantee malloc() success.
- */
-void *
-safe_malloc(size_t size)
-{
-	void *data;
-
-	if ((data = calloc(1, size)) == NULL) {
-		(void) fprintf(stderr, "internal error: out of memory\n");
-		exit(1);
-	}
-
-	return (data);
-}
-
-/*
  * Display an out of memory error message and abort the current program.
  */
 void

--- a/cmd/zpool/zpool_util.h
+++ b/cmd/zpool/zpool_util.h
@@ -35,7 +35,6 @@ extern "C" {
 /*
  * Basic utility functions
  */
-void *safe_malloc(size_t);
 void zpool_no_memory(void);
 uint_t num_logs(nvlist_t *nv);
 

--- a/cmd/zstreamdump/zstreamdump.c
+++ b/cmd/zstreamdump/zstreamdump.c
@@ -35,6 +35,7 @@
 #include <sys/dmu.h>
 #include <sys/zfs_ioctl.h>
 #include <zfs_fletcher.h>
+#include <libzfs.h>
 
 uint64_t drr_record_count[DRR_NUMTYPES];
 uint64_t total_write_size = 0;
@@ -80,7 +81,7 @@ ssread(void *buf, size_t len, zio_cksum_t *cksum)
 int
 main(int argc, char *argv[])
 {
-	char *buf = malloc(INITIAL_BUFLEN);
+	char *buf = safe_malloc(INITIAL_BUFLEN);
 	dmu_replay_record_t thedrr;
 	dmu_replay_record_t *drr = &thedrr;
 	struct drr_begin *drrb = &thedrr.drr_u.drr_begin;
@@ -212,7 +213,7 @@ main(int argc, char *argv[])
 
 				if (sz > 1<<20) {
 					free(buf);
-					buf = malloc(sz);
+					buf = safe_malloc(sz);
 				}
 				(void) ssread(buf, sz, &zc);
 				if (ferror(send_stream))

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -124,6 +124,7 @@
 #include <math.h>
 #include <sys/fs/zfs.h>
 #include <libnvpair.h>
+#include <libzfs.h>
 
 static int ztest_fd_data = -1;
 static int ztest_fd_rand = -1;
@@ -2709,7 +2710,7 @@ ztest_split_pool(ztest_ds_t *zd, uint64_t id)
 	VERIFY(nvlist_lookup_nvlist_array(tree, ZPOOL_CONFIG_CHILDREN, &child,
 	    &children) == 0);
 
-	schild = malloc(rvd->vdev_children * sizeof (nvlist_t *));
+	schild = safe_malloc(rvd->vdev_children * sizeof (nvlist_t *));
 	for (c = 0; c < children; c++) {
 		vdev_t *tvd = rvd->vdev_child[c];
 		nvlist_t **mchild;

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -691,6 +691,7 @@ extern int zfs_append_partition(char *path, size_t max_len);
 extern int zfs_resolve_shortname(const char *name, char *path, size_t pathlen);
 extern int zfs_strcmp_pathname(char *name, char *cmp_name, int wholedisk);
 extern void *safe_malloc(size_t);
+extern char *safe_strdup(const char *str);
 
 /*
  * Mount support functions.

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -690,6 +690,7 @@ extern int zfs_spa_version(zfs_handle_t *, int *);
 extern int zfs_append_partition(char *path, size_t max_len);
 extern int zfs_resolve_shortname(const char *name, char *path, size_t pathlen);
 extern int zfs_strcmp_pathname(char *name, char *cmp_name, int wholedisk);
+extern void *safe_malloc(size_t);
 
 /*
  * Mount support functions.

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -356,12 +356,7 @@ process_share(sa_handle_impl_t impl_handle, sa_share_impl_t impl_share,
 	}
 
 	if (dataset != NULL) {
-		dataset_dup = strdup(dataset);
-
-		if (dataset_dup == NULL) {
-			rc = SA_NO_MEMORY;
-			goto err;
-		}
+		dataset_dup = safe_strdup(dataset);
 	}
 
 	free(impl_share->dataset);
@@ -373,12 +368,7 @@ process_share(sa_handle_impl_t impl_handle, sa_share_impl_t impl_share,
 	while (fstype != NULL) {
 		if (strcmp(fstype->name, proto) == 0) {
 			if (resource != NULL) {
-				resource_dup = strdup(resource);
-
-				if (resource_dup == NULL) {
-					rc = SA_NO_MEMORY;
-					goto err;
-				}
+				resource_dup = safe_strdup(resource);
 			}
 
 			free(FSINFO(impl_share, fstype)->resource);
@@ -740,12 +730,7 @@ alloc_share(const char *sharepath)
 	if (impl_share == NULL)
 		return (NULL);
 
-	impl_share->sharepath = strdup(sharepath);
-
-	if (impl_share->sharepath == NULL) {
-		free(impl_share);
-		return (NULL);
-	}
+	impl_share->sharepath = safe_strdup(sharepath);
 
 	impl_share->fsinfo = calloc(sizeof (sa_share_fsinfo_t), fstypes_count);
 

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -64,10 +64,7 @@ foreach_nfs_shareopt(const char *shareopts,
 	if (shareopts == NULL)
 		return (SA_OK);
 
-	shareopts_dup = strdup(shareopts);
-
-	if (shareopts_dup == NULL)
-		return (SA_NO_MEMORY);
+	shareopts_dup = safe_strdup(shareopts);
 
 	opt = shareopts_dup;
 	was_nul = 0;
@@ -143,10 +140,7 @@ foreach_nfs_host_cb(const char *opt, const char *value, void *pcookie)
 
 		access = opt;
 
-		host_dup = strdup(value);
-
-		if (host_dup == NULL)
-			return (SA_NO_MEMORY);
+		host_dup = safe_strdup(value);
 
 		host = host_dup;
 
@@ -211,13 +205,9 @@ get_linux_hostspec(const char *solaris_hostspec, char **plinux_hostspec)
 		 * Solaris host specifier, e.g. @192.168.0.0/16; we just need
 		 * to skip the @ in this case
 		 */
-		*plinux_hostspec = strdup(solaris_hostspec + 1);
+		*plinux_hostspec = safe_strdup(solaris_hostspec + 1);
 	} else {
-		*plinux_hostspec = strdup(solaris_hostspec);
-	}
-
-	if (*plinux_hostspec == NULL) {
-		return (SA_NO_MEMORY);
+		*plinux_hostspec = safe_strdup(solaris_hostspec);
 	}
 
 	return (SA_OK);
@@ -602,10 +592,7 @@ nfs_update_shareopts(sa_share_impl_t impl_share, const char *resource,
 		nfs_disable_share(impl_share);
 	}
 
-	shareopts_dup = strdup(shareopts);
-
-	if (shareopts_dup == NULL)
-		return (SA_NO_MEMORY);
+	shareopts_dup = safe_strdup(shareopts);
 
 	if (old_shareopts != NULL)
 		free(old_shareopts);

--- a/lib/libshare/smb.c
+++ b/lib/libshare/smb.c
@@ -106,11 +106,7 @@ smb_retrieve_shares(void)
 			goto out;
 		}
 
-		name = strdup(directory->d_name);
-		if (name == NULL) {
-			rc = SA_NO_MEMORY;
-			goto out;
-		}
+		name = safe_strdup(directory->d_name);
 
 		while (fgets(line, sizeof (line), share_file_fp)) {
 			if (line[0] == '#')
@@ -130,11 +126,7 @@ smb_retrieve_shares(void)
 			value = token + 1;
 			*token = '\0';
 
-			dup_value = strdup(value);
-			if (dup_value == NULL) {
-				rc = SA_NO_MEMORY;
-				goto out;
-			}
+			dup_value = safe_strdup(value);
 
 			if (strcmp(key, "path") == 0)
 				path = dup_value;
@@ -286,7 +278,7 @@ smb_disable_share_one(const char *sharename)
 	argv[2] = NET_CMD_ARG_HOST;
 	argv[3] = (char *)"usershare";
 	argv[4] = (char *)"delete";
-	argv[5] = strdup(sharename);
+	argv[5] = safe_strdup(sharename);
 	argv[6] = NULL;
 
 	rc = libzfs_run_process(argv[0], argv, 0);
@@ -385,10 +377,7 @@ smb_update_shareopts(sa_share_impl_t impl_share, const char *resource,
 		smb_disable_share(impl_share);
 	}
 
-	shareopts_dup = strdup(shareopts);
-
-	if (shareopts_dup == NULL)
-		return (SA_NO_MEMORY);
+	shareopts_dup = safe_strdup(shareopts);
 
 	if (old_shareopts != NULL)
 		free(old_shareopts);

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -2987,11 +2987,11 @@ zfs_create_ancestors(libzfs_handle_t *hdl, const char *path)
 	if (check_parents(hdl, path, NULL, B_TRUE, &prefix) != 0)
 		return (-1);
 
-	if ((path_copy = strdup(path)) != NULL) {
-		rc = create_parents(hdl, path_copy, prefix);
-		free(path_copy);
-	}
-	if (path_copy == NULL || rc != 0)
+	path_copy = safe_strdup(path);
+	rc = create_parents(hdl, path_copy, prefix);
+	free(path_copy);
+
+	if (rc != 0)
 		return (-1);
 
 	return (0);

--- a/lib/libzfs/libzfs_fru.c
+++ b/lib/libzfs/libzfs_fru.c
@@ -166,14 +166,8 @@ libzfs_fru_gather(topo_hdl_t *thp, tnode_t *tn, void *arg)
 		return (TOPO_WALK_NEXT);
 	}
 
-	if ((frup->zf_device = strdup(devpath)) == NULL ||
-	    (frup->zf_fru = strdup(frustr)) == NULL) {
-		free(frup->zf_device);
-		free(frup);
-		_topo_hdl_strfree(thp, devpath);
-		_topo_hdl_strfree(thp, frustr);
-		return (TOPO_WALK_NEXT);
-	}
+	frup->zf_device = safe_strdup(devpath);
+	frup->zf_fru = safe_strdup(devpath);
 
 	_topo_hdl_strfree(thp, devpath);
 	_topo_hdl_strfree(thp, frustr);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2020,8 +2020,7 @@ vdev_to_nvlist_iter(nvlist_t *nv, nvlist_t *search, boolean_t *avail_spare,
 			 * that the srchval is composed of a type and
 			 * vdev id pair (i.e. mirror-4).
 			 */
-			if ((type = strdup(srchval)) == NULL)
-				return (NULL);
+			type = safe_strdup(srchval);
 
 			if ((p = strrchr(type, '-')) == NULL) {
 				free(type);
@@ -3292,8 +3291,7 @@ devid_to_path(char *devid_str)
 	if (ret != 0)
 		return (NULL);
 
-	if ((path = strdup(list[0].devname)) == NULL)
-		return (NULL);
+	path = safe_strdup(list[0].devname);
 
 	devid_free_nmlist(list);
 

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -579,6 +579,24 @@ zfs_strdup(libzfs_handle_t *hdl, const char *str)
 }
 
 /*
+ * A safe form of strdup() that does not depend on libzfs_handle_t
+ */
+char *
+safe_strdup(const char *str)
+{
+	char *ret;
+
+	ret = strdup(str);
+
+	if (ret == NULL) {
+		(void) fprintf(stderr, "internal error: out of memory\n");
+		exit(1);
+	}
+
+	return (ret);
+}
+
+/*
  * Convert a number to an appropriately human-readable output.
  */
 void
@@ -882,7 +900,7 @@ zfs_resolve_shortname(const char *name, char *path, size_t len)
 	errno = ENOENT;
 
 	if (env) {
-		envdup = strdup(env);
+		envdup = safe_strdup(env);
 		dir = strtok(envdup, ":");
 		while (dir && error) {
 			(void) snprintf(path, len, "%s/%s", dir, name);
@@ -919,7 +937,7 @@ zfs_strcmp_shortname(char *name, char *cmp_name, int wholedisk)
 	env = getenv("ZPOOL_IMPORT_PATH");
 
 	if (env) {
-		envdup = strdup(env);
+		envdup = safe_strdup(env);
 		dir = strtok(envdup, ":");
 	} else {
 		dir =  zpool_default_import_path[i];

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -508,6 +508,21 @@ zfs_alloc(libzfs_handle_t *hdl, size_t size)
 }
 
 /*
+ * A safe form of malloc() that doesn't depend on libzfs_handle_t
+ */
+void *
+safe_malloc(size_t size) {
+	void *data;
+
+	if ((data = calloc(1, size)) == NULL) {
+		(void) fprintf(stderr, "internal error: out of memory\n");
+		exit(1);
+	}
+
+	return (data);
+}
+
+/*
  * A safe form of asprintf() which will die if the allocation fails.
  */
 /*PRINTFLIKE2*/

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -514,7 +514,9 @@ void *
 safe_malloc(size_t size) {
 	void *data;
 
-	if ((data = calloc(1, size)) == NULL) {
+	data = calloc(1, size);
+
+	if (data == NULL) {
 		(void) fprintf(stderr, "internal error: out of memory\n");
 		exit(1);
 	}

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3342,7 +3342,7 @@ zfs_unmount_snap(const char *snapname)
 
 	dsname = kmem_alloc(ptr - snapname + 1, KM_SLEEP);
 	strlcpy(dsname, snapname, ptr - snapname + 1);
-	fullname = strdup(snapname);
+	fullname = safe_strdup(snapname);
 
 	if (zfs_sb_hold(dsname, FTAG, &zsb, B_FALSE) == 0) {
 		ASSERT(!dsl_pool_config_held(dmu_objset_pool(zsb->z_os)));
@@ -5670,13 +5670,9 @@ zfsdev_ioctl(struct file *filp, unsigned cmd, unsigned long arg)
 		goto out;
 
 	/* legacy ioctls can modify zc_name */
-	saved_poolname = strdup(zc->zc_name);
-	if (saved_poolname == NULL) {
-		error = SET_ERROR(ENOMEM);
-		goto out;
-	} else {
-		saved_poolname[strcspn(saved_poolname, "/@#")] = '\0';
-	}
+	saved_poolname = safe_strdup(zc->zc_name);
+	
+	saved_poolname[strcspn(saved_poolname, "/@#")] = '\0';
 
 	if (vec->zvec_func != NULL) {
 		nvlist_t *outnvl;


### PR DESCRIPTION
It seems like there is a few places where ```calloc()``` is called and then we simply cross our fingers and hope that the user got memory available. Now it prints an error message and exits with code ```1```, if we get a ```NULL``` pointer.