### PR TITLE
Relax restriction on zfs_ioc_next_obj iteration over objects.

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4724,8 +4724,7 @@ zfs_ioc_next_obj(zfs_cmd_t *zc)
 	if (error != 0)
 		return (error);
 
-	error = dmu_object_next(os, &zc->zc_obj, B_FALSE,
-	    dsl_dataset_phys(os->os_dsl_dataset)->ds_prev_snap_txg);
+	error = dmu_object_next(os, &zc->zc_obj, B_FALSE, 0);
 
 	dmu_objset_rele(os, FTAG);
 	return (error);


### PR DESCRIPTION
Addresses #2081 by not requiring the object returned by dmu_object_next to have been created or modified since the first transaction (it just need only have been _deleted_).