### PR TITLE
Reorder zfs-* services to allow /var on separate dataset

### DIFF
--- a/etc/init.d/README.md
+++ b/etc/init.d/README.md
@@ -42,36 +42,31 @@ INSTALLING INIT SCRIPT LINKS
   To setup the init script links in /etc/rc?.d manually on a Debian GNU/Linux
   (or derived) system, run the following commands (the order is important!):
 
-    update-rc.d zfs-zed    start 07 S .       stop 08 0 1 6 .
-    update-rc.d zfs-import start 07 S .       stop 07 0 1 6 .
-    update-rc.d zfs-mount  start 02 2 3 4 5 . stop 06 0 1 6 .
+    update-rc.d zfs-import start 07 S .       stop 08 0 1 6 .
+    update-rc.d zfs-mount  start 02 2 3 4 5 . stop 07 0 1 6 .
+    update-rc.d zfs-zed    start 26 2 3 4 5 . stop 06 0 1 6 .
     update-rc.d zfs-share  start 27 2 3 4 5 . stop 05 0 1 6 .
 
   To do the same on RedHat, Fedora and/or CentOS:
 
-    chkconfig zfs-zed
     chkconfig zfs-import
     chkconfig zfs-mount
+    chkconfig zfs-zed
     chkconfig zfs-share
 
   On Gentoo:
 
-    rc-update add zfs-zed boot
     rc-update add zfs-import boot
     rc-update add zfs-mount boot
+    rc-update add zfs-zed default
     rc-update add zfs-share default
 
+  The idea here is to make sure all of the ZFS filesystems, including possibly
+  separate datasets like /var, are mounted before anything else is started.
 
-  The idea here is to make sure ZED is started before the imports (so that
-  we can start consuming pool events before pools are imported).
+  Then, ZED, which depends on /var, can be started.  It will consume and act
+  on events that occurred before it started.  ZED may also play a role in
+  sharing filesystems in the future, so it is important to start before the
+  'share' service.
 
-  Then import any/all pools (except the root pool which is mounted in the
-  initrd before the system even boots - basically before the S (single-user)
-  mode).
-
-  Then we mount all filesystems before we start any network service (such as
-  NFSd, AFSd, Samba, iSCSI targets and what not). Even if the share* in ZFS
-  isn't used, the filesystem must be mounted for the service to start properly.
-
-  Then, at almost the very end, we share filesystems configured with the
-  share* property in ZFS.
+  Finally, we share filesystems configured with the share\* property.

--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -10,8 +10,8 @@
 #
 ### BEGIN INIT INFO
 # Provides:          zfs-import
-# Required-Start:    zfs-zed
-# Required-Stop:     zfs-zed
+# Required-Start:    mtab
+# Required-Stop:     $local_fs mtab
 # Default-Start:     S
 # Default-Stop:      0 1 6
 # X-Start-Before:    checkfs
@@ -19,6 +19,11 @@
 # Short-Description: Import ZFS pools
 # Description: Run the `zpool import` or `zpool export` commands.
 ### END INIT INFO
+#
+# NOTE: Not having '$local_fs' on Required-Start but only on Required-Stop
+#       is on purpose. If we have '$local_fs' in both (and X-Start-Before=checkfs)
+#       we get conflicts - import needs to be started extremely early,
+#       but not stopped too late.
 #
 # Released under the 2-clause BSD license.
 #
@@ -34,7 +39,7 @@
 
 do_depend()
 {
-	after sysfs udev zfs-zed
+	after sysfs udev
 	keyword -lxc -openvz -prefix -vserver
 }
 
@@ -246,15 +251,18 @@ do_import()
 # Export all pools
 do_export()
 {
-	local pool root_pool RET r
+	local already_imported pool root_pool RET r
 	RET=0
 
 	root_pool=$(get_root_pool)
 
 	[ -n "$init" ] && zfs_log_begin_msg "Exporting ZFS pool(s)"
-	TMPFILE=$(mktemp --tmpdir=/var/tmp zpool.XXXXX)
-	"$ZPOOL" list -H -oname > "$TMPFILE"
-	while read pool; do
+
+	# Find list of already imported pools.
+	already_imported=$(find_pools "$ZPOOL" list -H -oname)
+
+	OLD_IFS="$IFS" ; IFS=";"
+	for pool in $already_imported; do
 		[ "$pool" = "$root_pool" ] && continue
 
 		if [ -z "$init" ]
@@ -269,9 +277,12 @@ do_export()
 		"$ZPOOL" export "$pool"
 		r="$?" ; RET=$((RET + r))
 		[ -z "$init" ] && zfs_log_end_msg "$r"
-	done < "$TMPFILE"
-	rm -f "$TMPFILE"
+	done
+	IFS="$OLD_IFS"
+
 	[ -n "$init" ] && zfs_log_end_msg "$RET"
+
+	return "$RET"
 }
 
 # Output the status and list of pools

