### PR TITLE
Fix avl_find() panic (master branch)

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,3 +1,3 @@
-SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest zpios
+SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest zpios zfsmount_check
 SUBDIRS += mount_zfs fsck_zfs zvol_id vdev_id arcstat dbufstat zed
 SUBDIRS += arc_summary

--- a/cmd/zfsmount_check/Makefile.am
+++ b/cmd/zfsmount_check/Makefile.am
@@ -1,0 +1,7 @@
+include $(top_srcdir)/config/Rules.am
+
+sbin_PROGRAMS = zfsmount_check
+
+zfsmount_check_SOURCES = \
+	$(top_srcdir)/cmd/zfsmount_check/zfsmount_check.c
+

--- a/cmd/zfsmount_check/zfsmount_check.c
+++ b/cmd/zfsmount_check/zfsmount_check.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+
+/* A side-effect free way of reading /proc/mounts and reporting if directory argument is mounted.
+For use with zfs snapshots, since the commands mountpoint and sync, force automount behaviour.
+*/
+int main (int argc, char** argv){
+char* mounts="/proc/mounts";
+FILE* in;
+char* targ;
+char* line=NULL;
+size_t read,len;
+char dev[2048],path[2048],vfs[2048];
+
+
+/* We take one argument, if no arg, report failed (0). and fail silently. If mounted report 1. */
+if (argc>1){
+targ=(char*)malloc(strlen(argv[1])+1);
+strncpy(targ,argv[1],strlen(argv[1]));
+
+in=fopen(mounts,"r");
+if(in==NULL){exit(0);};
+ while ((read = getline(&line, &len, in)) != -1) {
+          /* fprintf(stderr,"Retrieved line of length %zu :\n", read); */
+           sscanf(line,"%s%s%s",dev,path,vfs);
+         /*  fprintf(stderr,"dev=%s path=%s vfs=%s \n",dev,path,vfs); */
+	   if(strcmp(vfs,"zfs")==0)
+	  	if(strncmp(path,targ,strlen(path))==0){
+		/*	fprintf(stderr,"found match to %s with %s \n",targ,path);*/
+			exit(1);
+	  	}
+       }
+fclose(in);
+exit(0);
+}else{
+exit(0);
+}
+
+}/*end main */

--- a/cmd/zfsmount_check/zfsmount_check.c
+++ b/cmd/zfsmount_check/zfsmount_check.c
@@ -3,39 +3,52 @@
 #include <stdlib.h>
 
 
