### PR TITLE
Store common Linux xattrs as native SA with xattr=sa (WIP)

### DIFF
--- a/include/sys/zfs_sa.h
+++ b/include/sys/zfs_sa.h
@@ -74,6 +74,10 @@ typedef enum zpl_attr {
 	ZPL_SCANSTAMP,
 	ZPL_DACL_ACES,
 	ZPL_DXATTR,
+	ZPL_SECURITY_SELINUX,
+	ZPL_SECURITY_CAPABILITY,
+	ZPL_SYSTEM_POSIX_ACL_ACCESS,
+	ZPL_SYSTEM_POSIX_ACL_DEFAULT,
 	ZPL_END
 } zpl_attr_t;
 
@@ -137,6 +141,9 @@ void zfs_sa_get_scanstamp(struct znode *, xvattr_t *);
 void zfs_sa_set_scanstamp(struct znode *, xvattr_t *, dmu_tx_t *);
 int zfs_sa_get_xattr(struct znode *);
 int zfs_sa_set_xattr(struct znode *);
+int zfs_sa_native_get_xattr(struct znode *, zpl_attr_t, void *, size_t *);
+int zfs_sa_native_set_xattr(struct znode *, zpl_attr_t, const char *,
+	const void *, size_t, dmu_tx_t *);
 void zfs_sa_upgrade(struct sa_handle  *, dmu_tx_t *);
 void zfs_sa_upgrade_txholds(dmu_tx_t *, struct znode *);
 void zfs_sa_init(void);

--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -82,7 +82,7 @@ typedef struct zfs_sb {
 	boolean_t	z_use_fuids;	/* version allows fuids */
 	boolean_t	z_replay;	/* set during ZIL replay */
 	boolean_t	z_use_sa;	/* version allow system attributes */
-	boolean_t	z_xattr_sa;	/* allow xattrs to be stores as SA */
+	boolean_t	z_xattr_sa;	/* allow xattrs to be stored as SA */
 	uint64_t	z_version;	/* ZPL version */
 	uint64_t	z_shares_dir;	/* hidden shares dir */
 	kmutex_t	z_lock;

--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -76,7 +76,9 @@ extern struct file_system_type zpl_fs_type;
 /* zpl_xattr.c */
 extern ssize_t zpl_xattr_list(struct dentry *dentry, char *buf, size_t size);
 extern int zpl_xattr_security_init(struct inode *ip, struct inode *dip,
-    const struct qstr *qstr);
+    const struct qstr *qstr, nvlist_t *xattr_list);
+extern int zpl_xattr_set(struct inode *ip, const char *name, const void *value,
+    size_t size, int flags);
 #if defined(CONFIG_FS_POSIX_ACL)
 extern int zpl_set_acl(struct inode *ip, int type, struct posix_acl *acl);
 extern struct posix_acl *zpl_get_acl(struct inode *ip, int type);
@@ -92,7 +94,7 @@ extern int zpl_permission(struct inode *ip, int mask);
 #endif /*  HAVE_CHECK_ACL | HAVE_PERMISSION */
 #endif /* HAVE_GET_ACL */
 
