### PR TITLE
Illumos 5347 idle pool may run itself out of space

### DIFF
--- a/include/sys/uberblock.h
+++ b/include/sys/uberblock.h
@@ -22,6 +22,9 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
 
 #ifndef _SYS_UBERBLOCK_H
 #define	_SYS_UBERBLOCK_H
@@ -36,8 +39,8 @@ extern "C" {
 
 typedef struct uberblock uberblock_t;
 
-extern int uberblock_verify(uberblock_t *ub);
-extern int uberblock_update(uberblock_t *ub, vdev_t *rvd, uint64_t txg);
+extern int uberblock_verify(uberblock_t *);
+extern boolean_t uberblock_update(uberblock_t *, vdev_t *, uint64_t);
 
 #ifdef	__cplusplus
 }

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -1528,11 +1528,15 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 			    dp->dp_bptree_obj, tx));
 			dp->dp_bptree_obj = 0;
 			scn->scn_async_destroying = B_FALSE;
+			scn->scn_async_stalled = B_FALSE;
 		} else {
 			/*
-			 * If we didn't make progress, mark the async destroy as
-			 * stalled, so that we will not initiate a spa_sync() on
-			 * its behalf.
+			 * If we didn't make progress, mark the async
+			 * destroy as stalled, so that we will not initiate
+			 * a spa_sync() on its behalf.  Note that we only
+			 * check this if we are not finished, because if the
+			 * bptree had no blocks for us to visit, we can
+			 * finish without "making progress".
 			 */
 			scn->scn_async_stalled =
 			    (scn->scn_visited_this_txg == 0);

--- a/module/zfs/uberblock.c
+++ b/module/zfs/uberblock.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2014 by Delphix. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -40,10 +40,10 @@ uberblock_verify(uberblock_t *ub)
 }
 
 /*
- * Update the uberblock and return a boolean value indicating whether
- * anything changed in this transaction group.
+ * Update the uberblock and return TRUE if anything changed in this
+ * transaction group.
  */
-int
+boolean_t
 uberblock_update(uberblock_t *ub, vdev_t *rvd, uint64_t txg)
 {
 	ASSERT(ub->ub_txg < txg);


### PR DESCRIPTION
Reviewed by: Alex Reece <alex.reece@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Steven Hartland <killing@multiplay.co.uk>
Reviewed by: Richard Elling <richard.elling@richardelling.com>
Approved by: Dan McDonald <danmcd@omniti.com>

References:
https://github.com/illumos/illumos-gate/commit/231aab857f14a3e7a0ed5f2879399c3cd6ae92ea
https://www.illumos.org/issues/5347
https://github.com/zfsonlinux/zfs/commit/89b1cd6581528c576bd4ff7f713f671b23b051b5 (partial commit & fix for ZoL)

https://github.com/zfsonlinux/zfs/commit/fbeddd60b79690b6a6ececc9b00b6014d21405aa Illumos 4390 - I/O errors can corrupt space map when deleting fs/vol

https://github.com/zfsonlinux/zfs/commit/2696dfafd9ebce5e3aa227c630b13f2c5b26bce9 Illumos #3642, #3643

https://github.com/illumos/illumos-gate/commit/4a92375985c37d61406d66cd2b10ee642eb1f5e7 3642 dsl_scan_active() should not issue I/O to determine if async destrying is active

Porting notes:
This is completing the partial fix from FreeBSD (https://github.com/zfsonlinux/zfs/commit/89b1cd6581528c576bd4ff7f713f671b23b051b5)

Ported-by: kernelOfTruth kerneloftruth@gmail.com