### PR TITLE
Replace zfs.redhat.in with zfs.lsb.in init script

### DIFF
--- a/etc/init.d/zfs.redhat.in
+++ b/etc/init.d/zfs.redhat.in
@@ -11,136 +11,108 @@
 #
 ### BEGIN INIT INFO
 # Provides: zfs
-# Required-Start:
-# Required-Stop:
-# Should-Start:
+# Required-Start: $local_fs
+# Required-Stop: $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
 # Should-Stop:
-# Default-Start: 2 3 4 5
-# Default-Stop: 1
 # Short-Description: Mount/umount the zfs filesystems
 # Description: ZFS is an advanced filesystem designed to simplify managing
 #              and protecting your data.  This service mounts the ZFS
 #              filesystems and starts all related zfs services.
 ### END INIT INFO
 
-export PATH=/usr/local/sbin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+LOCKFILE=/var/lock/zfs
+ZFS="@sbindir@/zfs"
+ZPOOL="@sbindir@/zpool"
+ZPOOL_CACHE="/etc/zfs/zpool.cache"
+USE_DISK_BY_ID=0
+VERBOSE_MOUNT=0
+DO_OVERLAY_MOUNTS=0
+MOUNT_EXTRA_OPTIONS=""
+
+# Source zfs configuration.
+[ -r '/etc/sysconfig/zfs' ] &&  . /etc/default/zfs
+
+[ -x "$ZPOOL" ] || exit 1
+[ -x "$ZFS" ] || exit 2
 
 if [ -z "$init" ]; then
     # Not interactive
     grep -qE '(^|[^\\](\\\\)* )zfs=(off|no)( |$)' /proc/cmdline && exit 3
 fi
 
-# Source function library & LSB routines
-. /etc/rc.d/init.d/functions
-
-# script variables
-RETVAL=0
-ZFS="@sbindir@/zfs"
-ZPOOL="@sbindir@/zpool"
-ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
-servicename=zfs
-LOCKFILE=/var/lock/subsys/$servicename
-
-# functions
-zfs_installed() {
-	modinfo zfs > /dev/null 2>&1 || return 5
-	$ZPOOL  > /dev/null 2>&1
-	[ $? == 127 ] && return 5
-	$ZFS    > /dev/null 2>&1
-	[ $? == 127 ] && return 5
-	return 0
-}
-
-# i need a bash guru to simplify this, since this is copy and paste, but donno how
-# to correctly dereference variable names in bash, or how to do this right
-
-# first parameter is a regular expression that filters fstab
-read_fstab() {
-        unset FSTAB
-	n=0
-        while read -r fs mntpnt fstype opts blah ; do
-                fs=`printf '%b\n' "$fs"`
-                FSTAB[$n]=$fs
-		let n++
-        done < <(egrep "$1" /etc/fstab)
-}
-
 start()
 {
-	# Disable lockfile check
-	# if [ -f "$LOCKFILE" ] ; then return 0 ; fi
-
-	# check if ZFS is installed.  If not, comply to FC standards and bail
-	zfs_installed || {
-		action $"Checking if ZFS is installed: not installed" /bin/false
-		return 5
-	}
+	[ -f "$LOCKFILE" ] && return 3
 
 	# Delay until all required block devices are present.
-	if [ -x /sbin/udevadm ]; then
-		/sbin/udevadm settle
-	elif [ -x /sbin/udevsettle ]; then
-		/sbin/udevsettle
+	udevadm settle
+
+	# Load the zfs module stack
+	/sbin/modprobe zfs
+
+	# Ensure / exists in /etc/mtab, if not update mtab accordingly.
+	# This should be handled by rc.sysinit but lets be paranoid.
+	awk '$2 == "/" { exit 1 }' /etc/mtab
+	RETVAL=$?
+	if [ "$RETVAL" -eq 0 ]; then
+		/bin/mount -f /
 	fi
 
-	# load kernel module infrastructure
-	if ! grep -q zfs /proc/modules ; then
-		action $"Loading kernel ZFS infrastructure: " modprobe zfs || return 5
+	# Import all pools described by the cache file, and then mount
+	# all filesystem based on their properties.
+	if [ "$USE_DISK_BY_ID" -eq 1 ]; then
+		action $"Importing ZFS pools" \
+			"$ZPOOL" import -d /dev/disk/by-id -aN 2>/dev/null
+		ret=$?
+		[ "$ret" -eq 0 ] && POOL_IMPORTED=1
+	elif [ -f "$ZPOOL_CACHE" ] ; then
+		action $"Importing ZFS pools" \
+			"$ZPOOL" import -c "$ZPOOL_CACHE" -aN 2>/dev/null
+		ret=$?
+		[ "$ret" -eq 0 ] && POOL_IMPORTED=1
 	fi
-	sleep 1
 
-	action $"Mounting automounted ZFS filesystems: " $ZFS mount -a || return 152
+	if [ -n "$POOL_IMPORTED" ]; then
+		if [ "$VERBOSE_MOUNT" -eq 1 ]; then
+			verbose=v
+		fi
 
-	action $"Exporting ZFS filesystems: " $ZFS share -a || return 153
+		if [ "$DO_OVERLAY_MOUNTS" -eq 1 ]; then
+			overlay=O
+		fi
 
-	# Read fstab, try to mount zvols ignoring error
-	read_fstab "^/dev/(zd|zvol)"
-	template=$"Mounting volume %s registered in fstab: "
-	for volume in "${FSTAB[@]}" ; do
-		string=`printf "$template" "$volume"`
-		action "$string" mount "$volume" 2>/dev/null || /bin/true
-	done
+		action $"Mounting ZFS filesystems" \
+			"$ZFS" mount -a$verbose$overlay$MOUNT_EXTRA_OPTIONS
 
-	# touch "$LOCKFILE"
+		action $"Sharing ZFS filesystems" \
+			"$ZFS" share -a
+	fi
+
+	touch "$LOCKFILE"
 }
 
 stop()
 {
-	# Disable lockfile check
-	# if [ ! -f "$LOCKFILE" ] ; then return 0 ; fi
+	[ ! -f "$LOCKFILE" ] && return 3
 
-	# check if ZFS is installed.  If not, comply to FC standards and bail
-	zfs_installed || {
-		action $"Checking if ZFS is installed: not installed" /bin/false
-		return 5
-	}
-
-	# the poweroff of the system takes care of this
-	# but it never unmounts the root filesystem itself
-	# shit
-
-	action $"Syncing ZFS filesystems: " sync
-	     # about the only thing we can do, and then we
-	     # hope that the umount process will succeed
-	     # unfortunately the umount process does not dismount
-	     # the root file system, there ought to be some way
-	     # we can tell zfs to just flush anything in memory
-	     # when a request to remount,ro comes in
-
-	#echo -n $"Unmounting ZFS filesystems: "
-	#$ZFS umount -a
-	#RETVAL=$?
-	#if [ $RETVAL -ne 0 ]; then
-	#	failure
-
-	#	return 8
-	#fi
-	#success
+	action $"Unsharing ZFS filesystems" "$ZFS" unshare -a
+	action $"Unmounting ZFS filesystems" "$ZFS" umount -a
 
 	rm -f "$LOCKFILE"
 }
 
