### PR TITLE
zio performance

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1382,17 +1382,6 @@ Default value: \fB1,048,576\fR.
 .sp
 .ne 2
 .na
-\fBzio_bulk_flags\fR (int)
-.ad
-.RS 12n
-Additional flags to pass to bulk buffers
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
 \fBzio_delay_max\fR (int)
 .ad
 .RS 12n

--- a/scripts/zpios-survey.sh
+++ b/scripts/zpios-survey.sh
@@ -120,40 +120,13 @@ zpios_survey_pending() {
 		tee -a ${ZPIOS_SURVEY_LOG}
 }
 
-# To avoid memory fragmentation issues our slab implementation can be
-# based on a virtual address space.  Interestingly, we take a pretty
-# substantial performance penalty for this somewhere in the low level
-# IO drivers.  If we back the slab with kmem pages we see far better
-# read performance numbers at the cost of memory fragmention and general
-# system instability due to large allocations.  This may be because of
-# an optimization in the low level drivers due to the contigeous kmem
-# based memory.  This needs to be explained.  The good news here is that
-# with zerocopy interfaces added at the DMU layer we could gaurentee
-# kmem based memory for a pool of pages.
-#
-# 0x100 = KMC_KMEM - Force kmem_* based slab
-# 0x200 = KMC_VMEM - Force vmem_* based slab
-zpios_survey_kmem() {
-	TEST_NAME="${ZPOOL_CONFIG}+${ZPIOS_TEST}+kmem"
-	print_header ${TEST_NAME}
-
-	${ZFS_SH} ${VERBOSE_FLAG}             \  
-		zfs="zio_bulk_flags=0x100" | \
-		tee -a ${ZPIOS_SURVEY_LOG}
-	${ZPIOS_SH} ${VERBOSE_FLAG} -c ${ZPOOL_CONFIG} -t ${ZPIOS_TEST} | \
-		tee -a ${ZPIOS_SURVEY_LOG}
-	${ZFS_SH} -u ${VERBOSE_FLAG} | \
-		tee -a ${ZPIOS_SURVEY_LOG}
-}
-
 # Apply all possible turning concurrently to get a best case number
 zpios_survey_all() {
 	TEST_NAME="${ZPOOL_CONFIG}+${ZPIOS_TEST}+all"
 	print_header ${TEST_NAME}
 
 	${ZFS_SH} ${VERBOSE_FLAG}                \  
-		zfs="zfs_vdev_max_pending=1024" \
-		zfs="zio_bulk_flags=0x100" |    \
+		zfs="zfs_vdev_max_pending=1024" | \
 		tee -a ${ZPIOS_SURVEY_LOG}
 	${ZPIOS_SH} ${VERBOSE_FLAG} -c ${ZPOOL_CONFIG} -t ${ZPIOS_TEST} \
 		-o "--noprefetch --zerocopy"                           \
@@ -209,7 +182,6 @@ zpios_survey_prefetch
 zpios_survey_zerocopy
 zpios_survey_checksum
 zpios_survey_pending
-zpios_survey_kmem
 zpios_survey_all
 
 exit 0


### PR DESCRIPTION
Two patches designed to bring ZoL's zio create/destroy code back in sync with Illumos/FreeBSD.  They also act as a starting point for further optimization.  Profiling clearly shows that a considerable amount of time is being spent in `zio_create()` which can limit throughput on high-end systems.

This profiling also revealed significant contention in `spa_dispatch_ent()` during a heavy write workload.  One possible fix for this is to increase the number of write taskqs to reduce the contention, and a patch is provided which does this.  However, other possible solutions should be explored.

NOTE: These changes are based on the currently unmerged large block feature branch.