### PR TITLE
Update ZED copyright boilerplate

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -29,3 +29,8 @@ Unless otherwise noted, all files in this distribution are released
 under the Common Development and Distribution License (CDDL).
 Exceptions are noted within the associated source files.  See the file
 OPENSOLARIS.LICENSE for more information.
+
+Unless otherwise noted, authoritative up-to-date copyright attribution
+can be found in the git commit log:
+
+https://github.com/zfsonlinux/zfs.git

--- a/cmd/zed/zed.c
+++ b/cmd/zed/zed.c
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #include <errno.h>

--- a/cmd/zed/zed.h
+++ b/cmd/zed/zed.h
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #ifndef	ZED_H

--- a/cmd/zed/zed_conf.c
+++ b/cmd/zed/zed_conf.c
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #include <assert.h>
@@ -198,8 +199,6 @@ _zed_conf_display_license(void)
 	    "  <http://opensource.org/licenses/CDDL-1.0>.",
 	    "Developed at Lawrence Livermore National Laboratory"
 	    " (LLNL-CODE-403049).",
-	    "Copyright (C) 2013-2014"
-	    " Lawrence Livermore National Security, LLC.",
 	    "",
 	    NULL
 	};

--- a/cmd/zed/zed_conf.h
+++ b/cmd/zed/zed_conf.h
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #ifndef	ZED_CONF_H

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #include <ctype.h>

--- a/cmd/zed/zed_event.h
+++ b/cmd/zed/zed_event.h
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #ifndef	ZED_EVENT_H

--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #include <assert.h>

--- a/cmd/zed/zed_exec.h
+++ b/cmd/zed/zed_exec.h
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #ifndef	ZED_EXEC_H

--- a/cmd/zed/zed_file.c
+++ b/cmd/zed/zed_file.c
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #include <errno.h>

--- a/cmd/zed/zed_file.h
+++ b/cmd/zed/zed_file.h
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #ifndef	ZED_FILE_H

--- a/cmd/zed/zed_log.c
+++ b/cmd/zed/zed_log.c
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #include <assert.h>

--- a/cmd/zed/zed_log.h
+++ b/cmd/zed/zed_log.h
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #ifndef	ZED_LOG_H

--- a/cmd/zed/zed_strings.c
+++ b/cmd/zed/zed_strings.c
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #include <assert.h>

--- a/cmd/zed/zed_strings.h
+++ b/cmd/zed/zed_strings.h
@@ -21,7 +21,8 @@
 
 /*
  * Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
- * Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+ * Authoritative copyright attribution can be found in the git commit log:
+ * <https://github.com/zfsonlinux/zfs.git>.
  */
 
 #ifndef	ZED_STRINGS_H

--- a/man/man8/zed.8.in
+++ b/man/man8/zed.8.in
@@ -19,7 +19,8 @@
 .\" CDDL HEADER END
 .\"
 .\" Developed at Lawrence Livermore National Laboratory (LLNL-CODE-403049).
-.\" Copyright (C) 2013-2014 Lawrence Livermore National Security, LLC.
+.\" Authoritative copyright attribution can be found in the git commit log:
+.\" <https://github.com/zfsonlinux/zfs.git>.
 .\"
 .TH ZED 8 "Octember 1, 2013" "ZFS on Linux" "System Administration Commands"
 
@@ -249,12 +250,6 @@ Internationalization support via gettext has not been added.
 The configuration file is not yet implemented.
 .PP
 The diagnosis engine is not yet implemented.
-
-.SH COPYRIGHT
-.PP
-Developed at Lawrence Livermore National Laboratory (LLNL\-CODE\-403049).
-.br
-Copyright (C) 2013\-2014 Lawrence Livermore National Security, LLC.
 
 .SH LICENSE
 .PP


### PR DESCRIPTION
The copyright boilerplate within the ZED subtree currently uses the
2013-2014 date range.  It is too easy to overlook updating this
line per file for every commit.  Furthermore, I would prefer not
having a separate copyright line for anyone making a change to a
given file; this can become a pernicious source of merge conflicts.
This information is better maintained by the commit log.

This commit updates the copyright boilerplate within the ZED subtree
to refer to the git commit log for authoritative up-to-date copyright
attribution.  The top-level COPYRIGHT file is also similarly updated.