### PR TITLE
Allow to specify relay host for zed scripts.

### DIFF
--- a/cmd/zed/zed.d/zed-functions.sh
+++ b/cmd/zed/zed.d/zed-functions.sh
@@ -217,6 +217,7 @@ zed_notify()
 #
 # Globals
 #   ZED_EMAIL
+#   ZED_EMAIL_SMARTHOST
 #
 # Return
 #   0: notification sent
@@ -227,6 +228,7 @@ zed_notify_email()
 {
     local subject="$1"
     local pathname="${2:-"/dev/null"}"
+    local RELAY=""
 
     [ -n "${ZED_EMAIL}" ] || return 2
 
@@ -238,7 +240,11 @@ zed_notify_email()
 
     zed_check_cmd "mail" || return 1
 
-    mail -s "${subject}" "${ZED_EMAIL}" < "${pathname}" >/dev/null 2>&1; rv=$?
+    # User is responsible to verify that the installed mailx understands
+    # the -S option!
+    [ -n "${ZED_EMAIL_RELAY}" ] && RELAY="-S ${ZED_EMAIL_RELAY}"
+
+    mail -s "${subject}" ${RELAY} "${ZED_EMAIL}" < "${pathname}" >/dev/null 2>&1; rv=$?
     if [ "${rv}" -ne 0 ]; then
         zed_log_err "mail exit=${rv}"
         return 1

--- a/cmd/zed/zed.d/zed.rc
+++ b/cmd/zed/zed.d/zed.rc
@@ -10,6 +10,22 @@
 #ZED_DEBUG_LOG="/tmp/zed.debug.log"
 
 ##
+# Email smart/relay host
+#   Make sure that your 'mail'/'mailx' commands accepts the '-S' option to
+#   set 'sendmail options'.
+#
+#   Allows for "host:port".
+#
+#   If you want/need extra options (such as authentication and what not),
+#   add this after the "host[:port]" part.
+#   See heirloom-mailx(1) for more information.
+#
+#   By default, mail/mailx is using 'localhost' as a smart/relay host.
+#
+#ZED_EMAIL_RELAY="localhost"
+#ZED_EMAIL_RELAY="localhost -S smtp-use-starttls -S smtp-auth=login [... etc]"
+
+##
 # Email address of the zpool administrator for receipt of notifications.
 #   Email will only be sent if ZED_EMAIL is defined.
 # Disabled by default; uncomment to enable.


### PR DESCRIPTION
Do this by using the '-S <opt>' option to the 'mailx' command. This doesn't work with the (usually) default "bsd-mailx". Works fine with 'heirloom-mailx' though.

Signed-off-by: Turbo Fredriksson <turbo@bayour.com>
Closes #3631