### PR TITLE
Use MUTEX_FSTRANS mutex type

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -273,6 +273,7 @@ typedef struct kmutex {
 } kmutex_t;
 
 #define	MUTEX_DEFAULT	0
+#define	MUTEX_FSTRANS	MUTEX_DEFAULT
 #define	MUTEX_HELD(m)	((m)->m_owner == curthread)
 #define	MUTEX_NOT_HELD(m) (!MUTEX_HELD(m))
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -928,7 +928,7 @@ retry:
 
 	for (i = 0; i < BUF_LOCKS; i++) {
 		mutex_init(&buf_hash_table.ht_locks[i].ht_lock,
-		    NULL, MUTEX_DEFAULT, NULL);
+		    NULL, MUTEX_FSTRANS, NULL);
 	}
 }
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -331,7 +331,7 @@ retry:
 	    0, dbuf_cons, dbuf_dest, NULL, NULL, NULL, 0);
 
 	for (i = 0; i < DBUF_MUTEXES; i++)
-		mutex_init(&h->hash_mutexes[i], NULL, MUTEX_DEFAULT, NULL);
+		mutex_init(&h->hash_mutexes[i], NULL, MUTEX_FSTRANS, NULL);
 
 	dbuf_stats_init(h);
 }


### PR DESCRIPTION
There are regions in the ZFS code where it is desirable to be able
to be set PF_FSTRANS while a specific mutex is held.  The ZFS code
could be updated to set/clear this flag in all the correct places,
but this is undesirable for a few reasons.

1) It would require changes to a significant amount of the ZFS
   code.  This would complicate applying patches from upstream.

2) It would be easy to accidentally miss a critical region in
   the initial patch or to have an future change introduce a
   new one.

Both of these concerns can be addressed by adding a new mutex type
which is responsible for managing PF_FSTRANS.  This lets us make a
a small change to the ZFS source where the mutex is initialized
and then be certain that all future use of that mutex will be safe.

NOTES: The ht_locks are no longer aligned on 64-byte boundaries.
We've never studied if this is actually critical for performance
when there are a large number of hash buckets.  The dbuf hash has
never made this optimization.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3050
Issue #3055