### PR TITLE
Remove unused 'dsl_pool_t *dp' variable

### DIFF
--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -875,9 +875,8 @@ dmu_send_estimate(dsl_dataset_t *ds, dsl_dataset_t *fromds, uint64_t *sizep)
 {
 	int err;
 	uint64_t size;
-	ASSERTV(dsl_pool_t *dp = ds->ds_dir->dd_pool);
 
-	ASSERT(dsl_pool_config_held(dp));
+	ASSERT(dsl_pool_config_held(ds->ds_dir->dd_pool));
 
 	/* tosnap must be a snapshot */
 	if (!ds->ds_is_snapshot)
@@ -930,11 +929,10 @@ int
 dmu_send_estimate_from_txg(dsl_dataset_t *ds, uint64_t from_txg,
     uint64_t *sizep)
 {
-	dsl_pool_t *dp = ds->ds_dir->dd_pool;
 	int err;
 	uint64_t size = 0;
 
-	ASSERT(dsl_pool_config_held(dp));
+	ASSERT(dsl_pool_config_held(ds->ds_dir->dd_pool));
 
 	/* tosnap must be a snapshot */
 	if (!dsl_dataset_is_snapshot(ds))


### PR DESCRIPTION
When ASSERTs are compiled out by using the --disable-debug configure
option.  Then the local variable 'dsl_pool_t *dp' will be unused and
generate a compiler warning.  Since this variable is only used once
in the ASSERT replace it with 'ds->ds_dir->dd_pool'.

This has the additional advantage of potentially saving a few bytes
on the stack depending on how gcc decides to compile the function.

This issue was not noticed immediately because the automated builders
use --enable-debug to make the testing as rigorous as possible.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>