### PR TITLE
Refactored dracut module

### DIFF
--- a/dracut/90zfs/.gitignore
+++ b/dracut/90zfs/.gitignore
@@ -2,3 +2,4 @@ export-zfs.sh
 module-setup.sh
 mount-zfs.sh
 parse-zfs.sh
+zfs-lib.sh

--- a/dracut/90zfs/Makefile.am
+++ b/dracut/90zfs/Makefile.am
@@ -3,13 +3,15 @@ pkgdracut_SCRIPTS = \
 	$(top_srcdir)/dracut/90zfs/export-zfs.sh \
 	$(top_srcdir)/dracut/90zfs/module-setup.sh \
 	$(top_srcdir)/dracut/90zfs/mount-zfs.sh \
-	$(top_srcdir)/dracut/90zfs/parse-zfs.sh
+	$(top_srcdir)/dracut/90zfs/parse-zfs.sh \
+	$(top_srcdir)/dracut/90zfs/zfs-lib.sh
 
 EXTRA_DIST = \
 	$(top_srcdir)/dracut/90zfs/export-zfs.sh.in \
 	$(top_srcdir)/dracut/90zfs/module-setup.sh.in \
 	$(top_srcdir)/dracut/90zfs/mount-zfs.sh.in \
-	$(top_srcdir)/dracut/90zfs/parse-zfs.sh.in
+	$(top_srcdir)/dracut/90zfs/parse-zfs.sh.in \
+	$(top_srcdir)/dracut/90zfs/zfs-lib.sh.in
 
 $(pkgdracut_SCRIPTS):
 	-$(SED) -e 's,@bindir\@,$(bindir),g' \

--- a/dracut/90zfs/export-zfs.sh.in
+++ b/dracut/90zfs/export-zfs.sh.in
@@ -1,35 +1,29 @@
 #!/bin/sh
 
+. /lib/dracut-zfs-lib.sh
+
 _do_zpool_export() {
 	local ret=0
-	local final=$1
-	local force
-	local OLDIFS="$IFS"
-	local NEWLINE="
-"
+	local final="${1}"
+	local opts=""
 
-	if [ "x$final" != "x" ]; then
-		force="-f"
+	if [ "x${final}" != "x" ]; then
+		opts="-f"
 	fi
 
-	info "Exporting ZFS storage pools"
-	# Change IFS to allow for blanks in pool names.
-	IFS="$NEWLINE"
-	for fs in `zpool list -H -o name` ; do
-		zpool export $force "$fs" || ret=$?
-	done
-	IFS="$OLDIFS"
+	info "Exporting ZFS storage pools."
+	export_all ${opts} || ret=$?
 
-	if [ "x$final" != "x" ]; then
+	if [ "x${final}" != "x" ]; then
 		info "zpool list"
 		zpool list 2>&1 | vinfo
 	fi
 
-	return $ret
+	return ${ret}
 }
 
 if command -v zpool >/dev/null; then
-	_do_zpool_export $1
+	_do_zpool_export "${1}"
 else
 	:
 fi

--- a/dracut/90zfs/module-setup.sh.in
+++ b/dracut/90zfs/module-setup.sh.in
@@ -2,7 +2,7 @@
 
 check() {
 	# We depend on udev-rules being loaded
-	[ "$1" = "-d" ] && return 0
+	[ "${1}" = "-d" ] && return 0
 
 	# Verify the zfs tool chain
 	which zpool >/dev/null 2>&1 || return 1
@@ -39,10 +39,11 @@ install() {
 	dracut_install hostid
 	dracut_install awk
 	dracut_install head
-	inst_hook cmdline 95 "$moddir/parse-zfs.sh"
-	inst_hook mount 98 "$moddir/mount-zfs.sh"
-	inst_hook shutdown 30 "$moddir/export-zfs.sh"
+	inst_hook cmdline 95 "${moddir}/parse-zfs.sh"
+	inst_hook mount 98 "${moddir}/mount-zfs.sh"
+	inst_hook shutdown 30 "${moddir}/export-zfs.sh"
 
+	inst_simple "${moddir}/zfs-lib.sh" "/lib/dracut-zfs-lib.sh"
 	if [ -e @sysconfdir@/zfs/zpool.cache ]; then
 		inst @sysconfdir@/zfs/zpool.cache
 	fi
@@ -56,5 +57,5 @@ install() {
 	BB=`hostid | cut -b 3,4`
 	CC=`hostid | cut -b 5,6`
 	DD=`hostid | cut -b 7,8`
-	printf "\x$DD\x$CC\x$BB\x$AA" > "$initdir/etc/hostid"
+	printf "\x${DD}\x${CC}\x${BB}\x${AA}" > "${initdir}/etc/hostid"
 }

--- a/dracut/90zfs/mount-zfs.sh.in
+++ b/dracut/90zfs/mount-zfs.sh.in
@@ -21,7 +21,7 @@ if [ "${root}" = "zfs:AUTO" ] ; then
 		ZFS_DATASET="$(find_bootfs)"
 		if [ $? -ne 0 ] ; then
 			warn "ZFS: No bootfs attribute found in importable pools."
-			export_all
+			export_all || export_all "-f"
 
 			rootok=0
 			return 1

--- a/dracut/90zfs/mount-zfs.sh.in
+++ b/dracut/90zfs/mount-zfs.sh.in
@@ -1,82 +1,45 @@
 #!/bin/sh
 
 . /lib/dracut-lib.sh
+. /lib/dracut-zfs-lib.sh
 
-ZPOOL_FORCE=""
-OLDIFS="$IFS"
-NEWLINE="
-"
+ZFS_DATASET=""
+ZFS_POOL=""
 
-if getargbool 0 zfs_force -y zfs.force -y zfsforce ; then
-	warn "ZFS: Will force-import pools if necessary."
-	ZPOOL_FORCE="-f"
-fi
+case "${root}" in
+	zfs:*) ;;
+	*) return ;;
+esac
 
 # Delay until all required block devices are present.
 udevadm settle
 
