### PR TITLE
Direct reclaim torture test mechanism

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -42,7 +42,7 @@ typedef struct arc_buf_hdr arc_buf_hdr_t;
 typedef struct arc_buf arc_buf_t;
 typedef struct arc_prune arc_prune_t;
 typedef void arc_done_func_t(zio_t *zio, arc_buf_t *buf, void *private);
-typedef void arc_prune_func_t(int64_t bytes, void *private);
+typedef void arc_prune_func_t(int64_t bytes, void *private, int flags);
 typedef int arc_evict_func_t(void *private);
 
 /* generic arc_done_func_t's which you can use */

--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -175,7 +175,7 @@ extern int zfs_sb_create(const char *name, zfs_sb_t **zsbp);
 extern int zfs_sb_setup(zfs_sb_t *zsb, boolean_t mounting);
 extern void zfs_sb_free(zfs_sb_t *zsb);
 extern int zfs_sb_prune(struct super_block *sb, unsigned long nr_to_scan,
-    int *objects);
+    int *objects, int flags);
 extern int zfs_sb_teardown(zfs_sb_t *zsb, boolean_t unmounting);
 extern int zfs_check_global_label(const char *dsname, const char *hexsl);
 extern boolean_t zfs_is_readonly(zfs_sb_t *zsb);

--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -63,7 +63,7 @@ extern const struct file_operations zpl_file_operations;
 extern const struct file_operations zpl_dir_file_operations;
 
 /* zpl_super.c */
-extern void zpl_prune_sb(int64_t nr_to_scan, void *arg);
+extern void zpl_prune_sb(int64_t nr_to_scan, void *arg, int flags);
 
 typedef struct zpl_mount_data {
 	const char *z_osname;	/* Dataset name */

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2141,7 +2141,7 @@ arc_adjust(void)
  * by higher layers.  (i.e. the zpl)
  */
 static void
-arc_do_user_prune(int64_t adjustment)
+arc_do_user_prune(int64_t adjustment, int flags)
 {
 	arc_prune_func_t *func;
 	void *private;
@@ -2158,7 +2158,7 @@ arc_do_user_prune(int64_t adjustment)
 		mutex_exit(&arc_prune_mtx);
 
 		if (func != NULL)
-			func(adjustment, private);
+			func(adjustment, private, flags);
 
 		mutex_enter(&arc_prune_mtx);
 
@@ -2285,7 +2285,7 @@ restart:
 
 			if (zfs_arc_meta_prune) {
 				prune += zfs_arc_meta_prune;
-				arc_do_user_prune(prune);
+				arc_do_user_prune(prune, 1);
 			}
 		}
 
@@ -2628,6 +2628,42 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 SPL_SHRINKER_CALLBACK_WRAPPER(arc_shrinker_func);
 
 SPL_SHRINKER_DECLARE(arc_shrinker, arc_shrinker_func, DEFAULT_SEEKS);
+
+#ifdef KMEM_DEBUG_DIRECT_RECLAIM
+static void
+zfs_debug_direct_reclaim_func(int flags, unsigned long *last, const char *c)
+{
+	int rand = 0;
+	unsigned long l = *last;
+
+	/* frequent hitter, throttle it by random number */
+	if (jiffies - l < (HZ/2)) {
+		get_random_bytes(&rand, 2);
+		if ((rand & 0x3ff) != 0)
+			return;
+	}
+	*last = jiffies;
+
+	printk_ratelimited("%s\n", c);
+	/* prevent recursive direct reclaim */
+	current->flags |= PF_MEMALLOC;
+	arc_do_user_prune(16, 0);
+	current->flags &= ~PF_MEMALLOC;
+
+}
+
+void
+zfs_debug_direct_reclaim_init(void)
+{
+	spl_kmem_debug_direct_reclaim_register(zfs_debug_direct_reclaim_func);
+}
+
+void
+zfs_debug_direct_reclaim_fini(void)
+{
+	spl_kmem_debug_direct_reclaim_unregister();
+}
+#endif
 #endif /* _KERNEL */
 
 /*

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5953,6 +5953,11 @@ zfs_allow_log_destroy(void *arg)
 #define	ZFS_DEBUG_STR	""
 #endif
 
+#ifdef KMEM_DEBUG_DIRECT_RECLAIM
+void zfs_debug_direct_reclaim_init(void);
+void zfs_debug_direct_reclaim_fini(void);
+#endif
+
 static int __init
 _init(void)
 {
@@ -5988,6 +5993,9 @@ _init(void)
 	printk(KERN_NOTICE "ZFS: Posix ACLs disabled by kernel\n");
 #endif /* CONFIG_FS_POSIX_ACL */
 
+#ifdef KMEM_DEBUG_DIRECT_RECLAIM
+	zfs_debug_direct_reclaim_init();
+#endif
 	return (0);
 
 out2:
@@ -6005,6 +6013,9 @@ out1:
 static void __exit
 _fini(void)
 {
+#ifdef KMEM_DEBUG_DIRECT_RECLAIM
+	zfs_debug_direct_reclaim_fini();
+#endif
 	zfs_detach();
 	zvol_fini();
 	zfs_fini();

--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -1080,7 +1080,8 @@ EXPORT_SYMBOL(zfs_root);
  * blocks but can't because they are all pinned by entries in these caches.
  */
 int
-zfs_sb_prune(struct super_block *sb, unsigned long nr_to_scan, int *objects)
+zfs_sb_prune(struct super_block *sb, unsigned long nr_to_scan, int *objects,
+    int flags)
 {
 	zfs_sb_t *zsb = sb->s_fs_info;
 	int error = 0;
@@ -1092,7 +1093,8 @@ zfs_sb_prune(struct super_block *sb, unsigned long nr_to_scan, int *objects)
 	};
 #endif
 
-	ZFS_ENTER(zsb);
+	if (flags)
+		ZFS_ENTER(zsb);
 
 #if defined(HAVE_SPLIT_SHRINKER_CALLBACK)
 	*objects = (*shrinker->scan_objects)(shrinker, &sc);
@@ -1111,7 +1113,8 @@ zfs_sb_prune(struct super_block *sb, unsigned long nr_to_scan, int *objects)
 	*objects = 0;
 	shrink_dcache_parent(sb->s_root);
 #endif
-	ZFS_EXIT(zsb);
+	if (flags)
+		ZFS_EXIT(zsb);
 
 	dprintf_ds(zsb->z_os->os_dsl_dataset,
 	    "pruning, nr_to_scan=%lu objects=%d error=%d\n",

--- a/module/zfs/zpl_super.c
+++ b/module/zfs/zpl_super.c
@@ -282,12 +282,12 @@ zpl_kill_sb(struct super_block *sb)
 }
 
 void
-zpl_prune_sb(int64_t nr_to_scan, void *arg)
+zpl_prune_sb(int64_t nr_to_scan, void *arg, int flags)
 {
 	struct super_block *sb = (struct super_block *)arg;
 	int objects = 0;
 
-	(void) -zfs_sb_prune(sb, nr_to_scan, &objects);
+	(void) -zfs_sb_prune(sb, nr_to_scan, &objects, flags);
 }
 
 #ifdef HAVE_NR_CACHED_OBJECTS


### PR DESCRIPTION
As I mentioned in #3192, now I finally implemented it.

The idea is simple, for every memory allocation, we check for the flags to see if it can do direct reclaim. If it can than we by some random chance force the direct reclaim to occur. This patch still have some rough edges, like those ad hoc numbers. But I'm able to produce deadlocks with it rather easily.

Depends on zfsonlinux/spl#442

Signed-off-by: Chunwei Chen <tuxoko@gmail.com>