### PR TITLE
Replace P2ROUNDUP* macro implementations by Linux kernel variants.

### DIFF
--- a/lib/libspl/include/sys/sysmacros.h
+++ b/lib/libspl/include/sys/sysmacros.h
@@ -49,15 +49,11 @@
  */
 #define	P2ALIGN(x, align)	((x) & -(align))
 #define	P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
-#define	P2ROUNDUP(x, align)	(-(-(x) & -(align)))
-#define	P2ROUNDUP_TYPED(x, align, type) \
-				(-(-(type)(x) & -(type)(align)))
+#define	P2ROUNDUP(x, align)	((((x) - 1) | ((align) - 1)) + 1)
 #define	P2BOUNDARY(off, len, align) \
 				(((off) ^ ((off) + (len) - 1)) > (align) - 1)
 #define	P2PHASE(x, align)	((x) & ((align) - 1))
 #define	P2NPHASE(x, align)	(-(x) & ((align) - 1))
-#define	P2NPHASE_TYPED(x, align, type) \
-				(-(type)(x) & ((type)(align) - 1))
 #define	ISP2(x)			(((x) & ((x) - 1)) == 0)
 #define	IS_P2ALIGNED(v, a)	((((uintptr_t)(v)) & ((uintptr_t)(a) - 1)) == 0)
 
@@ -79,7 +75,7 @@
 #define	P2NPHASE_TYPED(x, align, type)		\
 	(-(type)(x) & ((type)(align) - 1))
 #define	P2ROUNDUP_TYPED(x, align, type)		\
-	(-(-(type)(x) & -(type)(align)))
+	((((x) - 1) | ((type)((align) - 1))) + 1)
 #define	P2END_TYPED(x, align, type)		\
 	(-(~(type)(x) & -(type)(align)))
 #define	P2PHASEUP_TYPED(x, align, phase, type)	\


### PR DESCRIPTION
This replaces the implementation of P2ROUNDUP* by the implementation used in Linux's `round_up()` macro. This PR should be considered in tandem with https://github.com/zfsonlinux/spl/pull/423: please consult there for more information.