-case "$root" in
-	zfs:*)
-		# We have ZFS modules loaded, so we're able to import pools now.
-		if [ "$root" = "zfs:AUTO" ] ; then
-			# Need to parse bootfs attribute
-			info "ZFS: Attempting to detect root from imported ZFS pools."
+if [ "${root}" = "zfs:AUTO" ] ; then
+	ZFS_DATASET="$(find_bootfs)"
+	if [ $? -ne 0 ] ; then
+		zpool import -N -a ${ZPOOL_IMPORT_OPTS}
+		ZFS_DATASET="$(find_bootfs)"
+		if [ $? -ne 0 ] ; then
+			warn "ZFS: No bootfs attribute found in importable pools."
+			export_all
 
-			# Might be imported by the kernel module, so try searching before
-			# we import anything.
-			zfsbootfs=`zpool list -H -o bootfs | sed -n '/^-$/ !p' | sed 'q'`
-			if [ $? -ne 0 ] || [ -z "$zfsbootfs" ] || \
-				[ "$zfsbootfs" = "no pools available" ] ; then
-				# Not there, so we need to import everything.
-				info "ZFS: Attempting to import additional pools."
-				zpool import -N -a ${ZPOOL_FORCE}
-				zfsbootfs=`zpool list -H -o bootfs | sed -n '/^-$/ !p' | sed 'q'`
-				if [ $? -ne 0 ] || [ -z "$zfsbootfs" ] || \
-					[ "$zfsbootfs" = "no pools available" ] ; then
-					rootok=0
-					pool=""
-
-					warn "ZFS: No bootfs attribute found in importable pools."
-
-					# Re-export everything since we're not prepared to take
-					# responsibility for them.
-					# Change IFS to allow for blanks in pool names.
-					IFS="$NEWLINE"
-					for fs in `zpool list -H -o name` ; do
-						zpool export "$fs"
-					done
-					IFS="$OLDIFS"
-
-					return 1
-				fi
-			fi
-			info "ZFS: Using ${zfsbootfs} as root."
-		else
-			# Should have an explicit pool set, so just import it and we're done.
-			zfsbootfs="${root#zfs:}"
-			pool="${zfsbootfs%%/*}"
-			if ! zpool list -H "$pool" > /dev/null ; then
-				# pool wasn't imported automatically by the kernel module, so
-				# try it manually.
-				info "ZFS: Importing pool ${pool}..."
-				if ! zpool import -N ${ZPOOL_FORCE} "$pool" ; then
-					warn "ZFS: Unable to import pool ${pool}."
-					rootok=0
-
-					return 1
-				fi
-			fi
+			rootok=0
+			return 1
 		fi
+	fi
+	info "ZFS: Using ${ZFS_DATASET} as root."
+fi
 
-		# Above should have left our rpool imported and pool/dataset in $root.
-		# We need zfsutil for non-legacy mounts and not for legacy mounts.
-		mountpoint=`zfs get -H -o value mountpoint "$zfsbootfs"`
-		if [ "$mountpoint" = "legacy" ] ; then
-			mount -t zfs "$zfsbootfs" "$NEWROOT" && ROOTFS_MOUNTED=yes
-		else
-			mount -o zfsutil -t zfs "$zfsbootfs" "$NEWROOT" && ROOTFS_MOUNTED=yes
-		fi
+ZFS_DATASET="${ZFS_DATASET:-${root#zfs:}}"
+ZFS_POOL="${ZFS_DATASET%%/*}"
 
