### PR TITLE
Illumos 5134 - if ZFS_DEBUG or debug= is set, libzpool should enable debug prints

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -5807,6 +5807,8 @@ main(int argc, char **argv)
 	(void) setlocale(LC_ALL, "");
 	(void) textdomain(TEXT_DOMAIN);
 
+	dprintf_setup(&argc, argv);
+
 	opterr = 0;
 
 	/*

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -846,6 +846,9 @@ dprintf_setup(int *argc, char **argv)
 	 */
 	if (dprintf_find_string("on"))
 		dprintf_print_all = 1;
+
+	if (dprintf_string != NULL)
+		zfs_flags |= ZFS_DEBUG_DPRINTF;
 }
 
 /*


### PR DESCRIPTION
Reviewed by: Christopher Siden christopher.siden@delphix.com
Reviewed by: Adam Leventhal adam.leventhal@delphix.com
Original author: Matthew Ahrens

References:
  https://www.illumos.org/projects/illumos-gate/issues/5134
  https://github.com/illumos/illumos-gate/commit/7fa49ea

Ported by: Turbo Fredriksson <turbo@bayour.com>