### PR TITLE
Additional SYSV init script fixes.

### DIFF
--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -371,13 +371,16 @@ read_mtab()
 	# Unset all MTAB_* variables
 	unset $(env | grep ^MTAB_ | sed 's,=.*,,')
 
-	while read -r fs mntpnt fstype opts rest; do
-		if echo "$fs $mntpnt $fstype $opts" | grep -qE "$match"; then
-			mntpnt=$(printf '%b\n' "$mntpnt" | sed -e 's,/,_,g' \
-			    -e 's,-,_,g' -e 's,\.,_,g')
-			eval export MTAB_$mntpnt="$fs"
-		fi
-	done < /proc/mounts
+	mount | \
+	    grep -E "$match" | \
+	    sed "s,\(.*\) on \(.*\) type .*,\1;\2," | \
+	    while read line; do
+		mntpnt=$(echo "$line" | sed -e 's,;.*,,' -e 's,/,_,g' \
+		    -e 's,-,_,g' -e 's,\.,_,g' -e 's, ,_,g')
+		fs=$(echo "$line" | sed 's,.*;,,')
+
+		eval export MTAB_$mntpnt="'$fs'"
+	done
 }
 
 in_mtab()


### PR DESCRIPTION
Additional SYSV init script fixes.
    
Use the 'mount' command instead of /proc/mounts to get a list of matching filesystems.
    
This because there seems to be a ... "problem" with /proc/mounts in that it records a pool with a space ("rpool 1") as "rpool\0401". This seems to be an invalid HEX value for 'printf "%b"' which we use to filter out other illegal characters (such as slash, space etc which can't be used in the variable name).
We get a ^A instead of the space we expected. The correct value should have been "rpool\00401" (an additional zero).
    
So use 'mount', which interprets all backslash-escapes correctly, instead.
    
Signed-off-by: Turbo Fredriksson turbo@bayour.com
Closes #3488