### PR TITLE
Fix removal of SA in sa_modify_attrs()

### DIFF
--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -1730,10 +1730,8 @@ sa_modify_attrs(sa_handle_t *hdl, sa_attr_type_t newattr,
 			if (attr == newattr) {
 				if (length == 0)
 					++length_idx;
-				if (action == SA_REMOVE) {
-					j++;
+				if (action == SA_REMOVE)
 					continue;
-				}
 				ASSERT(length == 0);
 				ASSERT(action == SA_REPLACE);
 				SA_ADD_BULK_ATTR(attr_desc, j, attr,


### PR DESCRIPTION
The sa_modify_attrs() function can add, remove or replace an SA.
The main loop in the function uses the index "i" to iterate over the
existing SAs and uses the index "j" for writing them into a new buffer
~~bia~~ via SA_ADD_BULK_ATTR().  The write index, "j" is incremented on remove
(SA_REMOVE) operations which leads to a corruption in the new SA buffer.
This patch remove the increment for SA_REMOVE operations.