### PR TITLE
Rewrite of nfs.c to keep options per host separated.

### DIFF
--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -56,6 +56,65 @@ static int update_zfs_shares(sa_handle_impl_t impl_handle, const char *proto);
 static int fstypes_count;
 static sa_fstype_t *fstypes;
 
+/*
+ * Invokes the specified callback function for each Solaris share option
+ * listed in the specified string.
+ */
+int
+foreach_shareopt(const char *shareopts,
+    nfs_shareopt_callback_t callback, void *cookie)
+{
+	char *shareopts_dup, *opt, *cur, *value;
+	int was_nul, rc;
+
+	if (shareopts == NULL)
+		return (SA_OK);
+
+	shareopts_dup = strdup(shareopts);
+	if (shareopts_dup == NULL)
+		return (SA_NO_MEMORY);
+
+	opt = shareopts_dup;
+	was_nul = 0;
+
+	while (1) {
+		cur = opt;
+
+		while (*cur != ',' && *cur != '\0')
+			cur++;
+
+		if (*cur == '\0')
+			was_nul = 1;
+
+		*cur = '\0';
+
+		if (cur > opt) {
+			value = strchr(opt, '=');
+
+			if (value != NULL) {
+				*value = '\0';
+				value++;
+			}
+
+			rc = callback(opt, value, cookie);
+
+			if (rc != SA_OK) {
+				free(shareopts_dup);
+				return (rc);
+			}
+		}
+
+		opt = cur + 1;
+
+		if (was_nul)
+			break;
+	}
+
+	free(shareopts_dup);
+
+	return (SA_OK);
+}
+
 sa_fstype_t *
 register_fstype(const char *name, const sa_share_ops_t *ops)
 {

--- a/lib/libshare/libshare_impl.h
+++ b/lib/libshare/libshare_impl.h
@@ -67,4 +67,7 @@ typedef struct sa_handle_impl {
 	sa_share_impl_t shares;
 } *sa_handle_impl_t;
 
+typedef int (*nfs_shareopt_callback_t)(const char *, const char *, void *);
+
 sa_fstype_t *register_fstype(const char *name, const sa_share_ops_t *ops);
+int foreach_shareopt(const char *, nfs_shareopt_callback_t, void *);

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -44,71 +44,8 @@ static sa_fstype_t *nfs_fstype;
  */
 static int nfs_exportfs_temp_fd = -1;
 
-typedef int (*nfs_shareopt_callback_t)(const char *opt, const char *value,
-    void *cookie);
-
 typedef int (*nfs_host_callback_t)(const char *sharepath, const char *host,
     const char *security, const char *access, void *cookie);
-
-/*
- * Invokes the specified callback function for each Solaris share option
- * listed in the specified string.
- */
-static int
-foreach_nfs_shareopt(const char *shareopts,
-    nfs_shareopt_callback_t callback, void *cookie)
-{
-	char *shareopts_dup, *opt, *cur, *value;
-	int was_nul, rc;
-
-	if (shareopts == NULL)
-		return (SA_OK);
-
-	shareopts_dup = strdup(shareopts);
-
-	if (shareopts_dup == NULL)
-		return (SA_NO_MEMORY);
-
-	opt = shareopts_dup;
-	was_nul = 0;
-
-	while (1) {
-		cur = opt;
-
-		while (*cur != ',' && *cur != '\0')
-			cur++;
-
-		if (*cur == '\0')
-			was_nul = 1;
-
-		*cur = '\0';
-
-		if (cur > opt) {
-			value = strchr(opt, '=');
-
-			if (value != NULL) {
-				*value = '\0';
-				value++;
-			}
-
-			rc = callback(opt, value, cookie);
-
-			if (rc != SA_OK) {
-				free(shareopts_dup);
-				return (rc);
-			}
-		}
-
-		opt = cur + 1;
-
-		if (was_nul)
-			break;
-	}
-
-	free(shareopts_dup);
-
-	return (0);
-}
 
 typedef struct nfs_host_cookie_s {
 	nfs_host_callback_t callback;
@@ -118,7 +55,7 @@ typedef struct nfs_host_cookie_s {
 } nfs_host_cookie_t;
 
 /*
- * Helper function for foreach_nfs_host. This function checks whether the
+ * Helper function for foreach_host. This function checks whether the
  * current share option is a host specification and invokes a callback
  * function with information about the host.
  */
@@ -390,7 +327,7 @@ get_linux_shareopts(const char *shareopts, char **plinux_opts)
 	(void) add_linux_shareopt(plinux_opts, "no_root_squash", NULL);
 	(void) add_linux_shareopt(plinux_opts, "mountpoint", NULL);
 
-	rc = foreach_nfs_shareopt(shareopts, get_linux_shareopts_cb,
+	rc = foreach_shareopt(shareopts, get_linux_shareopts_cb,
 	    plinux_opts);
 
 	if (rc != SA_OK) {

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -29,12 +29,18 @@
 #include <strings.h>
 #include <fcntl.h>
 #include <sys/wait.h>
+#include <sys/list.h>
 #include <unistd.h>
 #include <libzfs.h>
 #include <libshare.h>
 #include "libshare_impl.h"
 
+#if !defined(offsetof)
+#define	offsetof(s, m)  ((size_t)(&(((s *)0)->m)))
+#endif
+
 static boolean_t nfs_available(void);
+static int nfs_enable_share_one(const char *, const char *, char *);
 
 static sa_fstype_t *nfs_fstype;
 
@@ -44,93 +50,37 @@ static sa_fstype_t *nfs_fstype;
  */
 static int nfs_exportfs_temp_fd = -1;
 
-typedef int (*nfs_host_callback_t)(const char *sharepath, const char *host,
-    const char *security, const char *access, void *cookie);
+typedef int (*nfs_shareopt_callback_t)(const char *opt, const char *value,
+    void *cookie);
 
-typedef struct nfs_host_cookie_s {
-	nfs_host_callback_t callback;
-	const char *sharepath;
-	void *cookie;
-	const char *security;
-} nfs_host_cookie_t;
+/* List of hosts and their options */
+/* NOTE: share path is stored elsewhere */
+typedef struct nfs_share_list_s {
+	char	host[255];
+	char	opts[255];
 
-/*
- * Helper function for foreach_host. This function checks whether the
- * current share option is a host specification and invokes a callback
- * function with information about the host.
- */
+	list_node_t next;
+} nfs_share_list_t;
+
+/* Global list of shares */
+list_t all_nfs_shares_list;
+
 static int
-foreach_nfs_host_cb(const char *opt, const char *value, void *pcookie)
+find_option(char *opt, const char *needle)
 {
-	int rc;
-	const char *access;
-	char *host_dup, *host, *next;
-	nfs_host_cookie_t *udata = (nfs_host_cookie_t *)pcookie;
+	char *token, *dup;
 
-#ifdef DEBUG
-	fprintf(stderr, "foreach_nfs_host_cb: key=%s, value=%s\n", opt, value);
-#endif
+	dup = strdup(opt);
 
-	if (strcmp(opt, "sec") == 0)
-		udata->security = value;
+	token = strtok(dup, ",");
+	while (token != NULL) {
+		if (strncmp(token, needle, strlen(needle)) == 0)
+			return (1);
 
-	if (strcmp(opt, "rw") == 0 || strcmp(opt, "ro") == 0) {
-		if (value == NULL)
-			value = "*";
-
-		access = opt;
-
-		host_dup = strdup(value);
-
-		if (host_dup == NULL)
-			return (SA_NO_MEMORY);
-
-		host = host_dup;
-
-		do {
-			next = strchr(host, ':');
-			if (next != NULL) {
-				*next = '\0';
-				next++;
-			}
-
-			rc = udata->callback(udata->sharepath, host,
-			    udata->security, access, udata->cookie);
-
-			if (rc != SA_OK) {
-				free(host_dup);
-
-				return (rc);
-			}
-
-			host = next;
-		} while (host != NULL);
-
-		free(host_dup);
+		token = strtok(NULL, ",");
 	}
 
-	return (SA_OK);
-}
-
-/*
- * Invokes a callback function for all NFS hosts that are set for a share.
- */
-static int
-foreach_nfs_host(sa_share_impl_t impl_share, nfs_host_callback_t callback,
-    void *cookie)
-{
-	nfs_host_cookie_t udata;
-	char *shareopts;
-
-	udata.callback = callback;
-	udata.sharepath = impl_share->sharepath;
-	udata.cookie = cookie;
-	udata.security = "sys";
-
-	shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
-
-	return foreach_nfs_shareopt(shareopts, foreach_nfs_host_cb,
-	    &udata);
+	return (0);
 }
 
 /*
@@ -149,13 +99,11 @@ get_linux_hostspec(const char *solaris_hostspec, char **plinux_hostspec)
 		 * to skip the @ in this case
 		 */
 		*plinux_hostspec = strdup(solaris_hostspec + 1);
-	} else {
+	} else
 		*plinux_hostspec = strdup(solaris_hostspec);
-	}
 
-	if (*plinux_hostspec == NULL) {
+	if (*plinux_hostspec == NULL)
 		return (SA_NO_MEMORY);
-	}
 
 	return (SA_OK);
 }
@@ -164,45 +112,23 @@ get_linux_hostspec(const char *solaris_hostspec, char **plinux_hostspec)
  * Used internally by nfs_enable_share to enable sharing for a single host.
  */
 static int
-nfs_enable_share_one(const char *sharepath, const char *host,
-    const char *security, const char *access, void *pcookie)
+nfs_enable_share_one(const char *sharepath, const char *host, char *opts)
 {
 	int rc;
-	char *linuxhost, *hostpath, *opts;
-	const char *linux_opts = (const char *)pcookie;
+	char *hostpath;
 	char *argv[6];
 
-	/* exportfs -i -o sec=XX,rX,<opts> <host>:<sharepath> */
+	/* exportfs -i -o sec=XX,<opts> <host>:<sharepath> */
 
-	rc = get_linux_hostspec(host, &linuxhost);
-
-	if (rc < 0)
-		exit(1);
-
-	hostpath = malloc(strlen(linuxhost) + 1 + strlen(sharepath) + 1);
-
-	if (hostpath == NULL) {
-		free(linuxhost);
-
-		exit(1);
-	}
-
-	sprintf(hostpath, "%s:%s", linuxhost, sharepath);
-
-	free(linuxhost);
-
-	if (linux_opts == NULL)
-		linux_opts = "";
-
-	opts = malloc(4 + strlen(security) + 4 + strlen(linux_opts) + 1);
-
-	if (opts == NULL)
-		exit(1);
-
-	sprintf(opts, "sec=%s,%s,%s", security, access, linux_opts);
+	hostpath = malloc(strlen(host) + 1 +
+	    strlen(sharepath) + 1);
+	if (hostpath == NULL)
+		return (SA_NO_MEMORY);
+	sprintf(hostpath, "%s:%s", host, sharepath);
 
 #ifdef DEBUG
-	fprintf(stderr, "sharing %s with opts %s\n", hostpath, opts);
+	fprintf(stderr, "sharing %s with opts %s\n",
+		hostpath, (opts ? opts : "NULL"));
 #endif
 
 	argv[0] = "/usr/sbin/exportfs";
@@ -212,10 +138,17 @@ nfs_enable_share_one(const char *sharepath, const char *host,
 	argv[4] = hostpath;
 	argv[5] = NULL;
 
+#if DEBUG >= 2
+	int i;
+	fprintf(stderr, "CMD: ");
+	for (i = 0; i < 5; i++)
+		fprintf(stderr, "%s ", argv[i]);
+	fprintf(stderr, "\n");
+#endif
+
 	rc = libzfs_run_process(argv[0], argv, 0);
 
 	free(hostpath);
-	free(opts);
 
 	if (rc < 0)
 		return (SA_SYSTEM_ERR);
@@ -232,12 +165,16 @@ add_linux_shareopt(char **plinux_opts, const char *key, const char *value)
 	size_t len = 0;
 	char *new_linux_opts;
 
-	if (*plinux_opts != NULL)
+	if (*plinux_opts != NULL) {
 		len = strlen(*plinux_opts);
+
+		/* Skip value that already exist */
+		if (find_option(*plinux_opts, key))
+			return (SA_OK);
+	}
 
 	new_linux_opts = realloc(*plinux_opts, len + 1 + strlen(key) +
 	    (value ? 1 + strlen(value) : 0) + 1);
-
 	if (new_linux_opts == NULL)
 		return (SA_NO_MEMORY);
 
@@ -258,19 +195,104 @@ add_linux_shareopt(char **plinux_opts, const char *key, const char *value)
 	return (SA_OK);
 }
 
+static int
+update_host_list(void *cookie)
+{
+	char **plinux_opts = (char **)cookie;
+	nfs_share_list_t *cur_share, *new_share;
+
+	/* Get the last entry in the list. */
+	cur_share = list_tail(&all_nfs_shares_list);
+	if (cur_share == NULL)
+		return (SA_OK);
+
+	/* Create a new object list */
+	new_share = (nfs_share_list_t *)
+		malloc(sizeof (nfs_share_list_t));
+	if (new_share == NULL)
+		return (SA_NO_MEMORY);
+	list_link_init(&new_share->next);
+
+	/* If the current list is empty, the new list is 'world'. */
+	if (cur_share == NULL)
+		strcpy(new_share->host, "*");
+	else
+		strcpy(new_share->host, cur_share->host);
+	sprintf(new_share->opts, "%s", *plinux_opts);
+
+	/* Replace the old head with this new object */
+	if (cur_share->host != NULL)
+		list_link_replace(&cur_share->next, &new_share->next);
+	else
+		list_insert_tail(&all_nfs_shares_list, new_share);
+
+	return (SA_OK);
+}
+
 /*
  * Validates and converts a single Solaris share option to its Linux
- * equivalent.
+ * equivalent, verifies that the option is valid and then stores it
+ * in "cookie"..
  */
 static int
 get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
 {
 	char **plinux_opts = (char **)cookie;
+	nfs_share_list_t *opts = NULL;
 
-	/* host-specific options, these are taken care of elsewhere */
-	if (strcmp(key, "ro") == 0 || strcmp(key, "rw") == 0 ||
-	    strcmp(key, "sec") == 0)
-		return (SA_OK);
+// TODO: Make sure that a 'sec=yyy' (or any other option) BEFORE a/any
+//       'rw[=@xxx]' or 'ro[=@xxx]' works.
+	if (strcmp(key, "ro") == 0 || strcmp(key, "rw") == 0) {
+		opts = (nfs_share_list_t *)
+			malloc(sizeof (nfs_share_list_t));
+		if (opts == NULL)
+			return (SA_NO_MEMORY);
+
+		list_link_init(&opts->next);
+
+		if (*plinux_opts != NULL) {
+			/*
+			 * We're in a new host list, so update the
+			 * previous host definition
+			 */
+			update_host_list(cookie);
+
+			/*
+			 * Zero the current list of options
+			 * so that the next host definition
+			 * starts with an empty option list
+			 */
+			*plinux_opts = NULL;
+		}
+
+		/* Start a new host opts definition */
+		if (value && value[0] == '@') {
+			int rc;
+			char *host;
+
+			/*
+			 * Extract the host or network address from the
+			 * 'rw=@...' value.
+			 */ 
+			rc = get_linux_hostspec(value, &host);
+			if (rc < 0)
+				return (rc);
+
+			strncpy(opts->host, host, sizeof (opts->host));
+			opts->opts[0] = '\0';
+
+			/*
+			 * Make sure we don't add the '@...' to the options
+			 * list by setting the value to NULL after we're
+			 * done with it.
+			 */
+			value = NULL;
+		} else {
+			strcpy(opts->host, "*");
+			opts->opts[0] = '\0';
+		}
+		list_insert_tail(&all_nfs_shares_list, opts);
+	}
 
 	if (strcmp(key, "anon") == 0)
 		key = "anonuid";
@@ -283,24 +305,37 @@ get_linux_shareopts_cb(const char *key, const char *value, void *cookie)
 	if (strcmp(key, "nosub") == 0)
 		key = "subtree_check";
 
-	if (strcmp(key, "insecure") != 0 && strcmp(key, "secure") != 0 &&
-	    strcmp(key, "async") != 0 && strcmp(key, "sync") != 0 &&
-	    strcmp(key, "no_wdelay") != 0 && strcmp(key, "wdelay") != 0 &&
-	    strcmp(key, "nohide") != 0 && strcmp(key, "hide") != 0 &&
+	if (strcmp(key, "rw") != 0 &&
+	    strcmp(key, "ro") != 0 &&
+	    strcmp(key, "sec") != 0 &&
+	    strcmp(key, "insecure") != 0 &&
+	    strcmp(key, "secure") != 0 &&
+	    strcmp(key, "async") != 0 &&
+	    strcmp(key, "sync") != 0 &&
+	    strcmp(key, "no_wdelay") != 0 &&
+	    strcmp(key, "wdelay") != 0 &&
+	    strcmp(key, "nohide") != 0 &&
+	    strcmp(key, "hide") != 0 &&
 	    strcmp(key, "crossmnt") != 0 &&
 	    strcmp(key, "no_subtree_check") != 0 &&
 	    strcmp(key, "subtree_check") != 0 &&
 	    strcmp(key, "insecure_locks") != 0 &&
 	    strcmp(key, "secure_locks") != 0 &&
-	    strcmp(key, "no_auth_nlm") != 0 && strcmp(key, "auth_nlm") != 0 &&
-	    strcmp(key, "no_acl") != 0 && strcmp(key, "mountpoint") != 0 &&
-	    strcmp(key, "mp") != 0 && strcmp(key, "fsuid") != 0 &&
-	    strcmp(key, "refer") != 0 && strcmp(key, "replicas") != 0 &&
+	    strcmp(key, "no_auth_nlm") != 0 &&
+	    strcmp(key, "auth_nlm") != 0 &&
+	    strcmp(key, "no_acl") != 0 &&
+	    strcmp(key, "mountpoint") != 0 &&
+	    strcmp(key, "mp") != 0 &&
+	    strcmp(key, "fsuid") != 0 &&
+	    strcmp(key, "refer") != 0 &&
+	    strcmp(key, "replicas") != 0 &&
 	    strcmp(key, "root_squash") != 0 &&
 	    strcmp(key, "no_root_squash") != 0 &&
 	    strcmp(key, "all_squash") != 0 &&
-	    strcmp(key, "no_all_squash") != 0 && strcmp(key, "fsid") != 0 &&
-	    strcmp(key, "anonuid") != 0 && strcmp(key, "anongid") != 0) {
+	    strcmp(key, "no_all_squash") != 0 &&
+	    strcmp(key, "fsid") != 0 &&
+	    strcmp(key, "anonuid") != 0 &&
+	    strcmp(key, "anongid") != 0) {
 		return (SA_SYNTAX_ERR);
 	}
 
@@ -320,20 +355,35 @@ get_linux_shareopts(const char *shareopts, char **plinux_opts)
 
 	assert(plinux_opts != NULL);
 
-	*plinux_opts = NULL;
+	/* Create global list of share host(s) and options */
+	list_create(&all_nfs_shares_list, sizeof (nfs_share_list_t),
+	    offsetof(nfs_share_list_t, next));
 
-	/* default options for Solaris shares */
-	(void) add_linux_shareopt(plinux_opts, "no_subtree_check", NULL);
-	(void) add_linux_shareopt(plinux_opts, "no_root_squash", NULL);
-	(void) add_linux_shareopt(plinux_opts, "mountpoint", NULL);
+	if (strncmp(shareopts, "rw\0", 3) == 0) {
+		/*
+		 * 'sharenfs=on' => use default options for Solaris shares.
+		 * The 'on' part is changed in nfs_update_shareopts() to 'rw'.
+		 */
+		(void) add_linux_shareopt(plinux_opts, "no_subtree_check",
+		    NULL);
+		(void) add_linux_shareopt(plinux_opts, "no_root_squash", NULL);
+		(void) add_linux_shareopt(plinux_opts, "mountpoint", NULL);
+// TODO: Make sure a 'sharenfs=zzz' WITHOUT a 'rw[=@xxx]' or 'ro[=@xxx]' works
+//	} else if(strcmp(shareopts, "ro\0") != 0) {
+//		/* 'else' only: Doesn't work if there's a 'ro[=@xxx]' somewhere. */
+//		/* 'else if(strcmp(shareopts, "ro\0") == 0)': Doesn't work if there's ONLY a 'ro'. */
+//fprintf(stderr, "  + adding 'rw'\n"); // DEBUG
+//		strcat((char *)shareopts, ",rw");
+	}
 
 	rc = foreach_shareopt(shareopts, get_linux_shareopts_cb,
 	    plinux_opts);
-
 	if (rc != SA_OK) {
 		free(*plinux_opts);
 		*plinux_opts = NULL;
 	}
+
+	update_host_list(plinux_opts);
 
 	return (rc);
 }
@@ -344,24 +394,30 @@ get_linux_shareopts(const char *shareopts, char **plinux_opts)
 static int
 nfs_enable_share(sa_share_impl_t impl_share)
 {
+	int rc = SA_OK;
 	char *shareopts, *linux_opts;
-	int rc;
+	nfs_share_list_t *share;
 
-	if (!nfs_available()) {
+	if (!nfs_available())
 		return (SA_SYSTEM_ERR);
-	}
 
 	shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
-
 	if (shareopts == NULL)
 		return (SA_OK);
 
-	rc = get_linux_shareopts(shareopts, &linux_opts);
+	linux_opts = calloc(sizeof (nfs_share_list_t), 1);
 
+	rc = get_linux_shareopts(shareopts, &linux_opts);
 	if (rc != SA_OK)
 		return (rc);
 
-	rc = foreach_nfs_host(impl_share, nfs_enable_share_one, linux_opts);
+	for (share = list_head(&all_nfs_shares_list);
+	    share != NULL;
+	    share = list_next(&all_nfs_shares_list, share)) {
+
+		rc = nfs_enable_share_one(impl_share->sharepath,
+		    share->host, share->opts);
+	}
 
 	free(linux_opts);
 
@@ -372,28 +428,18 @@ nfs_enable_share(sa_share_impl_t impl_share)
  * Used internally by nfs_disable_share to disable sharing for a single host.
  */
 static int
-nfs_disable_share_one(const char *sharepath, const char *host,
-    const char *security, const char *access, void *cookie)
+nfs_disable_share_one(const char *sharepath, const char *host, char *opts)
 {
 	int rc;
-	char *linuxhost, *hostpath;
+	char *hostpath;
 	char *argv[4];
 
-	rc = get_linux_hostspec(host, &linuxhost);
+	/* exportfs -u <host>:<sharepath> */
 
-	if (rc < 0)
-		exit(1);
-
-	hostpath = malloc(strlen(linuxhost) + 1 + strlen(sharepath) + 1);
-
-	if (hostpath == NULL) {
-		free(linuxhost);
-		exit(1);
-	}
-
-	sprintf(hostpath, "%s:%s", linuxhost, sharepath);
-
-	free(linuxhost);
+	hostpath = malloc(strlen(host) + 1 + strlen(sharepath) + 1);
+	if (hostpath == NULL)
+		return (SA_NO_MEMORY);
+	sprintf(hostpath, "%s:%s", host, sharepath);
 
 #ifdef DEBUG
 	fprintf(stderr, "unsharing %s\n", hostpath);
@@ -403,6 +449,14 @@ nfs_disable_share_one(const char *sharepath, const char *host,
 	argv[1] = "-u";
 	argv[2] = hostpath;
 	argv[3] = NULL;
+
+#if DEBUG >= 2
+	int i;
+	fprintf(stderr, "CMD: ");
+	for (i = 0; i < 3; i++)
+		fprintf(stderr, "%s ", argv[i]);
+	fprintf(stderr, "\n");
+#endif
 
 	rc = libzfs_run_process(argv[0], argv, 0);
 
@@ -420,6 +474,14 @@ nfs_disable_share_one(const char *sharepath, const char *host,
 static int
 nfs_disable_share(sa_share_impl_t impl_share)
 {
+	int rc = SA_OK;
+	char *shareopts, *linux_opts;
+	nfs_share_list_t *share;
+
+#ifdef DEBUG
+	fprintf(stderr, "nfs_disable_share: %s\n", impl_share->sharepath);
+#endif
+
 	if (!nfs_available()) {
 		/*
 		 * The share can't possibly be active, so nothing
@@ -428,7 +490,27 @@ nfs_disable_share(sa_share_impl_t impl_share)
 		return (SA_OK);
 	}
 
-	return (foreach_nfs_host(impl_share, nfs_disable_share_one, NULL));
+	shareopts = FSINFO(impl_share, nfs_fstype)->shareopts;
+	if (shareopts == NULL)
+		return (SA_OK);
+
+	linux_opts = calloc(sizeof (nfs_share_list_t), 1);
+
+	rc = get_linux_shareopts(shareopts, &linux_opts);
+	if (rc != SA_OK)
+		return (rc);
+
+	for (share = list_head(&all_nfs_shares_list);
+	    share != NULL;
+	    share = list_next(&all_nfs_shares_list, share)) {
+
+		rc = nfs_disable_share_one(impl_share->sharepath,
+		    share->host, NULL);
+	}
+
+	free(linux_opts);
+
+	return (rc);
 }
 
 /*
@@ -439,6 +521,8 @@ nfs_validate_shareopts(const char *shareopts)
 {
 	char *linux_opts;
 	int rc;
+
+	linux_opts = calloc(sizeof (nfs_share_list_t), 1);
 
 	rc = get_linux_shareopts(shareopts, &linux_opts);
 
@@ -602,7 +686,6 @@ nfs_check_exportfs(void)
 		close(nfs_exportfs_temp_fd);
 
 	nfs_exportfs_temp_fd = mkstemp(nfs_exportfs_tempfile);
-
 	if (nfs_exportfs_temp_fd < 0)
 		return (SA_SYSTEM_ERR);
 
@@ -644,12 +727,10 @@ nfs_check_exportfs(void)
 		exit(1);
 
 	rc = execlp("/usr/sbin/exportfs", "exportfs", "-v", NULL);
-
-	if (rc < 0) {
+	if (rc < 0)
 		exit(1);
-	}
-
-	exit(0);
+	else
+		exit(0);
 }
 
 /*


### PR DESCRIPTION
Example: Setting sharenfs to
```
  "rw=@192.168.69.8,no_subtree_check,no_root_squash,ro=@192.168.69.45,no_subtree_check,root_squash"
```
will create the option string
```
  sec=sys,ro,no_subtree_check,no_root_squash,mountpoint,no_subtree_check,no_root_squash,no_subtree_check,root_squash
```
which is then run on _each host_!. Part of this is "default" options.

Instead, go through the option string, look for hosts and then make sure options for each host is kept apart by using a linked list (maintained by the ZFS list_* functions).
Also, the default options should only be added to the list of options if setting sharenfs to <code>on</code>.

Closes: #2773