-		need_shutdown
-		;;
-esac
+if import_pool "${ZFS_POOL}" ; then
+	info "ZFS: Mounting dataset ${ZFS_DATASET}..."
+	if mount_dataset "${ZFS_DATASET}" ; then
+		ROOTFS_MOUNTED=yes
+		return 0
+	fi
+fi
+
+rootok=0
+need_shutdown

--- a/dracut/90zfs/mount-zfs.sh.in
+++ b/dracut/90zfs/mount-zfs.sh.in
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-. /lib/dracut-lib.sh
 . /lib/dracut-zfs-lib.sh
 
 ZFS_DATASET=""

--- a/dracut/90zfs/parse-zfs.sh.in
+++ b/dracut/90zfs/parse-zfs.sh.in
@@ -4,22 +4,22 @@
 
 # Let the command line override our host id.
 spl_hostid=`getarg spl_hostid=`
-if [ "${spl_hostid}" != "" ] ; then
+if [ -n "${spl_hostid}" ] ; then
 	info "ZFS: Using hostid from command line: ${spl_hostid}"
 	AA=`echo ${spl_hostid} | cut -b 1,2`
 	BB=`echo ${spl_hostid} | cut -b 3,4`
 	CC=`echo ${spl_hostid} | cut -b 5,6`
 	DD=`echo ${spl_hostid} | cut -b 7,8`
-	printf "\x$DD\x$CC\x$BB\x$AA" >/etc/hostid
-elif [ -f /etc/hostid ] ; then
+	printf "\x${DD}\x${CC}\x${BB}\x${AA}" >/etc/hostid
+elif [ -f "/etc/hostid" ] ; then
 	info "ZFS: Using hostid from /etc/hostid: `hostid`"
 else
-	warn "ZFS: No hostid found on kernel command line or /etc/hostid.  "
+	warn "ZFS: No hostid found on kernel command line or /etc/hostid."
 	warn "ZFS: Pools may not import correctly."
 fi
 
 wait_for_zfs=0
-case "$root" in
+case "${root}" in
 	""|zfs|zfs:)
 		# We'll take root unset, root=zfs, or root=zfs:
 		# No root set, so we want to read the bootfs attribute.  We
@@ -55,5 +55,5 @@ esac
 # modules to settle before mounting.
 if [ ${wait_for_zfs} -eq 1 ]; then
 	ln -s /dev/null /dev/root 2>/dev/null
-	echo '[ -e /dev/zfs ]' > $hookdir/initqueue/finished/zfs.sh
+	echo '[ -e /dev/zfs ]' > "${hookdir}/initqueue/finished/zfs.sh"
 fi

--- a/dracut/90zfs/zfs-lib.sh.in
+++ b/dracut/90zfs/zfs-lib.sh.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. /lib/dracut-lib.sh
+command -v getarg >/dev/null || . /lib/dracut-lib.sh
 
 OLDIFS="${IFS}"
 NEWLINE="

--- a/dracut/90zfs/zfs-lib.sh.in
+++ b/dracut/90zfs/zfs-lib.sh.in
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+. /lib/dracut-lib.sh
+
+OLDIFS="${IFS}"
+NEWLINE="
+"
+
+ZPOOL_IMPORT_OPTS=""
+if getargbool 0 zfs_force -y zfs.force -y zfsforce ; then
+	warn "ZFS: Will force-import pools if necessary."
+	ZPOOL_IMPORT_OPTS="${ZPOOL_IMPORT_OPTS} -f"
+fi
+
+# find_bootfs
+#   returns the first dataset with the bootfs attribute.
+find_bootfs() {
+	IFS="${NEWLINE}"
+	for dataset in $(zpool list -H -o bootfs); do
+		case "${dataset}" in
+			"" | "-")
+				continue
+				;;
+			"no pools available")
+				IFS="${OLDIFS}"
+				return 1
+				;;
+			*)
+				IFS="${OLDIFS}"
+				echo "${dataset}"
+				return 0
+				;;
+		esac
+	done
+
+	IFS="${OLDIFS}"
+	return 1
+}
+
+# import_pool POOL
+#   imports the given zfs pool if it isn't imported already.
+import_pool() {
+	local pool="${1}"
+
+	if ! zpool list -H "${pool}" 2>&1 > /dev/null ; then
+		info "ZFS: Importing pool ${pool}..."
+		if ! zpool import -N ${ZPOOL_IMPORT_OPTS} "${pool}" ; then
+			warn "ZFS: Unable to import pool ${pool}"
+			return 1
+		fi
+	fi
+
+	return 0
+}
+
+# mount_dataset DATASET
+#   mounts the given zfs dataset.
+mount_dataset() {
+	local dataset="${1}"
+	local mountpoint="$(zfs get -H -o value mountpoint "${dataset}")"
+
+	# We need zfsutil for non-legacy mounts and not for legacy mounts.
+	if [ "${mountpoint}" = "legacy" ] ; then
+		mount -t zfs "${dataset}" "${NEWROOT}"
+	else
+		mount -o zfsutil -t zfs "${dataset}" "${NEWROOT}"
+	fi
+
+	return $?
+}
+
+# export_all OPTS
+#   exports all imported zfs pools.
+export_all() {
+	local opts="${1}"
+	local ret=0
+
+	IFS="${NEWLINE}"
+	for pool in `zpool list -H -o name` ; do
+		if zpool list -H "${pool}" 2>&1 > /dev/null ; then
+			zpool export "${pool}" ${opts} || ret=$?
+		fi
+	done
+	IFS="${OLDIFS}"
+
+	return ${ret}
+}

