### PR TITLE
Fix corner cases in Dracut scripts

### DIFF
--- a/dracut/90zfs/export-zfs.sh.in
+++ b/dracut/90zfs/export-zfs.sh.in
@@ -10,7 +10,7 @@ _do_zpool_export() {
 	fi
 
 	info "Exporting ZFS storage pools"
-	zpool list -H | while read fs rest ; do
+	for fs in `zpool list -H -o name` ; do
 		zpool export $force "$fs" || ret=$?
 	done
 

--- a/dracut/90zfs/export-zfs.sh.in
+++ b/dracut/90zfs/export-zfs.sh.in
@@ -4,15 +4,21 @@ _do_zpool_export() {
 	local ret=0
 	local final=$1
 	local force
+	local OLDIFS="$IFS"
+	local NEWLINE="
+"
 
 	if [ "x$final" != "x" ]; then
 		force="-f"
 	fi
 
 	info "Exporting ZFS storage pools"
+	# Change IFS to allow for blanks in pool names.
+	IFS="$NEWLINE"
 	for fs in `zpool list -H -o name` ; do
 		zpool export $force "$fs" || ret=$?
 	done
+	IFS="$OLDIFS"
 
 	if [ "x$final" != "x" ]; then
 		info "zpool list"

--- a/dracut/90zfs/mount-zfs.sh.in
+++ b/dracut/90zfs/mount-zfs.sh.in
@@ -3,6 +3,9 @@
 . /lib/dracut-lib.sh
 
 ZPOOL_FORCE=""
+OLDIFS="$IFS"
+NEWLINE="
+"
 
 if getargbool 0 zfs_force -y zfs.force -y zfsforce ; then
 	warn "ZFS: Will force-import pools if necessary."
@@ -34,9 +37,12 @@ case "$root" in
 
 					# Re-export everything since we're not prepared to take
 					# responsibility for them.
-					zpool list -H | while read fs rest ; do
+					# Change IFS to allow for blanks in pool names.
+					IFS="$NEWLINE"
+					for fs in `zpool list -H -o name` ; do
 						zpool export "$fs"
 					done
+					IFS="$OLDIFS"
 
 					return 1
 				fi
@@ -46,11 +52,11 @@ case "$root" in
 			# Should have an explicit pool set, so just import it and we're done.
 			zfsbootfs="${root#zfs:}"
 			pool="${zfsbootfs%%/*}"
-			if ! zpool list -H $pool > /dev/null ; then
+			if ! zpool list -H "$pool" > /dev/null ; then
 				# pool wasn't imported automatically by the kernel module, so
 				# try it manually.
 				info "ZFS: Importing pool ${pool}..."
-				if ! zpool import -N ${ZPOOL_FORCE} $pool ; then
+				if ! zpool import -N ${ZPOOL_FORCE} "$pool" ; then
 					warn "ZFS: Unable to import pool ${pool}."
 					rootok=0
 
@@ -61,7 +67,7 @@ case "$root" in
 
 		# Above should have left our rpool imported and pool/dataset in $root.
 		# We need zfsutil for non-legacy mounts and not for legacy mounts.
-		mountpoint=`zfs get -H -o value mountpoint $zfsbootfs`
+		mountpoint=`zfs get -H -o value mountpoint "$zfsbootfs"`
 		if [ "$mountpoint" = "legacy" ] ; then
 			mount -t zfs "$zfsbootfs" "$NEWROOT" && ROOTFS_MOUNTED=yes
 		else


### PR DESCRIPTION
Commit dcae93f24eb855c1505b11bb822693796399ab06 fixes an oversight of me (sorry!) in that `export-zfs.sh` always signaled success to Dracut even if some pools could not be exported. An example scenario which triggers this bug would be a zpool layered on dm layered on another zpool: In that case Dracut should export the "inner" zpool in a first run of `export-zfs.sh`, notice based on the return code that a re-run is necessary, close the dm target and then export the "outer" zpool with a second run of `export-zfs.sh`.

Commit c1a1fbe4ab8fa33d427f148b9bdd20b368bf712a allows for blanks in pool and dataset names which are legal as per [zpool(8)](https://github.com/zfsonlinux/zfs/blob/master/man/man8/zpool.8#L927) and [module/zcommon/zfs_namecheck.c:valid_char()](https://github.com/zfsonlinux/zfs/blob/master/module/zcommon/zfs_namecheck.c#L58).