### PR TITLE
Fix warning about AM_INIT_AUTOMAKE arguments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,8 +30,8 @@
  * CDDL HEADER END
  */
 
-AC_INIT(m4_esyscmd_s(grep Name META | cut -d ':' -f 2 | tr -d ' '),
-	m4_esyscmd_s(grep Version META | cut -d ':' -f 2 | tr -d ' '))
+AC_INIT(m4_esyscmd(grep Name META | cut -d ':' -f 2 | tr -d ' \n'),
+	m4_esyscmd(grep Version META | cut -d ':' -f 2 | tr -d ' \n'))
 AC_LANG(C)
 ZFS_AC_META
 AC_CONFIG_AUX_DIR([config])

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,8 @@
  * CDDL HEADER END
  */
 
-AC_INIT
+AC_INIT(m4_esyscmd_s(grep Name META | cut -d ':' -f 2 | tr -d ' '),
+	m4_esyscmd_s(grep Version META | cut -d ':' -f 2 | tr -d ' '))
 AC_LANG(C)
 ZFS_AC_META
 AC_CONFIG_AUX_DIR([config])
@@ -38,7 +39,7 @@ AC_CONFIG_MACRO_DIR([config])
 AC_CANONICAL_SYSTEM
 AM_MAINTAINER_MODE
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
-AM_INIT_AUTOMAKE([$ZFS_META_NAME], [$ZFS_META_VERSION])
+AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([zfs_config.h], [
 	(mv zfs_config.h zfs_config.h.tmp &&
 	awk -f ${ac_srcdir}/config/config.awk zfs_config.h.tmp >zfs_config.h &&


### PR DESCRIPTION
As of automake 1.14.2, currently shipped with Ubuntu 14.04, automake
warns about AM_INIT_AUTOMAKE having more than one argument:

```
configure.ac:41: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
configure.ac:41: http://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
```

This commit fixes the warnings by following above link's advice, so
AM_INIT gets called with the package's name and version. As both are
defined in the META file we're parsing it with `grep`, `cut` and `tr`.

The warnings about `subdir-objects` are quite tedious to fix manually, I suggest waiting for Automake 1.16 which fixes http://debbugs.gnu.org/cgi/bugreport.cgi?bug=13928