-/* A side-effect free way of reading /proc/mounts and reporting if directory argument is mounted.
-For use with zfs snapshots, since the commands mountpoint and sync, force automount behaviour.
-*/
-int main (int argc, char** argv){
-char* mounts="/proc/mounts";
-FILE* in;
-char* targ;
-char* line=NULL;
-size_t read,len;
-char dev[2048],path[2048],vfs[2048];
+	/*
+	 * A side-effect free way of reading /proc/mounts and reporting if
+	 * directory argument is mounted.  For use with zfs snapshots,
+	 * since the commands mountpoint and sync, force automount behaviour.
+	 */
 
 
-/* We take one argument, if no arg, report failed (0). and fail silently. If mounted report 1. */
-if (argc>1){
-targ=(char*)malloc(strlen(argv[1])+1);
-strncpy(targ,argv[1],strlen(argv[1]));
 
-in=fopen(mounts,"r");
-if(in==NULL){exit(0);};
- while ((read = getline(&line, &len, in)) != -1) {
-          /* fprintf(stderr,"Retrieved line of length %zu :\n", read); */
-           sscanf(line,"%s%s%s",dev,path,vfs);
-         /*  fprintf(stderr,"dev=%s path=%s vfs=%s \n",dev,path,vfs); */
-	   if(strcmp(vfs,"zfs")==0)
-	  	if(strncmp(path,targ,strlen(path))==0){
-		/*	fprintf(stderr,"found match to %s with %s \n",targ,path);*/
+int main(int argc, char ** argv) {
+
+char * mounts = "/proc/mounts";
+FILE * in = NULL;
+char * targ = NULL;
+char * line = NULL;
+size_t read, len;
+char dev[2048], path[2048], vfs[2048];
+
+
+/*
+ * We take one argument, if no arg, report failed (0).
+ * and fail silently.
+ * If mounted report 1.
+ */
+
+if (argc > 1) {
+	targ = (char *)malloc(strlen(argv[1])+1);
+	strncpy(targ, argv[1], strlen(argv[1]));
+
+	in = fopen(mounts, "r");
+	if (in == NULL)
+		exit(0);
+
+	while ((read = getline(&line, &len, in)) != -1) {
+	/* fprintf(stderr,"Retrieved line of length %zu :\n", read); */
+		sscanf(line, "%s%s%s", dev, path, vfs);
+		/*  fprintf(stderr,"dev=%s path=%s vfs=%s \n",dev,path,vfs); */
+		if (strcmp(vfs, "zfs") == 0)
+			if (strncmp(path, targ, strlen(path)) == 0) {
+	/* fprintf(stderr,"found match to %s with %s \n", targ, path); */
 			exit(1);
-	  	}
-       }
-fclose(in);
-exit(0);
-}else{
+		}
+	} /* end while */
+	fclose(in);
+	exit(0);
+} else {
 exit(0);
 }
-
-}/*end main */
+/* end main */
+}

--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,7 @@ AC_CONFIG_FILES([
 	cmd/Makefile
 	cmd/zdb/Makefile
 	cmd/zhack/Makefile
+	cmd/zfsmount_check/Makefile
 	cmd/zfs/Makefile
 	cmd/zinject/Makefile
 	cmd/zpool/Makefile

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -754,7 +754,7 @@ __zfsctl_unmount_snapshot(zfs_snapentry_t *sep, int flags)
 
 		if (!stat2) {
 			ismounted = 0;
-			printk(
+			dprintf(
 		"ZFS: snapshot %s was unmounted from mounted state.\n",
 			sep->se_path);
 			error = 0; /* signifies no error */
@@ -769,7 +769,7 @@ __zfsctl_unmount_snapshot(zfs_snapentry_t *sep, int flags)
 		 * Unmounted cannot change
 		 * state
 		 */
-		printk("ZFS: snapshot %s not mounted.  Ignoring\n",
+		dprintf("ZFS: snapshot %s not mounted.  Ignoring\n",
 			sep->se_path);
 			error = SET_ERROR(ENOENT);
 	}
@@ -813,10 +813,10 @@ zfsctl_unmount_snapshot(zfs_sb_t *zsb, char *name, int flags)
 
 		mutex_enter(&zsb->z_ctldir_lock);
 		if (error == EBUSY) {
-		    printk("ZFS: Could not unmount Busy snapshot %s\n",
+		    dprintf("ZFS: Could not unmount Busy snapshot %s\n",
 			sep->se_path);
 		} else if (error == ENOENT) {
-			printk("ZFS: Ignore unmounted snapshot %s\n",
+			dprintf("ZFS: Ignore unmounted snapshot %s\n",
 			sep->se_path);
 			error = 0; /* do nothing */
 		} else {
@@ -824,7 +824,7 @@ zfsctl_unmount_snapshot(zfs_sb_t *zsb, char *name, int flags)
 		 * We only remove when the unmount is successful
 		 *  not if never mounted.
 		 */
-		printk("ZFS: success unmounting snapshot %s\n",
+		dprintf("ZFS: success unmounting snapshot %s\n",
 			sep->se_path);
 			avl_remove(&zsb->z_ctldir_snaps, sep);
 			zfsctl_sep_free(sep);

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -754,8 +754,9 @@ __zfsctl_unmount_snapshot(zfs_snapentry_t *sep, int flags)
 
 		if (!stat2) {
 			ismounted = 0;
-			printk("ZFS: snapshot %s was unmounted
-				from mounted state.\n", sep->se_path);
+			printk(
+		"ZFS: snapshot %s was unmounted from mounted state.\n",
+			sep->se_path);
 			error = 0; /* signifies no error */
 			} else {
 			ismounted = 1;

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -695,33 +695,83 @@ zfsctl_snapdir_inactive(struct inode *ip)
 	"exec 0</dev/null " \
 	"     1>/dev/null " \
 	"     2>/dev/null; " \
-	"umount -t zfs -n %s'%s'"
+	"umount -t zfs -n -l %s'%s'"
+
+#define STAT_CMD \
+	"exec 0</dev/null "\
+	"     1>/dev/null " \
+	"     2>/dev/null; "\
+	"zfsmount_check '%s'"
 
 static int
 __zfsctl_unmount_snapshot(zfs_snapentry_t *sep, int flags)
 {
 	char *argv[] = { "/bin/sh", "-c", NULL, NULL };
 	char *envp[] = { NULL };
-	int error;
+	int error,stat1,stat2;
+	int ismounted=0;
 
-	argv[2] = kmem_asprintf(SET_UNMOUNT_CMD,
-	    flags & MNT_FORCE ? "-f " : "", sep->se_path);
-	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
+	/* 
+	 Since we don't get back status information as we are not waiting for umount , 
+	 we use a stat to see if the mount still exists. if it *does* this would be the error condition
+	 in the original scheme, since the mount might be in use. Note, we assume /proc/mounts in sync... */
+
+	argv[2] = kmem_asprintf(STAT_CMD, sep->se_path); /* note, only one arg */
+	stat1 = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 	strfree(argv[2]);
-
+	if(!stat1){
+		ismounted=1; /* before we try and unmount, is it mounted? */
+	}else{
+		ismounted=0;
+	}
+	
 	/*
-	 * The umount system utility will return 256 on error.  We must
-	 * assume this error is because the file system is busy so it is
-	 * converted to the more sensible EBUSY.
+	 * The "stat"(zfsmount_check, our side-effect free program)  call will return 1 on error, in otherwords the mount does not exist.
+	 * This is the opposite behaviour of before.
+	 * Hence, if  no error, mount is present, EBUSY is probably true.
+	 *  
 	 */
-	if (error)
-		error = SET_ERROR(EBUSY);
+
+	if (ismounted){
+		argv[2] = kmem_asprintf(SET_UNMOUNT_CMD,
+		   	flags & MNT_FORCE ? "-f " : "", sep->se_path);
+		error = call_usermodehelper(argv[0], argv, envp, UMH_NO_WAIT);
+		strfree(argv[2]);
+
+		/* OK we tried to unmount. Change in state? */
+		argv[2] = kmem_asprintf(STAT_CMD, sep->se_path); /* note, only one arg */
+		stat2 = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
+		strfree(argv[2]);
+
+		/* Since we only try to unmount if mounted. if still mounted then EBUSY is correct.
+	   	If stat2=0 then success unmounting, so change state.
+		*/
+		if(!stat2){
+	      		ismounted=0;
+	  		printk("ZFS: snapshot %s was unmounted from mounted state.\n",  sep->se_path );
+	   		error=0; /* signifies no error */
+		}else{
+	      		ismounted=1;
+			error = SET_ERROR(EBUSY);
+		}
+
+	}else{ /* if not mounted initially, we notice this. Unmounted cannot change state */
+	  		printk("ZFS: snapshot %s not mounted. Ignoring\n",  sep->se_path );
+			error = SET_ERROR(ENOENT);
+	}
+
+
+
+
+
+	/* make sure we return EBUSY if still mounted*/
+	/* make sure we return ENOENT if was never  mounted*/
 
 	/*
 	 * This was the result of a manual unmount, cancel the delayed work
 	 * to prevent zfsctl_expire_snapshot() from attempting a unmount.
 	 */
-	if ((error == 0) && !(flags & MNT_EXPIRE))
+	if ((ismounted==0) && !(flags & MNT_EXPIRE))
 		taskq_cancel_id(zfs_expire_taskq, sep->se_taskqid);
 
 
@@ -734,29 +784,33 @@ zfsctl_unmount_snapshot(zfs_sb_t *zsb, char *name, int flags)
 	zfs_snapentry_t search;
 	zfs_snapentry_t *sep;
 	int error = 0;
-
 	mutex_enter(&zsb->z_ctldir_lock);
 
 	search.se_name = name;
 	sep = avl_find(&zsb->z_ctldir_snaps, &search, NULL);
 	if (sep) {
-		avl_remove(&zsb->z_ctldir_snaps, sep);
 		mutex_exit(&zsb->z_ctldir_lock);
 
 		error = __zfsctl_unmount_snapshot(sep, flags);
 
 		mutex_enter(&zsb->z_ctldir_lock);
-		if (error == EBUSY)
-			avl_add(&zsb->z_ctldir_snaps, sep);
-		else
+		if (error == EBUSY){
+		    printk("ZFS: Could not unmount Busy snapshot %s\n",  sep->se_path );
+		}else if ( error == ENOENT){
+		    printk("ZFS: Ignore unmounted snapshot %s\n",  sep->se_path );
+		    error=0; /* do nothing */
+		}else{
+		/* We only remove when the unmount is successful not if never mounted */
+		    printk("ZFS: success unmounting snapshot %s\n",  sep->se_path );
+   			avl_remove(&zsb->z_ctldir_snaps, sep);
 			zfsctl_sep_free(sep);
-	} else {
+		}
+	} else { /* This indicates the snapshot was not found internally */
 		error = SET_ERROR(ENOENT);
 	}
 
 	mutex_exit(&zsb->z_ctldir_lock);
 	ASSERT3S(error, >=, 0);
-
 	return (error);
 }
 
@@ -773,22 +827,25 @@ zfsctl_unmount_snapshots(zfs_sb_t *zsb, int flags, int *count)
 
 	*count = 0;
 
+ZFS_ENTER(zsb);
 	ASSERT(zsb->z_ctldir != NULL);
 	mutex_enter(&zsb->z_ctldir_lock);
 
 	sep = avl_first(&zsb->z_ctldir_snaps);
 	while (sep != NULL) {
 		next = AVL_NEXT(&zsb->z_ctldir_snaps, sep);
-		avl_remove(&zsb->z_ctldir_snaps, sep);
 		mutex_exit(&zsb->z_ctldir_lock);
 
 		error = __zfsctl_unmount_snapshot(sep, flags);
 
 		mutex_enter(&zsb->z_ctldir_lock);
 		if (error == EBUSY) {
-			avl_add(&zsb->z_ctldir_snaps, sep);
+		/* don't need this now 	avl_add(&zsb->z_ctldir_snaps, sep); */
 			(*count)++;
-		} else {
+		} if (error == ENOENT) { /* was never mounted. Ignore */
+
+		} else { /* we get here, it was mounted, and unmounted successfully. */
+			avl_remove(&zsb->z_ctldir_snaps, sep);
 			zfsctl_sep_free(sep);
 		}
 
@@ -796,7 +853,7 @@ zfsctl_unmount_snapshots(zfs_sb_t *zsb, int flags, int *count)
 	}
 
 	mutex_exit(&zsb->z_ctldir_lock);
-
+ZFS_EXIT(zsb);
 	return ((*count > 0) ? EEXIST : 0);
 }
 


### PR DESCRIPTION
This patch is to address the avl_find avl_add z_unmount panic on zfs with snapshots.

The cause of the problem is that avl_add() panics if it finds a node that already exists.

This patch addresses this by removing the unnecessary calls to avl_add() and potential panic.

The root of the problem is the avl_remove() is called before an "unmount" and if EBUSY tries to re-add a node.

This is logically incorrect, because the EBUSY doesnot accurately reflect the filesystem state. In addition mount/unmount can occur
simultaneously on muti-threaded systems.

The solution in the following patch is to:

a) properly guarded using ZFS_ENTER/ZFS_EXIT operations around the filesystem. Linux (and Solaris)
kernel mutex's are not-reentrant. There is evidence this might cause other problems with other processes accessing the filesystem during these operations.

b) a simple userspace program (zfsmount_check)that returns a side-effect free state of mount (by reading /proc/mounts) and therefore
can determine the state of the filesystem before unmount. If a mount is not present it is ignored. An EBUSY is returned ONLY if a mounted was present before the attempted umount.
The unmount is changed to be non-blocking (WH_NO_WAIT) as this is NOT safe to be blocking. umount can fail in many interesting ways and this will torpedo the module. Hence we use the userspace "zfsmount_check" program to test for a mount before and after the unmount command. It may be necessary to add a delay for sanity, but as it is, it doesn't matter as we actively test for mounted snapshots.

c) the addition of ENOENT state for __zfsctl_unmount_snapshot() to reflect the snapshot was not mounted.

The machine this was tested on is running linux 4.1.1, zfs/spl 0.6.4.2-1, 32 threads, 256G memory,  and correctly creates/removes and mounts and unmounts snapshots.

There remains some non-fatal  problems. The operation "cd $snapshot && cat /proc/mounts" the mount for $snapshot is shown. Immediately after it disappears. I have instrumented the unmount code in zfs_ctrdir.c so I know it is not there. There also remains the problems of too many links, which I think is connected to the ".." structure.

The simple userspace code zfsmount_check, has no license so add whatever you feel is necessary for inclusion. It might be more appropriate as a module function, but a simple drop in for "stat" and "mountpoint" programs for developement. Both "stat" and "mountpoint"  force an automount when testing for the mountpoint.