### PR TITLE
Add the '-a' option to 'zpool export' (WIP)

### DIFF
--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -241,12 +241,13 @@ for_each_pool(int argc, char **argv, boolean_t unavail,
 	int ret = 0;
 
 	if ((list = pool_list_get(argc, argv, proplist, &ret)) == NULL)
-		return (1);
+		return (ret);
 
 	if (pool_list_iter(list, unavail, func, data) != 0)
 		ret = 1;
 
-	pool_list_free(list);
+	if (!ret)
+		pool_list_free(list);
 
 	return (ret);
 }

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -222,7 +222,7 @@ get_usage(zpool_help_t idx) {
 	case HELP_DETACH:
 		return (gettext("\tdetach <pool> <device>\n"));
 	case HELP_EXPORT:
-		return (gettext("\texport [-f] <pool> ...\n"));
+		return (gettext("\texport [-af] <pool> ...\n"));
 	case HELP_HISTORY:
 		return (gettext("\thistory [-il] [<pool>] ...\n"));
 	case HELP_IMPORT:
@@ -1212,9 +1212,41 @@ zpool_do_destroy(int argc, char **argv)
 	return (ret);
 }
 
+typedef struct export_cbdata {
+	boolean_t force;
+	boolean_t hardforce;
+} export_cbdata_t;
+
+/*
+ * Export one pool
+ */
+int
+zpool_export_one(zpool_handle_t *zhp, void *data)
+{
+	export_cbdata_t *cb = data;
+	int ret = 0;
+
+	if (zpool_disable_datasets(zhp, cb->force) != 0) {
+		zpool_close(zhp);
+		return (1);
+	}
+
+	/* The history must be logged as part of the export */
+	log_history = B_FALSE;
+
+	if (cb->hardforce) {
+		if (zpool_export_force(zhp, history_str) != 0)
+			return (1);
+	} else if (zpool_export(zhp, cb->force, history_str) != 0)
+		return (1);
+
+	return (ret);
+}
+
 /*
  * zpool export [-f] <pool> ...
  *
+ *	-a	Export all pools
  *	-f	Forcefully unmount datasets
  *
  * Export the given pools.  By default, the command will attempt to cleanly
@@ -1224,16 +1256,19 @@ zpool_do_destroy(int argc, char **argv)
 int
 zpool_do_export(int argc, char **argv)
 {
+	zpool_handle_t *zhp;
+	export_cbdata_t cb;
+	boolean_t do_all = B_FALSE;
 	boolean_t force = B_FALSE;
 	boolean_t hardforce = B_FALSE;
-	int c;
-	zpool_handle_t *zhp;
-	int ret;
-	int i;
+	int c, i, ret;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "fF")) != -1) {
+	while ((c = getopt(argc, argv, "afF")) != -1) {
 		switch (c) {
+		case 'a':
+			do_all = B_TRUE;
+			break;
 		case 'f':
 			force = B_TRUE;
 			break;
@@ -1247,8 +1282,20 @@ zpool_do_export(int argc, char **argv)
 		}
 	}
 
+	cb.force = force;
+	cb.hardforce = hardforce;
 	argc -= optind;
 	argv += optind;
+
+	if (do_all) {
+		if (argc != 0) {
+			(void) fprintf(stderr, gettext("too many arguments\n"));
+			usage(B_FALSE);
+		}
+
+		return (for_each_pool(0, NULL, B_FALSE, NULL,
+				zpool_export_one, &cb));
+	}
 
 	/* check arguments */
 	if (argc < 1) {
@@ -1263,21 +1310,8 @@ zpool_do_export(int argc, char **argv)
 			continue;
 		}
 
-		if (zpool_disable_datasets(zhp, force) != 0) {
-			ret = 1;
-			zpool_close(zhp);
-			continue;
-		}
 
-		/* The history must be logged as part of the export */
-		log_history = B_FALSE;
-
-		if (hardforce) {
-			if (zpool_export_force(zhp, history_str) != 0)
-				ret = 1;
-		} else if (zpool_export(zhp, force, history_str) != 0) {
-			ret = 1;
-		}
+		ret = zpool_export_one(zhp, &cb);
 
 		zpool_close(zhp);
 	}

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -62,6 +62,11 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
+\fBzpool export\fR [\fB-af\fR]
+.fi
+
+.LP
+.nf
 \fBzpool get\fR [\fB-pH\fR] "\fIall\fR" | \fIproperty\fR[,...] \fIpool\fR ...
 .fi
 
@@ -1072,6 +1077,47 @@ Exports the given pools from the system. All devices are marked as exported, but
 Before exporting the pool, all datasets within the pool are unmounted. A pool can not be exported if it has a shared spare that is currently being used.
 .sp
 For pools to be portable, you must give the \fBzpool\fR command whole disks, not just partitions, so that \fBZFS\fR can label the disks with portable \fBEFI\fR labels. Otherwise, disk drivers on platforms of different endianness will not recognize the disks.
+.sp
+.ne 2
+.mk
+.na
+\fB\fB-f\fR\fR
+.ad
+.RS 6n
+.rt  
+Forcefully unmount all datasets, using the "\fBunmount -f\fR" command.
+.sp
+This command will forcefully export the pool even if it has a shared spare that is currently being used. This may lead to potential data corruption.
+.RE
+
+.RE
+
+.sp
+.ne 2
+.mk
+.na
+\fB\fBzpool export\fR [\fB-af\fR]
+.ad
+.sp .6
+.RS 4n
+Export pool(s) from the system. All devices are marked as exported, but are still considered in use by other subsystems. The devices can be moved between systems (even those of different endianness) and imported as long as a sufficient number of devices are present.
+.sp
+Before exporting the pool, all datasets within the pool are unmounted. A pool can not be exported if it has a shared spare that is currently being used.
+.sp
+For pools to be portable, you must give the \fBzpool\fR command whole disks, not just partitions, so that \fBZFS\fR can label the disks with portable \fBEFI\fR labels. Otherwise, disk drivers on platforms of different endianness will not recognize the disks.
+.sp
+.ne 2
+.mk
+.na
+\fB\fB-a\fR\fR
+.ad
+.RS 6n
+.rt
+Exports all pools imported on the system. 
+.sp
+This command will export all pools imported to the system.
+.RE
+
 .sp
 .ne 2
 .mk


### PR DESCRIPTION
Add the '-a' option to 'zpool export'.

Support exporting all imported pools in one go, using 'zpool export -a'.

Do this by moving the export parts from zpool_do_export() to the new function zpool_export_one().

If '-a' is called, call this function from within for_each_pool().

In cmd/zpool/zpool_iter.c:for_each_pool(), we need to make sure that the pool_list_iter() function returned without a failure. Otherwise, we'll get a seg fault.

This happens if the pool can't be exported (for whatever reason).

Signed-off-by: Turbo Fredriksson <turbo@bayour.com>
Closes: #3203