### PR TITLE
Add Vagrantfile to contrib directory

### DIFF
--- a/contrib/vagrant-ubuntu/Vagrantfile
+++ b/contrib/vagrant-ubuntu/Vagrantfile
@@ -1,0 +1,53 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  #
+  # Don't share an additional folder to the guest VM. At some point, it
+  # would be nice to share any local SPL and ZFS repositories with the
+  # guest VM. This would allow edits to happen outside of the VM (e.g.
+  # in any graphical editor of the user's choice) but get automatically
+  # shared with the VM for ease of compilation and testing.
+  #
+  # Unfortunately, this would require knowing the path to the local
+  # repositories relative to the Vagrant file. I'm not sure how to pass
+  # this information in, and any hard coded paths places unneeded
+  # restrictions on where the repositories must live in the developers
+  # file system.
+  #
+  # For now, simply disable sharing any additional folders. Instead, the
+  # SPL and ZFS repositories will be cloned into the default user's home
+  # directory. A developer can 'vagrant ssh' to log into the VM and edit
+  # the source directly with a CLI editor (e.g. Vim), or pull down any
+  # changes from a remote git repositories (e.g. from GitHub). Likewise,
+  # code changes can be exported out of the VM by pushing to a remote
+  # git repository.
+  #
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  #
+  # Pull in any packages needed to edit, compile, and test the code.
+  #
+  config.vm.provision "shell", inline: <<-SHELL
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -q
+    apt-get install -q -y \
+      -o Dpkg::Options::="--force-confdef" \
+      -o Dpkg::Options::="--force-confold" \
+      git autoconf automake libtool zlib1g-dev uuid-dev dpkg-dev alien
+  SHELL
+
+  #
+  # Since we aren't sharing the SPL and ZFS repositories with the guest
+  # VM via the "synced folder" functionality (see comment above), the
+  # two repositories are automatically cloned into the default user's
+  # home directory.
+  #
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    git clone git://github.com/zfsonlinux/spl.git
+    git clone git://github.com/zfsonlinux/zfs.git
+  SHELL
+
+end


### PR DESCRIPTION
This adds a Vagrantfile to the contrib directory to make it easy to
stand up and provision an Ubuntu VM for development using Vagrant. With
the necessary packages installed on a developers workstation (e.g.
vagrant and virtualbox) it should be as simple as the following:

    # NOTE: An internet connection is necessary to perform the initial
    # download of the Ubuntu VM image, update the system with necessary
    # compilers and tools, and checkout the SPL and ZFS source code.

    workstation $ cd contrib/vagrant-ubuntu
    workstation $ vagrant up
    workstation $ vagrant ssh
    ubuntu-vm $ uptime && uname -a
    ubuntu-vm $ cd ~/spl && ./autogen.sh && ./configure && make
    ubuntu-vm $ cd ~/zfs && ./autogen.sh && ./configure && make
    ubuntu-vm $ cd ~/zfs/scripts && sudo ./zfs.sh && sudo ./zfs.sh -u
    ubuntu-vm $ dmesg | grep -E "SPL|ZFS"
    ubuntu-vm $ exit
    workstation $ vagrant destroy -f

Following the invocation of `vagrant destroy -f`, the Ubuntu VM will be
forcefully shutdown and backing image files destroyed; at this point a
new VM will need to be re-created using `vagrant up` as needed. Be
aware, this will also delete the source repositories that were contained
in the guest system (!!) along with any changes made to them; so be sure
to push any changes you wish to keep to a remote repository external to
the guest VM.

If one doesn't want to completely destroy the VM and just wants to shut
it down (e.g. to continue development at a later time), `vagrant halt`
or `vagrant resume` can be used. The benefit of these is the guest VM
will not need to be re-created and re-provisioned to continue
development at a later time; and thus, a network connection isn't
necessary for the next invocation `vagrant up` or `vagrant resume`. Any
code changes to the repositories contained in the VM will remain intact.

Signed-off-by: Prakash Surya <prakash.surya@delphix.com>