### PR TITLE
Fix some minor issues with the SYSV init and initramfs scripts.

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -37,9 +37,12 @@ if CONFIG_USER
 	pkg6=libzfs2-devel-$${version}.$${arch}.rpm; \
 	pkg7=$${name}-test-$${version}.$${arch}.rpm; \
 	pkg8=$${name}-dracut-$${version}.$${arch}.rpm; \
+	pkg9=$${name}-initramfs-$${version}.$${arch}.rpm; \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb \
-	    $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 $$pkg8; \
-	$(RM) $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 $$pkg8;
+	    $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
+	    $$pkg8 $$pkg9;
+	$(RM) $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
+	    $$pkg8 $$pkg9;
 endif
 
 deb: deb-kmod deb-utils

--- a/contrib/initramfs/hooks/zfs
+++ b/contrib/initramfs/hooks/zfs
@@ -9,7 +9,7 @@ PREREQ="zdev"
 # These prerequisites are provided by the zfsutils package. The zdb utility is
 # not strictly required, but it can be useful at the initramfs recovery prompt.
 COPY_EXEC_LIST="/sbin/zdb /sbin/zpool /sbin/zfs /sbin/mount.zfs"
-COPY_EXEC_LIST="$COPY_EXEC_LIST /usr/bin/dirname"
+COPY_EXEC_LIST="$COPY_EXEC_LIST /usr/bin/dirname /lib/udev/vdev_id"
 COPY_FILE_LIST="/etc/hostid /etc/zfs/zpool.cache /etc/default/zfs"
 COPY_FILE_LIST="$COPY_FILE_LIST /etc/zfs/zfs-functions /etc/zfs/vdev_id.conf"
 COPY_FILE_LIST="$COPY_FILE_LIST /lib/udev/rules.d/69-vdev.rules"
@@ -65,7 +65,7 @@ done
 for ii in $COPY_FILE_LIST
 do
 	dir=$(dirname "$ii")
-	[ -d "$dir" ] || mkdir -p "$dir"
+	[ -d "$dir" ] && mkdir -p "$DESTDIR/$dir"
 	[ -f "$ii" ] && cp -p "$ii" "$DESTDIR/$ii"
 done
 

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -282,7 +282,7 @@ load_module_initrd()
 	[ ! -f /etc/mtab ] && cat /proc/mounts > /etc/mtab
 
 	# Load the module
-	load_module || return 1
+	load_module "zfs" || return 1
 
 	if [ "$ZFS_INITRD_POST_MODPROBE_SLEEP" > 0 ]
 	then
@@ -388,7 +388,7 @@ decrypt_fs()
 	do
 		[ "$quiet" != "y" ] && zfs_log_progress_msg "${mod} "
 
-		ZFS_CMD="/sbin/modprobe $mod"
+		ZFS_CMD="load_module $mod"
 		ZFS_STDERR="$(${ZFS_CMD} 2>&1)"
 		ZFS_ERROR="$?"
 

--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -312,14 +312,18 @@ get_root_pool()
 
 check_module_loaded()
 {
-	[ -r /sys/module/zfs/version ] && return 0 || return 1
+	module="$1"
+
+	[ -r "/sys/module/${module}/version" ] && return 0 || return 1
 }
 
 load_module()
 {
+	module="$1"
+
 	# Load the zfs module stack
-	if ! check_module_loaded; then
-		if ! modprobe zfs; then
+	if ! check_module_loaded "$module"; then
+		if ! /sbin/modprobe "$module"; then
 			return 5
 		fi
 	fi

--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -277,7 +277,7 @@ do_export()
 # Output the status and list of pools
 do_status()
 {
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	"$ZPOOL" status && echo "" && "$ZPOOL" list
 }
@@ -298,7 +298,7 @@ do_start()
 		    zfs_log_begin_msg "Loading kernel ZFS infrastructure"
 		fi
 
-		if ! load_module
+		if ! load_module "zfs"
 		then
 			[ "$VERBOSE_MOUNT" = 'yes' ] && zfs_log_end_msg 1
 			return 5
@@ -316,7 +316,7 @@ do_start()
 do_stop()
 {
 	# Check to see if the module is even loaded.
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	do_export
 }

--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -163,7 +163,7 @@ do_unmount()
 
 do_start()
 {
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	case "$ZFS_MOUNT" in
 		[Oo][Ff][Ff]|[Nn][Oo]|''|0)
@@ -189,7 +189,7 @@ do_stop()
 			;;
 	esac
 
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	do_unmount
 }

--- a/etc/init.d/zfs-share.in
+++ b/etc/init.d/zfs-share.in
@@ -46,7 +46,7 @@ do_start()
 			;;
 	esac
 
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	zfs_action "Sharing ZFS filesystems" "$ZFS" share -a
 }
@@ -59,7 +59,7 @@ do_stop()
 			;;
 	esac
 
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	zfs_action "Unsharing ZFS filesystems" "$ZFS" unshare -a
 }

--- a/etc/init.d/zfs-zed.in
+++ b/etc/init.d/zfs-zed.in
@@ -60,7 +60,7 @@ do_depend()
 
 do_start()
 {
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	ZED_ARGS="$ZED_ARGS -p $ZED_PIDFILE"
 
@@ -72,7 +72,7 @@ do_start()
 do_stop()
 {
 	local pools RET
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	zfs_action "Stopping ZFS Event Daemon" zfs_daemon_stop \
 	   "$ZED_PIDFILE" "$ZED" "$ZED_NAME"
@@ -95,7 +95,7 @@ do_stop()
 
 do_status()
 {
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	zfs_daemon_status "$ZED_PIDFILE" "$ZED" "$ZED_NAME"
 	return "$?"
@@ -103,7 +103,7 @@ do_status()
 
 do_reload()
 {
-	check_module_loaded || exit 0
+	check_module_loaded "zfs" || exit 0
 
 	zfs_action "Reloading ZFS Event Daemon" zfs_daemon_reload \
 	    "$ZED_PIDFILE" "$ZED_NAME"


### PR DESCRIPTION
This is some minor fixes to commits 2cac7f5f11756663525a5d4604d9f0a3202d4024 and 2a34db1bdbcecf5019c4a59f2a44c92fe82010f2.

* Make sure to alien'ate the new initramfs rpm package as well!
  The rpm package is build correctly, but alien isn't run on it to
  create the deb.
* Before copying file from COPY_FILE_LIST, make sure the DESTDIR/dir exists.
* Include /lib/udev/vdev_id file in the initrd.
* Because the initrd needs to use '/sbin/modprobe' instead of 'modprobe',
  we need to use this in load_module() as well.
  * Make sure that load_module() can be used more globaly, instead of
    calling '/sbin/modprobe' all over the place.
  * Make sure that check_module_loaded() have a parameter - module to
    check.

Signed-off-by: Turbo Fredriksson <turbo@bayour.com>