### PR TITLE
Set the maximum ZVOL transfer size correctly

### DIFF
--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -420,7 +420,7 @@ dmu_tx_hold_write(dmu_tx_t *tx, uint64_t object, uint64_t off, int len)
 	dmu_tx_hold_t *txh;
 
 	ASSERT(tx->tx_txg == 0);
-	ASSERT(len < DMU_MAX_ACCESS);
+	ASSERT(len <= DMU_MAX_ACCESS);
 	ASSERT(len == 0 || UINT64_MAX - off >= len - 1);
 
 	txh = dmu_tx_hold_object_impl(tx, tx->tx_objset,

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1389,7 +1389,7 @@ __zvol_create_minor(const char *name, boolean_t ignore_snapdev)
 
 	set_capacity(zv->zv_disk, zv->zv_volsize >> 9);
 
-	blk_queue_max_hw_sectors(zv->zv_queue, UINT_MAX);
+	blk_queue_max_hw_sectors(zv->zv_queue, DMU_MAX_ACCESS / 512);
 	blk_queue_max_segments(zv->zv_queue, UINT16_MAX);
 	blk_queue_max_segment_size(zv->zv_queue, UINT_MAX);
 	blk_queue_physical_block_size(zv->zv_queue, zv->zv_volblocksize);


### PR DESCRIPTION
ZoL had been setting max_sectors to UINT_MAX, but until Linux 3.19, it
the kernel artifically capped it at 1024 (BLK_DEF_MAX_SECTORS).
This cap was removed in torvalds/linux@34b48db.  This patch changes
it to DMU_MAX_ACCESS (in sectors) and also changes the ASSERT in
dmu_tx_hold_write() to allow the maximum transfer size.