### PR TITLE
New stable API (For Initial Review)

### DIFF
--- a/cmd/zfs/zfs_iter.h
+++ b/cmd/zfs/zfs_iter.h
@@ -47,6 +47,7 @@ typedef struct zfs_sort_column {
 #define	ZFS_ITER_RECVD_PROPS	   (1 << 4)
 #define	ZFS_ITER_LITERAL_PROPS	   (1 << 5)
 #define	ZFS_ITER_SIMPLE		   (1 << 6)
+#define	ZFS_ITER_TYPES_SPECIFIED   (1 << 7)
 
 int zfs_for_each(int, char **, int options, zfs_type_t,
     zfs_sort_column_t *, zprop_list_t **, int, zfs_iter_f, void *);

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1714,7 +1714,7 @@ zfs_do_get(int argc, char **argv)
 
 		case 't':
 			types = 0;
-			flags &= ~ZFS_ITER_PROP_LISTSNAPS;
+			flags |= ZFS_ITER_TYPES_SPECIFIED;
 			while (*optarg != '\0') {
 				static char *type_subopts[] = { "filesystem",
 				    "volume", "snapshot", "bookmark",
@@ -3034,14 +3034,13 @@ zfs_do_list(int argc, char **argv)
 	static char default_fields[] =
 	    "name,used,available,referenced,mountpoint";
 	int types = ZFS_TYPE_DATASET;
-	boolean_t types_specified = B_FALSE;
 	char *fields = NULL;
 	list_cbdata_t cb = { 0 };
 	char *value;
 	int limit = 0;
 	int ret = 0;
 	zfs_sort_column_t *sortcol = NULL;
-	int flags = ZFS_ITER_PROP_LISTSNAPS | ZFS_ITER_ARGS_CAN_BE_PATHS;
+	int flags = ZFS_ITER_ARGS_CAN_BE_PATHS;
 
 	/* check options */
 	while ((c = getopt(argc, argv, "HS:d:o:prs:t:")) != -1) {
@@ -3080,8 +3079,7 @@ zfs_do_list(int argc, char **argv)
 			break;
 		case 't':
 			types = 0;
-			types_specified = B_TRUE;
-			flags &= ~ZFS_ITER_PROP_LISTSNAPS;
+			flags |= ZFS_ITER_TYPES_SPECIFIED;
 			while (*optarg != '\0') {
 				static char *type_subopts[] = { "filesystem",
 				    "volume", "snapshot", "snap", "bookmark",
@@ -3142,7 +3140,7 @@ zfs_do_list(int argc, char **argv)
 	/*
 	 * If "-o space" and no types were specified, don't display snapshots.
 	 */
-	if (strcmp(fields, "space") == 0 && types_specified == B_FALSE)
+	if (strcmp(fields, "space") == 0 && (flags & ZFS_ITER_TYPES_SPECIFIED))
 		types &= ~ZFS_TYPE_SNAPSHOT;
 
 	/*

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -553,6 +553,8 @@ void zprop_print_one_property(const char *, zprop_get_cbdata_t *,
  * Iterator functions.
  */
 typedef int (*zfs_iter_f)(zfs_handle_t *, void *);
+extern int zfs_iter_generic(libzfs_handle_t *, const char *, zfs_type_t,
+    int64_t, zfs_iter_f, void *);
 extern int zfs_iter_root(libzfs_handle_t *, zfs_iter_f, void *);
 extern int zfs_iter_children(zfs_handle_t *, zfs_iter_f, void *);
 extern int zfs_iter_dependents(zfs_handle_t *, boolean_t, zfs_iter_f, void *);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -38,6 +38,7 @@ extern "C" {
 int libzfs_core_init(void);
 void libzfs_core_fini(void);
 
+int lzc_list (const char *, int, nvlist_t *);
 int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -55,6 +55,9 @@ int lzc_hold(nvlist_t *, int, nvlist_t **);
 int lzc_release(nvlist_t *, nvlist_t **);
 int lzc_get_holds(const char *, nvlist_t **);
 
+int lzc_rename(const char *oldname, const char *newname, nvlist_t *opts,
+    char **errname);
+
 enum lzc_send_flags {
 	LZC_SEND_FLAG_EMBED_DATA = 1 << 0
 };

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -41,6 +41,7 @@ void libzfs_core_fini(void);
 int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);
+int lzc_promote(const char *);
 int lzc_destroy_snaps(nvlist_t *, boolean_t, nvlist_t **);
 int lzc_bookmark(nvlist_t *, nvlist_t **);
 int lzc_get_bookmarks(const char *, nvlist_t *, nvlist_t **);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -57,6 +57,7 @@ enum lzc_send_flags {
 };
 
 int lzc_send(const char *, const char *, int, enum lzc_send_flags);
+int lzc_send_ext(const char *, const char *, int, nvlist_t *);
 int lzc_receive(const char *, nvlist_t *, const char *, boolean_t, int);
 int lzc_send_space(const char *, const char *, uint64_t *);
 

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -42,6 +42,7 @@ int lzc_snapshot(nvlist_t *, nvlist_t *, nvlist_t **);
 int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);
 int lzc_promote(const char *);
+int lzc_set_props(const char *, nvlist_t *, boolean_t);
 int lzc_destroy_snaps(nvlist_t *, boolean_t, nvlist_t **);
 int lzc_bookmark(nvlist_t *, nvlist_t **);
 int lzc_get_bookmarks(const char *, nvlist_t *, nvlist_t **);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -55,6 +55,7 @@ int lzc_hold(nvlist_t *, int, nvlist_t **);
 int lzc_release(nvlist_t *, nvlist_t **);
 int lzc_get_holds(const char *, nvlist_t **);
 
+int lzc_inherit(const char *fsname, const char *propname, nvlist_t *opts);
 int lzc_rename(const char *oldname, const char *newname, nvlist_t *opts,
     char **errname);
 

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -44,6 +44,7 @@ int lzc_create(const char *, dmu_objset_type_t, nvlist_t *);
 int lzc_clone(const char *, const char *, nvlist_t *);
 int lzc_promote(const char *);
 int lzc_set_props(const char *, nvlist_t *, boolean_t);
+int lzc_destroy_one(const char *, nvlist_t *);
 int lzc_destroy_snaps(nvlist_t *, boolean_t, nvlist_t **);
 int lzc_bookmark(nvlist_t *, nvlist_t **);
 int lzc_get_bookmarks(const char *, nvlist_t *, nvlist_t **);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -61,6 +61,7 @@ int lzc_send(const char *, const char *, int, enum lzc_send_flags);
 int lzc_send_ext(const char *, const char *, int, nvlist_t *);
 int lzc_receive(const char *, nvlist_t *, const char *, boolean_t, int);
 int lzc_send_space(const char *, const char *, uint64_t *);
+int lzc_send_progress(const char *, int, uint64_t *);
 
 boolean_t lzc_exists(const char *);
 

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -275,8 +275,8 @@ int dsl_destroy_snapshots_nvl(struct nvlist *snaps, boolean_t defer,
     struct nvlist *errlist);
 int dmu_objset_snapshot_one(const char *fsname, const char *snapname);
 int dmu_objset_snapshot_tmp(const char *, const char *, int);
-int dmu_objset_find(char *name, int func(const char *, void *), void *arg,
-    int flags);
+int dmu_objset_find(const char *name, int func(const char *, void *),
+    void *arg, int flags);
 void dmu_objset_byteswap(void *buf, size_t size);
 int dsl_dataset_rename_snapshot(const char *fsname,
     const char *oldsnapname, const char *newsnapname, boolean_t recursive);

--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -147,6 +147,9 @@ void dmu_objset_fast_stat(objset_t *os, dmu_objset_stats_t *stat);
 void dmu_objset_space(objset_t *os, uint64_t *refdbytesp, uint64_t *availbytesp,
     uint64_t *usedobjsp, uint64_t *availobjsp);
 uint64_t dmu_objset_fsid_guid(objset_t *os);
+int dmu_objset_find_dp_impl(struct dsl_pool *dp, uint64_t ddobj,
+    int func(struct dsl_pool *, struct dsl_dataset *, void *),
+    void *arg, int flags, unsigned int depth);
 int dmu_objset_find_dp(struct dsl_pool *dp, uint64_t ddobj,
     int func(struct dsl_pool *, struct dsl_dataset *, void *),
     void *arg, int flags);

--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -171,6 +171,13 @@ int dmu_objset_userspace_upgrade(objset_t *os);
 boolean_t dmu_objset_userspace_present(objset_t *os);
 int dmu_fsname(const char *snapname, char *buf);
 
+/* Code for handling userspace interface */
+extern const char *dmu_objset_types[];
+
+const char *dmu_objset_type_name(dmu_objset_type_t type);
+nvlist_t *dmu_objset_stats_nvlist(dmu_objset_stats_t *stat);
+int dmu_objset_stat_nvlts (nvlist_t *nvl, dmu_objset_stats_t *stat);
+
 void dmu_objset_init(void);
 void dmu_objset_fini(void);
 

--- a/include/sys/dmu_send.h
+++ b/include/sys/dmu_send.h
@@ -38,7 +38,7 @@ struct drr_begin;
 struct avl_tree;
 
 int dmu_send(const char *tosnap, const char *fromsnap, boolean_t embedok,
-    int outfd, struct vnode *vp, offset_t *off);
+    boolean_t fromorigin, int outfd, struct vnode *vp, offset_t *off);
 int dmu_send_estimate(struct dsl_dataset *ds, struct dsl_dataset *fromds,
     uint64_t *sizep);
 int dmu_send_obj(const char *pool, uint64_t tosnap, uint64_t fromsnap,

--- a/include/sys/dsl_prop.h
+++ b/include/sys/dsl_prop.h
@@ -66,6 +66,7 @@ int dsl_prop_get(const char *ddname, const char *propname,
 int dsl_prop_get_integer(const char *ddname, const char *propname,
     uint64_t *valuep, char *setpoint);
 int dsl_prop_get_all(objset_t *os, nvlist_t **nvp);
+int dsl_prop_get_all_new(objset_t *os, nvlist_t **nvp);
 int dsl_prop_get_received(const char *dsname, nvlist_t **nvp);
 int dsl_prop_get_ds(struct dsl_dataset *ds, const char *propname,
     int intsz, int numints, void *buf, char *setpoint);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -893,6 +893,11 @@ typedef enum zfs_ioc {
 	 */
 	ZFS_IOC_FREEBSD = ('Z' << 8) + 0xC0,
 
+	/*
+	 * OpenZFS - 1/64 numbers reserved.
+	 */
+	ZFS_IOC_OPENZFS = ('Z' << 8) + 0x100,
+	ZFS_IOC_LIBZFS_CORE,
 	ZFS_IOC_LAST
 } zfs_ioc_t;
 

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -354,6 +354,14 @@ typedef struct zfs_cmd {
 	zfs_stat_t	zc_stat;
 } zfs_cmd_t;
 
+typedef struct zfs_pipe_record {
+	uint32_t	zpr_data_size;		/* Payload size */
+	uint8_t		zpr_header_size;	/* Extension space after 8 bytes */
+	uint8_t		zpr_err;		/* Return code */
+	uint8_t		zpr_endian;		/* Endian bit: 0 is BE, 1 is LE */
+	uint8_t		zpr_reserved;		/* Reserved space */
+} zfs_pipe_record_t;
+
 typedef struct zfs_useracct {
 	char zu_domain[256];
 	uid_t zu_rid;

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -643,7 +643,10 @@ zfs_open(libzfs_handle_t *hdl, const char *path, int types)
 		return (NULL);
 	}
 
-	if (!(types & zhp->zfs_type)) {
+	/*
+	 * types == 0 is set when we have the kernel check the type for us.
+	 */
+	if (types && !(types & zhp->zfs_type)) {
 		(void) zfs_error(hdl, EZFS_BADTYPE, errbuf);
 		zfs_close(zhp);
 		return (NULL);

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1495,6 +1495,8 @@ zprop_parse_value(libzfs_handle_t *hdl, nvpair_t *elem, int prop,
 			    zprop_values(prop, type));
 			goto error;
 		}
+		*ivalp = 0;
+		*svalp = value;
 		break;
 
 	default:

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -554,6 +554,27 @@ lzc_send_space(const char *snapname, const char *fromsnap, uint64_t *spacep)
 	return (err);
 }
 
+/*
+ * Query number of bytes written in a given send stream
+ * for a given snapshot thus far.
+ */
+int
+lzc_send_progress(const char *snapname, int fd, uint64_t *bytesp)
+{
+	nvlist_t *args;
+	nvlist_t *result;
+	int err;
+
+	args = fnvlist_alloc();
+	fnvlist_add_int32(args, "fd", fd);
+	err = lzc_ioctl("zfs_send_progress", snapname, args, NULL, &result, 0);
+	nvlist_free(args);
+	if (err == 0)
+		*bytesp = fnvlist_lookup_uint64(result, "offset");
+	nvlist_free(result);
+	return (err);
+}
+
 static int
 recv_read(int fd, void *buf, int ilen)
 {

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -503,6 +503,28 @@ lzc_send(const char *snapname, const char *from, int fd,
 }
 
 /*
+ * Like lzc_send() but the additional flags and options are passed via an
+ * nvlist_t parameter.
+ */
+int
+lzc_send_ext(const char *snapname, const char *from, int fd, nvlist_t *params)
+{
+	nvlist_t *args;
+	int err;
+
+	args = fnvlist_alloc();
+	if (params != NULL)
+		fnvlist_merge(args, params);
+	fnvlist_add_int32(args, "fd", fd);
+	nvlist_remove_all(args, "fromsnap");
+	if (from != NULL)
+		fnvlist_add_string(args, "fromsnap", from);
+	err = lzc_ioctl("zfs_send", snapname, args, NULL, NULL, 0);
+	nvlist_free(args);
+	return (err);
+}
+
+/*
  * If fromsnap is NULL, a full (non-incremental) stream will be estimated.
  */
 int

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -814,6 +814,32 @@ lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
 }
 
 /*
+ * Resets a property on a  DSL directory (i.e. filesystems, volumes, snapshots)
+ * to its original value.
+ *
+ * The following are the valid properties in opts, all of which are booleans:
+ *
+ * "received" - resets property value to from `zfs recv` if it set a value
+ */
+int
+lzc_inherit(const char *fsname, const char *propname, nvlist_t *opts)
+{
+	nvlist_t *args;
+	int error;
+
+	if (fsname == NULL || (propname == NULL ||
+	    strlen(fsname) == 0 || strlen(propname) == 0))
+		return (EINVAL);
+
+	args = fnvlist_alloc();
+	fnvlist_add_string(args, "prop", propname);
+	error = lzc_ioctl("zfs_inherit", fsname, args, opts, NULL, 0);
+	fnvlist_free(args);
+
+	return (error);
+}
+
+/*
  * Rename DSL directory (i.e. filesystems, volumes, snapshots)
  *
  * The opts flag accepts a boolean named "recursive" to signal that the

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -840,6 +840,34 @@ lzc_inherit(const char *fsname, const char *propname, nvlist_t *opts)
 }
 
 /*
+ * Destroys a DSL directory that is either a filesystems or a volume.
+ * Destroying snapshots and bookmarks is not currently supported. Call
+ * lzc_destroy_snaps and lzc_destroy_bookmarks for those respectively.
+ *
+ * The only currently valud property is the booleans "defer_destroy". It makes
+ * destruction asynchronous such that the only error code back is if we try to
+ * destroy something that does not exist. The caller must unmount the dataset
+ * before calling this. Otherwise, it will fail.
+ */
+
+int
+lzc_destroy_one(const char *fsname, nvlist_t *opts)
+{
+	nvlist_t *args;
+	int error;
+
+	if (fsname == NULL ||
+	    strlen(fsname) == 0)
+		return (EINVAL);
+
+	args = fnvlist_alloc();
+	error = lzc_ioctl("zfs_destroy", fsname, args, opts, NULL, 0);
+	fnvlist_free(args);
+
+	return (error);
+}
+
+/*
  * Rename DSL directory (i.e. filesystems, volumes, snapshots)
  *
  * The opts flag accepts a boolean named "recursive" to signal that the

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -220,6 +220,15 @@ lzc_clone(const char *fsname, const char *origin,
 	return (error);
 }
 
+int
+lzc_promote(const char *fsname)
+{
+	int error;
+
+	error = lzc_ioctl("zfs_promote", fsname, NULL, NULL, NULL, 0);
+	return (error);
+}
+
 /*
  * Creates snapshots.
  *

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -229,6 +229,19 @@ lzc_promote(const char *fsname)
 	return (error);
 }
 
+int
+lzc_set_props(const char *fsname, nvlist_t *props, boolean_t received)
+{
+	int error;
+	nvlist_t *opts = fnvlist_alloc();
+
+	if (received)
+		fnvlist_add_boolean(opts, "received");
+	error = lzc_ioctl("zfs_set_props", fsname, props, opts, NULL, 0);
+	nvlist_free(opts);
+	return (error);
+}
+
 /*
  * Creates snapshots.
  *

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1773,7 +1773,7 @@ dmu_objset_find_impl(spa_t *spa, const char *name,
  * See comment above dmu_objset_find_impl().
  */
 int
-dmu_objset_find(char *name, int func(const char *, void *), void *arg,
+dmu_objset_find(const char *name, int func(const char *, void *), void *arg,
     int flags)
 {
 	spa_t *spa;

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2015 by ClusterHQ, Inc. All rights reserved.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -1815,6 +1816,72 @@ dmu_fsname(const char *snapname, char *buf)
 	(void) strlcpy(buf, snapname, atp - snapname + 1);
 	return (0);
 }
+
+/* Code for handling userspace interface */
+const char *dmu_objset_types[DMU_OST_NUMTYPES] = {
+	"NONE", "META", "ZPL", "ZVOL", "OTHER", "ANY" };
+
+#define	DMU_OT_COUNT	(sizeof (dmu_objset_types) /\
+	sizeof (&dmu_objset_types[0]))
+
+const char *
+dmu_objset_type_name(dmu_objset_type_t type)
+{
+	return ((type < DMU_OST_NUMTYPES) ? dmu_objset_types[type] : NULL);
+}
+
+nvlist_t *
+dmu_objset_stats_nvlist(dmu_objset_stats_t *stat)
+{
+	nvlist_t *nvl = fnvlist_alloc();
+
+	nvlist_add_uint64(nvl, "dds_num_clones", stat->dds_num_clones);
+	nvlist_add_uint64(nvl, "dds_creation_txg", stat->dds_creation_txg);
+	nvlist_add_uint64(nvl, "dds_guid", stat->dds_guid);
+
+	fnvlist_add_string(nvl, "dds_type",
+	    dmu_objset_type_name(stat->dds_type));
+
+	fnvlist_add_boolean_value(nvl, "dds_is_snapshot",
+	    stat->dds_is_snapshot);
+	fnvlist_add_boolean_value(nvl, "dds_inconsistent",
+	    stat->dds_inconsistent);
+
+	fnvlist_add_string(nvl, "dds_origin", stat->dds_origin);
+
+	return (nvl);
+}
+
+int
+dmu_objset_stat_nvlts(nvlist_t *nvl, dmu_objset_stats_t *stat)
+{
+	char *type;
+	boolean_t issnap, inconsist;
+	int i;
+
+	if (nvlist_lookup_uint64(nvl, "dds_num_clones",
+	    &stat->dds_num_clones) ||
+	    nvlist_lookup_uint64(nvl, "dds_creation_txg",
+	    &stat->dds_creation_txg) ||
+	    nvlist_lookup_uint64(nvl, "dds_guid", &stat->dds_guid) ||
+	    nvlist_lookup_string(nvl, "dds_type", &type) ||
+	    nvlist_lookup_boolean_value(nvl, "dds_is_snapshot", &issnap) ||
+	    nvlist_lookup_boolean_value(nvl, "dds_inconsistent", &inconsist))
+		return (EINVAL);
+
+	stat->dds_inconsistent = inconsist;
+	stat->dds_is_snapshot = issnap;
+
+	for (i = 0; i < DMU_OT_COUNT; i++) {
+		if (strcmp(dmu_objset_types[i], type) == 0) {
+			stat->dds_type = i;
+			return (0);
+		}
+	}
+
+	return (EINVAL);
+}
+
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
 EXPORT_SYMBOL(dmu_objset_zil);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -730,14 +730,14 @@ dmu_send_obj(const char *pool, uint64_t tosnap, uint64_t fromsnap,
 
 int
 dmu_send(const char *tosnap, const char *fromsnap, boolean_t embedok,
-    int outfd, vnode_t *vp, offset_t *off)
+    boolean_t fromorigin, int outfd, vnode_t *vp, offset_t *off)
 {
 	dsl_pool_t *dp;
 	dsl_dataset_t *ds;
 	int err;
 	boolean_t owned = B_FALSE;
 
-	if (fromsnap != NULL && strpbrk(fromsnap, "@#") == NULL)
+	if ((fromsnap != NULL || fromorigin) && strpbrk(fromsnap, "@#") == NULL)
 		return (SET_ERROR(EINVAL));
 
 	err = dsl_pool_hold(tosnap, FTAG, &dp);
@@ -759,7 +759,32 @@ dmu_send(const char *tosnap, const char *fromsnap, boolean_t embedok,
 		return (err);
 	}
 
-	if (fromsnap != NULL) {
+	if (fromorigin) {
+		zfs_bookmark_phys_t zb;
+		dsl_dataset_t *fromds;
+		uint64_t fromobj;
+
+		if (!dsl_dir_is_clone(tosnap->ds_dir)) {
+			dsl_dataset_rele(ds, FTAG);
+			dsl_pool_rele(dp, FTAG);
+			return (SET_ERROR(EINVAL));
+		}
+		fromobj = ds->ds_dir->dd_phys->dd_origin_obj;
+		err = dsl_dataset_hold_obj(dp, fromobj, FTAG, &fromds);
+		if (err =! 0) {
+			dsl_dataset_rele(ds, FTAG);
+			dsl_pool_rele(dp, FTAG);
+			return (err);
+		}
+		zb.zbm_creation_time =
+		    fromds->ds_phys->ds_creation_time;
+		zb.zbm_creation_txg =
+		    fromds->ds_phys->ds_creation_txg;
+		zb.zbm_guid = fromds->ds_phys->ds_guid;
+		dsl_dataset_rele(fromds, FTAG);
+		err = dmu_send_impl(FTAG, dp, ds, &zb, B_TRUE, embedok,
+		    outfd, vp, off);
+	} else if (fromsnap != NULL) {
 		zfs_bookmark_phys_t zb;
 		boolean_t is_clone = B_FALSE;
 		int fsnamelen = strchr(tosnap, '@') - tosnap;

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -764,14 +764,14 @@ dmu_send(const char *tosnap, const char *fromsnap, boolean_t embedok,
 		dsl_dataset_t *fromds;
 		uint64_t fromobj;
 
-		if (!dsl_dir_is_clone(tosnap->ds_dir)) {
+		if (!dsl_dir_is_clone(ds->ds_dir)) {
 			dsl_dataset_rele(ds, FTAG);
 			dsl_pool_rele(dp, FTAG);
 			return (SET_ERROR(EINVAL));
 		}
 		fromobj = ds->ds_dir->dd_phys->dd_origin_obj;
 		err = dsl_dataset_hold_obj(dp, fromobj, FTAG, &fromds);
-		if (err =! 0) {
+		if (err != 0) {
 			dsl_dataset_rele(ds, FTAG);
 			dsl_pool_rele(dp, FTAG);
 			return (err);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2511,7 +2511,15 @@ zfs_prop_set_special(const char *dsname, zprop_source_t source,
 	if (zfs_prop_get_type(prop) == PROP_TYPE_STRING)
 		return (-1);
 
-	VERIFY(0 == nvpair_value_uint64(pair, &intval));
+	if (((nvpair_type(pair) == DATA_TYPE_STRING) &&
+	    (zfs_prop_get_type(prop) == PROP_TYPE_INDEX))) {
+		char *strval;
+		if (nvpair_value_string(pair, &strval) != 0)
+			return (-1);
+		if (zfs_prop_string_to_index(prop, strval, &intval) != 0)
+			return (-1);
+	} else
+		VERIFY(0 == nvpair_value_uint64(pair, &intval));
 
 	switch (prop) {
 	case ZFS_PROP_QUOTA:
@@ -2655,20 +2663,29 @@ retry:
 			err = zfs_check_settable(dsname, pair, CRED());
 
 		if (err == 0) {
+			nvlist_t *tnvl = NULL;
 			err = zfs_prop_set_special(dsname, source, pair);
 			if (err == -1) {
 				/*
 				 * For better performance we build up a list of
 				 * properties to set in a single transaction.
 				 */
-				err = nvlist_add_nvpair(genericnvl, pair);
+				tnvl = genericnvl;
 			} else if (err != 0 && nvl != retrynvl) {
 				/*
 				 * This may be a spurious error caused by
 				 * receiving quota and reservation out of order.
 				 * Try again in a second pass.
 				 */
-				err = nvlist_add_nvpair(retrynvl, pair);
+				tnvl = retrynvl;
+			}
+			if (tnvl) {
+				if (nvpair_type(propval) == DATA_TYPE_STRING &&
+				    zfs_prop_get_type(prop) == PROP_TYPE_INDEX)
+					err = nvlist_add_uint64(tnvl, propname,
+					    intval);
+				else
+					err = nvlist_add_nvpair(tnvl, pair);
 			}
 		}
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5423,7 +5423,6 @@ LIBZFS_CORE_WRAPPER_FUNC(release)
 LIBZFS_CORE_WRAPPER_FUNC(get_holds)
 LIBZFS_CORE_WRAPPER_FUNC(rollback)
 LIBZFS_CORE_WRAPPER_FUNC(bookmark)
-LIBZFS_CORE_WRAPPER_FUNC(get_bookmarks)
 LIBZFS_CORE_WRAPPER_FUNC(destroy_bookmarks)
 
 /*
@@ -5535,14 +5534,6 @@ static const zfs_stable_ioc_vec_t zfs_stable_ioc_vec[] = {
 	.zvec_pool_check	= POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY,
 	.zvec_smush_outnvlist	= B_TRUE,
 	.zvec_allow_log		= B_TRUE,
-},
-{	.zvec_name		= "zfs_get_bookmarks",
-	.zvec_func		= zfs_stable_ioc_zfs_get_bookmarks,
-	.zvec_secpolicy		= zfs_secpolicy_read,
-	.zvec_namecheck		= DATASET_NAME,
-	.zvec_pool_check	= POOL_CHECK_SUSPENDED,
-	.zvec_smush_outnvlist	= B_FALSE,
-	.zvec_allow_log		= B_FALSE,
 },
 {	.zvec_name		= "zfs_destroy_bookmarks",
 	.zvec_func		= zfs_stable_ioc_zfs_destroy_bookmarks,

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5506,7 +5506,7 @@ zfs_stable_ioc_set_props(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
 {
 	zprop_source_t source;
 	boolean_t received;
-	int error;
+	int error = 0;
 
 	received = nvlist_exists(opts, "received");
 	source = (received ? ZPROP_SRC_RECEIVED : ZPROP_SRC_LOCAL);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2612,8 +2612,19 @@ retry:
 			}
 		} else if (err == 0) {
 			if (nvpair_type(propval) == DATA_TYPE_STRING) {
-				if (zfs_prop_get_type(prop) != PROP_TYPE_STRING)
+				switch (zfs_prop_get_type(prop)) {
+				case PROP_TYPE_INDEX:
+					strval = fnvpair_value_string(propval);
+					if (zfs_prop_string_to_index(prop,
+					    strval, &intval) != 0)
+						err = SET_ERROR(EINVAL);
+					break;
+				case PROP_TYPE_STRING:
+					break;
+				default:
 					err = SET_ERROR(EINVAL);
+					break;
+				}
 			} else if (nvpair_type(propval) == DATA_TYPE_UINT64) {
 				const char *unused;
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5458,10 +5458,12 @@ zfs_stable_ioc_promote(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
 {
 	char parentname[MAXNAMELEN];
 	char conflsnap[MAXNAMELEN];
+	dsl_pool_t *dp;
 	dsl_dataset_t *clone;
 	dsl_dataset_t *origin = NULL;
 	dsl_dir_t *dd;
 	char *cp;
+	int error;
 
 	error = dsl_pool_hold(fsname, FTAG, &dp);
 	if (error != 0)
@@ -5495,7 +5497,7 @@ zfs_stable_ioc_promote(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl,
 	if (error != 0)
 		fnvlist_add_string(outnvl, "conflsnap", conflsnap);
 
-	return (error)
+	return (error);
 }
 
 static int


### PR DESCRIPTION
This is the foundation for a stable /dev/zfs API for management that moves the kernel-userland interface away from binary data structures and numerical values to XDR-encoded nvlists and string values to enable ease of programming and long term interface stability. Most of the existing libzfs_core API functions have been migrated to the proposed API and the following new ones have been implemented for use by flocker and others:

1. lzc_send_ext()
2. lzc_promote()
3. lzc_send_progress()
4. lzc_set_props()
5. lzc_list()
6. lzc_rename()
7. lzc_inherit()
8. lzc_destroy_one()

In most cases, the userland tools have been modified to use them. A few open questions that need to be answered are:

0. Is our documentation of these functions sufficient?
1. Do we want lzc_inherit() to only process 1 dataset at a time?
2. Are there any other functions that we should include in the initial implementation?
3. Do we want to pass the meta-nvlist as an input to the history logging?
4. Do we want to continue using the legacy zfs_cmd_t structure?
5. The `zfs list` command fails to list an individual bookmark. This is a pre-existing userland bug. Should we address it here?

Lastly, this depends on zfsonlinux/spl#449.