### PR TITLE
Add new zvol property 'volmode'

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -155,6 +155,7 @@ typedef enum {
 	ZFS_PROP_RELATIME,
 	ZFS_PROP_REDUNDANT_METADATA,
 	ZFS_PROP_OVERLAY,
+	ZFS_PROP_VOLMODE,
 	ZFS_NUM_PROPS
 } zfs_prop_t;
 
@@ -352,6 +353,13 @@ typedef enum {
 	ZFS_SYNC_ALWAYS = 1,
 	ZFS_SYNC_DISABLED = 2
 } zfs_sync_type_t;
+
+typedef enum {
+	ZFS_VOLMODE_DEFAULT = 0,
+	ZFS_VOLMODE_GEOM = 1,
+	ZFS_VOLMODE_DEV = 2,
+	ZFS_VOLMODE_NONE = 3
+} zfs_volmode_t;
 
 typedef enum {
 	ZFS_XATTR_OFF = 0,

--- a/include/sys/zvol.h
+++ b/include/sys/zvol.h
@@ -46,6 +46,7 @@ extern void zvol_rename_minors(const char *oldname, const char *newname);
 extern int zvol_set_volsize(const char *, uint64_t);
 extern int zvol_set_volblocksize(const char *, uint64_t);
 extern int zvol_set_snapdev(const char *, uint64_t);
+extern int zvol_set_volmode(const char *, uint64_t);
 
 extern int zvol_init(void);
 extern void zvol_fini(void);

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1356,6 +1356,17 @@ Though not recommended, a "sparse volume" (also known as "thin provisioning") ca
 .ne 2
 .mk
 .na
+\fB\fBvolmode\fR=\fBdefault\fR | \fBgeom\fR |  | \fBdev\fR | \fBnone\fR\fR
+.ad
+.sp .6
+.RS 4n
+Controls how volumes are exposed to the OS. Setting the volume to \fBnone\fB will prevent the volume from being exposed outside of ZFS.
+.RE
+
+.sp
+.ne 2
+.mk
+.na
 \fB\fBvscan\fR=\fBon\fR | \fBoff\fR\fR
 .ad
 .sp .6

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -202,6 +202,14 @@ zfs_prop_init(void)
 		{ NULL }
 	};
 
+	static zprop_index_t volmode_table[] = {
+		{ "default",	ZFS_VOLMODE_DEFAULT },
+		{ "geom",		ZFS_VOLMODE_GEOM },
+		{ "dev",		ZFS_VOLMODE_DEV },
+		{ "none",		ZFS_VOLMODE_NONE },
+		{ NULL }
+	};
+
 	static zprop_index_t xattr_table[] = {
 		{ "off",	ZFS_XATTR_OFF },
 		{ "on",		ZFS_XATTR_DIR },
@@ -226,6 +234,10 @@ zfs_prop_init(void)
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "standard | always | disabled", "SYNC",
 	    sync_table);
+	zprop_register_index(ZFS_PROP_VOLMODE, "volmode",
+	    ZFS_VOLMODE_DEFAULT, PROP_INHERIT,
+	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
+	    "default | geom | dev | none", "VOLMODE", volmode_table);
 	zprop_register_index(ZFS_PROP_CHECKSUM, "checksum",
 	    ZIO_CHECKSUM_DEFAULT, PROP_INHERIT, ZFS_TYPE_FILESYSTEM |
 	    ZFS_TYPE_VOLUME,

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2443,6 +2443,9 @@ zfs_prop_set_special(const char *dsname, zprop_source_t source,
 	case ZFS_PROP_VOLSIZE:
 		err = zvol_set_volsize(dsname, intval);
 		break;
+	case ZFS_PROP_VOLMODE:
+		err = zvol_set_volmode(dsname, intval);
+		break;
 	case ZFS_PROP_SNAPDEV:
 		err = zvol_set_snapdev(dsname, intval);
 		break;


### PR DESCRIPTION
Adds a new zvol property modeled after the snapdev property that
will inhibit the creation of the zvol device itself. The property
is independent from snapdev allowing you to have zvols hidden while
the snapshots are visible.

I found myself creating thousands of sparse clones for a research project, and while ZFS handles it like a champ, I found the resulting number of devices being created would cause issues with udev, systemd and other applications.  While I only ever need access to a handful of the devices at any given time, I prefer they remain in the pool for instant accessibility in the future.   I only found a kernel option called zvol_inhibit_dev that applies to all volumes globally, so I went ahead and created a per-zvol property based on that and the code used in the snapdev property. 