### PR TITLE
Change default cachefile property to 'none'.

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -236,7 +236,7 @@ Use \fB1\fR for yes (default) and \fB0\fR for no.
 .RS 12n
 SPA config file
 .sp
-Default value: \fB/etc/zfs/zpool.cache\fR.
+Default value: \fBnone\fR.
 .RE
 
 .sp

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -698,9 +698,11 @@ Identifies the default bootable dataset for the root pool. This property is expe
 .ad
 .sp .6
 .RS 4n
-Controls the location of where the pool configuration is cached. Discovering all pools on system startup requires a cached copy of the configuration data that is stored on the root file system. All pools in this cache are automatically imported when the system boots. Some environments, such as install and clustering, need to cache this information in a different location so that pools are not automatically imported. Setting this property caches the pool configuration in a different location that can later be imported with "\fBzpool import -c\fR". Setting it to the special value "\fBnone\fR" creates a temporary pool that is never cached, and the special value \fB\&''\fR (empty string) uses the default location. 
+Controls the location of where the pool configuration is cached. Discovering all pools on system startup requires a cached copy of the configuration data that is stored on the root file system. All pools in this cache are automatically imported when the system boots. Some environments, such as install and clustering, need to cache this information in a different location so that pools are not automatically imported. Setting this property caches the pool configuration in a different location that can later be imported with "\fBzpool import -c\fR". Setting it to the special value "\fBnone\fR" creates a temporary pool that is never cached, and the special value \fB\&''\fR (empty string) uses the default location (\fI/etc/zfs/zpool.cache\fR). 
 .sp
 Multiple pools can share the same cache file. Because the kernel destroys and recreates this file when pools are added and removed, care should be taken when attempting to access this file. When the last pool using a \fBcachefile\fR is exported or destroyed, the file is removed.
+.sp
+On Linux, a cache file is almost never needed. So the default for Linux is set to \fBnone\fR.
 .RE
 
 .sp

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -69,7 +69,7 @@ zpool_prop_init(void)
 	    ZFS_TYPE_POOL, "<path>", "ALTROOT");
 	zprop_register_string(ZPOOL_PROP_BOOTFS, "bootfs", NULL, PROP_DEFAULT,
 	    ZFS_TYPE_POOL, "<filesystem>", "BOOTFS");
-	zprop_register_string(ZPOOL_PROP_CACHEFILE, "cachefile", NULL,
+	zprop_register_string(ZPOOL_PROP_CACHEFILE, "cachefile", "none",
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "<file> | none", "CACHEFILE");
 	zprop_register_string(ZPOOL_PROP_COMMENT, "comment", NULL,
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "<comment-string>", "COMMENT");

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -63,7 +63,7 @@ static uint64_t spa_config_generation = 1;
  * This can be overridden in userland to preserve an alternate namespace for
  * userland pools when doing testing.
  */
-char *spa_config_path = ZPOOL_CACHE;
+char *spa_config_path = "none";
 int zfs_autoimport_disable = 1;
 
 /*
@@ -574,7 +574,7 @@ EXPORT_SYMBOL(spa_config_generate);
 EXPORT_SYMBOL(spa_config_update);
 
 module_param(spa_config_path, charp, 0444);
-MODULE_PARM_DESC(spa_config_path, "SPA config file (/etc/zfs/zpool.cache)");
+MODULE_PARM_DESC(spa_config_path, "SPA config file (none)");
 
 module_param(zfs_autoimport_disable, int, 0644);
 MODULE_PARM_DESC(zfs_autoimport_disable, "Disable pool import at module load");


### PR DESCRIPTION
This in preparation to a later complete removal of cache file.

A cache file is almost never needed, at least not on Linux, so the long-time plan is to remove it altogether. This is the first step.

I noticed that this affects the <code>import</code> as well as <code>create</code> (which was not my intention - I only wanted it for the <code>create</code> command). That is, if I create a pool with the old code, using defaults (<code>-</code>), export it and then import it with the new code, the <code>cachefile</code> property will be <code>none</code>.

That _might_ not be what we want, although I'm for it...