### PR TITLE
[buildbot crunching] Illumos-5175 implement dmu_read_uio_dbuf() to improve cached read performance

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -714,6 +714,7 @@ int dmu_read_req(objset_t *os, uint64_t object, struct request *req);
 int dmu_write_req(objset_t *os, uint64_t object, struct request *req,
 	dmu_tx_t *tx);
 int dmu_read_uio(objset_t *os, uint64_t object, struct uio *uio, uint64_t size);
+int dmu_read_uio_dbuf(dmu_buf_t *zdb, struct uio *uio, uint64_t size);
 int dmu_write_uio(objset_t *os, uint64_t object, struct uio *uio, uint64_t size,
 	dmu_tx_t *tx);
 int dmu_write_uio_dbuf(dmu_buf_t *zdb, struct uio *uio, uint64_t size,

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -376,7 +376,6 @@ mappedread(struct inode *ip, int nbytes, uio_t *uio)
 	struct address_space *mp = ip->i_mapping;
 	struct page *pp;
 	znode_t *zp = ITOZ(ip);
-	objset_t *os = ITOZSB(ip)->z_os;
 	int64_t	start, off;
 	uint64_t bytes;
 	int len = nbytes;
@@ -403,7 +402,8 @@ mappedread(struct inode *ip, int nbytes, uio_t *uio)
 			unlock_page(pp);
 			page_cache_release(pp);
 		} else {
-			error = dmu_read_uio(os, zp->z_id, uio, bytes);
+			error = dmu_read_uio_dbuf(sa_get_db(zp->z_sa_hdl),
+			    uio, bytes);
 		}
 
 		len -= bytes;
@@ -440,7 +440,6 @@ zfs_read(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 {
 	znode_t		*zp = ITOZ(ip);
 	zfs_sb_t	*zsb = ITOZSB(ip);
-	objset_t	*os;
 	ssize_t		n, nbytes;
 	int		error = 0;
 	rl_t		*rl;
@@ -450,7 +449,6 @@ zfs_read(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 
 	ZFS_ENTER(zsb);
 	ZFS_VERIFY_ZP(zp);
-	os = zsb->z_os;
 
 	if (zp->z_pflags & ZFS_AV_QUARANTINED) {
 		ZFS_EXIT(zsb);
@@ -531,10 +529,12 @@ zfs_read(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 		nbytes = MIN(n, zfs_read_chunk_size -
 		    P2PHASE(uio->uio_loffset, zfs_read_chunk_size));
 
-		if (zp->z_is_mapped && !(ioflag & O_DIRECT))
+		if (zp->z_is_mapped && !(ioflag & O_DIRECT)) {
 			error = mappedread(ip, nbytes, uio);
-		else
-			error = dmu_read_uio(os, zp->z_id, uio, nbytes);
+		} else {
+			error = dmu_read_uio_dbuf(sa_get_db(zp->z_sa_hdl),
+			    uio, nbytes);
+		}
 
 		if (error) {
 			/* convert checksum errors into IO errors */


### PR DESCRIPTION
On a synthetic benchmark of cached reads of 8k blocks, lots of time is spent
holding the dnode. We should implement and use a dmu_read_uio_dbuf() that
takes the dbuf rather than the object ID, analogous to dmu_write_uio_dbuf().

Tests show that this results in a ~10% performance improvement.

Reviewed by: Adam Leventhal <ahl@delphix.com>
Reviewed by: Alex Reece <alex.reece@delphix.com>
Reviewed by: George Wilson <george@delphix.com>
Reviewed by: Richard Elling <richard.elling@gmail.com>
Approved by: Robert Mustacchi <rm@joyent.com>

Porting notes:

Rather difficult to track changes mainly related due to:

https://github.com/zfsonlinux/zfs/commit/428870ff734fdaccc342b33fc53cf94724409a46 Update core ZFS code from build 121 to build 141
https://github.com/zfsonlinux/zfs/commit/3558fd73b5d863304102f6745c26e0b592aca60a Prototype/structure update for Linux

References:

https://www.illumos.org/issues/5175
https://github.com/illumos/illumos-gate/commit/f8554bb92be6be88a684bea58293b41a6168a538

Ported by: kernelOfTruth kerneloftruth@gmail.com