### PR TITLE
Rework zed_notify_email for configurable PROG / OPTS

### DIFF
--- a/cmd/zed/zed.d/zed-functions.sh
+++ b/cmd/zed/zed.d/zed-functions.sh
@@ -75,7 +75,7 @@ zed_log_msg()
 zed_log_err()
 {
     logger -p "${ZED_SYSLOG_PRIORITY}" -t "${ZED_SYSLOG_TAG}" -- "error:" \
-        "$(basename -- "$0"):" "${ZEVENT_EID:+"eid=${ZEVENT_EID}:"}" "$@"
+        "$(basename -- "$0"):""${ZEVENT_EID:+" eid=${ZEVENT_EID}:"}" "$@"
 }
 
 

--- a/cmd/zed/zed.d/zed.rc
+++ b/cmd/zed/zed.d/zed.rc
@@ -10,11 +10,28 @@
 #ZED_DEBUG_LOG="/tmp/zed.debug.log"
 
 ##
-# Email address of the zpool administrator for receipt of notifications.
-#   Email will only be sent if ZED_EMAIL is defined.
+# Email address of the zpool administrator for receipt of notifications;
+#   multiple addresses can be specified if they are delimited by whitespace.
+# Email will only be sent if ZED_EMAIL_ADDR is defined.
 # Disabled by default; uncomment to enable.
 #
-#ZED_EMAIL="root"
+#ZED_EMAIL_ADDR="root"
+
+##
+# Name or path of executable responsible for sending notifications via email;
+#   the mail program must be capable of reading a message body from stdin.
+# Email will only be sent if ZED_EMAIL_ADDR is defined.
+#
+#ZED_EMAIL_PROG="mail"
+
+##
+# Command-line options for ZED_EMAIL_PROG.
+# The string @ADDRESS@ will be replaced with the recipient email address(es).
+# The string @SUBJECT@ will be replaced with the notification subject;
+#   this should be protected with quotes to prevent word-splitting.
+# Email will only be sent if ZED_EMAIL_ADDR is defined.
+#
+#ZED_EMAIL_OPTS="-s '@SUBJECT@' @ADDRESS@"
 
 ##
 # Default directory for zed lock files.


### PR DESCRIPTION
This reworks the `zed_notify_email()` function to allow configuration of the mail executable and command-line arguments.

* `ZED_EMAIL_PROG` specifies the name or path of the executable responsible for sending notifications via email.  This variable defaults to "`mail`".

* `ZED_EMAIL_OPTS` specifies command-line options passed to `ZED_EMAIL_PROG`. The following keyword substitutions are performed:

  *  `@ADDRESS@` is replaced with the recipient email address(es)
  * `@SUBJECT@` is replaced with the notification subject

  This variable defaults to "`-s '@SUBJECT@' @ADDRESS@`".

* `ZED_EMAIL_ADDR` replaces `ZED_EMAIL` (although the latter is retained for backward compatibility).  This variable can contain multiple addresses as long as they are delimited by whitespace.
