### PR TITLE
Set default _initconfdir directory

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -28,6 +28,11 @@
 %endif
 %endif
 
+# Set the default _initconfdir when undefined.
+%if %{undefined _initconfdir}
+%global _initconfdir /etc/sysconfig
+%endif
+
 %bcond_with    debug
 %bcond_with    blkid
 %bcond_with    systemd


### PR DESCRIPTION
The _initconfdir macro is normally provided by global rpm macros
file for use in the spec file.  However, older distributions such
as CentOS 6 do not define it.  To prevent a build failure in this
case the spec file has been updated to use a reasonable default
when the value is undefined.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>