### PR TITLE
ZFS_ENTER/ZFS_EXIT (WIP)

### DIFF
--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -44,6 +44,7 @@ struct znode;
 typedef struct zfs_sb {
 	struct super_block *z_sb;	/* generic super_block */
 	struct backing_dev_info z_bdi;	/* generic backing dev info */
+	fstrans_cookie_t z_fstrans;	/* PF_FSTRANS */
 	struct zfs_sb	*z_parent;	/* parent fs */
 	objset_t	*z_os;		/* objset reference */
 	uint64_t	z_flags;	/* super_block flags */

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -285,8 +285,6 @@ typedef struct znode {
 	mutex_tryenter(ZFS_OBJ_MUTEX((zsb), (obj_num)))
 #define	ZFS_OBJ_HOLD_EXIT(zsb, obj_num) \
 	mutex_exit(ZFS_OBJ_MUTEX((zsb), (obj_num)))
-#define	ZFS_OBJ_HOLD_OWNED(zsb, obj_num) \
-	mutex_owned(ZFS_OBJ_MUTEX((zsb), (obj_num)))
 
 /* Encode ZFS stored time values from a struct timespec */
 #define	ZFS_TIME_ENCODE(tp, stmp)		\

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -253,6 +253,7 @@ typedef struct znode {
 #define	ZFS_ENTER(zsb) \
 	{ \
 		rrw_enter_read(&(zsb)->z_teardown_lock, FTAG); \
+		(zsb)->z_fstrans = spl_fstrans_mark(); \
 		if ((zsb)->z_unmounted) { \
 			ZFS_EXIT(zsb); \
 			return (EIO); \
@@ -262,6 +263,7 @@ typedef struct znode {
 /* Must be called before exiting the vop */
 #define	ZFS_EXIT(zsb) \
 	{ \
+		spl_fstrans_unmark((zsb)->z_fstrans); \
 		rrw_exit(&(zsb)->z_teardown_lock, FTAG); \
 		tsd_exit(); \
 	}

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -1097,24 +1097,13 @@ zfs_zinactive(znode_t *zp)
 {
 	zfs_sb_t *zsb = ZTOZSB(zp);
 	uint64_t z_id = zp->z_id;
-	boolean_t drop_mutex = 0;
 
 	ASSERT(zp->z_sa_hdl);
 
 	/*
-	 * Don't allow a zfs_zget() while were trying to release this znode.
-	 *
-	 * Linux allows direct memory reclaim which means that any KM_SLEEP
-	 * allocation may trigger inode eviction.  This can lead to a deadlock
-	 * through the ->shrink_icache_memory()->evict()->zfs_inactive()->
-	 * zfs_zinactive() call path.  To avoid this deadlock the process
-	 * must not reacquire the mutex when it is already holding it.
+	 * Don't allow a zfs_zget() while were trying to release this znode
 	 */
-	if (!ZFS_OBJ_HOLD_OWNED(zsb, z_id)) {
-		ZFS_OBJ_HOLD_ENTER(zsb, z_id);
-		drop_mutex = 1;
-	}
-
+	ZFS_OBJ_HOLD_ENTER(zsb, z_id);
 	mutex_enter(&zp->z_lock);
 
 	/*
@@ -1123,19 +1112,14 @@ zfs_zinactive(znode_t *zp)
 	 */
 	if (zp->z_unlinked) {
 		mutex_exit(&zp->z_lock);
-
-		if (drop_mutex)
-			ZFS_OBJ_HOLD_EXIT(zsb, z_id);
-
+		ZFS_OBJ_HOLD_EXIT(zsb, z_id);
 		zfs_rmnode(zp);
 		return;
 	}
 
 	mutex_exit(&zp->z_lock);
 	zfs_znode_dmu_fini(zp);
-
-	if (drop_mutex)
-		ZFS_OBJ_HOLD_EXIT(zsb, z_id);
+	ZFS_OBJ_HOLD_EXIT(zsb, z_id);
 }
 
 static inline int


### PR DESCRIPTION
Mark ZFS_ENTER/ZFS_EXIT regions with PF_FSTRANS
    
For the moment mark all system call entry points with PF_FSTRANS.  This is a bit heavy handed but it has the advantage of being functionally similar to the previous KM_PUSHPAGE behavior.