--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -16,7 +16,7 @@
 # Required-Stop:     $local_fs zfs-import
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# X-Stop-After:      zfs-share
+# X-Stop-After:      zfs-zed
 # Short-Description: Mount ZFS filesystems and volumes
 # Description: Run the `zfs mount -a` or `zfs umount -a` commands.
 ### END INIT INFO
@@ -57,7 +57,7 @@ do_depend()
 	# bootmisc will log to /var which may be a different zfs than root.
 	before bootmisc logger
 
-	after procfs zfs-import sysfs procps
+	after zfs-import sysfs
 	use mtab
 	keyword -lxc -openvz -prefix -vserver
 }

--- a/etc/init.d/zfs-share.in
+++ b/etc/init.d/zfs-share.in
@@ -9,12 +9,12 @@
 #
 ### BEGIN INIT INFO
 # Provides:          zfs-share
-# Required-Start:    $local_fs $network $remote_fs zfs-mount
-# Required-Stop:     $local_fs $network $remote_fs zfs-mount
+# Required-Start:    $local_fs $network $remote_fs zfs-mount zfs-zed
+# Required-Stop:     $local_fs $network $remote_fs zfs-mount zfs-zed
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Should-Start:      iscsi iscsitarget istgt scst @NFS_SRV@ samba samba4 zfs-mount
-# Should-Stop:       iscsi iscsitarget istgt scst @NFS_SRV@ samba samba4 zfs-mount
+# Should-Start:      iscsi iscsitarget istgt scst @NFS_SRV@ samba samba4 zfs-mount zfs-zed
+# Should-Stop:       iscsi iscsitarget istgt scst @NFS_SRV@ samba samba4 zfs-mount zfs-zed
 # Short-Description: Network share ZFS datasets and volumes.
 # Description:       Run the `zfs share -a` or `zfs unshare -a` commands
 #                    for controlling iSCSI, NFS, or CIFS network shares.
@@ -34,7 +34,7 @@
 
 do_depend()
 {
-	after sysfs zfs-mount
+	after sysfs zfs-mount zfs-zed
 	keyword -lxc -openvz -prefix -vserver
 }
 

--- a/etc/init.d/zfs-zed.in
+++ b/etc/init.d/zfs-zed.in
@@ -2,28 +2,22 @@
 #
 # zfs-zed
 #
-# chkconfig:    2345 01 99
+# chkconfig:    2345 29 99
 # description:  This script will start and stop the ZFS Event Daemon.
 # probe: true
 #
 ### BEGIN INIT INFO
 # Provides:          zfs-zed
-# Required-Start:    mtab
-# Required-Stop:     $local_fs mtab
-# Default-Start:     S
+# Required-Start:    zfs-mount
+# Required-Stop:     zfs-mount
+# Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# X-Start-Before:    checkfs
-# X-Stop-After:      zfs-import
+# X-Stop-After:      zfs-share
 # Short-Description: ZFS Event Daemon
 # Description:       zed monitors ZFS events. When a zevent is posted, zed
 #                    will run any scripts that have been enabled for the
 #                    corresponding zevent class.
 ### END INIT INFO
-#
-# NOTE: Not having '$local_fs' on Required-Start but only on Required-Stop
-#       is on purpose. If we have '$local_fs' in both (and X-Start-Before=checkfs)
-#       we get conflicts - zed and import needs to be started extremely early,
-#       but not stopped too late.
 #
 # Released under the 2-clause BSD license.
 #
@@ -45,8 +39,7 @@ ZED_PIDFILE="@runstatedir@/$ZED_NAME.pid"
 
 do_depend()
 {
-	before zfs-import
-	after sysfs
+	after zfs-mount localmount
 }
 
 do_start()


### PR DESCRIPTION
This pull request addresses issue #3513 which causes the various `zfs-*` boot services to fail when `/var` is a separate dataset.

As discussed in the issue, I've moved the `zfs-zed` service from starting first to starting after `zfs-mount` but before `zfs-share`.  ZED will consume events queued during import and mount so it does not need to start first.  And it may be used for sharing in the future, so it should start before `zfs-share`.

I also found that during shutdown, the `zfs-import` service would fail when exporting pools because it attempted to write to /var/tmp, which is unmounted at that point.  I've changed the export function to be more like the import function which does not need to write any temporary files.

I've updated the `README.md` file associated with the init scripts to reflect the new boot order.

I have attempted to reorder both the OpenRC and the SysV interpretations of the init scripts, but I only have access to a Gentoo system with ZFS.  So while the OpenRC version has been tested and works, the SysV interpretation was just my best effort.  Someone with more Debian/Red Hat experience will need to review and test the changes to the SysV interpretation.