### PR TITLE
The mount helper mount.zfs MUST be in /sbin (not '$sbindir').

### DIFF
--- a/config/mount-helper.m4
+++ b/config/mount-helper.m4
@@ -2,7 +2,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_MOUNT_HELPER], [
 	AC_ARG_WITH(mounthelperdir,
 		AC_HELP_STRING([--with-mounthelperdir=DIR],
 		[install mount.zfs in dir [[/sbin]]]),
-		mounthelperdir=$withval,mounthelperdir=$sbindir)
+		mounthelperdir=$withval,mounthelperdir=/sbin)
 
 	AC_SUBST(mounthelperdir)
 ])


### PR DESCRIPTION
Make sure that <code>mounthelperdir</code> is set to <code>/sbin</code> (not <code>$sbindir</code>) as default (unless specified on the <code>configure</code> command line with <code>--with-mounthelperdir</code>).

Example: If <code>--prefix=/usr/local/ZoL</code> is specified, then <code>mount.zfs</code> would be installed into <code>/usr/local/ZoL/sbin</code>, which won't work.