### PR TITLE
Make `zpool import -d|-c` behave consistently

### DIFF
--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -444,7 +444,6 @@ get_configs(libzfs_handle_t *hdl, pool_list_t *pl, boolean_t active_ok)
 	boolean_t isactive;
 	uint64_t hostid;
 	nvlist_t *nvl;
-	boolean_t found_one = B_FALSE;
 	boolean_t valid_top_config = B_FALSE;
 
 	if (nvlist_alloc(&ret, 0, 0) != 0)
@@ -813,14 +812,8 @@ add_pool:
 		if (nvlist_add_nvlist(ret, name, config) != 0)
 			goto nomem;
 
-		found_one = B_TRUE;
 		nvlist_free(config);
 		config = NULL;
-	}
-
-	if (!found_one) {
-		nvlist_free(ret);
-		ret = NULL;
 	}
 
 	return (ret);


### PR DESCRIPTION
When importing pools with zpool import -aN there is inconsistent
behavior between '-d /dev/disk/by-id' (or another path) and
'-c /etc/zfs/zpool.cache'.

The difference in behavior is caused by zpool_find_import_cached()
returning an empty nvlist_t when there are no pools to import but
zpool_find_import_impl() returns NULL for the same situation. The
behavior of zpool_find_import_cached() is arguably more correct
because it allows returning NULL to be used for an error case and
not an empty set.

This change resolves the issue by updating get_configs() such that
it returns an empty set instead of NULL when no config is found.
The updated behavior will now always return 0 for this case.

$ zpool import -aN; echo $?
no pools available to import
0

$ zpool import -aN -d /var/tmp/; echo $?
no pools available to import
0

$ zpool import -aN -c /etc/zfs/zpool.cache; echo $?
no pools available to import
0

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #2080