### PR TITLE
Log ARC hash_lock holder [DEBUG ONLY]

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1718,6 +1718,10 @@ arc_buf_remove_ref(arc_buf_t *buf, void* tag)
 	arc_buf_hdr_t *hdr = buf->b_hdr;
 	kmutex_t *hash_lock = NULL;
 	boolean_t no_callback = (buf->b_efunc == NULL);
+#ifdef _KERNEL
+	int count = 1, timeout = 60 * MICROSEC;
+	struct task_struct *task;
+#endif
 
 	if (hdr->b_state == arc_anon) {
 		ASSERT(hdr->b_datacnt == 1);
@@ -1726,7 +1730,24 @@ arc_buf_remove_ref(arc_buf_t *buf, void* tag)
 	}
 
 	hash_lock = HDR_LOCK(hdr);
+#ifdef _KERNEL
+retry:
+	if ((mutex_tryenter(hash_lock)) == 0) {
+		if (((count++) % timeout) == 0) {
+			task = mutex_owner(hash_lock);
+			cmn_err(CE_WARN,
+			    "%s (%d) holding hash lock for %ds\n",
+			    task ? task->comm : "NULL",
+			    task ? task->pid : -1,
+			    count / MICROSEC);
+		}
+
+		udelay(1);
+		goto retry;
+	}
+#else
 	mutex_enter(hash_lock);
+#endif
 	hdr = buf->b_hdr;
 	ASSERT3P(hash_lock, ==, HDR_LOCK(hdr));
 	ASSERT(hdr->b_state != arc_anon);


### PR DESCRIPTION
A debug patch for #3160 designed to log the holder of the ARC
hash_lock if it cannot be acquired for over 60 seconds.  This
patch may impact performance and is for debug purposes only.t

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3160