### PR TITLE
Memory leak in make_root_vdev()

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -1699,8 +1699,10 @@ make_root_vdev(zpool_handle_t *zhp, nvlist_t *props, int force, int check_rep,
 	if ((newroot = construct_spec(props, argc, argv)) == NULL)
 		return (NULL);
 
-	if (zhp && ((poolconfig = zpool_get_config(zhp, NULL)) == NULL))
+	if (zhp && ((poolconfig = zpool_get_config(zhp, NULL)) == NULL)) {
+		nvlist_free(newroot);
 		return (NULL);
+	}
 
 	/*
 	 * Validate each device to make sure that its not shared with another


### PR DESCRIPTION
The newroot nvlist should be freed before returning.

Signed-off-by: Isaac Huang <he.huang@intel.com>
Closes #3264