### PR TITLE
Fix for recent zdb -h | -i crashes (seg fault)

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1079,8 +1079,11 @@ dump_history(spa_t *spa)
 	char internalstr[MAXPATHLEN];
 	int i;
 
-	if ((buf = malloc(SPA_OLD_MAXBLOCKSIZE)) == NULL)
+	if ((buf = malloc(SPA_OLD_MAXBLOCKSIZE)) == NULL) {
+		(void) fprintf(stderr, "%s: unable to allocate I/O buffer\n",
+		    __func__);
 		return;
+	}
 
 	do {
 		len = SPA_OLD_MAXBLOCKSIZE;

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1069,7 +1069,7 @@ static void
 dump_history(spa_t *spa)
 {
 	nvlist_t **events = NULL;
-	char buf[SPA_MAXBLOCKSIZE];
+	char *buf;
 	uint64_t resid, len, off = 0;
 	uint_t num = 0;
 	int error;
@@ -1079,12 +1079,16 @@ dump_history(spa_t *spa)
 	char internalstr[MAXPATHLEN];
 	int i;
 
+	if ((buf = malloc(SPA_OLD_MAXBLOCKSIZE)) == NULL)
+		return;
+
 	do {
-		len = sizeof (buf);
+		len = SPA_OLD_MAXBLOCKSIZE;
 
 		if ((error = spa_history_get(spa, &off, &len, buf)) != 0) {
 			(void) fprintf(stderr, "Unable to read history: "
 			    "error %d\n", error);
+			free(buf);
 			return;
 		}
 
@@ -1135,6 +1139,7 @@ next:
 			dump_nvlist(events[i], 2);
 		}
 	}
+	free(buf);
 }
 
 /*ARGSUSED*/

--- a/cmd/zdb/zdb_il.c
+++ b/cmd/zdb/zdb_il.c
@@ -124,7 +124,7 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 	char *data, *dlimit;
 	blkptr_t *bp = &lr->lr_blkptr;
 	zbookmark_phys_t zb;
-	char buf[SPA_MAXBLOCKSIZE];
+	char *buf;
 	int verbose = MAX(dump_opt['d'], dump_opt['i']);
 	int error;
 
@@ -133,6 +133,9 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 	    (u_longlong_t)lr->lr_length);
 
 	if (txtype == TX_WRITE2 || verbose < 5)
+		return;
+
+	if ((buf = malloc(SPA_MAXBLOCKSIZE)) == NULL)
 		return;
 
 	if (lr->lr_common.lrc_reclen == sizeof (lr_write_t)) {
@@ -145,13 +148,13 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 		if (BP_IS_HOLE(bp)) {
 			(void) printf("\t\t\tLSIZE 0x%llx\n",
 			    (u_longlong_t)BP_GET_LSIZE(bp));
-			bzero(buf, sizeof (buf));
+			bzero(buf, SPA_MAXBLOCKSIZE);
 			(void) printf("%s<hole>\n", prefix);
-			return;
+			goto exit;
 		}
 		if (bp->blk_birth < zilog->zl_header->zh_claim_txg) {
 			(void) printf("%s<block already committed>\n", prefix);
-			return;
+			goto exit;
 		}
 
 		SET_BOOKMARK(&zb, dmu_objset_id(zilog->zl_os),
@@ -162,7 +165,7 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 		    bp, buf, BP_GET_LSIZE(bp), NULL, NULL,
 		    ZIO_PRIORITY_SYNC_READ, ZIO_FLAG_CANFAIL, &zb));
 		if (error)
-			return;
+			goto exit;
 		data = buf;
 	} else {
 		data = (char *)(lr + 1);
@@ -180,6 +183,8 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 		data++;
 	}
 	(void) printf("\n");
+exit:
+	free(buf);
 }
 
 /* ARGSUSED */


### PR DESCRIPTION
Allocating `SPA_MAXBLOCKSIZE` on the stack is a bad idea. Use malloc instead when allocating temporary block buffer memory.

This was a regression from the recent large block support commit f1512ee6 (illumos issue 5027).

This crash is very easy to reproduce for "-h" case.  The "-i" crash requires an active ZIL log with a dirty `TX_WRITE` record. The ziltest tool easily provides this condition and will crash when it invokes  `zdb -ivv`  to display the transactions to replay.