### PR TITLE
Mount filesystem as soon as it's been received

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3068,6 +3068,9 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		}
 	}
 
+	if (clp)
+		err |= changelist_postfix(clp);
+
 	/*
 	 * Mount the target filesystem (if created).  Also mount any
 	 * children of the target filesystem if we did a replication
@@ -3084,22 +3087,24 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 			if (h->zfs_type == ZFS_TYPE_VOLUME) {
 				*cp = '@';
 			} else if (newfs || stream_avl) {
-				/*
-				 * Track the first/top of hierarchy fs,
-				 * for mounting and sharing later.
-				 */
+				/* Track the first/top of hierarchy fs */
 				if (top_zfs && *top_zfs == NULL)
 					*top_zfs = zfs_strdup(hdl, zc.zc_value);
+
+				/* mount and share received datasets */
+				clp = changelist_gather(h, ZFS_PROP_MOUNTPOINT,
+							CL_GATHER_MOUNT_ALWAYS,
+							0);
+				if (clp)
+					err |= changelist_postfix(clp);
 			}
 			zfs_close(h);
 		}
 		*cp = '@';
 	}
 
-	if (clp) {
-		err |= changelist_postfix(clp);
+	if (clp)
 		changelist_free(clp);
-	}
 
 	if (prop_errflags & ZPROP_ERR_NOCLEAR) {
 		(void) fprintf(stderr, dgettext(TEXT_DOMAIN, "Warning: "


### PR DESCRIPTION
Instead of storing the filesystem just received in top_zfs, mount and share it directly in zfs_receive_one().

This will make a filesystem be mounted as soon as it's been received, instead of waiting to the very end - which might take days.

Signed-off-by: Turbo Fredriksson <turbo@bayour.com>

Closes: #2673