### PR TITLE
Some OpenRC dependency logic belongs in mount

### DIFF
--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -46,6 +46,17 @@ chkroot() {
 
 do_depend()
 {
+	# Try to allow people to mix and match fstab with ZFS in a way that makes sense.
+	if [ "$(mountinfo -s /)" = 'zfs' ]
+	then
+		before localmount
+	else
+		after localmount
+	fi
+
+	# bootmisc will log to /var which may be a different zfs than root.
+	before bootmisc logger
+
 	after procfs zfs-import sysfs procps
 	use mtab
 	keyword -lxc -openvz -prefix -vserver

--- a/etc/init.d/zfs-zed.in
+++ b/etc/init.d/zfs-zed.in
@@ -45,16 +45,7 @@ ZED_PIDFILE="@runstatedir@/$ZED_NAME.pid"
 
 do_depend()
 {
-	# Try to allow people to mix and match fstab with ZFS in a way that makes sense.
-	if [ "$(mountinfo -s /)" = 'zfs' ]
-	then
-		before localmount
-	else
-		after localmount
-	fi
-
-	# bootmisc will log to /var which may be a different zfs than root.
-	before bootmisc logger zfs-import
+	before zfs-import
 	after sysfs
 }
 


### PR DESCRIPTION
The dependencies for handling / on ZFS belong in the mount script, not
the zed script.

Signed-off-by: Richard Yao <ryao@gentoo.org>