### PR TITLE
Add dfree_zfs for changing how Samba reports space

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,3 +1,3 @@
 SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest zpios
 SUBDIRS += mount_zfs fsck_zfs zvol_id vdev_id arcstat dbufstat zed
-SUBDIRS += arc_summary
+SUBDIRS += arc_summary dfree_zfs

--- a/cmd/dfree_zfs/Makefile.am
+++ b/cmd/dfree_zfs/Makefile.am
@@ -1,0 +1,2 @@
+bin_SCRIPTS = dfree_zfs
+EXTRA_DIST = $(bin_SCRIPTS)

--- a/cmd/dfree_zfs/dfree_zfs
+++ b/cmd/dfree_zfs/dfree_zfs
@@ -1,0 +1,84 @@
+#!/bin/sh
+# File: /usr/bin/dfree-zfs
+#
+# This is "dfree_zfs", which can be used as Samba's "dfree command" to
+# get a consistent display of space usage when using shares residing on
+# ZFS pools.
+#
+# To make use of this script add this line to your smb.conf, either in
+# its [general] section or for specific shares:
+#
+# dfree command = /usr/bin/dfree_zfs
+#
+# Without "dfree_zfs" Samba will display free space according to "df",
+# which is not always correct about space consumed by datasets and their
+# children, see below. "dfree_zfs" fixes this, by getting the space used
+# by the dataset including its children.
+#
+# By default "dfree_zfs" will calculate the pool's total used space,
+# this behavior can be changed in "/etc/zfs/dfree_zfs.conf".
+#
+# The output is what Samba expects: "$TOTAL $AVAILABLE" in 1K-blocks.
+#
+# "df" vs "zfs get used":
+#
+# Three datasets on a pool, each dataset contains a single file.
+# - tank/a:   10 GB
+# - tank/a/c:  5 GB
+# - tank/b:   25 GB
+#
+# "df" ignores datasets' children:
+#
+# root@interzone:~# df /tank/*/*
+# Filesystem     1K-blocks     Used Available Use% Mounted on
+# tank/a          54713472 10491008  44222464  20% /tank/a
+# tank/a/c        49468032  5245568  44222464  11% /tank/a/c
+# tank/b          70449920 26227456  44222464  38% /tank/b
+#
+# "dfree_zfs" showing the pool's total size:
+# root@interzone:~# echo $(cd /tank/a; dfree_zfs)
+# 86188032 44222464
+# root@interzone:~# echo $(cd /tank/a/c; dfree_zfs)
+# 86188032 44222464
+# root@interzone:~# echo $(cd /tank/b; dfree_zfs)
+# 86188032 44222464
+#
+# After changing "use_pool_used" in "/etc/zfs/dfree_zfs.conf",
+# "dfree_zfs" shows the dataset's total size, including children:
+#
+# root@interzone:~# sed -i 's,yes,no,' /etc/zfs/dfree_zfs.conf
+#
+# root@interzone:~# echo $(cd /tank/a; dfree_zfs)
+# 59959112 44222464
+# root@interzone:~# echo $(cd /tank/a/c; dfree_zfs)
+# 49468048 44222464
+# root@interzone:~# echo $(cd /tank/b; dfree_zfs)
+# 70449968 44222464
+
+CONFIG=/etc/zfs/dfree_zfs.conf
+
+
+CUR_PATH=$(pwd)
+FILESYSTEM=$(df -PT "$CUR_PATH" | tail -1 | awk '{print $2}')
+USE_POOL_USED=yes
+
+if [ -r $CONFIG ] ; then
+	USE_POOL_USED=$(awk "\$1 == \"use_pool_used\" {print \$2; exit}" $CONFIG)
+fi
+
+if [ "$FILESYSTEM" = 'zfs' ] ; then
+	# get the pool's USED instead of this dataset's USED
+	if [ "$USE_POOL_USED" = "yes" ] ; then
+		POOL_NAME=$(echo "$CUR_PATH" | cut -d '/' -f -2)
+		USED_PATH="$POOL_NAME"
+	else
+		USED_PATH="$CUR_PATH"
+	fi
+	USED=$(($(sudo zfs get -o value -Hp used "$USED_PATH") / 1024)) > /dev/null
+	AVAIL=$(($(sudo zfs get -o value -Hp available "$CUR_PATH") / 1024)) > /dev/null
+	TOTAL=$((USED+AVAIL)) > /dev/null
+
+	echo "$TOTAL" "$AVAIL"
+else
+	df -PT "$CUR_PATH" | tail -1 | awk '{print $3" "$5}'
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,7 @@ AC_CONFIG_FILES([
 	etc/systemd/Makefile
 	etc/systemd/system/Makefile
 	etc/modules-load.d/Makefile
+	etc/sudoers.d/Makefile
 	man/Makefile
 	man/man1/Makefile
 	man/man5/Makefile
@@ -110,6 +111,7 @@ AC_CONFIG_FILES([
 	cmd/vdev_id/Makefile
 	cmd/arcstat/Makefile
 	cmd/dbufstat/Makefile
+	cmd/dfree_zfs/Makefile
 	cmd/arc_summary/Makefile
 	cmd/zed/Makefile
 	contrib/Makefile

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,2 +1,2 @@
-SUBDIRS = zfs $(ZFS_INIT_SYSTEMD) $(ZFS_INIT_SYSV) $(ZFS_MODULE_LOAD)
-DIST_SUBDIRS = init.d zfs systemd modules-load.d
+SUBDIRS = zfs $(ZFS_INIT_SYSTEMD) $(ZFS_INIT_SYSV) $(ZFS_MODULE_LOAD) sudoers.d
+DIST_SUBDIRS = init.d zfs systemd modules-load.d sudoers.d

--- a/etc/sudoers.d/Makefile.am
+++ b/etc/sudoers.d/Makefile.am
@@ -1,0 +1,6 @@
+pkgsysconfdir = $(sysconfdir)/sudoers.d
+
+pkgsysconf_DATA = \
+	dfree_zfs
+
+EXTRA_DIST = $(pkgsysconf_DATA)

--- a/etc/sudoers.d/dfree_zfs
+++ b/etc/sudoers.d/dfree_zfs
@@ -1,0 +1,5 @@
+Cmnd_Alias C_DFREE_ZFS =                 \
+  /sbin/zfs get -o value -Hp used *,     \
+  /sbin/zfs get -o value -Hp available *
+
+ALL ALL = (root) NOPASSWD: C_DFREE_ZFS

--- a/etc/zfs/Makefile.am
+++ b/etc/zfs/Makefile.am
@@ -4,6 +4,7 @@ pkgsysconf_DATA = \
 	vdev_id.conf.alias.example \
 	vdev_id.conf.sas_direct.example \
 	vdev_id.conf.sas_switch.example \
-	vdev_id.conf.multipath.example
+	vdev_id.conf.multipath.example \
+	dfree_zfs.conf
 
 EXTRA_DIST = $(pkgsysconf_DATA)

--- a/etc/zfs/dfree_zfs.conf
+++ b/etc/zfs/dfree_zfs.conf
@@ -1,0 +1,6 @@
+# If set to "yes" dfree_zfs will report the space used by the whole pool instead
+# of the current dataset and its descendants, making the share's usage display
+# in a more consistent way.
+# To use dfree_zfs add "dfree command = /usr/bin/dfree_zfs" to smb.conf, either
+# in its [global] part or directly to single shares.
+use_pool_used yes

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -266,6 +266,7 @@ exit 0
 %else
 %{_sysconfdir}/init.d/*
 %endif
+%{_sysconfdir}/sudoers.d/*
 
 %files -n libzpool2
 %{_libdir}/libzpool.so.*


### PR DESCRIPTION
This commit adds the script "dfree_zfs", which can be used as Samba's
"dfree command" to get a consistent display of space usage when using
shares residing on ZFS pools.

Without "dfree_zfs" Samba will display free space according to "df",
which is not always correct about space consumed by datasets and their
children, see below. "dfree_zfs" fixes this, by getting the space used
by the dataset including its children.

By default "dfree_zfs" will calculate the pool's total used space,
this behavior can be changed in "/etc/zfs/dfree_zfs.conf".

The output is what Samba expects: "$TOTAL $AVAILABLE" in 1K-blocks.

# "df" vs "zfs get used"

Three datasets on a pool, each dataset contains a single file.
- tank/a:   10 GB
- tank/a/c:  5 GB
- tank/b:   25 GB

## "df" ignores datasets' children:

```
root@interzone:~# df /tank/*/*
Filesystem     1K-blocks     Used Available Use% Mounted on
tank/a          54713472 10491008  44222464  20% /tank/a
tank/a/c        49468032  5245568  44222464  11% /tank/a/c
tank/b          70449920 26227456  44222464  38% /tank/b
```

## With dfree_zfs
```
"dfree_zfs" showing the pool's total size:
root@interzone:~# echo $(cd /tank/a; dfree_zfs)
86188032 44222464
root@interzone:~# echo $(cd /tank/a/c; dfree_zfs)
86188032 44222464
root@interzone:~# echo $(cd /tank/b; dfree_zfs)
86188032 44222464
```

After changing "use_pool_used" in "/etc/zfs/dfree_zfs.conf",
"dfree_zfs" shows the dataset's total size, including children:

```
root@interzone:~# sed -i 's,yes,no,' /etc/zfs/dfree_zfs.conf

root@interzone:~# echo $(cd /tank/a; dfree_zfs)
59959112 44222464
root@interzone:~# echo $(cd /tank/a/c; dfree_zfs)
49468048 44222464
root@interzone:~# echo $(cd /tank/b; dfree_zfs)
70449968 44222464
```

# Sample images from Windows

## Samba's default
![image](https://cloud.githubusercontent.com/assets/733892/6597142/b5dadece-c7fa-11e4-88e5-ee95e95c92c6.png)

## With "dfree_zfs"
![image](https://cloud.githubusercontent.com/assets/733892/6597146/c06e3692-c7fa-11e4-9453-e1a00cf10638.png)

## When using "dfree_zfs" without "use_pool_used yes"
![image](https://cloud.githubusercontent.com/assets/733892/6597153/cea74d8e-c7fa-11e4-830a-a7116a70b980.png)