### PR TITLE
Restore dbuf_write_ready() early return

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2639,6 +2639,12 @@ dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 	dnode_diduse_space(dn, delta - zio->io_prev_space_delta);
 	zio->io_prev_space_delta = delta;
 
+	if (BP_IS_HOLE(bp)) {
+		ASSERT0(bp->blk_fill);
+		DB_DNODE_EXIT(db);
+		return;
+	}
+
 	if (bp->blk_birth != 0) {
 		ASSERT((db->db_blkid != DMU_SPILL_BLKID &&
 		    BP_GET_TYPE(bp) == dn->dn_type) ||
@@ -2673,11 +2679,7 @@ dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 					fill++;
 			}
 		} else {
-			if (BP_IS_HOLE(bp)) {
-				fill = 0;
-			} else {
-				fill = 1;
-			}
+			fill = 1;
 		}
 	} else {
 		blkptr_t *ibp = db->db.db_data;


### PR DESCRIPTION
Commit b0bc7a8 reworked the dbuf_write_ready() function to remove the
early return when a hole is detected.  This does simplify the code but
it means additional contention of the db->db_mtx lock which can impact
performance.

Specificially the tiotest benchmark shows a significant performance
regression because it reads/writes zero-filled buffers which are converted
to holes.  Without the early return optimization the additional lock
contention on the dbufs is significant.  Cached read performance for
holes is cut in half.  The performance of non-hole block pointers
remains roughly the same as expected.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3106