-# See how we are called
+status()
+{
+	[ ! -f "$LOCKFILE" ] && return 3
+
+	"$ZPOOL" status && echo "" && "$ZPOOL" list
+}
+
 case "$1" in
 	start)
 		start
@@ -151,24 +123,21 @@ case "$1" in
 		RETVAL=$?
 		;;
 	status)
-		lsmod | grep -q zfs || RETVAL=3
-		$ZPOOL status && echo && $ZFS list || {
-			[ -f "$LOCKFILE" ] && RETVAL=2 || RETVAL=4
-		}
+		status
+		RETVAL=$?
 		;;
 	restart)
 		stop
 		start
 		;;
 	condrestart)
-		if [ -f "$LOCKFILE" ] ; then
+		if [ -f "$LOCKFILE" ]; then
 			stop
 			start
 		fi
 		;;
 	*)
 		echo $"Usage: $0 {start|stop|status|restart|condrestart}"
-		RETVAL=3
 		;;
 esac
 


### PR DESCRIPTION
This commit replaces the zfs.redhat.in init script with a slightly
modified version of the existing zfs.lsb.in init script.  This was
done to minimize the functional differences between platforms.
The lsb version of the script was choosen because it's heavily
tested and provides the most functionality.

Changes made for RHEL systems:
* Configuration: /etc/default/zfs -> /etc/sysconfig/zfs
* LSB functions: /lib/lsb/init-functions -> /etc/rc.d/init.d/functions
* Logging: log_begin_msg/log_end_msg -> action

Features in LSB which are now in RHEL:
* USE_DISK_BY_ID=0      - Use the by-id names
* VERBOSE_MOUNT=0       - Verbose mounts by default
* DO_OVERLAY_MOUNTS=0   - Overlay mounts by default
* MOUNT_EXTRA_OPTIONS=0 - Generic extra options

Existing RHEL features which were removed:
* Automatically mounting FSs on ZVOLs listed in /etc/fstab

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3153