-extern int zpl_init_acl(struct inode *ip, struct inode *dir);
+extern int zpl_init_acl(struct inode *ip, struct inode *dir, nvlist_t *xattr_list);
 extern int zpl_chmod_acl(struct inode *ip);
 #else
 static inline int

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -1747,10 +1747,8 @@ sa_modify_attrs(sa_handle_t *hdl, sa_attr_type_t newattr,
 			if (attr == newattr) {
 				if (length == 0)
 					++length_idx;
-				if (action == SA_REMOVE) {
-					j++;
+				if (action == SA_REMOVE)
 					continue;
-				}
 				ASSERT(length == 0);
 				ASSERT(action == SA_REPLACE);
 				SA_ADD_BULK_ATTR(attr_desc, j, attr,

--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -90,9 +90,9 @@ zpl_init_xattrs(struct inode *ip, struct inode *dir, struct dentry *dentry)
 	nvpair_t *xattr;
 
 	xattrs = fnvlist_alloc();
-	error = zpl_xattr_security_init(ip, dir, &dentry->d_name, &xattrs);
-	if (error == 0)
-		error = zpl_init_acl(ip, dir, &xattrs);
+	error = zpl_xattr_security_init(ip, dir, &dentry->d_name, xattrs);
+	if (error == 0 && !S_ISLNK(ip->i_mode))
+		error = zpl_init_acl(ip, dir, xattrs);
 
 	for (xattr = nvlist_next_nvpair(xattrs, NULL);
 	    xattr != NULL; xattr = nvlist_next_nvpair(xattrs, xattr)) {
@@ -316,7 +316,7 @@ zpl_symlink(struct inode *dir, struct dentry *dentry, const char *name)
 
 	error = -zfs_symlink(dir, dname(dentry), vap, (char *)name, &ip, cr, 0);
 	if (error == 0) {
-		VERIFY0(zpl_xattr_security_init(ip, dir, &dentry->d_name));
+		VERIFY0(zpl_init_xattrs(ip, dir, dentry));
 		d_instantiate(dentry, ip);
 	}
 

--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -83,6 +83,18 @@ zpl_vap_init(vattr_t *vap, struct inode *dir, zpl_umode_t mode, cred_t *cr)
 }
 
 static int
+zpl_init_xattrs(struct inode *ip, struct inode *dir, struct dentry *dentry)
+{
+	int error;
+
+	error = zpl_xattr_security_init(ip, dir, &dentry->d_name);
+	if (error == 0)
+		error = zpl_init_acl(ip, dir);
+
+	return (error);
+}
+
+static int
 #ifdef HAVE_CREATE_NAMEIDATA
 zpl_create(struct inode *dir, struct dentry *dentry, zpl_umode_t mode,
     struct nameidata *nd)
@@ -102,8 +114,7 @@ zpl_create(struct inode *dir, struct dentry *dentry, zpl_umode_t mode,
 
 	error = -zfs_create(dir, dname(dentry), vap, 0, mode, &ip, cr, 0, NULL);
 	if (error == 0) {
-		VERIFY0(zpl_xattr_security_init(ip, dir, &dentry->d_name));
-		VERIFY0(zpl_init_acl(ip, dir));
+		VERIFY0(zpl_init_xattrs(ip, dir, dentry));
 		d_instantiate(dentry, ip);
 	}
 
@@ -137,8 +148,7 @@ zpl_mknod(struct inode *dir, struct dentry *dentry, zpl_umode_t mode,
 
 	error = -zfs_create(dir, dname(dentry), vap, 0, mode, &ip, cr, 0, NULL);
 	if (error == 0) {
-		VERIFY0(zpl_xattr_security_init(ip, dir, &dentry->d_name));
-		VERIFY0(zpl_init_acl(ip, dir));
+		VERIFY0(zpl_init_xattrs(ip, dir, dentry));
 		d_instantiate(dentry, ip);
 	}
 
@@ -177,8 +187,7 @@ zpl_mkdir(struct inode *dir, struct dentry *dentry, zpl_umode_t mode)
 
 	error = -zfs_mkdir(dir, dname(dentry), vap, &ip, cr, 0, NULL);
 	if (error == 0) {
-		VERIFY0(zpl_xattr_security_init(ip, dir, &dentry->d_name));
-		VERIFY0(zpl_init_acl(ip, dir));
+		VERIFY0(zpl_init_xattrs(ip, dir, dentry));
 		d_instantiate(dentry, ip);
 	}
 


### PR DESCRIPTION
There are 2 commits here.  The first, dweeezil/zfs@c53847e, fixes deletion of system attributes.

The second is a intended to be the foundation for fixing #2718 but it should otherwise be able to stand on its own.

I've given this patch stack fairly light manual testing as well as running the "pjd" posixacl test suite and some short ztest runs.

I'm submitting this now as a functional WIP to get feedback from other developers regarding the overall concept and its implementation.  There are a handful of issues I'll point out about the code:
 - The list of xattrs to store as native SAs is stored statically in ```zpl_xattr.c``` which made it difficult to share with ```zdb```.  The same list (in a different format) exists within ```zdb.c``` as part of the new ```dump_znode_native_sa_xattr()``` function.
 - The management of existing ZPL_DXATTR SAs required a helper function to translate from a ```zpl_attr_t``` to its name.  As far as I could tell, there were no existing "upcalls" from the ZoL ZPL to the native Solaris ZPL.  Rather than trying to ```#include``` the ZPL definitions in ```zfs_sa.c```, I simply added an appropriate ```extern``` declaration.  This goes against the current coding style.
 - The ZPL_DXATTR SA cleanup performed by ```zfs_sa_remove_xattr``` adds overhead which could be avoided if it was known that no ZPL_DXATTRs exist.  To that end, it's only invoked after determining whether a ZPL_DXATTR exists (which should be a low-overhead operation).
 - I'd like to add a feature flag which is activated when a Native SA xattr is set for the first time; the feature flag would not be able to be deactivated.  We might also want a feature flag to do the same with the existing ZPL_DXATTR SAs.

I'd also like feedback on the first commit in this stack.  I discovered the problem during testing.  My concern is that all other OpenZFS implementations likely share the identical code.  I think the problem isn't seen often because SAs are rarely deleted.  My test system created sort of a "perfect storm" by "stacking" all the variably-sized SAs at the ends of the registration.
