### PR TITLE
align zfs_autoimport_disable manpage with reality

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -488,7 +488,7 @@ Default value: \fB5\fR.
 .RS 12n
 Disable pool import at module load by ignoring the cache file (typically \fB/etc/zfs/zpool.cache\fR).
 .sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
+Use \fB1\fR for yes (default) and \fB0\fR for no.
 .RE
 
 .sp


### PR DESCRIPTION
The default was changed in #2820.