### PR TITLE
Fix zvol detection

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -210,6 +210,12 @@ efi_get_info(int fd, struct dk_cinfo *dki_info)
 		rval = sscanf(dev_path, "/dev/%[a-zA-Z]%hu",
 		    dki_info->dki_dname,
 		    &dki_info->dki_partition);
+	} else if ((strncmp(dev_path, "/dev/zd", 7) == 0)) {
+		strcpy(dki_info->dki_cname, "zd");
+		dki_info->dki_ctype = DKC_MD;
+		rval = sscanf(dev_path, "/dev/%[a-zA-Z]%hu",
+		    dki_info->dki_dname,
+		    &dki_info->dki_partition);
 	} else if ((strncmp(dev_path, "/dev/dm-", 8) == 0)) {
 		strcpy(dki_info->dki_cname, "pseudo");
 		dki_info->dki_ctype = DKC_VBD;


### PR DESCRIPTION
The zpool create subcomand should not return an error on debug builds of
the userland tools when given zvols.

Signed-off-by: Richard Yao <ryao@gentoo.org>