### PR TITLE
Mark zfs_inactive() with PF_FSTRANS

### DIFF
--- a/module/zfs/zpl_super.c
+++ b/module/zfs/zpl_super.c
@@ -98,9 +98,13 @@ zpl_dirty_inode(struct inode *ip)
 static void
 zpl_evict_inode(struct inode *ip)
 {
+	fstrans_cookie_t cookie;
+
+	cookie = spl_fstrans_mark();
 	truncate_setsize(ip, 0);
 	clear_inode(ip);
 	zfs_inactive(ip);
+	spl_fstrans_unmark(cookie);
 }
 
 #else
@@ -108,7 +112,11 @@ zpl_evict_inode(struct inode *ip)
 static void
 zpl_clear_inode(struct inode *ip)
 {
+	fstrans_cookie_t cookie;
+
+	cookie = spl_fstrans_mark();
 	zfs_inactive(ip);
+	spl_fstrans_unmark(cookie);
 }
 
 static void


### PR DESCRIPTION
Allowing direct reclaim to re-enter the VFS in the zfs_inactive()
call path has historically been problematic for ZoL.  Therefore,
in order to avoid an entire class of current and future issues
caused by this PF_FSTRANS is set for all zfs_inactive() callers.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>