### PR TITLE
Clear QUEUE_FLAG_ADD_RANDOM on zvols

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1427,6 +1427,9 @@ __zvol_create_minor(const char *name, boolean_t ignore_snapdev)
 #ifdef HAVE_BLK_QUEUE_NONROT
 	queue_flag_set_unlocked(QUEUE_FLAG_NONROT, zv->zv_queue);
 #endif
+#ifdef QUEUE_FLAG_ADD_RANDOM
+	queue_flag_clear_unlocked(QUEUE_FLAG_ADD_RANDOM, zv->zv_queue);
+#endif
 
 	if (spa_writeable(dmu_objset_spa(os))) {
 		if (zil_replay_disable)


### PR DESCRIPTION
zvols should not be an entropy source for the kernel. Disable it to be
consistent with the upstream kernel.

torvalds/linux@b277da0a8a594308e17881f4926879bd5fca2a2d

Signed-off-by: Richard Yao <ryao@gentoo.org>