### PR TITLE
Illumos 5368 - ARC should cache more metadata

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -394,6 +394,17 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
+\fBzfs_arc_meta_min\fR (ulong)
+.ad
+.RS 12n
+Meta minimum for arc size
+.sp
+Default value: \fB0\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_arc_meta_prune\fR (int)
 .ad
 .RS 12n


### PR DESCRIPTION
5368 ARC should cache more metadata
 Reviewed by: Alex Reece <alex.reece@delphix.com>
 Reviewed by: Christopher Siden <christopher.siden@delphix.com>
 Reviewed by: George Wilson <george.wilson@delphix.com>
 Reviewed by: Richard Elling <richard.elling@richardelling.com>
 Approved by: Dan McDonald <danmcd@omniti.com>

References:
  illumos/illumos-gate@3a5286a1cffceafcd8cf79c4156fad605129bf50
  https://www.illumos.org/issues/5368

Porting notes:
  1) Style change to eliminate gcc compiler warning in arc_init
     variable initialization

  2) Module parameter exported and added to the man page.

  3) Module parameter supports dynamic modification like other
     ARC tunables.

Ported by: DHE <git@dehacked.net>