### PR TITLE
Linux 4.0 compat: bdi_setup_and_register() __must_check

### DIFF
--- a/config/kernel-bdi-setup-and-register.m4
+++ b/config/kernel-bdi-setup-and-register.m4
@@ -10,7 +10,8 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI_SETUP_AND_REGISTER], [
 	], [
 		struct backing_dev_info bdi;
 		char *name = "bdi";
-		(void) bdi_setup_and_register(&bdi, name);
+		int error __attribute__((unused)) =
+		    bdi_setup_and_register(&bdi, name);
 	], [bdi_setup_and_register], [mm/backing-dev.c], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_2ARGS_BDI_SETUP_AND_REGISTER, 1,
@@ -24,7 +25,8 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI_SETUP_AND_REGISTER], [
 			struct backing_dev_info bdi;
 			char *name = "bdi";
 			unsigned int cap = BDI_CAP_MAP_COPY;
-			(void) bdi_setup_and_register(&bdi, name, cap);
+			int error __attribute__((unused)) =
+			    bdi_setup_and_register(&bdi, name, cap);
 		], [bdi_setup_and_register], [mm/backing-dev.c], [
 			AC_MSG_RESULT(yes)
 			AC_DEFINE(HAVE_3ARGS_BDI_SETUP_AND_REGISTER, 1,


### PR DESCRIPTION
Explicitly disable the unused by set warnings in the autoconf check
for bdi_setup_and_register().  This is required because the function
is defined with the __must_check attribute.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3141