### PR TITLE
Dbuf hash table should be sized as is the arc hash table

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -51,6 +51,9 @@ typedef void arc_done_func_t(zio_t *zio, arc_buf_t *buf, void *private);
 typedef void arc_prune_func_t(int64_t bytes, void *private);
 typedef int arc_evict_func_t(void *private);
 
+/* Shared module parameters */
+extern int zfs_arc_average_blocksize;
+
 /* generic arc_done_func_t's which you can use */
 arc_done_func_t arc_bcopy_func;
 arc_done_func_t arc_getbuf_func;

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -376,10 +376,11 @@ dbuf_init(void)
 
 	/*
 	 * The hash table is big enough to fill all of physical memory
-	 * with an average 4K block size.  The table will take up
-	 * totalmem*sizeof(void*)/4K (i.e. 2MB/GB with 8-byte pointers).
+	 * with an average block size of zfs_arc_average_blocksize (default 8K).
+	 * By default, the table will take up
+	 * totalmem * sizeof(void*) / 8K (1MB per GB with 8-byte pointers).
 	 */
-	while (hsize * 4096 < physmem * PAGESIZE)
+	while (hsize * zfs_arc_average_blocksize < physmem * PAGESIZE)
 		hsize <<= 1;
 
 retry:


### PR DESCRIPTION
Commit 49ddb315066e372f31bda29a5c546a9eccc8b418 added the
zfs_arc_average_blocksize parameter to allow control over the size of
the arc hash table.  The dbuf hash table's size should be determined
similarly.