### PR TITLE
Change the order of the function library check/load.

### DIFF
--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -15,7 +15,7 @@ EXTRA_DIST = \
 	$(top_srcdir)/etc/init.d/zfs-zed.in \
 	$(top_srcdir)/etc/init.d/zfs.in
 
-$(init_SCRIPTS) $(initconf_SCRIPTS) $(initcommon_SCRIPTS):
+$(init_SCRIPTS) $(initconf_SCRIPTS) $(initcommon_SCRIPTS): $(EXTRA_DIST)
 	-(if [ -e /etc/debian_version ]; then \
 		NFS_SRV=nfs-kernel-server; \
 	  else \

--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -13,15 +13,15 @@
 PATH=/sbin:/bin:/usr/bin:/usr/sbin
 
 # Source function library
-if [ -f /lib/lsb/init-functions ]; then
-	# LSB, Debian GNU/Linux and derivates
-	. /lib/lsb/init-functions
-elif [ -f /etc/rc.d/init.d/functions ]; then
+if [ -f /etc/rc.d/init.d/functions ]; then
 	# RedHat and derivates
 	. /etc/rc.d/init.d/functions
 elif [ -L /etc/init.d/functions.sh ]; then
 	# Gentoo
 	. /etc/init.d/functions.sh
+elif [ -f /lib/lsb/init-functions ]; then
+	# LSB, Debian GNU/Linux and derivates
+	. /lib/lsb/init-functions
 fi
 
 # Of course the functions we need are called differently
@@ -373,7 +373,8 @@ read_mtab()
 
 	while read -r fs mntpnt fstype opts rest; do
 		if echo "$fs $mntpnt $fstype $opts" | grep -qE "$match"; then
-			mntpnt=$(printf '%b\n' "$mntpnt" | sed 's,/,_,g')
+			mntpnt=$(printf '%b\n' "$mntpnt" | sed -e 's,/,_,g' \
+			    -e 's,-,_,g' -e 's,\.,_,g')
 			eval export MTAB_$mntpnt="$fs"
 		fi
 	done < /proc/mounts

--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -88,13 +88,13 @@ do_import()
 			# make sure we're able to actually import it/them later.
 			USE_DISK_BY_ID='yes'
 
-			# Filter out duplicates (pools found with the simpl
-			# "zpool import" but which is also found with the
-			# "zpool import -d ...").
-			npools=$(echo "$npools" | sed "s,$available_pools,,")
-
 			if [ -n "$available_pools" ]
 			then
+				# Filter out duplicates (pools found with the simpl
+				# "zpool import" but which is also found with the
+				# "zpool import -d ...").
+				npools=$(echo "$npools" | sed "s,$available_pools,,")
+
 				# Add the list to the existing list of
 				# available pools
 				available_pools="$available_pools;$npools"
@@ -141,14 +141,22 @@ do_import()
 	if [ -n "$USE_DISK_BY_ID" -a -z "$ZPOOL_IMPORT_PATH" ]
 	then
 		local dirs
-		dirs="$(find /dev/disk/by-* -maxdepth 0 -type d | \
-			grep -v by-vdev)"
-		dirs="$(echo "$dirs" | sed 's, ,:,g')"
+		dirs="$(for dir in $(echo /dev/disk/by-*)
+		do
+			# Ignore by-vdev here - we wan't it first!
+			echo "$dir" | grep -q /by-vdev && continue
+			[ ! -d "$dir" ] && continue
+
+			echo -n "$dir:"
+		done | sed 's,:$,,g')"
+
 		if [ -d "/dev/disk/by-vdev" ]
 		then
 			# Add by-vdev at the beginning.
 			ZPOOL_IMPORT_PATH="/dev/disk/by-vdev:"
 		fi
+
+		# ... and /dev at the very end, just for good measure.
 		ZPOOL_IMPORT_PATH="$ZPOOL_IMPORT_PATH$dirs:/dev"
 	fi
 

--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -33,6 +33,17 @@
 
 # ----------------------------------------------------
 
+chkroot() {
+	while read line; do
+		set -- $line
+		if [ "$2" = "/" ]; then
+			return 0
+		fi
+	done < /etc/mtab
+
+	return 1
+}
+
 do_depend()
 {
 	after procfs zfs-import sysfs procps
@@ -166,9 +177,7 @@ do_start()
 
 	# Ensure / exists in /etc/mtab, if not update mtab accordingly.
 	# This should be handled by rc.sysinit but lets be paranoid.
-	awk '$2 = "/" { exit 1 }' /etc/mtab
-	RETVAL=$?
-	if [ "$RETVAL" -eq 0 ]
+	if ! chkroot
 	then
 		mount -f /
 	fi


### PR DESCRIPTION
* Change the order of the function library check/load.
  Redhat based system _can_ have a /lib/lsb/init-functions file (from
  the redhat-lsb-core package), but it's only partially what we can use.
  Instead, look for that file last, giving the script a chance to catch
  the 'real' distribution file.
* Filter out dashes in dataset name in read_mtab().

Signed-off-by: Turbo Fredriksson turbo@bayour.com
Closes #3463