### PR TITLE
zdb -d has false positive warning when feature@large_blocks=disabled

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -3111,18 +3111,18 @@ dump_zpool(spa_t *spa)
 
 		if (feature_get_refcount(spa,
 		    &spa_feature_table[SPA_FEATURE_LARGE_BLOCKS],
-		    &refcount) == ENOTSUP) {
-			refcount = 0;
-		}
-		if (num_large_blocks != refcount) {
-			(void) printf("large_blocks feature refcount mismatch: "
-			    "expected %lld != actual %lld\n",
-			    (longlong_t)num_large_blocks,
-			    (longlong_t)refcount);
-			rc = 2;
-		} else {
-			(void) printf("Verified large_blocks feature refcount "
-			    "is correct (%llu)\n", (longlong_t)refcount);
+		    &refcount) != ENOTSUP) {
+			if (num_large_blocks != refcount) {
+				(void) printf("large_blocks feature refcount "
+				    "mismatch: expected %lld != actual %lld\n",
+				    (longlong_t)num_large_blocks,
+				    (longlong_t)refcount);
+				rc = 2;
+			} else {
+				(void) printf("Verified large_blocks feature "
+				    "refcount is correct (%llu)\n",
+				    (longlong_t)refcount);
+			}
 		}
 	}
 	if (rc == 0 && (dump_opt['b'] || dump_opt['c']))

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2015, Intel Corporation.
  */
 
 #include <stdio.h>
@@ -3086,6 +3087,7 @@ dump_zpool(spa_t *spa)
 
 	if (dump_opt['d'] || dump_opt['i']) {
 		uint64_t refcount;
+
 		dump_dir(dp->dp_meta_objset);
 		if (dump_opt['d'] >= 3) {
 			dump_full_bpobj(&spa->spa_deferred_bpobj,
@@ -3107,8 +3109,11 @@ dump_zpool(spa_t *spa)
 		(void) dmu_objset_find(spa_name(spa), dump_one_dir,
 		    NULL, DS_FIND_SNAPSHOTS | DS_FIND_CHILDREN);
 
-		(void) feature_get_refcount(spa,
-		    &spa_feature_table[SPA_FEATURE_LARGE_BLOCKS], &refcount);
+		if (feature_get_refcount(spa,
+		    &spa_feature_table[SPA_FEATURE_LARGE_BLOCKS],
+		    &refcount) == ENOTSUP) {
+			refcount = 0;
+		}
 		if (num_large_blocks != refcount) {
 			(void) printf("large_blocks feature refcount mismatch: "
 			    "expected %lld != actual %lld\n",


### PR DESCRIPTION
Observed failure (from a 0.6.4 vintage pool):
```
[root]# zpool get feature@large_blocks mercury
NAME     PROPERTY              VALUE                 SOURCE
mercury  feature@large_blocks  disabled              local

[root]# zdb -d mercury
Dataset mos [META], ID 0, cr_txg 4, 768K, 47 objects
Dataset mercury [ZPL], ID 21, cr_txg 1, 4.42G, 544695 objects
large_blocks feature refcount mismatch: expected 0 != actual 140467913867480
```

Can also easily reproduce using:
```
[root]# fallocate -l 200m /tmp/zdev
[root]# zpool create -o version=28 fail /tmp/zdev 
[root]# zdb -d fail
Dataset mos [META], ID 0, cr_txg 4, 61.5K, 33 objects
Dataset tank [ZPL], ID 21, cr_txg 1, 30.0K, 6 objects
large_blocks feature refcount mismatch: expected 0 != actual 140102985584856
```