### PR TITLE
Read spl_hostid module parameter before gethostid()

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1917,7 +1917,7 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 	} else if (state != POOL_STATE_EXPORTED &&
 	    !(flags & ZFS_IMPORT_ANY_HOST)) {
 		uint64_t hostid = 0;
-		unsigned long system_hostid = gethostid() & 0xffffffff;
+		unsigned long system_hostid = get_system_hostid();
 
 		(void) nvlist_lookup_uint64(config, ZPOOL_CONFIG_HOSTID,
 		    &hostid);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -350,6 +350,7 @@ typedef enum {
 	ZPOOL_STATUS_OK
 } zpool_status_t;
 
+extern unsigned long get_system_hostid(void);
 extern zpool_status_t zpool_get_status(zpool_handle_t *, char **,
     zpool_errata_t *);
 extern zpool_status_t zpool_import_status(nvlist_t *, char **,

--- a/lib/libzfs/libzfs_status.c
+++ b/lib/libzfs/libzfs_status.c
@@ -195,7 +195,7 @@ check_status(nvlist_t *config, boolean_t isimport, zpool_errata_t *erratap)
 	uint64_t suspended;
 	uint64_t hostid = 0;
 	uint64_t errata = 0;
-	unsigned long system_hostid = gethostid() & 0xffffffff;
+	unsigned long system_hostid = get_system_hostid();
 
 	verify(nvlist_lookup_uint64(config, ZPOOL_CONFIG_VERSION,
 	    &version) == 0);


### PR DESCRIPTION
If spl_hostid is set via module parameter, it's likely different from
gethostid(). Therefore, the userspace tool should read it first before falling
back to gethostid().

Signed-off-by: Chunwei Chen <tuxoko@gmail.com>