### PR TITLE
Add extra keyword 'slot' to vdev_id.conf

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -32,7 +32,7 @@
 # multipath     no
 # topology      sas_direct
 # phys_per_port 4
-# slot		bay
+# slot          bay
 #
 # #       PCI_ID  HBA PORT  CHANNEL NAME
 # channel 85:00.0 1         A

--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -32,6 +32,7 @@
 # multipath     no
 # topology      sas_direct
 # phys_per_port 4
+# slot		bay
 #
 # #       PCI_ID  HBA PORT  CHANNEL NAME
 # channel 85:00.0 1         A
@@ -93,6 +94,7 @@ PHYS_PER_PORT=
 DEV=
 MULTIPATH=
 TOPOLOGY=
+BAY=
 
 usage() {
 	cat << EOF
@@ -252,7 +254,25 @@ sas_handler() {
 		i=$(($i + 1))
 	done
 
-	SLOT=`cat $end_device_dir/bay_identifier 2>/dev/null`
+	SLOT=
+	case $BAY in
+	    "bay") 
+		SLOT=`cat $end_device_dir/bay_identifier 2>/dev/null`
+		;;
+	    "phy") 
+		SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`
+		;;
+	    "id")
+		i=$(($i + 1))
+		d=$(eval echo \${$i})
+		SLOT=`echo $d | sed -e 's/^.*://'`
+		;;
+	    "lun")
+		i=$(($i + 2))
+		d=$(eval echo \${$i})
+		SLOT=`echo $d | sed -e 's/^.*://'`
+		;;
+	esac
 	if [ -z "$SLOT" ] ; then
 		return
 	fi
@@ -356,10 +376,15 @@ if [ -z "$TOPOLOGY" ] ; then
 	TOPOLOGY=`awk "\\$1 == \"topology\" {print \\$2; exit}" $CONFIG`
 fi
 
+if [ -z "$BAY" ] ; then
+	BAY=`awk "\\$1 == \"slot\" {print \\$2; exit}" $CONFIG`
+fi
+
 # First check if an alias was defined for this device.
 ID_VDEV=`alias_handler`
 
 if [ -z "$ID_VDEV" ] ; then
+	BAY=${BAY:-bay}
 	TOPOLOGY=${TOPOLOGY:-sas_direct}
 	case $TOPOLOGY in
 		sas_direct|sas_switch)

--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -256,18 +256,18 @@ sas_handler() {
 
 	SLOT=
 	case $BAY in
-	    "bay") 
+	"bay") 
 		SLOT=`cat $end_device_dir/bay_identifier 2>/dev/null`
 		;;
-	    "phy") 
+	"phy") 
 		SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`
 		;;
-	    "id")
+	"id")
 		i=$(($i + 1))
 		d=$(eval echo \${$i})
 		SLOT=`echo $d | sed -e 's/^.*://'`
 		;;
-	    "lun")
+	"lun")
 		i=$(($i + 2))
 		d=$(eval echo \${$i})
 		SLOT=`echo $d | sed -e 's/^.*://'`

--- a/man/man5/vdev_id.conf.5
+++ b/man/man5/vdev_id.conf.5
@@ -96,7 +96,7 @@ taken.  The default is bay.
 
 \fIbay\fR - read the slot number from the bay identifier.
 
-\fIbay\fR - read the slot number from the phy identifier.
+\fIphy\fR - read the slot number from the phy identifier.
 
 \fIid\fR - use the scsi id as the slot number.
 

--- a/man/man5/vdev_id.conf.5
+++ b/man/man5/vdev_id.conf.5
@@ -88,6 +88,19 @@ switch port.
 .BR vdev_id (8)
 internally uses this value to determine which HBA or switch port a
 device is connected to.  The default is 4.
+
+.TP
+\fIslot\fR <bay|phy|id|lun>
+Specifies from which element of a SAS identifier the slot number is
+taken.  The default is bay.
+
+\fIbay\fR - read the slot number from the bay identifier.
+
+\fIbay\fR - read the slot number from the phy identifier.
+
+\fIid\fR - use the scsi id as the slot number.
+
+\fIlun\fR - use the scsi lun as the slot number.
 .SH EXAMPLES
 A non-multipath configuration with direct-attached SAS enclosures and an
 arbitrary slot re-mapping.
@@ -96,6 +109,7 @@ arbitrary slot re-mapping.
 	multipath     no
 	topology      sas_direct
 	phys_per_port 4
+	slot          bay
 
 	#       PCI_SLOT HBA PORT  CHANNEL NAME
 	channel 85:00.0  1         A


### PR DESCRIPTION
Add new keyword 'slot' to vdev_id.conf
This selects from where to get the slot number for a SAS/SATA disk
Needed to enable access to the physical position of a disk in a
Supermicro 2027R-AR24NV .

See issue #3662 .