### PR TITLE
Document zfs_flags module parameter

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -822,9 +822,45 @@ Default value: \fB300\fR.
 \fBzfs_flags\fR (int)
 .ad
 .RS 12n
-Set additional debugging flags
+Set additional debugging flags. The following flags may be bitwise-or'd
+together.
 .sp
-Default value: \fB1\fR.
+.TS
+box;
+rB lB
+lB lB
+r l.
+Value	Symbolic Name
+	Description
+_
+1	ZFS_DEBUG_DPRINTF
+	Enable dprintf entries in the debug log.
+_
+2	ZFS_DEBUG_DBUF_VERIFY *
+	Enable extra dbuf verifications.
+_
+4	ZFS_DEBUG_DNODE_VERIFY *
+	Enable extra dnode verifications.
+_
+8	ZFS_DEBUG_SNAPNAMES
+	Enable snapshot name verification.
+_
+16	ZFS_DEBUG_MODIFY
+	Check for illegally modified ARC buffers.
+_
+32	ZFS_DEBUG_SPA
+	Enable spa_dbgmsg entries in the debug log.
+_
+64	ZFS_DEBUG_ZIO_FREE
+	Enable verification of block frees.
+_
+128	ZFS_DEBUG_HISTOGRAM_VERIFY
+	Enable extra spacemap histogram verifications.
+.TE
+.sp
+* Requires debug build.
+.sp
+Default value: \fB0\fR.
 .RE
 
 .sp

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1980,7 +1980,7 @@ EXPORT_SYMBOL(spa_mode);
 
 EXPORT_SYMBOL(spa_namespace_lock);
 
-module_param(zfs_flags, int, 0644);
+module_param(zfs_flags, uint, 0644);
 MODULE_PARM_DESC(zfs_flags, "Set additional debugging flags");
 
 module_param(zfs_recover, int, 0644);


### PR DESCRIPTION
Add a table describing the debugging flags that can be set in the zfs_flags
module parameter.  Also change the module_param type to 'uint' so users aren't
shown a negative value. The updated man page text is reproduced below for
convenience.

```
zfs_flags (int)

Set additional debugging flags. The following flags may be
bitwise-or'd together. The ZFS_DEBUG_DBUF_VERIFY and ZFS_DEBUG_DNODE flags are
ignored  unless  ZFS  was  built  with  debugging enabled.

Value   Symbolic Name              Description
    1   ZFS_DEBUG_DPRINTF          Enable dprintf entries in the debug log
    2   ZFS_DEBUG_DBUF_VERIFY      Enable extra dbuf verifications
    4   ZFS_DEBUG_DNODE_VERIFY     Enable extra dnode verifications
    8   ZFS_DEBUG_SNAPNAMES        Enable snapshot name verification
   16   ZFS_DEBUG_MODIFY           Check for illegally modified ARC buffers
   32   ZFS_DEBUG_SPA              Enable spa_dbgmsg entries in the debug log
   64   ZFS_DEBUG_ZIO_FREE         Enable verification of block frees
  128   ZFS_DEBUG_HISTOGRAM_VERIFY Enable extra spacemap histogram verifications

Default value: 0.
```
Signed-off-by: Ned Bass <bass6@llnl.gov>