### PR TITLE
configure bdi_setup_and_register: don't blow config stack

### DIFF
--- a/config/kernel-bdi-setup-and-register.m4
+++ b/config/kernel-bdi-setup-and-register.m4
@@ -7,8 +7,8 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI_SETUP_AND_REGISTER], [
 	AC_MSG_CHECKING([whether bdi_setup_and_register() wants 2 args])
 	ZFS_LINUX_TRY_COMPILE_SYMBOL([
 		#include <linux/backing-dev.h>
-	], [
 		struct backing_dev_info bdi;
+	], [
 		char *name = "bdi";
 		int error __attribute__((unused)) =
 		    bdi_setup_and_register(&bdi, name);
@@ -21,8 +21,8 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI_SETUP_AND_REGISTER], [
 		AC_MSG_CHECKING([whether bdi_setup_and_register() wants 3 args])
 		ZFS_LINUX_TRY_COMPILE_SYMBOL([
 			#include <linux/backing-dev.h>
-		], [
 			struct backing_dev_info bdi;
+		], [
 			char *name = "bdi";
 			unsigned int cap = BDI_CAP_MAP_COPY;
 			int error __attribute__((unused)) =


### PR DESCRIPTION
Pull struct backing_dev_info off the stack: by linux-4.1 it's grown
past our 1024 byte stack frame warning limit.

Signed-off-by: Chris Dunlop <chris@onthe.net.au>
Closes #3671