### PR TITLE
Use kmem_vasprintf() in log_internal()

### DIFF
--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -440,8 +440,6 @@ log_internal(nvlist_t *nvl, const char *operation, spa_t *spa,
     dmu_tx_t *tx, const char *fmt, va_list adx)
 {
 	char *msg;
-	va_list adx1;
-	int size;
 
 	/*
 	 * If this is part of creating a pool, not everything is
@@ -453,15 +451,9 @@ log_internal(nvlist_t *nvl, const char *operation, spa_t *spa,
 		return;
 	}
 
-	va_copy(adx1, adx);
-	size = vsnprintf(NULL, 0, fmt, adx1) + 1;
-	msg = kmem_alloc(size, KM_PUSHPAGE);
-	va_end(adx1);
-	va_copy(adx1, adx);
-	(void) vsprintf(msg, fmt, adx1);
-	va_end(adx1);
+	msg = kmem_vasprintf(fmt, adx);
 	fnvlist_add_string(nvl, ZPOOL_HIST_INT_STR, msg);
-	kmem_free(msg, size);
+	strfree(msg);
 
 	fnvlist_add_string(nvl, ZPOOL_HIST_INT_NAME, operation);
 	fnvlist_add_uint64(nvl, ZPOOL_HIST_TXG, tx->tx_txg);


### PR DESCRIPTION
An attempt to debug zfsonlinux/zfs#2781 revealed that this code could be
simplified by using kmem_asprintf(). It is not clear that switching to
kmem_asprintf() addresses zfsonlinux/zfs#2781. However, switching to
kmem_asprintf() is cleanup that simplifies debugging such that it would
become clear that this is a bug in glibc should the issue persist.

Switching to kmem_asprintf() has the side effect of making
log_internal() allocate memory with KM_SLEEP instead of KM_PUSHPAGE.
That allocation originally used KM_SLEEP until it was switched to
KM_PUSHPAGE in b8d06fca089fae4680c3a552fc55c512bfb02202 as part of an
attempt to prevent deadlocks on swap. A cursory review suggests that
log_internal() is only used outside of DMU transactions, the sync task
and the quiesce task. It follows that the original rationale for
switching this particular allocation from KM_SLEEP to KM_PUSHPAGE was
invalid. Switching back to KM_SLEEP is therefore not only safe, but
desireable to avoid unnecessary use of the kernel's emergency memory
pools under low memory situations.

This also implicitly reverts 222b94805903dfa6879565ab9b1c8e3b0d70cbdf by
using `strfree()` instead of `kmem_free()`. This is possible because
kmem_vasprintf() is implicitly mapped to kmalloc() by the SPL, which
avoids creating a false positive in the kmem leak detection.

Signed-off-by: Richard Yao <ryao@gentoo.org>