### PR TITLE
Add /dev/mapper to the list of possible sources for pool devices.

### DIFF
--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -156,6 +156,15 @@ do_import()
 			ZPOOL_IMPORT_PATH="/dev/disk/by-vdev:"
 		fi
 
+		# Help with getting LUKS partitions etc imported.
+		if [ -d "/dev/mapper" ]; then
+			if [ -n "$ZPOOL_IMPORT_PATH" ]; then
+				ZPOOL_IMPORT_PATH="$ZPOOL_IMPORT_PATH:/dev/mapper:"
+			else
+				ZPOOL_IMPORT_PATH="/dev/mapper:"
+			fi
+		fi
+
 		# ... and /dev at the very end, just for good measure.
 		ZPOOL_IMPORT_PATH="$ZPOOL_IMPORT_PATH$dirs:/dev"
 	fi


### PR DESCRIPTION
This is especially needed when using LUKS backed pools.

Signed-off-by: Turbo Fredriksson <turbo@bayour.com>
Closes #3536