### PR TITLE
Linux 3.12 compat: split shrinker has s_shrink

### DIFF
--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -1068,7 +1068,7 @@ zfs_root(zfs_sb_t *zsb, struct inode **ipp)
 }
 EXPORT_SYMBOL(zfs_root);
 
-#ifdef HAVE_SHRINK
+#if defined(HAVE_SHRINK) || defined(HAVE_SPLIT_SHRINKER_CALLBACK)
 int
 zfs_sb_prune(struct super_block *sb, unsigned long nr_to_scan, int *objects)
 {
@@ -1080,13 +1080,17 @@ zfs_sb_prune(struct super_block *sb, unsigned long nr_to_scan, int *objects)
 	};
 
 	ZFS_ENTER(zsb);
+#ifdef HAVE_SPLIT_SHRINKER_CALLBACK
+	*objects = (*shrinker->scan_objects)(shrinker, &sc);
+#else
 	*objects = (*shrinker->shrink)(shrinker, &sc);
+#endif
 	ZFS_EXIT(zsb);
 
 	return (0);
 }
 EXPORT_SYMBOL(zfs_sb_prune);
-#endif /* HAVE_SHRINK */
+#endif /* defined(HAVE_SHRINK) || defined(HAVE_SPLIT_SHRINKER_CALLBACK) */
 
 /*
  * Teardown the zfs_sb_t.

--- a/module/zfs/zpl_super.c
+++ b/module/zfs/zpl_super.c
@@ -268,7 +268,7 @@ zpl_kill_sb(struct super_block *sb)
 #endif /* HAVE_S_INSTANCES_LIST_HEAD */
 }
 
-#ifdef HAVE_SHRINK
+#if defined(HAVE_SHRINK) || defined(HAVE_SPLIT_SHRINKER_CALLBACK)
 /*
  * Linux 3.1 - 3.x API
  *
@@ -288,17 +288,17 @@ zpl_prune_sb(struct super_block *sb, void *arg)
 	error = -zfs_sb_prune(sb, *(unsigned long *)arg, &objects);
 	ASSERT3S(error, <=, 0);
 }
-#endif /* HAVE_SHRINK */
+#endif /* defined(HAVE_SHRINK) || defined(HAVE_SPLIT_SHRINKER_CALLBACK) */
 
 void
 zpl_prune_sbs(int64_t bytes_to_scan, void *private)
 {
-#ifdef HAVE_SHRINK
+#if defined(HAVE_SHRINK) || defined(HAVE_SPLIT_SHRINKER_CALLBACK)
 	unsigned long nr_to_scan = (bytes_to_scan / sizeof (znode_t));
 
 	iterate_supers_type(&zpl_fs_type, zpl_prune_sb, &nr_to_scan);
 	kmem_reap();
-#endif /* HAVE_SHRINK */
+#endif /* defined(HAVE_SHRINK) || defined(HAVE_SPLIT_SHRINKER_CALLBACK) */
 }
 
 #ifdef HAVE_NR_CACHED_OBJECTS


### PR DESCRIPTION
The split count/scan shrinker callbacks introduced in 3.12 broke the
test for HAVE_SHRINK, effectively disabling the per-superblock shrinkers.

This patch re-enables the per-superblock shrinkers when the split shrinker
callbacks have been detected.