### PR TITLE
Require libblkid

### DIFF
--- a/config/user-libblkid.m4
+++ b/config/user-libblkid.m4
@@ -16,20 +16,13 @@ dnl # Otherwise we disable blkid support and resort to manual probing.
 dnl #
 AC_DEFUN([ZFS_AC_CONFIG_USER_LIBBLKID], [
 	AC_ARG_WITH([blkid],
-		[AS_HELP_STRING([--with-blkid],
-		[support blkid caching @<:@default=check@:>@])],
+		[AS_HELP_STRING([--without-blkid],
+		[disable suport for  blkid])],
 		[],
-		[with_blkid=check])
+		[with_blkid=yes])
 
 	LIBBLKID=
-	AS_IF([test "x$with_blkid" = xyes],
-	[
-		AC_SUBST([LIBBLKID], ["-lblkid"])
-		AC_DEFINE([HAVE_LIBBLKID], 1,
-			[Define if you have libblkid])
-	])
-
-	AS_IF([test "x$with_blkid" = xcheck],
+	AS_IF([test "x$with_blkid" != xno],
 	[
 		AC_CHECK_LIB([blkid], [blkid_get_cache],
 		[
@@ -96,17 +89,13 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBBLKID], [
 			[
 				rm -f $ZFS_DEV
 				AC_MSG_RESULT([no])
-				AS_IF([test "x$with_blkid" != xcheck],
-					[AC_MSG_FAILURE(
-					[--with-blkid given but unavailable])])
+				AC_MSG_FAILURE([libblkid test failed (--without-libblkid to disable)])
 			])
 
 			LIBS="$saved_LIBS"
 		],
 		[
-			AS_IF([test "x$with_blkid" != xcheck],
-				[AC_MSG_FAILURE(
-				[--with-blkid given but unavailable])])
+			AC_MSG_FAILURE([libblkid test failed (--without-libblkid to disable)])
 		]
 		[])
 	])

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -213,11 +213,6 @@ image which is ZFS aware.
 %else
     %define debug --disable-debug
 %endif
-%if %{with blkid}
-    %define blkid --with-blkid
-%else
-    %define blkid --without-blkid
-%endif
 %if 0%{?_systemd}
     %define systemd --enable-systemd --with-systemdunitdir=%{_unitdir} --with-systemdpresetdir=%{_presetdir} --disable-sysvinit
 %else
@@ -234,8 +229,8 @@ image which is ZFS aware.
     --with-dracutdir=%{_dracutdir} \
     --disable-static \
     %{debug} \
-    %{blkid} \
-    %{systemd}
+    %{systemd} \
+    %{?_with_blkid}
 make %{?_smp_mflags}
 
 %install

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -34,7 +34,7 @@
 %endif
 
 %bcond_with    debug
-%bcond_with    blkid
+%bcond_without blkid
 %bcond_with    systemd
 
 # Generic enable switch for systemd


### PR DESCRIPTION
Require --with-blkid for packages.  I still have at least two concerns about these patches.

* Does this break the build on any platform?  The buildbot should answer that question for us.

* It may be wise to rework this check in to two (or more) parts.
  * Does libblkid exist.  This would be enough to identify non-ZFS filesystems on devices.
  * Can the installed version of libblkid detect a ZFS filesystem.  There's currently some cares which are not handled such as detecting L2ARC devices, or devices without enough uber blocks.  