### PR TITLE
Default to --with-blkid in RPM packaging

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -34,7 +34,7 @@
 %endif
 
 %bcond_with    debug
-%bcond_with    blkid
+%bcond_without blkid
 %bcond_with    systemd
 
 # Generic enable switch for systemd


### PR DESCRIPTION
Support for libblkid has been in the ZoL for years but has been
disabled by default in the packaging.  When libblkid is disabled
the 'zpool create' command will not warn you if you're going to
overwrite an existing filesystem.  For this reason the default
behavior has been changed to require libblkid.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #2448