### PR TITLE
Skip evicting dbufs when walking the dbuf hash

### DIFF
--- a/module/zfs/dbuf_stats.c
+++ b/module/zfs/dbuf_stats.c
@@ -151,9 +151,11 @@ dbuf_stats_hash_table_data(char *buf, size_t size, void *data)
 		mutex_enter(&db->db_mtx);
 		mutex_exit(DBUF_HASH_MUTEX(h, dsh->idx));
 
-		length = __dbuf_stats_hash_table_data(buf, size, db);
-		buf += length;
-		size -= length;
+		if (db->db_state != DB_EVICTING) {
+			length = __dbuf_stats_hash_table_data(buf, size, db);
+			buf += length;
+			size -= length;
+		}
 
 		mutex_exit(&db->db_mtx);
 		mutex_enter(DBUF_HASH_MUTEX(h, dsh->idx));


### PR DESCRIPTION
When a dbuf is in the DB_EVICTING state it may no longer be on the
dn_dbufs list.  In which case it's unsafe to call DB_DNODE_ENTER.
Therefore, any dbuf which is found in this safe must be skipped.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #2553
Issue #2495