### PR TITLE
Support the "version" property on volumes via the zfs_prop_get_int() API

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1959,6 +1959,9 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 		(void) strlcpy(zc.zc_name, zhp->zfs_name, sizeof (zc.zc_name));
 		if (zfs_ioctl(zhp->zfs_hdl, ZFS_IOC_OBJSET_ZPLPROPS, &zc)) {
 			zcmd_free_nvlists(&zc);
+			if (prop == ZFS_PROP_VERSION &&
+			    zhp->zfs_type == ZFS_TYPE_VOLUME)
+				*val = zfs_prop_default_numeric(prop);
 			return (-1);
 		}
 		if (zcmd_read_dst_nvlist(zhp->zfs_hdl, &zc, &zplprops) != 0 ||


### PR DESCRIPTION
As of this commit, volumes do not possess the version property in
any existing OpenZFS implementation.  The zpool upgrade code, however,
uses zfs_prop_get_int() to fetch the version property of all children in
a pool.  The semantics of the function, however, demand that it only be
used for known valid properties so it returns a garbage value for volumes.

This patch causes the version of a volume to appear to callers using
the zfs_prop_get_int() API to be that of the default ZPL version for
the implementation.  In the future, should volumes gain the property,
its actual value will be used.

Fixes #3313