### PR TITLE
Restructure spa_features_check()

### DIFF
--- a/include/sys/zfeature.h
+++ b/include/sys/zfeature.h
@@ -52,7 +52,10 @@ extern boolean_t spa_feature_is_active(struct spa *, spa_feature_t);
 extern boolean_t spa_feature_enabled_txg(spa_t *spa, spa_feature_t fid,
     uint64_t *txg);
 extern uint64_t spa_feature_refcount(spa_t *, spa_feature_t, uint64_t);
-extern boolean_t spa_features_check(spa_t *, boolean_t, nvlist_t *, nvlist_t *);
+extern boolean_t spa_features_read_supported(spa_t *);
+extern boolean_t spa_features_write_supported(spa_t *);
+extern void spa_features_get_unsupported(spa_t *, boolean_t, nvlist_t *);
+extern void spa_features_get_enabled(spa_t *, nvlist_t *);
 
 /*
  * These functions are only exported for zhack and zdb; normal callers should

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2388,29 +2388,29 @@ spa_load_impl(spa_t *spa, uint64_t pool_guid, nvlist_t *config,
 			return (spa_vdev_err(rvd, VDEV_AUX_CORRUPT_DATA, EIO));
 		}
 
-		enabled_feat = fnvlist_alloc();
 		unsup_feat = fnvlist_alloc();
 
-		if (!spa_features_check(spa, B_FALSE,
-		    unsup_feat, enabled_feat))
-			missing_feat_read = B_TRUE;
-
-		if (spa_writeable(spa) || state == SPA_LOAD_TRYIMPORT) {
-			if (!spa_features_check(spa, B_TRUE,
-			    unsup_feat, enabled_feat)) {
-				missing_feat_write = B_TRUE;
-			}
-		}
-
+		enabled_feat = fnvlist_alloc();
+		spa_features_get_enabled(spa, enabled_feat);
 		fnvlist_add_nvlist(spa->spa_load_info,
 		    ZPOOL_CONFIG_ENABLED_FEAT, enabled_feat);
+		fnvlist_free(enabled_feat);
 
-		if (!nvlist_empty(unsup_feat)) {
+		missing_feat_read = !spa_features_read_supported(spa);
+
+		if (spa_writeable(spa) || state == SPA_LOAD_TRYIMPORT)
+			missing_feat_write = !spa_features_write_supported(spa);
+
+		if (missing_feat_read)
+			spa_features_get_unsupported(spa, B_FALSE, unsup_feat);
+
+		if (missing_feat_write)
+			spa_features_get_unsupported(spa, B_TRUE, unsup_feat);
+
+		if (!nvlist_empty(unsup_feat))
 			fnvlist_add_nvlist(spa->spa_load_info,
 			    ZPOOL_CONFIG_UNSUP_FEAT, unsup_feat);
-		}
 
-		fnvlist_free(enabled_feat);
 		fnvlist_free(unsup_feat);
 
 		if (!missing_feat_read) {


### PR DESCRIPTION
A boolean checker function with side effects makes for poorly readable
code.  This patch restructures spa_features_check() to eliminate its
side effects, and replaces it with a pair of functions
spa_features_read_supported() spa_features_write_supported().  It also
adds two new functions to supply the functionality previously provided
by the side effects of spa_features_check(). Finally, spa_load_impl() is
updated to use the new interfaces. The goal is to make the intent of the
modified code in spa_load_impl() more obvious.

Signed-off-by: Ned Bass <bass6@llnl.gov>