### PR TITLE
In zfs_nicenum() if the value is '0', it means "0B[ytes]'.

### DIFF
--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -605,7 +605,7 @@ zfs_nicenum(uint64_t num, char *buf, size_t buflen)
 	u = " KMGTPE"[index];
 
 	if (index == 0) {
-		(void) snprintf(buf, buflen, "%llu", (u_longlong_t) n);
+		(void) snprintf(buf, buflen, "%lluB", (u_longlong_t) n);
 	} else if ((num & ((1ULL << 10 * index) - 1)) == 0) {
 		/*
 		 * If this is an even multiple of the base, always display


### PR DESCRIPTION
Previously, a scrub or resilver that didn't repair anything would output:

    scan: scrub repaired 0 in 224h4m with 0 errors on Tue Jul 14 14:58:25 2015

This leads to the question "repaired zero what"? It's resonable to assume that it means 'bytes', but to make it more clear, make sure that zfs_nicenum() is specific about this.

Signed-off-by: Turbo Fredriksson <turbo@bayour.com>
Closes #3594