### PR TITLE
Initialize the taskq entry embedded within struct vdev

### DIFF
--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -348,6 +348,7 @@ vdev_queue_init(vdev_t *vd)
 
 	mutex_init(&vq->vq_lock, NULL, MUTEX_DEFAULT, NULL);
 	vq->vq_vdev = vd;
+	taskq_init_ent(&vd->vdev_queue.vq_io_search.io_tqent);
 
 	avl_create(&vq->vq_active_tree, vdev_queue_offset_compare,
 	    sizeof (zio_t), offsetof(struct zio, io_queue_node));


### PR DESCRIPTION
As part of the stack reduction effort in
50b25b2187134ac7b19cf93bd35a420223f1d343, a zio_t containing a taskq_ent
was added to struct vdev_queue which itself is part of struct vdev.
The taskq entry should be initialized as is currently done in zio_create()
for newly-created bare zio_t object.  The rationale is the same as is
described in f467b05a265abcfb8e5a3269f79d08f36a58646a.