### PR TITLE
Wait interruptibly in prefetch thread

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -349,8 +349,8 @@ extern clock_t cv_timedwait_hires(kcondvar_t *cvp, kmutex_t *mp, hrtime_t tim,
     hrtime_t res, int flag);
 extern void cv_signal(kcondvar_t *cv);
 extern void cv_broadcast(kcondvar_t *cv);
-#define	cv_timedwait_interruptible(cv, mp, at)	cv_timedwait(cv, mp, at)
-#define	cv_wait_interruptible(cv, mp)		cv_wait(cv, mp)
+#define	cv_timedwait_sig(cv, mp, at)		cv_timedwait(cv, mp, at)
+#define	cv_wait_sig(cv, mp)			cv_wait(cv, mp)
 #define	cv_wait_io(cv, mp)			cv_wait(cv, mp)
 
 /*

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3077,7 +3077,7 @@ arc_adapt_thread(void)
 
 		/* block until needed, or one second, whichever is shorter */
 		CALLB_CPR_SAFE_BEGIN(&cpr);
-		(void) cv_timedwait_interruptible(&arc_reclaim_thread_cv,
+		(void) cv_timedwait_sig(&arc_reclaim_thread_cv,
 		    &arc_reclaim_lock, (ddi_get_lbolt() + hz));
 		CALLB_CPR_SAFE_END(&cpr, &arc_reclaim_lock);
 
@@ -3142,7 +3142,7 @@ arc_user_evicts_thread(void)
 		 * call the arc's kstat update function regularly).
 		 */
 		CALLB_CPR_SAFE_BEGIN(&cpr);
-		(void) cv_timedwait_interruptible(&arc_user_evicts_cv,
+		(void) cv_timedwait_sig(&arc_user_evicts_cv,
 		    &arc_user_evicts_lock, ddi_get_lbolt() + hz);
 		CALLB_CPR_SAFE_END(&cpr, &arc_user_evicts_lock);
 	}
@@ -6175,7 +6175,7 @@ l2arc_feed_thread(void)
 	cookie = spl_fstrans_mark();
 	while (l2arc_thread_exit == 0) {
 		CALLB_CPR_SAFE_BEGIN(&cpr);
-		(void) cv_timedwait_interruptible(&l2arc_feed_thr_cv,
+		(void) cv_timedwait_sig(&l2arc_feed_thr_cv,
 		    &l2arc_feed_thr_lock, next);
 		CALLB_CPR_SAFE_END(&cpr, &l2arc_feed_thr_lock);
 		next = ddi_get_lbolt() + hz;

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -250,7 +250,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		mutex_enter(&pd->pd_mtx);
 		ASSERT(pd->pd_bytes_fetched >= 0);
 		while (pd->pd_bytes_fetched < size && !pd->pd_exited)
-			cv_wait(&pd->pd_cv, &pd->pd_mtx);
+			cv_wait_sig(&pd->pd_cv, &pd->pd_mtx);
 		pd->pd_bytes_fetched -= size;
 		cv_broadcast(&pd->pd_cv);
 		mutex_exit(&pd->pd_mtx);
@@ -459,7 +459,7 @@ traverse_prefetcher(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 
 	mutex_enter(&pfd->pd_mtx);
 	while (!pfd->pd_cancel && pfd->pd_bytes_fetched >= zfs_pd_bytes_max)
-		cv_wait(&pfd->pd_cv, &pfd->pd_mtx);
+		cv_wait_sig(&pfd->pd_cv, &pfd->pd_mtx);
 	pfd->pd_bytes_fetched += BP_GET_LSIZE(bp);
 	cv_broadcast(&pfd->pd_cv);
 	mutex_exit(&pfd->pd_mtx);
@@ -571,7 +571,7 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 	pd->pd_cancel = B_TRUE;
 	cv_broadcast(&pd->pd_cv);
 	while (!pd->pd_exited)
-		cv_wait(&pd->pd_cv, &pd->pd_mtx);
+		cv_wait_sig(&pd->pd_cv, &pd->pd_mtx);
 	mutex_exit(&pd->pd_mtx);
 
 	mutex_destroy(&pd->pd_mtx);

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -676,7 +676,7 @@ zfs_zevent_wait(zfs_zevent_t *ze)
 	}
 
 	zevent_waiters++;
-	cv_wait_interruptible(&zevent_cv, &zevent_lock);
+	cv_wait_sig(&zevent_cv, &zevent_lock);
 	if (issig(JUSTLOOKING))
 		error = EINTR;
 

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -242,10 +242,10 @@ txg_thread_wait(tx_state_t *tx, callb_cpr_t *cpr, kcondvar_t *cv, clock_t time)
 	CALLB_CPR_SAFE_BEGIN(cpr);
 
 	if (time)
-		(void) cv_timedwait_interruptible(cv, &tx->tx_sync_lock,
+		(void) cv_timedwait_sig(cv, &tx->tx_sync_lock,
 		    ddi_get_lbolt() + time);
 	else
-		cv_wait_interruptible(cv, &tx->tx_sync_lock);
+		cv_wait_sig(cv, &tx->tx_sync_lock);
 
 	CALLB_CPR_SAFE_END(cpr, &tx->tx_sync_lock);
 }


### PR DESCRIPTION
The Linux kernel watchdog will automatically dump a backtrace for
any process while sleeps for over 120s in an uninterruptible state.

The solution is for the prefetch thread to sleep in an interruptible
state.  The way the existing code was written this is safe because
when woken it will always reevaluate its conditional.  As a general
rule it is preferable to sleep in an interruptible when possible.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>