### PR TITLE
Fix potential data abort issue (memory access over @oend by @ref and @op) during lz4 decompress with corrupted or invalid compression data

### DIFF
--- a/module/zfs/lz4.c
+++ b/module/zfs/lz4.c
@@ -978,6 +978,14 @@ LZ4_uncompress_unknownOutputSize(const char *source, char *dest, int isize,
 				 * destination buffer
 				 */
 				goto _output_error;
+			if ((ref + COPYLENGTH) > oend ||
+					(op + COPYLENGTH) > oend)
+				/*
+				 * If the part of the compression data are corrupted,
+				 * or the compression data is totally fake,
+				 * the memory access over the limit is possible.
+				 */
+				goto _output_error;
 			LZ4_SECURECOPY(ref, op, (oend - COPYLENGTH));
 			while (op < cpy)
 				*op++ = *ref++;


### PR DESCRIPTION
JeHyeon (Tom) Yeon from windriver.com found out, if compression
data was corrupted or altered in any way to be invalid,
this could lead to memory accesses over @oend by @ref and @op

Below is his lkml message and link:

If the part of the compression data are corrupted, or the compression
data is totally fake, the memory access over the limit is possible.

This is the log from my system usning lz4 decompression.
   [6502]data abort, halting
   [6503]r0  0x00000000 r1  0x00000000 r2  0xdcea0ffc r3  0xdcea0ffc
   [6509]r4  0xb9ab0bfd r5  0xdcea0ffc r6  0xdcea0ff8 r7  0xdce80000
   [6515]r8  0x00000000 r9  0x00000000 r10 0x00000000 r11 0xb9a98000
   [6522]r12 0xdcea1000 usp 0x00000000 ulr 0x00000000 pc  0x820149bc
   [6528]spsr 0x400001f3
and the memory addresses of some variables at the moment are
    ref:0xdcea0ffc, op:0xdcea0ffc, oend:0xdcea1000
As you can see, COPYLENGH is 8bytes, so @ref and @op can access the momory
over @oend.

Signed-off-by: tom.yeon <tom.yeon@windriver.com>

https://lkml.org/lkml/2015/3/12/139

--------------------------------------------------------------

applied to ZFS,
Signed-off-by: kernelOfTruth@gmail.com
Issue #3176 