### PR TITLE
Show thread names in gdb

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -5821,8 +5821,8 @@ ztest_run(ztest_shared_t *zs)
 	 * Create a thread to periodically resume suspended I/O.
 	 */
 	VERIFY3P((resume_thread = zk_thread_create(NULL, 0,
-	    (thread_func_t)ztest_resume_thread, spa, TS_RUN, NULL, 0, 0,
-	    PTHREAD_CREATE_JOINABLE)), !=, NULL);
+	    (thread_func_t)ztest_resume_thread, "ztest_resume_thread", spa,
+	    TS_RUN, NULL, 0, 0, PTHREAD_CREATE_JOINABLE)), !=, NULL);
 
 #if 0
 	/*
@@ -5873,7 +5873,7 @@ ztest_run(ztest_shared_t *zs)
 			return;
 
 		VERIFY3P(thread = zk_thread_create(NULL, 0,
-		    (thread_func_t)ztest_thread,
+		    (thread_func_t)ztest_thread, "ztest_thread",
 		    (void *)(uintptr_t)t, TS_RUN, NULL, 0, 0,
 		    PTHREAD_CREATE_JOINABLE), !=, NULL);
 		tid[t] = thread->t_tid;

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -240,7 +240,7 @@ typedef struct kthread {
 #define	getcomm()			"unknown"
 #define	thread_exit			zk_thread_exit
 #define	thread_create(stk, stksize, func, arg, len, pp, state, pri)	\
-	zk_thread_create(stk, stksize, (thread_func_t)func, arg,	\
+	zk_thread_create(stk, stksize, (thread_func_t)func, #func, arg,	\
 	    len, NULL, state, pri, PTHREAD_CREATE_DETACHED)
 #define	thread_join(t)			zk_thread_join(t)
 #define	newproc(f, a, cid, pri, ctp, pid)	(ENOSYS)
@@ -248,7 +248,7 @@ typedef struct kthread {
 extern kthread_t *zk_thread_current(void);
 extern void zk_thread_exit(void);
 extern kthread_t *zk_thread_create(caddr_t stk, size_t  stksize,
-	thread_func_t func, void *arg, size_t len,
+	thread_func_t func, const char *name, void *arg, size_t len,
 	proc_t *pp, int state, pri_t pri, int detachstate);
 extern void zk_thread_join(kt_did_t tid);
 

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -140,12 +140,14 @@ zk_thread_helper(void *arg)
 }
 
 kthread_t *
-zk_thread_create(caddr_t stk, size_t stksize, thread_func_t func, void *arg,
-    size_t len, proc_t *pp, int state, pri_t pri, int detachstate)
+zk_thread_create(caddr_t stk, size_t stksize, thread_func_t func,
+    const char *name, void *arg, size_t len, proc_t *pp, int state,
+    pri_t pri, int detachstate)
 {
 	kthread_t *kt;
 	pthread_attr_t attr;
 	char *stkstr;
+	char short_name[16];
 
 	ASSERT0(state & ~TS_RUN);
 
@@ -181,6 +183,10 @@ zk_thread_create(caddr_t stk, size_t stksize, thread_func_t func, void *arg,
 
 	VERIFY0(pthread_create(&kt->t_tid, &attr, &zk_thread_helper, kt));
 	VERIFY0(pthread_attr_destroy(&attr));
+
+	(void) snprintf(short_name, sizeof(short_name), "%s", name);
+	short_name[sizeof(short_name) - 1] = '\0';
+	VERIFY0(pthread_setname_np(kt->t_tid, short_name));
 
 	return (kt);
 }

--- a/lib/libzpool/taskq.c
+++ b/lib/libzpool/taskq.c
@@ -307,8 +307,9 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 	}
 
 	for (t = 0; t < nthreads; t++)
-		VERIFY((tq->tq_threadlist[t] = thread_create(NULL, 0,
-		    taskq_thread, tq, TS_RUN, NULL, 0, pri)) != NULL);
+		VERIFY((tq->tq_threadlist[t] = zk_thread_create(NULL, 0,
+		   taskq_thread, name, tq, TS_RUN, NULL, 0, pri,
+		   PTHREAD_CREATE_DETACHED)) != NULL);
 
 	return (tq);
 }


### PR DESCRIPTION
Debugging ztest core dumps is a pain because it is hard to tell which
thread is which. Linux has functionality for naming threads. Lets use
it.

Signed-off-by: Richard Yao <ryao@gentoo.org>