### PR TITLE
Change ASSERT(!"...") to  cmn_err(CE_PANIC, ...)

### DIFF
--- a/module/zcommon/zfs_deleg.c
+++ b/module/zcommon/zfs_deleg.c
@@ -227,7 +227,7 @@ zfs_deleg_whokey(char *attr, zfs_deleg_who_type_t type,
 		    ZFS_DELEG_FIELD_SEP_CHR);
 		break;
 	default:
-		ASSERT(!"bad zfs_deleg_who_type_t");
+		cmn_err(CE_PANIC, "bad zfs_deleg_who_type_t %d", type);
 	}
 }
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2944,7 +2944,7 @@ arc_access(arc_buf_hdr_t *buf, kmutex_t *hash_lock)
 		DTRACE_PROBE1(new_state__mfu, arc_buf_hdr_t *, buf);
 		arc_change_state(arc_mfu, buf, hash_lock);
 	} else {
-		ASSERT(!"invalid arc state");
+		cmn_err(CE_PANIC, "invalid arc state 0x%p", buf->b_state);
 	}
 }
 

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -925,7 +925,8 @@ dmu_tx_dirty_buf(dmu_tx_t *tx, dmu_buf_impl_t *db)
 				match_object = TRUE;
 				break;
 			default:
-				ASSERT(!"bad txh_type");
+				cmn_err(CE_PANIC, "bad txh_type %d",
+				    txh->txh_type);
 			}
 		}
 		if (match_object && match_offset) {

--- a/module/zfs/zap_leaf.c
+++ b/module/zfs/zap_leaf.c
@@ -79,8 +79,9 @@ stv(int len, void *addr, uint64_t value)
 	case 8:
 		*(uint64_t *)addr = value;
 		return;
+	default:
+		cmn_err(CE_PANIC, "bad int len %d", len);
 	}
-	ASSERT(!"bad int len");
 }
 
 static uint64_t
@@ -95,8 +96,9 @@ ldv(int len, const void *addr)
 		return (*(uint32_t *)addr);
 	case 8:
 		return (*(uint64_t *)addr);
+	default:
+		cmn_err(CE_PANIC, "bad int len %d", len);
 	}
-	ASSERT(!"bad int len");
 	return (0xFEEDFACEDEADBEEFULL);
 }
 
@@ -147,7 +149,8 @@ zap_leaf_byteswap(zap_leaf_phys_t *buf, int size)
 			/* la_array doesn't need swapping */
 			break;
 		default:
-			ASSERT(!"bad leaf type");
+			cmn_err(CE_PANIC, "bad leaf type %d",
+			    lc->l_free.lf_type);
 		}
 	}
 }

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -965,7 +965,7 @@ again:
 		start = 0;
 		goto again;
 	}
-	ASSERT(!"out of entries!");
+	cmn_err(CE_PANIC, "out of entries!");
 }
 
 int


### PR DESCRIPTION
There are a handful of ASSERT(!"...")'s throughout the code base for
cases which should be impossible.  This patch converts them to use
cmn_err(CE_PANIC, ...) to ensure they are always enabled and so that
additional debugging is logged if they were to occur.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #1445