### PR TITLE
Retire spl_module_init()/spl_module_fini()

### DIFF
--- a/module/avl/avl.c
+++ b/module/avl/avl.c
@@ -1030,13 +1030,19 @@ done:
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-#include <linux/module_compat.h>
+static int __init
+avl_init(void)
+{
+	return (0);
+}
 
-static int avl_init(void) { return 0; }
-static int avl_fini(void) { return 0; }
+static void __exit
+avl_fini(void)
+{
+}
 
-spl_module_init(avl_init);
-spl_module_exit(avl_fini);
+module_init(avl_init);
+module_exit(avl_fini);
 
 MODULE_DESCRIPTION("Generic AVL tree implementation");
 MODULE_AUTHOR(ZFS_META_AUTHOR);

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -3293,13 +3293,19 @@ nvs_xdr(nvstream_t *nvs, nvlist_t *nvl, char *buf, size_t *buflen)
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-#include <linux/module_compat.h>
+static int __init
+nvpair_init(void)
+{
+	return (0);
+}
 
-static int nvpair_init(void) { return 0; }
-static int nvpair_fini(void) { return 0; }
+static void __exit
+nvpair_fini(void)
+{
+}
 
-spl_module_init(nvpair_init);
-spl_module_exit(nvpair_fini);
+module_init(nvpair_init);
+module_exit(nvpair_fini);
 
 MODULE_DESCRIPTION("Generic name/value pair implementation");
 MODULE_AUTHOR(ZFS_META_AUTHOR);

--- a/module/unicode/u8_textprep.c
+++ b/module/unicode/u8_textprep.c
@@ -2133,13 +2133,18 @@ u8_textprep_str(char *inarray, size_t *inlen, char *outarray, size_t *outlen,
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-#include <linux/module_compat.h>
+static int __init
+unicode_init(void) {
+	return (0);
+}
 
-static int unicode_init(void) { return 0; }
-static int unicode_fini(void) { return 0; }
+static void __exit
+unicode_fini(void)
+{
+}
 
-spl_module_init(unicode_init);
-spl_module_exit(unicode_fini);
+module_init(unicode_init);
+module_exit(unicode_fini);
 
 MODULE_DESCRIPTION("Unicode implementation");
 MODULE_AUTHOR(ZFS_META_AUTHOR);

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -678,13 +678,19 @@ zfs_prop_align_right(zfs_prop_t prop)
 #endif
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-#include <linux/module_compat.h>
+static int __init
+zcommon_init(void)
+{
+	return (0);
+}
 
-static int zcommon_init(void) { return 0; }
-static int zcommon_fini(void) { return 0; }
+static void __exit
+zcommon_fini(void)
+{
+}
 
-spl_module_init(zcommon_init);
-spl_module_exit(zcommon_fini);
+module_init(zcommon_init);
+module_exit(zcommon_fini);
 
 MODULE_DESCRIPTION("Generic ZFS support");
 MODULE_AUTHOR(ZFS_META_AUTHOR);

--- a/module/zpios/pios.c
+++ b/module/zpios/pios.c
@@ -36,7 +36,6 @@
 #include <sys/txg.h>
 #include <sys/dsl_destroy.h>
 #include <linux/miscdevice.h>
-#include <linux/module_compat.h>
 #include "zpios-internal.h"
 
 
@@ -1292,7 +1291,7 @@ static struct miscdevice zpios_misc = {
 #define	ZFS_DEBUG_STR   ""
 #endif
 
-static int
+static int __init
 zpios_init(void)
 {
 	int error;
@@ -1308,7 +1307,7 @@ zpios_init(void)
 	return (error);
 }
 
-static int
+static void __exit
 zpios_fini(void)
 {
 	int error;
@@ -1319,12 +1318,10 @@ zpios_fini(void)
 
 	printk(KERN_INFO "ZPIOS: Unloaded module v%s-%s%s\n",
 	    ZFS_META_VERSION, ZFS_META_RELEASE, ZFS_DEBUG_STR);
-
-	return (0);
 }
 
-spl_module_init(zpios_init);
-spl_module_exit(zpios_fini);
+module_init(zpios_init);
+module_exit(zpios_fini);
 
 MODULE_AUTHOR("LLNL / Sun");
 MODULE_DESCRIPTION("Kernel PIOS implementation");


### PR DESCRIPTION
In the original implementation of the SPL wrappers were provided
for module initialization and cleanup.  This was done to abstract
away any compatibility code which might be needed for the SPL.

As it turned out the only significant compatibility issue was that
the default pwd during module load differed under Illumos and Linux.
Since this is such as minor thing and the wrappers complicate the
code they are being retired.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #2985