### PR TITLE
Add paranthesis to the ternary operator

### DIFF
--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -484,7 +484,7 @@ zap_lockdir(objset_t *os, uint64_t obj, dmu_tx_t *tx,
 		/* it was upgraded, now we only need reader */
 		ASSERT(lt == RW_WRITER);
 		ASSERT(RW_READER ==
-		    (!zap->zap_ismicro && fatreader) ? RW_READER : lti);
+		    ((!zap->zap_ismicro && fatreader) ? RW_READER : lti));
 		rw_downgrade(&zap->zap_rwlock);
 		lt = RW_READER;
 	}


### PR DESCRIPTION
Without the paranthesis, this particular ASSERT will evaluate to
"(RW_READER == (!zap->zap_ismicro && fatreader)) ? RW_READER : lti"

Signed-off-by: Chunwei Chen <tuxoko@gmail.com>