### PR TITLE
Rebuild init scripts on source file updates

### DIFF
--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -8,7 +8,7 @@ EXTRA_DIST = \
 	$(top_srcdir)/etc/init.d/zfs.lunar.in \
 	$(top_srcdir)/etc/init.d/zfs.redhat.in
 
-$(init_SCRIPTS):
+$(init_SCRIPTS): $(init_SCRIPTS).$(DEFAULT_INIT_SCRIPT).in
 	-$(SED) -e 's,@bindir\@,$(bindir),g' \
 		-e 's,@sbindir\@,$(sbindir),g' \
 		-e 's,@udevdir\@,$(udevdir),g' \


### PR DESCRIPTION
The resulting script is not removed by 'make clean' or rebuilt
when the source files are changed. Users with long standing git
trees may find their init script is out of date.

Signed-off-by: DHE <git@dehacked.net>