### PR TITLE
Use vmem_alloc() for nvlists

### DIFF
--- a/module/nvpair/nvpair_alloc_spl.c
+++ b/module/nvpair/nvpair_alloc_spl.c
@@ -26,17 +26,18 @@
 
 #include <sys/nvpair.h>
 #include <sys/kmem.h>
+#include <sys/vmem.h>
 
 static void *
 nv_alloc_sleep_spl(nv_alloc_t *nva, size_t size)
 {
-	return (kmem_alloc(size, KM_SLEEP));
+	return (vmem_alloc(size, KM_SLEEP));
 }
 
 static void *
 nv_alloc_pushpage_spl(nv_alloc_t *nva, size_t size)
 {
-	return (kmem_alloc(size, KM_PUSHPAGE));
+	return (vmem_alloc(size, KM_PUSHPAGE));
 }
 
 static void *

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1586,12 +1586,12 @@ load_nvlist(spa_t *spa, uint64_t obj, nvlist_t **value)
 	nvsize = *(uint64_t *)db->db_data;
 	dmu_buf_rele(db, FTAG);
 
-	packed = kmem_alloc(nvsize, KM_SLEEP);
+	packed = vmem_alloc(nvsize, KM_SLEEP);
 	error = dmu_read(spa->spa_meta_objset, obj, 0, nvsize, packed,
 	    DMU_READ_PREFETCH);
 	if (error == 0)
 		error = nvlist_unpack(packed, nvsize, value, 0);
-	kmem_free(packed, nvsize);
+	vmem_free(packed, nvsize);
 
 	return (error);
 }

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1328,20 +1328,20 @@ get_nvlist(uint64_t nvl, uint64_t size, int iflag, nvlist_t **nvp)
 	if (size == 0)
 		return (SET_ERROR(EINVAL));
 
-	packed = kmem_alloc(size, KM_SLEEP);
+	packed = vmem_alloc(size, KM_SLEEP);
 
 	if ((error = ddi_copyin((void *)(uintptr_t)nvl, packed, size,
 	    iflag)) != 0) {
-		kmem_free(packed, size);
+		vmem_free(packed, size);
 		return (error);
 	}
 
 	if ((error = nvlist_unpack(packed, size, &list, 0)) != 0) {
-		kmem_free(packed, size);
+		vmem_free(packed, size);
 		return (error);
 	}
 
-	kmem_free(packed, size);
+	vmem_free(packed, size);
 
 	*nvp = list;
 	return (0);


### PR DESCRIPTION
Several of the nvlist functions may perform allocations larger than
the 32k warning threshold.  Convert them to use vmem_alloc() so the
best allocation is used.

Commit efcd79a retired KM_NODEBUG which was used to suppress large
allocation warnings.  Concurrently in the SPL the warning threshold
was increased from 8k to 32k.  The goal was to identify the remaining
locations, such as this one, where the allocation can be larger than
32k.  This was expected fine tuning for the kmem-rework changes, see
commit 6e9710f.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3057