### PR TITLE
Fix vdev handling in initramfs

### DIFF
--- a/dracut/90zfs/module-setup.sh.in
+++ b/dracut/90zfs/module-setup.sh.in
@@ -37,12 +37,18 @@ install() {
 	dracut_install @udevdir@/zvol_id
 	dracut_install mount.zfs
 	dracut_install hostid
+	dracut_install awk
+	dracut_install head
 	inst_hook cmdline 95 "$moddir/parse-zfs.sh"
 	inst_hook mount 98 "$moddir/mount-zfs.sh"
 	inst_hook shutdown 30 "$moddir/export-zfs.sh"
 
 	if [ -e @sysconfdir@/zfs/zpool.cache ]; then
 		inst @sysconfdir@/zfs/zpool.cache
+	fi
+	
+	if [ -e @sysconfdir@/zfs/vdev_id.conf ]; then
+		inst @sysconfdir@/zfs/vdev_id.conf
 	fi
 
 	# Synchronize initramfs and system hostid

--- a/dracut/90zfs/parse-zfs.sh.in
+++ b/dracut/90zfs/parse-zfs.sh.in
@@ -18,6 +18,7 @@ else
 	warn "ZFS: Pools may not import correctly."
 fi
 
+wait_for_zfs=0
 case "$root" in
 	""|zfs|zfs:)
 		# We'll take root unset, root=zfs, or root=zfs:


### PR DESCRIPTION
When using the ZFS dracut module under CentOS 7 together with pools that use vdev-based device names, the pools fail to import because the vdev_id udev helper fails.

The problem can easily be fixed by installing awk and head (which are used internally by vdev_id) and the vdev_id.conf configuration file. I also silenced an error message that
appeared when the dracut module was enabled, but we were not booting from a ZFS root.