### PR TITLE
Fix module/avl/avl.c warning: ‘where’ may be used uninitialized in this function

### DIFF
--- a/module/avl/avl.c
+++ b/module/avl/avl.c
@@ -644,7 +644,7 @@ avl_add(avl_tree_t *tree, void *new_node)
 #else
 		ASSERT(0);
 #endif
-	avl_insert(tree, new_node, where);
+	avl_insert(tree, new_node, &where);
 }
 
 /*


### PR DESCRIPTION
add correct

avl_insert(tree, new_node, where);

to

avl_insert(tree, new_node, &where);

in module/avl/avl.c