### PR TITLE
Set zfs_autoimport_disable default value to 1

### DIFF
--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -64,7 +64,7 @@ static uint64_t spa_config_generation = 1;
  * userland pools when doing testing.
  */
 char *spa_config_path = ZPOOL_CACHE;
-int zfs_autoimport_disable = 0;
+int zfs_autoimport_disable = 1;
 
 /*
  * Called when the module is first loaded, this routine loads the configuration
@@ -81,8 +81,10 @@ spa_config_load(void)
 	struct _buf *file;
 	uint64_t fsize;
 
+#ifdef _KERNEL
 	if (zfs_autoimport_disable)
 		return;
+#endif
 
 	/*
 	 * Open the configuration file.


### PR DESCRIPTION
When loading the ZFS kernel modules they should not populate the
spa namespace using the cache file.  This behavior isn't consistent
with other Linux kernel modules and we need to move away from it.
Removing this makes the whole startup process predictable with four
basic steps which are driven by the init system.

  1) modprobe
  2) zpool import
  3) zfs mount
  4) zfs share

This change also helps lay the groundwork for eventually removing
the kobj_* compatibility code on the kernel side.  It may need to
be preserved in userspace because libzfs_init() depends on it.
This is why the conditional must be wrapped with an #ifdef _KERNEL.

Signed-off-by: Dan Swartzendruber <dswartz@druber.com>
Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #2779