### PR TITLE
Illumos 5610 zfs clone from different source and target pools produce…

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
+ * Copyright (c) 2015 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2015, STRATO AG, Inc. All rights reserved.
  */
 
@@ -949,11 +950,7 @@ dmu_objset_clone_check(void *arg, dmu_tx_t *tx)
 		dsl_dir_rele(pdd, FTAG);
 		return (SET_ERROR(EEXIST));
 	}
-	/* You can't clone across pools. */
-	if (pdd->dd_pool != dp) {
-		dsl_dir_rele(pdd, FTAG);
-		return (SET_ERROR(EXDEV));
-	}
+
 	error = dsl_fs_ss_limit_check(pdd, 1, ZFS_PROP_FILESYSTEM_LIMIT, NULL,
 	    doca->doca_cred);
 	if (error != 0) {
@@ -965,12 +962,6 @@ dmu_objset_clone_check(void *arg, dmu_tx_t *tx)
 	error = dsl_dataset_hold(dp, doca->doca_origin, FTAG, &origin);
 	if (error != 0)
 		return (error);
-
-	/* You can't clone across pools. */
-	if (origin->ds_dir->dd_pool != dp) {
-		dsl_dataset_rele(origin, FTAG);
-		return (SET_ERROR(EXDEV));
-	}
 
 	/* You can only clone snapshots, not the head datasets. */
 	if (!origin->ds_is_snapshot) {


### PR DESCRIPTION
…s coredump

Reviewed by: Josef 'Jeff' Sipek <josef.sipek@nexenta.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Approved by: Dan McDonald <danmcd@omniti.com>

References:
https://github.com/illumos/illumos-gate/commit/03b1c2971d24a9cd2c073d634f7e074fbd14e984
https://www.illumos.org/issues/5610
https://www.illumos.org/issues/5824
https://github.com/zfsonlinux/zfs/issues/2911
https://github.com/zfsonlinux/zfs/commit/9063f65476b7b7d78ccf096fec890b8727117e2a

Porting notes:
Remove the superfluous code, missing peaces from Illumos 5610, 5824

"remove those two checks for differing pools in dmu_objset_clone_check() that can never be true."

Ported-by: kernelOfTruth kerneloftruth@gmail.com