### PR TITLE
Illumos 5870 - dmu_recv_end_check() leaks origin_head hold if error happens in drc_force branch

### DIFF
--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -2040,7 +2040,7 @@ dmu_recv_end_check(void *arg, dmu_tx_t *tx)
 				error = dsl_dataset_hold_obj(dp, obj, FTAG,
 				    &snap);
 				if (error != 0)
-					return (error);
+					break;
 				if (snap->ds_dir != origin_head->ds_dir)
 					error = SET_ERROR(EINVAL);
 				if (error == 0)  {
@@ -2050,7 +2050,11 @@ dmu_recv_end_check(void *arg, dmu_tx_t *tx)
 				obj = dsl_dataset_phys(snap)->ds_prev_snap_obj;
 				dsl_dataset_rele(snap, FTAG);
 				if (error != 0)
-					return (error);
+					break;
+			}
+			if (error != 0) {
+				dsl_dataset_rele(origin_head, FTAG);
+				return (error);
 			}
 		}
 		error = dsl_dataset_clone_swap_check_impl(drc->drc_ds,


### PR DESCRIPTION
5870 dmu_recv_end_check() leaks origin_head hold if error happens in drc_force branch
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Andrew Stormont <andyjstormont@gmail.com>
Approved by: Dan McDonald <danmcd@omniti.com>

References:
* https://www.illumos.org/issues/5870
* illumos/illumos-gate@beddaa9

Ported-by: Andriy Gapon <avg@FreeBSD.org>