--- a/dracut/README.dracut.markdown
+++ b/dracut/README.dracut.markdown
@@ -80,6 +80,8 @@ to mount the root dataset.
 * `export-zfs.sh`: Run on shutdown after dracut has restored the initramfs
 and pivoted to it, allowing for a clean unmount and export of the ZFS root.
 
+* `zfs-lib.sh`: Utility functions used by the other files.
+
 `module-setup.sh`
 ---------------
 

--- a/dracut/README.dracut.markdown
+++ b/dracut/README.dracut.markdown
@@ -11,6 +11,12 @@ the dataset mountpoint property to '/'.
     $ zpool set bootfs=pool/dataset pool
     $ zfs set mountpoint=/ pool/dataset
 
+It is also possible to set the bootfs property for an entire pool, just in
+case you are not using a dedicated dataset for '/'.
+
+    $ zpool set bootfs=pool pool
+    $ zfs set mountpoint=/ pool
+
 Alternately, legacy mountpoints can be used by setting the 'root=' option
 on the kernel line of your grub.conf/menu.lst configuration file.  Then
 set the dataset mountpoint property to 'legacy'.
@@ -71,6 +77,8 @@ cache.  This file is not included in the initramfs.
 
 * `90-zfs.rules`: udev rules which trigger loading of the ZFS modules at boot.
 
+* `zfs-lib.sh`: Utility functions used by the other files.
+
 * `parse-zfs.sh`: Run early in the initramfs boot process to parse kernel
 command line and determine if ZFS is the active root filesystem.
 
@@ -80,10 +88,16 @@ to mount the root dataset.
 * `export-zfs.sh`: Run on shutdown after dracut has restored the initramfs
 and pivoted to it, allowing for a clean unmount and export of the ZFS root.
 
-* `zfs-lib.sh`: Utility functions used by the other files.
+`zfs-lib.sh`
+------------
+
+This file provides a few handy functions for working with ZFS. Those
+functions are used by the `mount-zfs.sh` and `export-zfs.sh` files.
+However, they could be used by any other file as well, as long as the file
+sources `/lib/dracut-zfs-lib.sh`.
 
 `module-setup.sh`
----------------
+-----------------
 
 This file is run by the Dracut script within the live system, not at boot
 time.  It's not included in the final initramfs.  Functions in this script
@@ -105,7 +119,7 @@ it.  If a generic initramfs is required, it may be preferable to omit these
 files and specify the `spl_hostid` from the boot loader instead.
 
 `parse-zfs.sh`
-------------
+--------------
 
 Run during the cmdline phase of the initramfs boot process, this script
 performs some basic sanity checks on kernel command line parameters to
@@ -137,7 +151,7 @@ phase of Dracut to wait for `/dev/zfs` to become available before attempting
 to mount anything.
 
 `mount-zfs.sh`
-------------
+--------------
 
 This script is run after udev has settled and all tasks in the initqueue
 have succeeded.  This ensures that `/dev/zfs` is available and that the
@@ -171,7 +185,7 @@ the required zpool was auto-imported by the kernel module, no additional
 `zpool import` commands are run, so nothing is forced.
 
 `export-zfs.sh`
--------------
+---------------
 
 Normally the zpool containing the root dataset cannot be exported on
 shutdown as it is still in use by the init process. To work around this,


### PR DESCRIPTION
This is a relatively big refactor of the ZFS dracut module. It works perfectly for my setup, the question is: does it work for other people as well? I would encourage more people to this.

The most notable change is that `zfs-lib.sh` was added which provides utility functions used by `zfs-export.sh` and `zfs-mount.sh`. This change made the code much cleaner and more modular and I guess that this is the biggest achievement of this refactoring. Furthermore, it should be much easier now to add additional functionality to the dracut module.

I don't know if it was possible before but you can also use a pool instead of a dataset as your root by setting the bootfs attribute on the pool directly using: `zpool set bootfs=zroot zroot` (this should be documented in the `README` by the way). Besides it also fixes a few bugs here and there…

Basically there are two things left to do here:

- [x] Update the README
- [ ] Test this for different setups