### PR TITLE
Check all vdev labels in 'zpool import'

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -239,7 +239,7 @@ parse_dataset(char *dataset)
 		if (fd < 0)
 			goto out;
 
-		error = zpool_read_label(fd, &config);
+		error = zpool_read_label(fd, &config, B_FALSE);
 		(void) close(fd);
 		if (error)
 			goto out;

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2008,6 +2008,9 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
  *       -D     Scan for previously destroyed pools or import all or only
  *              specified destroyed pools.
  *
+ *       -l     Scan for devices where only a single vdev label is intact.
+ *              Without this option all four labels must exist.
+ *
  *       -R	Temporarily import the pool, with all mountpoints relative to
  *		the given root.  The pool will remain exported when the machine
  *		is rebooted.
@@ -2062,13 +2065,14 @@ zpool_do_import(int argc, char **argv)
 	boolean_t dryrun = B_FALSE;
 	boolean_t do_rewind = B_FALSE;
 	boolean_t xtreme_rewind = B_FALSE;
+	boolean_t do_labels = B_TRUE;
 	uint64_t pool_state, txg = -1ULL;
 	char *cachefile = NULL;
 	importargs_t idata = { 0 };
 	char *endptr;
 
 	/* check options */
-	while ((c = getopt(argc, argv, ":aCc:d:DEfFmnNo:R:tT:VX")) != -1) {
+	while ((c = getopt(argc, argv, ":aCc:d:DEfFlmnNo:R:tT:VX")) != -1) {
 		switch (c) {
 		case 'a':
 			do_all = B_TRUE;
@@ -2097,6 +2101,9 @@ zpool_do_import(int argc, char **argv)
 			break;
 		case 'F':
 			do_rewind = B_TRUE;
+			break;
+		case 'l':
+			do_labels = B_FALSE;
 			break;
 		case 'm':
 			flags |= ZFS_IMPORT_MISSING_LOG;
@@ -2273,6 +2280,7 @@ zpool_do_import(int argc, char **argv)
 	idata.poolname = searchname;
 	idata.guid = searchguid;
 	idata.cachefile = cachefile;
+	idata.labels = do_labels;
 
 	pools = zpool_search_import(g_zfs, &idata);
 

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -597,7 +597,7 @@ is_spare(nvlist_t *config, const char *path)
 	if (zpool_in_use(g_zfs, fd, &state, &name, &inuse) != 0 ||
 	    !inuse ||
 	    state != POOL_STATE_SPARE ||
-	    zpool_read_label(fd, &label) != 0) {
+	    zpool_read_label(fd, &label, B_FALSE) != 0) {
 		free(name);
 		(void) close(fd);
 		return (B_FALSE);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -389,6 +389,7 @@ typedef struct importargs {
 	int can_be_active : 1;	/* can the pool be active?		*/
 	int unique : 1;		/* does 'poolname' already exist?	*/
 	int exists : 1;		/* set on return if pool already exists	*/
+	int labels : 1;		/* require all vdev labels		*/
 } importargs_t;
 
 extern nvlist_t *zpool_search_import(libzfs_handle_t *, importargs_t *);
@@ -757,7 +758,7 @@ extern int zpool_in_use(libzfs_handle_t *, int, pool_state_t *, char **,
 /*
  * Label manipulation.
  */
-extern int zpool_read_label(int, nvlist_t **);
+extern int zpool_read_label(int, nvlist_t **, boolean_t);
 extern int zpool_clear_label(int);
 
 /*


### PR DESCRIPTION
When using 'zpool import' to scan for available pools ignore devices which
do not have four valid labels.  There must be two labels at the start of
the device and two labels at the end of the device.  If any of these labels
are missing then the device has been damaged or somehow overwritten.

The -l option has been added which allows for devices with only a single
valid label to be used.  This may be helpful to recover from certain kinds
of damage but should not be needed under normal circumstances.

This behavior only applies when scanning /dev/ for valid pools.  If a
cache file exists the pools described by the cache file will be used.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3145