### PR TITLE
Add logic to try and recover an inode with an invalid mode

### DIFF
--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -339,8 +339,15 @@ zfs_inode_set_ops(zfs_sb_t *zsb, struct inode *ip)
 		break;
 
 	default:
-		printk("ZFS: Invalid mode: 0x%x\n", ip->i_mode);
-		VERIFY(0);
+		zfs_panic_recover("inode %llu has invalid mode: 0x%x\n",
+		    (u_longlong_t)ip->i_ino, ip->i_mode);
+
+		/* Assume the inode is a file and attempt to continue */
+		ip->i_mode = S_IFREG | 0644;
+		ip->i_op = &zpl_inode_operations;
+		ip->i_fop = &zpl_file_operations;
+		ip->i_mapping->a_ops = &zpl_address_space_operations;
+		break;
 	}
 }
 


### PR DESCRIPTION
When an inode is detected with invalid mode bits the safe thing to
do is panic the system.  This indicates a problem with the contents
of a dnode and it should never be possible.  This is the default
behavior.

Unfortunately, due to flaws in the system attribution implementation
it was possible that old versions of ZFS could create such dnodes.
This was a very rare issue because it depended on hitting a specific
race and having the xattr=sa property set.  Nevertheless a small number
of damaged pools do exist.  As of the 0.6.4 tag the root cause of this
issue has been fixed.

For pools which are exhibiting this damage the 'zfs_recover=1' module
may be set.  This will cause ZFS to interpret dnode with invalid mode
bits to be treated as files.  This may allows the files to be accessed
for recovery purposes.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>