### PR TITLE
Linux 3.18 compat: Snapshot automounting

### DIFF
--- a/module/zfs/zpl_ctldir.c
+++ b/module/zfs/zpl_ctldir.c
@@ -160,19 +160,9 @@ const struct inode_operations zpl_ops_root = {
 static struct vfsmount *
 zpl_snapdir_automount(struct path *path)
 {
-	struct dentry *dentry = path->dentry;
 	int error;
 
-	/*
-	 * We must briefly disable automounts for this dentry because the
-	 * user space mount utility will trigger another lookup on this
-	 * directory.  That will result in zpl_snapdir_automount() being
-	 * called repeatedly.  The DCACHE_NEED_AUTOMOUNT flag can be
-	 * safely reset once the mount completes.
-	 */
-	dentry->d_flags &= ~DCACHE_NEED_AUTOMOUNT;
 	error = -zfsctl_mount_snapshot(path, 0);
-	dentry->d_flags |= DCACHE_NEED_AUTOMOUNT;
 	if (error)
 		return (ERR_PTR(error));
 
@@ -188,8 +178,10 @@ zpl_snapdir_automount(struct path *path)
 #endif /* HAVE_AUTOMOUNT */
 
 /*
- * Revalidate any dentry in the snapshot directory on lookup, since a snapshot
- * having the same name have been created or destroyed since it was cached.
+ * Negative dentries must always be revalidated so newly created snapshots
+ * can be detected and automounted.  Normal dentries should be kept because
+ * as of the 3.18 kernel revaliding the mountpoint dentry will result in
+ * the snapshot being immediately unmounted.
  */
 static int
 #ifdef HAVE_D_REVALIDATE_NAMEIDATA
@@ -198,7 +190,7 @@ zpl_snapdir_revalidate(struct dentry *dentry, struct nameidata *i)
 zpl_snapdir_revalidate(struct dentry *dentry, unsigned int flags)
 #endif
 {
-	return (0);
+	return (!!dentry->d_inode);
 }
 
 dentry_operations_t zpl_dops_snapdirs = {
@@ -245,6 +237,7 @@ zpl_snapdir_lookup(struct inode *dip, struct dentry *dentry,
 	ASSERT(error == 0 || ip == NULL);
 	d_clear_d_op(dentry);
 	d_set_d_op(dentry, &zpl_dops_snapdirs);
+	dentry->d_flags |= DCACHE_NEED_AUTOMOUNT;
 
 	return (d_splice_alias(ip, dentry));
 }

--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -224,20 +224,8 @@ zpl_rmdir(struct inode * dir, struct dentry *dentry)
 static int
 zpl_getattr(struct vfsmount *mnt, struct dentry *dentry, struct kstat *stat)
 {
-	boolean_t issnap = ITOZSB(dentry->d_inode)->z_issnap;
 	int error;
 	fstrans_cookie_t cookie;
-
-	/*
-	 * Ensure MNT_SHRINKABLE is set on snapshots to ensure they are
-	 * unmounted automatically with the parent file system.  This
-	 * is done on the first getattr because it's not easy to get the
-	 * vfsmount structure at mount time.  This call path is explicitly
-	 * marked unlikely to avoid any performance impact.  FWIW, ext4
-	 * resorts to a similar trick for sysadmin convenience.
-	 */
-	if (unlikely(issnap && !(mnt->mnt_flags & MNT_SHRINKABLE)))
-		mnt->mnt_flags |= MNT_SHRINKABLE;
 
 	cookie = spl_fstrans_mark();
 	error = -zfs_getattr_fast(dentry->d_inode, stat);


### PR DESCRIPTION
Commit torvalds/linux@bafc9b7 caused snapshots automounted by ZFS to
be immediately unmounted when the dentry was revalidated.  This was
a consequence of ZFS invaliding all snapdir dentries to ensure that
negative dentries didn't mask new snapshots.  This patch modifies the
behavior such that only negative dentries are invalidated.  This solves
the issue and may result in a performance improvement.

In addition, the MNT_SHRINKABLE flag is now set after the automount
succeeds by travesing down in to the snapshot.  This is much cleaner
than being forced to do it post in a getattr.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3030