### PR TITLE
Add 'zpool version' command

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -95,6 +95,8 @@ static int zpool_do_events(int, char **);
 static int zpool_do_get(int, char **);
 static int zpool_do_set(int, char **);
 
+static int zpool_do_version(int, char **);
+
 /*
  * These libumem hooks provide a reasonable set of defaults for the allocator's
  * debugging facilities.
@@ -139,7 +141,8 @@ typedef enum {
 	HELP_SET,
 	HELP_SPLIT,
 	HELP_REGUID,
-	HELP_REOPEN
+	HELP_REOPEN,
+	HELP_VERSION
 } zpool_help_t;
 
 
@@ -193,6 +196,8 @@ static zpool_command_t command_table[] = {
 	{ NULL },
 	{ "get",	zpool_do_get,		HELP_GET		},
 	{ "set",	zpool_do_set,		HELP_SET		},
+	{ NULL },
+	{ "version",	zpool_do_version,	HELP_VERSION		},
 };
 
 #define	NCOMMAND	(sizeof (command_table) / sizeof (command_table[0]))
@@ -276,6 +281,8 @@ get_usage(zpool_help_t idx) {
 		    "[<device> ...]\n"));
 	case HELP_REGUID:
 		return (gettext("\treguid <pool>\n"));
+	case HELP_VERSION:
+		return (gettext("\tversion\n"));
 	}
 
 	abort();
@@ -5763,6 +5770,49 @@ find_command_idx(char *command, int *idx)
 		}
 	}
 	return (1);
+}
+
+static char *
+zpool_format_version(version_t *version) {
+	char *formatted;
+
+	ASSERT(version != NULL);
+
+	formatted = safe_malloc(sizeof (char) * 128);
+	snprintf(formatted, 128, "%d.%d.%d-%s",
+	    version->major, version->minor,
+	    version->revision, version->build);
+
+	return (formatted);
+}
+
+static int
+zpool_do_version(int argc, char **argv)
+{
+	char *str;
+	version_t *library_version, *kernel_version;
+
+	library_version = lzc_library_version();
+	if (library_version != NULL) {
+		str = zpool_format_version(library_version);
+		printf("ZFS utilities/tools version: %s\n", str);
+		free(str);
+	} else {
+		(void) fprintf(stderr, gettext("Tools version information "
+		    "not available\n"));
+	}
+
+	kernel_version = lzc_kernel_version();
+	if (kernel_version != NULL) {
+		str = zpool_format_version(kernel_version);
+		printf("ZFS kernel module version: %s\n", str);
+		free(str);
+	} else {
+		(void) fprintf(stderr, gettext("Module version information "
+		    "not available\n"));
+	}
+
+	return (0);
 }
 
 int

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -64,6 +64,16 @@ boolean_t lzc_exists(const char *);
 
 int lzc_rollback(const char *, char *, int);
 
+typedef struct version {
+	int major;
+	int minor;
+	int revision;
+	char build[64];
+} version_t;
+
+version_t *lzc_library_version(void);
+version_t *lzc_kernel_version(void);
+
 #ifdef	__cplusplus
 }
 #endif


### PR DESCRIPTION
Currently uses the /sys/module/zfs/version file to determine running kernel module version. I am not sure how portable this is.

Implements #2501

Tested on Ubuntu Server 14.04.

Output:
```
jos@zfsbox:~/zfs$ sudo zpool version
zfs 0.6.3-31_g04f118d
zfs-kms 0.6.3-30_g672692c
```

```
jos@zfsbox:~/zfs$ modinfo zfs | grep version
version:        0.6.3-31_g04f118d
srcversion:     B35693A5781A8C38BEB91F8
vermagic:       3.13.0-32-generic SMP mod_unload modversions
```