### PR TITLE
dmu_objset_userquota_get_ids uses dn_bonus unsafely

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2251,7 +2251,7 @@ dbuf_try_add_ref(dmu_buf_t *db_fake, objset_t *os, uint64_t obj, uint64_t blkid,
 	dmu_buf_impl_t *found_db;
 	boolean_t result = B_FALSE;
 
-	if (db->db_blkid == DMU_BONUS_BLKID)
+	if (blkid == DMU_BONUS_BLKID)
 		found_db = dbuf_find_bonus(os, obj);
 	else
 		found_db = dbuf_find(os, obj, 0, blkid);
@@ -2261,7 +2261,7 @@ dbuf_try_add_ref(dmu_buf_t *db_fake, objset_t *os, uint64_t obj, uint64_t blkid,
 			(void) refcount_add(&db->db_holds, tag);
 			result = B_TRUE;
 		}
-		mutex_exit(&db->db_mtx);
+		mutex_exit(&found_db->db_mtx);
 	}
 	return (result);
 }

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1314,6 +1314,7 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 	int flags = dn->dn_id_flags;
 	int error;
 	boolean_t have_spill = B_FALSE;
+	boolean_t have_bonus = B_FALSE;
 
 	if (!dmu_objset_userused_enabled(dn->dn_objset))
 		return;
@@ -1325,8 +1326,21 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 	if (before && dn->dn_bonuslen != 0)
 		data = DN_BONUS(dn->dn_phys);
 	else if (!before && dn->dn_bonuslen != 0) {
-		if (dn->dn_bonus) {
-			db = dn->dn_bonus;
+		db = dn->dn_bonus;
+		if (db != NULL) {
+			if (!RW_WRITE_HELD(&dn->dn_struct_rwlock)) {
+				have_bonus = dbuf_try_add_ref((dmu_buf_t *)db,
+				    dn->dn_objset, dn->dn_object,
+				    DMU_BONUS_BLKID, FTAG);
+
+				/*
+				 * The hold will fail if the buffer is
+				 * being evicted due to unlink, in which
+				 * case nothing needs to be done.
+				 */
+				if (!have_bonus)
+					return;
+			}
 			mutex_enter(&db->db_mtx);
 			data = dmu_objset_userquota_find_data(db, tx);
 		} else {
@@ -1401,7 +1415,7 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 		dn->dn_id_flags |= DN_ID_CHKED_BONUS;
 	}
 	mutex_exit(&dn->dn_mtx);
-	if (have_spill)
+	if (have_spill || have_bonus)
 		dmu_buf_rele((dmu_buf_t *)db, FTAG);
 }
 


### PR DESCRIPTION
The function dmu_objset_userquota_get_ids() checks and uses dn->dn_bonus
outside of dn_struct_rwlock. If the dnode is beeing freed then the bonus
dbuf may be in process of getting evicted. In this case there is a race
that may cause dmu_objset_userquota_get_ids() to access the dbuf after
it has been destroyed. To prevent this, ensure that we are either
holding dn_struct_rwlock or a reference to the bonus dbuf when calling
dmu_objset_userquota_get_ids(). Rename dmu_objset_userquota_get_ids()
with an _impl suffix and add a wrapper function take a reference on the
bonus dbuf (if needed) before calling it. This was done to keep the code
changes simple.

Secondly, make a small change to dbuf_try_add_ref(). It checks
db->db_blkid which may not be safe since it doesn't yet have a hold on
the dbuf. Use the blkid argument instead.

Signed-off-by: Ned Bass <bass6@llnl.gov>
Issue #3443