### PR TITLE
Additional SYSV init script fixes (3).

### DIFF
--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -371,16 +371,13 @@ read_mtab()
 	# Unset all MTAB_* variables
 	unset $(env | grep ^MTAB_ | sed 's,=.*,,')
 
-	mount | \
-	    grep -E "$match" | \
-	    sed "s,\(.*\) on \(.*\) type .*,\1;\2," | \
-	    while read line; do
-		mntpnt=$(echo "$line" | sed -e 's,;.*,,' -e 's,/,_,g' \
-		    -e 's,-,_,g' -e 's,\.,_,g' -e 's, ,_,g')
-		fs=$(echo "$line" | sed 's,.*;,,')
-
-		eval export MTAB_$mntpnt="'$fs'"
-	done
+	while read -r fs mntpnt fstype opts rest; do
+		if echo "$fs $mntpnt $fstype $opts" | grep -qE "$match"; then
+			mntpnt=$(printf '%b\n' "$mntpnt" | sed -e 's,/,_,g' \
+			    -e 's,-,_,g' -e 's,\.,_,g')
+			eval export MTAB_$mntpnt="$fs"
+		fi
+	done < /proc/mounts
 }
 
 in_mtab()

--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -68,7 +68,7 @@ elif type einfo > /dev/null 2>&1 ; then
 	# Gentoo functions
 	zfs_log_begin_msg() { ebegin "$1"; }
 	zfs_log_end_msg() { eend "$1"; }
-	zfs_log_failure_msg() { eerror "$1"; }
+	zfs_log_failure_msg() { eend "$1"; }
 #	zfs_log_progress_msg() { echo -n "$1"; }
 	zfs_log_progress_msg() { echo -n; }
 else
@@ -304,42 +304,6 @@ checksystem()
 	return 0
 }
 
-reregister_mounts()
-{
-	local fs mntpnt fstype opts rest tmpdir
-	tmpdir=removethismountpointhoweverpossible
-
-	while read -r fs mntpnt fstype opts rest ; do
-		fs=$(printf '%b\n' "$fs")
-		mntpnt=$(printf '%b\n' "$mntpnt")
-		if [ "$fstype" = "zfs" ] ; then
-			if [ "$mntpnt" = "/" ] ; then
-				mount -f -o zfsutil -t zfs --move / /$tmpdir
-				umount --fake /$tmpdir
-			else
-				umount --fake "$mntpnt"
-			fi
-		elif echo "$fs" | grep -qE "^/dev/(zd|zvol)" ; then
-			if [ "$mntpnt" = "/" ] ; then
-				mount -f -t "$fstype" --move / /$tmpdir
-				umount --fake /$tmpdir
-			else
-				umount --fake "$mntpnt"
-			fi
-		fi
-	done < /proc/mounts
-
-	while read -r fs mntpnt fstype opts rest ; do
-		fs=$(printf '%b\n' "$fs")
-		mntpnt=$(printf '%b\n' "$mntpnt")
-		if [ "$fstype" = "zfs" ] ; then
-			mount -f -t zfs -o zfsutil "$fs" "$mntpnt"
-		elif echo "$fs" | grep -q "^/dev/zd" ; then
-			mount -f -t "$fstype" -o "$opts" "$fs" "$mntpnt"
-		fi
-	done < /proc/mounts
-}
-
 get_root_pool()
 {
 	set -- $(mount | grep ' on / ')
@@ -373,9 +337,23 @@ read_mtab()
 
 	while read -r fs mntpnt fstype opts rest; do
 		if echo "$fs $mntpnt $fstype $opts" | grep -qE "$match"; then
+			# * Fix problems (!?) in the mounts file. It will record
+			#   'rpool 1' as 'rpool\0401' instead of 'rpool\00401'
+			#   which seems to be the correct (at least as far as
+			#   'printf' is concerned).
+			# * We need to use the external echo, because the
+			#   internal one would interpret the backslash code
+			#   (incorrectly), giving us a  instead.
+			mntpnt=$(/bin/echo "$mntpnt" | sed "s,\\\0,\\\00,")
+			fs=$(/bin/echo "$fs" | sed "s,\\\0,\\\00,")
+
+			# Replace 'unwanted' characters with underscore.
 			mntpnt=$(printf '%b\n' "$mntpnt" | sed -e 's,/,_,g' \
-			    -e 's,-,_,g' -e 's,\.,_,g')
-			eval export MTAB_$mntpnt="$fs"
+			    -e 's,-,_,g' -e 's,\.,_,g' -e 's, ,_,g')
+			fs=$(printf '%b\n' "$fs")
+
+			# Set the variable.
+			eval export MTAB_$mntpnt=\"$fs\"
 		fi
 	done < /proc/mounts
 }

--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -165,15 +165,11 @@ do_start()
 {
 	check_module_loaded || exit 0
 
-	# fix mtab to include already-mounted fs filesystems, in case there are any
-	# we ONLY do this if mtab does not point to /proc/mounts
-	# which is the case in some systems (systemd may bring that soon)
-	if ! readlink /etc/mtab | grep -q /proc ; then
-		if grep -qE "(^/dev/zd|^/dev/zvol| zfs )" /proc/mounts ; then
-			zfs_action "Registering already-mounted ZFS filesystems and volumes" \
-			    reregister_mounts
-		fi
-	fi
+	case "$ZFS_MOUNT" in
+		[Oo][Ff][Ff]|[Nn][Oo]|''|0)
+			exit 3
+			;;
+	esac
 
 	# Ensure / exists in /etc/mtab, if not update mtab accordingly.
 	# This should be handled by rc.sysinit but lets be paranoid.
@@ -181,12 +177,6 @@ do_start()
 	then
 		mount -f /
 	fi
-
-	case "$ZFS_MOUNT" in
-		[Oo][Ff][Ff]|[Nn][Oo]|''|0)
-			exit 3
-			;;
-	esac
 
 	do_mount
 }


### PR DESCRIPTION
Because #3509 came just after this commit was accepted and is related to the original problem the commit was supposed to fix, we need to solve the problem in another way.

* Revert "Additional SYSV init script fixes" (commit 036391c980c1e6504352b770eb385806a951b1cb).
* In read_mtab(), fix problems (!?) in the mounts file. It will record 'rpool 1' as 'rpool\0401' instead of 'rpool\00401' which seems to be the correct (at least as far as 'printf' is concerned). Use this using the external 'echo' command (and not the one built in to the shell) because the internal one would interpret the backslash code (incorrectly), giving us a ^A instead.
* In reregister_mounts(), the mount command options differ depending on if we're remounting is a legacy or native Z filesystem.
    
Signed-off-by: Turbo Fredriksson turbo@bayour.com
Closes #3488
Closes #3509