### PR TITLE
Execute "udevadm settle" before trying to import pools

### DIFF
--- a/dracut/90zfs/mount-zfs.sh.in
+++ b/dracut/90zfs/mount-zfs.sh.in
@@ -12,6 +12,8 @@ if getargbool 0 zfs_force -y zfs.force -y zfsforce ; then
 	ZPOOL_FORCE="-f"
 fi
 
+udevadm settle
+
 case "$root" in
 	zfs:*)
 		# We have ZFS modules loaded, so we're able to import pools now.


### PR DESCRIPTION
Execute "udevadm settle" before trying to import pools.  Otherwise the disk device nodes may not be ready before import time and dracut will bail to the emergency shell.