### PR TITLE
Direct reclaim deadlock fixes

### DIFF
--- a/include/sys/dmu_tx.h
+++ b/include/sys/dmu_tx.h
@@ -85,6 +85,7 @@ struct dmu_tx {
 	refcount_t tx_space_written;
 	refcount_t tx_space_freed;
 #endif
+	fstrans_cookie_t tx_cookie;
 };
 
 enum dmu_tx_hold_type {

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -481,14 +481,11 @@ int
 zpl_putpage(struct page *pp, struct writeback_control *wbc, void *data)
 {
 	struct address_space *mapping = data;
-	fstrans_cookie_t cookie;
 
 	ASSERT(PageLocked(pp));
 	ASSERT(!PageWriteback(pp));
 
-	cookie = spl_fstrans_mark();
 	(void) zfs_putpage(mapping->host, pp, wbc);
-	spl_fstrans_unmark(cookie);
 
 	return (0);
 }

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -577,7 +577,6 @@ zvol_write(void *arg)
 	struct request *req = (struct request *)arg;
 	struct request_queue *q = req->q;
 	zvol_state_t *zv = q->queuedata;
-	fstrans_cookie_t cookie = spl_fstrans_mark();
 	uint64_t offset = blk_rq_pos(req) << 9;
 	uint64_t size = blk_rq_bytes(req);
 	int error = 0;
@@ -622,7 +621,6 @@ zvol_write(void *arg)
 
 out:
 	blk_end_request(req, -error, size);
-	spl_fstrans_unmark(cookie);
 }
 
 #ifdef HAVE_BLK_QUEUE_DISCARD
@@ -632,7 +630,6 @@ zvol_discard(void *arg)
 	struct request *req = (struct request *)arg;
 	struct request_queue *q = req->q;
 	zvol_state_t *zv = q->queuedata;
-	fstrans_cookie_t cookie = spl_fstrans_mark();
 	uint64_t start = blk_rq_pos(req) << 9;
 	uint64_t end = start + blk_rq_bytes(req);
 	int error;
@@ -668,7 +665,6 @@ zvol_discard(void *arg)
 	zfs_range_unlock(rl);
 out:
 	blk_end_request(req, -error, blk_rq_bytes(req));
-	spl_fstrans_unmark(cookie);
 }
 #endif /* HAVE_BLK_QUEUE_DISCARD */
 
@@ -684,7 +680,6 @@ zvol_read(void *arg)
 	struct request *req = (struct request *)arg;
 	struct request_queue *q = req->q;
 	zvol_state_t *zv = q->queuedata;
-	fstrans_cookie_t cookie = spl_fstrans_mark();
 	uint64_t offset = blk_rq_pos(req) << 9;
 	uint64_t size = blk_rq_bytes(req);
 	int error;
@@ -707,7 +702,6 @@ zvol_read(void *arg)
 
 out:
 	blk_end_request(req, -error, size);
-	spl_fstrans_unmark(cookie);
 }
 
 /*


### PR DESCRIPTION
These are fixes for a couple of deadlocks that are possible in current HEAD. The first is a deadlock caused by recursive DMU transactions when atime updates are done by direct reclaim invoking zfs_inactive() inside DMU transactions. This is a rare issue, but one of SoftNAS' clieent systems were able to hit it consistently back in July. The fix had been in my original kmem rework proposal, but it was removed by the time it was merged. I did not notice until I rebased an old development branch. The second is a regression caused by the recent kmem rework where direct reclaim when an ARC buffer hash lock is held will attempt to lock an ARC buffer hash lock. This was not known to me when I first proposed spl_fstrans_mark()/spl_fstrans_unmark() and unfortuantely, it got past regression testing.

I do not have time to run them through my usual testing at the moment, so I am leaning on the buildbot to test them.