### PR TITLE
Use ExecStartPre to load zfs modules

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -9,4 +9,5 @@ ConditionPathExists=@sysconfdir@/zfs/zpool.cache
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/sbin/modprobe zfs && @sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
+ExecStartPre=/sbin/modprobe zfs
+ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -9,4 +9,5 @@ ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/sbin/modprobe zfs && @sbindir@/zpool import -d /dev/disk/by-id -aN
+ExecStartPre=/sbin/modprobe zfs
+ExecStart=@sbindir@/zpool import -d /dev/disk/by-id -aN


### PR DESCRIPTION
Commit 87abfcb broke the systemd import service by treating the
ExecStart line as if it were a shell command that could be executed.
This isn't the way systemd works and the correct way to handle this
case is with ExecStartPre.  This patch updates the zfs import service
files accordingly,

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3440