### PR TITLE
Limit max_hw_sectors_kb to 16M

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1389,7 +1389,7 @@ __zvol_create_minor(const char *name, boolean_t ignore_snapdev)
 
 	set_capacity(zv->zv_disk, zv->zv_volsize >> 9);
 
-	blk_queue_max_hw_sectors(zv->zv_queue, DMU_MAX_ACCESS / 512);
+	blk_queue_max_hw_sectors(zv->zv_queue, (DMU_MAX_ACCESS / 4) >> 9);
 	blk_queue_max_segments(zv->zv_queue, UINT16_MAX);
 	blk_queue_max_segment_size(zv->zv_queue, UINT_MAX);
 	blk_queue_physical_block_size(zv->zv_queue, zv->zv_volblocksize);


### PR DESCRIPTION
When support for large blocks was added DMU_MAX_ACCESS was increased
to allow for blocks of up to 16M to fix in a transaction handle.
This had the side effect of increasing the max_hw_sectors_kb for
volumes, which are scaled off DMU_MAX_ACCESS, to 64M from 10M.

This is an issue for volumes which by default use an 8K block size
because it results in dmu_buf_hold_array_by_dnode() allocating a
large array for the dbufs.  The solution is to restore the maximum
size to ~10M this patch specifically changes it to 16M which is
close enough.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3684