### PR TITLE
Fix kernel panic due to tsd_exit in ZFS_EXIT(zsb)

### DIFF
--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -263,7 +263,6 @@ typedef struct znode {
 #define	ZFS_EXIT(zsb) \
 	{ \
 		rrw_exit(&(zsb)->z_teardown_lock, FTAG); \
-		tsd_exit(); \
 	}
 
 /* Verifies the znode is valid */

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2156,6 +2156,8 @@ zfs_fsync(struct inode *ip, int syncflag, cred_t *cr)
 		zil_commit(zsb->z_log, zp->z_id);
 		ZFS_EXIT(zsb);
 	}
+	tsd_set(zfs_fsyncer_key, NULL);
+
 	return (0);
 }
 EXPORT_SYMBOL(zfs_fsync);


### PR DESCRIPTION
The following panic would occur under certain heavy load:
[ 4692.202686] Kernel panic - not syncing: thread ffff8800c4f5dd60 terminating with rrw lock ffff8800da1b9c40 held
[ 4692.228053] CPU: 1 PID: 6250 Comm: mmap_deadlock Tainted: P           OE  3.18.10 #7

The culprit is that ZFS_EXIT(zsb) would call tsd_exit() every time, which
would purge all tsd data for the thread. However, ZFS_ENTER is designed to be
reentrant, so we cannot allow ZFS_EXIT to blindly purge tsd data.

Instead, when we are doing rrw_exit, if we are removing the last rrn entry,
then we calls tsd_exit_key(rrw_tsd_key), which would only remove the
rrw_tsd_key tsd entry and also the PID_KEY tsd entry if it is the only entry
left for this thread.

The zfs_fsyncer_key tsds rely on ZFS_EXIT(zsb) to call tsd_exit() to do clean
up. Now we need to explicit call tsd_exit_key() on them. We also clean up the
zfs_allow_log_key when it's not needed.

Signed-off-by: Chunwei Chen <tuxoko@gmail.com>