### PR TITLE
Add temporary mount options

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -28,9 +28,13 @@
 #include <unistd.h>
 #include <sys/file.h>
 #include <sys/mount.h>
+#include <sys/mntent.h>
 #include <sys/stat.h>
 #include <libzfs.h>
 #include <locale.h>
+
+#define	ZS_COMMENT	0x00000000	/* comment */
+#define	ZS_ZFSUTIL	0x00000001	/* caller is zfs(8) */
 
 libzfs_handle_t *g_zfs;
 
@@ -335,14 +339,17 @@ mtab_update(char *dataset, char *mntpoint, char *type, char *mntopts)
 }
 
 static void
-__zfs_selinux_setcontext(const char *name, const char *context, char *mntopts,
-    char *mtabopt)
+append_mntopt(const char *name, const char *val, char *mntopts, char *mtabopt)
 {
 	char tmp[MNT_LINE_MAX];
 
-	snprintf(tmp, MNT_LINE_MAX, ",%s=\"%s\"", name, context);
-	strlcat(mntopts, tmp, MNT_LINE_MAX);
-	strlcat(mtabopt, tmp, MNT_LINE_MAX);
+	snprintf(tmp, MNT_LINE_MAX, ",%s=\"%s\"", name, val);
+
+	if (mntopts)
+		strlcat(mntopts, tmp, MNT_LINE_MAX);
+
+	if (mtabopt)
+		strlcat(mtabopt, tmp, MNT_LINE_MAX);
 }
 
 static void
@@ -354,7 +361,7 @@ zfs_selinux_setcontext(zfs_handle_t *zhp, zfs_prop_t zpt, const char *name,
 	if (zfs_prop_get(zhp, zpt, context, sizeof (context),
 	    NULL, NULL, 0, B_FALSE) == 0) {
 		if (strcmp(context, "none") != 0)
-		    __zfs_selinux_setcontext(name, context, mntopts, mtabopt);
+		    append_mntopt(name, context, mntopts, mtabopt);
 	}
 }
 
@@ -506,10 +513,12 @@ main(int argc, char **argv)
 			    ZFS_PROP_SELINUX_ROOTCONTEXT, MNTOPT_ROOTCONTEXT,
 			    mntopts, mtabopt);
 		} else {
-			__zfs_selinux_setcontext(MNTOPT_CONTEXT,
-			    prop, mntopts, mtabopt);
+			append_mntopt(MNTOPT_CONTEXT, prop, mntopts, mtabopt);
 		}
 	}
+
+	/* A hint used to determine an auto-mounted snapshot mount point */
+	append_mntopt(MNTOPT_MNTPOINT, mntpoint, mntopts, NULL);
 
 	/* treat all snapshots as legacy mount points */
 	if (zfs_get_type(zhp) == ZFS_TYPE_SNAPSHOT)

--- a/include/sys/Makefile.am
+++ b/include/sys/Makefile.am
@@ -33,6 +33,7 @@ COMMON_H = \
 	$(top_srcdir)/include/sys/efi_partition.h \
 	$(top_srcdir)/include/sys/metaslab.h \
 	$(top_srcdir)/include/sys/metaslab_impl.h \
+	$(top_srcdir)/include/sys/mntent.h \
 	$(top_srcdir)/include/sys/multilist.h \
 	$(top_srcdir)/include/sys/nvpair.h \
 	$(top_srcdir)/include/sys/nvpair_impl.h \

--- a/include/sys/mntent.h
+++ b/include/sys/mntent.h
@@ -95,8 +95,6 @@
 #define	MNTOPT_ACL	"acl"		/* passed by util-linux-2.24 mount */
 #define	MNTOPT_NOACL	"noacl"		/* likewise */
 #define	MNTOPT_POSIXACL	"posixacl"	/* likewise */
-
-#define	ZS_COMMENT	0x00000000	/* comment */
-#define	ZS_ZFSUTIL	0x00000001	/* caller is zfs(8) */
+#define	MNTOPT_MNTPOINT	"mntpoint"	/* mount point hint */
 
 #endif	/* _SYS_MNTENT_H */

--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -41,11 +41,33 @@ extern "C" {
 struct zfs_sb;
 struct znode;
 
+typedef struct zfs_mntopts {
+	char		*z_osname;	/* Objset name */
+	char		*z_mntpoint;	/* Primary mount point */
+	boolean_t	z_readonly;
+	boolean_t	z_do_readonly;
+	boolean_t	z_setuid;
+	boolean_t	z_do_setuid;
+	boolean_t	z_exec;
+	boolean_t	z_do_exec;
+	boolean_t	z_devices;
+	boolean_t	z_do_devices;
+	boolean_t	z_xattr;
+	boolean_t	z_do_xattr;
+	boolean_t	z_atime;
+	boolean_t	z_do_atime;
+	boolean_t	z_relatime;
+	boolean_t	z_do_relatime;
+	boolean_t	z_nbmand;
+	boolean_t	z_do_nbmand;
+} zfs_mntopts_t;
+
 typedef struct zfs_sb {
 	struct super_block *z_sb;	/* generic super_block */
 	struct backing_dev_info z_bdi;	/* generic backing dev info */
 	struct zfs_sb	*z_parent;	/* parent fs */
 	objset_t	*z_os;		/* objset reference */
+	zfs_mntopts_t	*z_mntopts;	/* passed mount options */
 	uint64_t	z_flags;	/* super_block flags */
 	uint64_t	z_root;		/* id of root znode */
 	uint64_t	z_unlinkedobj;	/* id of unlinked zapobj */
@@ -170,7 +192,10 @@ extern boolean_t zfs_fuid_overquota(zfs_sb_t *zsb, boolean_t isgroup,
 extern int zfs_set_version(zfs_sb_t *zsb, uint64_t newvers);
 extern int zfs_get_zplprop(objset_t *os, zfs_prop_t prop,
     uint64_t *value);
-extern int zfs_sb_create(const char *name, zfs_sb_t **zsbp);
+extern zfs_mntopts_t *zfs_mntopts_alloc(void);
+extern void zfs_mntopts_free(zfs_mntopts_t *zmo);
+extern int zfs_sb_create(const char *name, zfs_mntopts_t *zmo,
+    zfs_sb_t **zsbp);
 extern int zfs_sb_setup(zfs_sb_t *zsb, boolean_t mounting);
 extern void zfs_sb_free(zfs_sb_t *zsb);
 extern int zfs_sb_prune(struct super_block *sb, unsigned long nr_to_scan,
@@ -181,10 +206,10 @@ extern boolean_t zfs_is_readonly(zfs_sb_t *zsb);
 
 extern int zfs_register_callbacks(zfs_sb_t *zsb);
 extern void zfs_unregister_callbacks(zfs_sb_t *zsb);
-extern int zfs_domount(struct super_block *sb, void *data, int silent);
+extern int zfs_domount(struct super_block *sb, zfs_mntopts_t *zmo, int silent);
 extern void zfs_preumount(struct super_block *sb);
 extern int zfs_umount(struct super_block *sb);
-extern int zfs_remount(struct super_block *sb, int *flags, char *data);
+extern int zfs_remount(struct super_block *sb, int *flags, zfs_mntopts_t *zmo);
 extern int zfs_root(zfs_sb_t *zsb, struct inode **ipp);
 extern int zfs_statvfs(struct dentry *dentry, struct kstatfs *statp);
 extern int zfs_vget(struct super_block *sb, struct inode **ipp, fid_t *fidp);

--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -25,12 +25,14 @@
 #ifndef	_SYS_ZPL_H
 #define	_SYS_ZPL_H
 
+#include <sys/mntent.h>
 #include <sys/vfs.h>
 #include <linux/aio.h>
 #include <linux/dcache_compat.h>
 #include <linux/exportfs.h>
 #include <linux/falloc.h>
 #include <linux/file_compat.h>
+#include <linux/parser.h>
 #include <linux/task_io_accounting_ops.h>
 #include <linux/vfs_compat.h>
 #include <linux/writeback.h>
@@ -64,11 +66,6 @@ extern const struct file_operations zpl_dir_file_operations;
 
 /* zpl_super.c */
 extern void zpl_prune_sb(int64_t nr_to_scan, void *arg);
-
-typedef struct zpl_mount_data {
-	const char *z_osname;	/* Dataset name */
-	void *z_data;		/* Mount options string */
-} zpl_mount_data_t;
 
 extern const struct super_operations zpl_super_operations;
 extern const struct export_operations zpl_export_operations;

--- a/lib/libspl/include/sys/Makefile.am
+++ b/lib/libspl/include/sys/Makefile.am
@@ -26,7 +26,6 @@ libspl_HEADERS = \
 	$(top_srcdir)/lib/libspl/include/sys/list_impl.h \
 	$(top_srcdir)/lib/libspl/include/sys/mhd.h \
 	$(top_srcdir)/lib/libspl/include/sys/mkdev.h \
-	$(top_srcdir)/lib/libspl/include/sys/mntent.h \
 	$(top_srcdir)/lib/libspl/include/sys/mnttab.h \
 	$(top_srcdir)/lib/libspl/include/sys/mount.h \
 	$(top_srcdir)/lib/libspl/include/sys/note.h \

--- a/lib/libspl/include/sys/mnttab.h
+++ b/lib/libspl/include/sys/mnttab.h
@@ -39,7 +39,7 @@
 #endif /* MNTTAB */
 
 #define	MNTTAB		"/etc/mtab"
-#define	MNT_LINE_MAX	1024
+#define	MNT_LINE_MAX	4096
 
 #define	MNT_TOOLONG	1	/* entry exceeds MNT_LINE_MAX */
 #define	MNT_TOOMANY	2	/* too many fields in line */

--- a/lib/libspl/include/sys/mount.h
+++ b/lib/libspl/include/sys/mount.h
@@ -29,7 +29,6 @@
 #ifndef _LIBSPL_SYS_MOUNT_H
 #define	_LIBSPL_SYS_MOUNT_H
 
-#include <sys/mntent.h>
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1922,6 +1922,8 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 		mnt.mnt_mntopts = zhp->zfs_mntopts;
 
 	switch (prop) {
+	case ZFS_PROP_ATIME:
+	case ZFS_PROP_RELATIME:
 	case ZFS_PROP_DEVICES:
 	case ZFS_PROP_EXEC:
 	case ZFS_PROP_READONLY:
@@ -1944,8 +1946,6 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 		}
 		break;
 
-	case ZFS_PROP_ATIME:
-	case ZFS_PROP_RELATIME:
 	case ZFS_PROP_CANMOUNT:
 	case ZFS_PROP_VOLSIZE:
 	case ZFS_PROP_QUOTA:

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1535,6 +1535,9 @@ When a file system is mounted, either through \fBmount\fR(8) for legacy mounts o
      readonly                ro/rw
      setuid                  setuid/nosetuid
      xattr                   xattr/noxattr
+     atime                   atime/noatime
+     relatime                relatime/norelatime
+     nbmand                  nbmand/nonbmand
 .fi
 .in -2
 .sp

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1449,7 +1449,7 @@ zfs_sb_hold(const char *name, void *tag, zfs_sb_t **zsbp, boolean_t writer)
 	int error = 0;
 
 	if (get_zfs_sb(name, zsbp) != 0)
-		error = zfs_sb_create(name, zsbp);
+		error = zfs_sb_create(name, NULL, zsbp);
 	if (error == 0) {
 		rrm_enter(&(*zsbp)->z_teardown_lock, (writer) ? RW_WRITER :
 		    RW_READER, tag);

--- a/module/zfs/zpl_super.c
+++ b/module/zfs/zpl_super.c
@@ -184,35 +184,204 @@ zpl_statfs(struct dentry *dentry, struct kstatfs *statp)
 	return (error);
 }
 
+enum {
+	TOKEN_RO,
+	TOKEN_RW,
+	TOKEN_SETUID,
+	TOKEN_NOSETUID,
+	TOKEN_EXEC,
+	TOKEN_NOEXEC,
+	TOKEN_DEVICES,
+	TOKEN_NODEVICES,
+	TOKEN_XATTR,
+	TOKEN_NOXATTR,
+	TOKEN_ATIME,
+	TOKEN_NOATIME,
+	TOKEN_RELATIME,
+	TOKEN_NORELATIME,
+	TOKEN_NBMAND,
+	TOKEN_NONBMAND,
+	TOKEN_MNTPOINT,
+	TOKEN_LAST,
+};
+
+static const match_table_t zpl_tokens = {
+	{ TOKEN_RO,		MNTOPT_RO },
+	{ TOKEN_RW,		MNTOPT_RW },
+	{ TOKEN_SETUID,		MNTOPT_SETUID },
+	{ TOKEN_NOSETUID,	MNTOPT_NOSETUID },
+	{ TOKEN_EXEC,		MNTOPT_EXEC },
+	{ TOKEN_NOEXEC,		MNTOPT_NOEXEC },
+	{ TOKEN_DEVICES,	MNTOPT_DEVICES },
+	{ TOKEN_NODEVICES,	MNTOPT_NODEVICES },
+	{ TOKEN_XATTR,		MNTOPT_XATTR },
+	{ TOKEN_NOXATTR,	MNTOPT_NOXATTR },
+	{ TOKEN_ATIME,		MNTOPT_ATIME },
+	{ TOKEN_NOATIME,	MNTOPT_NOATIME },
+	{ TOKEN_RELATIME,	MNTOPT_RELATIME },
+	{ TOKEN_NORELATIME,	MNTOPT_NORELATIME },
+	{ TOKEN_NBMAND,		MNTOPT_NBMAND },
+	{ TOKEN_NONBMAND,	MNTOPT_NONBMAND },
+	{ TOKEN_MNTPOINT,	MNTOPT_MNTPOINT "=%s" },
+	{ TOKEN_LAST,		NULL },
+};
+
+static int
+zpl_parse_option(char *option, int token, substring_t *args,
+    zfs_mntopts_t *zmo, boolean_t isremount)
+{
+	switch (token) {
+	case TOKEN_RO:
+		zmo->z_readonly = B_TRUE;
+		zmo->z_do_readonly = B_TRUE;
+		break;
+	case TOKEN_RW:
+		zmo->z_readonly = B_FALSE;
+		zmo->z_do_readonly = B_TRUE;
+		break;
+	case TOKEN_SETUID:
+		zmo->z_setuid = B_TRUE;
+		zmo->z_do_setuid = B_TRUE;
+		break;
+	case TOKEN_NOSETUID:
+		zmo->z_setuid = B_FALSE;
+		zmo->z_do_setuid = B_TRUE;
+		break;
+	case TOKEN_EXEC:
+		zmo->z_exec = B_TRUE;
+		zmo->z_do_exec = B_TRUE;
+		break;
+	case TOKEN_NOEXEC:
+		zmo->z_exec = B_FALSE;
+		zmo->z_do_exec = B_TRUE;
+		break;
+	case TOKEN_DEVICES:
+		zmo->z_devices = B_TRUE;
+		zmo->z_do_devices = B_TRUE;
+		break;
+	case TOKEN_NODEVICES:
+		zmo->z_devices = B_FALSE;
+		zmo->z_do_devices = B_TRUE;
+		break;
+	case TOKEN_XATTR:
+		zmo->z_xattr = B_TRUE;
+		zmo->z_do_xattr = B_TRUE;
+		break;
+	case TOKEN_NOXATTR:
+		zmo->z_xattr = B_FALSE;
+		zmo->z_do_xattr = B_TRUE;
+		break;
+	case TOKEN_ATIME:
+		zmo->z_atime = B_TRUE;
+		zmo->z_do_atime = B_TRUE;
+		break;
+	case TOKEN_NOATIME:
+		zmo->z_atime = B_FALSE;
+		zmo->z_do_atime = B_TRUE;
+		break;
+	case TOKEN_RELATIME:
+		zmo->z_relatime = B_TRUE;
+		zmo->z_do_relatime = B_TRUE;
+		break;
+	case TOKEN_NORELATIME:
+		zmo->z_relatime = B_FALSE;
+		zmo->z_do_relatime = B_TRUE;
+		break;
+	case TOKEN_NBMAND:
+		zmo->z_nbmand = B_TRUE;
+		zmo->z_do_nbmand = B_TRUE;
+		break;
+	case TOKEN_NONBMAND:
+		zmo->z_nbmand = B_FALSE;
+		zmo->z_do_nbmand = B_TRUE;
+		break;
+	case TOKEN_MNTPOINT:
+		zmo->z_mntpoint = match_strdup(&args[0]);
+		if (zmo->z_mntpoint == NULL)
+			return (-ENOMEM);
+
+		break;
+	default:
+		break;
+	}
+
+	return (0);
+}
+
+/*
+ * Parse the mntopts string storing the results in provided zmo argument.
+ * If an error occurs the zmo argument will not be modified.  The caller
+ * needs to set isremount when recycling an existing zfs_mntopts_t.
+ */
+static int
+zpl_parse_options(char *osname, char *mntopts, zfs_mntopts_t *zmo,
+    boolean_t isremount)
+{
+	zfs_mntopts_t *tmp_zmo;
+	substring_t args[MAX_OPT_ARGS];
+	char *tmp_mntopts, *p;
+	int error, token;
+
+	if (mntopts == NULL)
+		return (-EINVAL);
+
+	tmp_zmo = zfs_mntopts_alloc();
+	tmp_zmo->z_osname = strdup(osname);
+	tmp_mntopts = strdup(mntopts);
+
+	while ((p = strsep(&tmp_mntopts, ",")) != NULL) {
+		if (!*p)
+			continue;
+
+		args[0].to = args[0].from = NULL;
+		token = match_token(p, zpl_tokens, args);
+		error = zpl_parse_option(p, token, args, tmp_zmo, isremount);
+		if (error) {
+			zfs_mntopts_free(tmp_zmo);
+			strfree(tmp_mntopts);
+			return (error);
+		}
+	}
+
+	strfree(tmp_mntopts);
+
+	if (isremount == B_TRUE) {
+		if (zmo->z_osname)
+			strfree(zmo->z_osname);
+
+		if (zmo->z_mntpoint)
+			strfree(zmo->z_mntpoint);
+	} else {
+		ASSERT3P(zmo->z_osname, ==, NULL);
+		ASSERT3P(zmo->z_mntpoint, ==, NULL);
+	}
+
+	memcpy(zmo, tmp_zmo, sizeof (zfs_mntopts_t));
+	kmem_free(tmp_zmo, sizeof (zfs_mntopts_t));
+
+	return (0);
+}
+
 static int
 zpl_remount_fs(struct super_block *sb, int *flags, char *data)
 {
+	zfs_sb_t *zsb = sb->s_fs_info;
 	fstrans_cookie_t cookie;
 	int error;
 
+	error = zpl_parse_options(zsb->z_mntopts->z_osname, data,
+	    zsb->z_mntopts, B_TRUE);
+	if (error)
+		return (error);
+
 	cookie = spl_fstrans_mark();
-	error = -zfs_remount(sb, flags, data);
+	error = -zfs_remount(sb, flags, zsb->z_mntopts);
 	spl_fstrans_unmark(cookie);
 	ASSERT3S(error, <=, 0);
 
 	return (error);
 }
 
-/*
- * ZFS specific features must be explicitly handled here, the VFS will
- * automatically handled the following generic functionality.
- *
- *   MNT_NOSUID,
- *   MNT_NODEV,
- *   MNT_NOEXEC,
- *   MNT_NOATIME,
- *   MNT_NODIRATIME,
- *   MNT_READONLY,
- *   MNT_STRICTATIME,
- *   MS_SYNCHRONOUS,
- *   MS_DIRSYNC,
- *   MS_MANDLOCK.
- */
 static int
 __zpl_show_options(struct seq_file *seq, zfs_sb_t *zsb)
 {
@@ -249,11 +418,12 @@ zpl_show_options(struct seq_file *seq, struct vfsmount *vfsp)
 static int
 zpl_fill_super(struct super_block *sb, void *data, int silent)
 {
+	zfs_mntopts_t *zmo = (zfs_mntopts_t *)data;
 	fstrans_cookie_t cookie;
 	int error;
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_domount(sb, data, silent);
+	error = -zfs_domount(sb, zmo, silent);
 	spl_fstrans_unmark(cookie);
 	ASSERT3S(error, <=, 0);
 
@@ -265,18 +435,32 @@ static struct dentry *
 zpl_mount(struct file_system_type *fs_type, int flags,
     const char *osname, void *data)
 {
-	zpl_mount_data_t zmd = { osname, data };
+	zfs_mntopts_t *zmo = zfs_mntopts_alloc();
+	int error;
 
-	return (mount_nodev(fs_type, flags, &zmd, zpl_fill_super));
+	error = zpl_parse_options((char *)osname, (char *)data, zmo, B_FALSE);
+	if (error) {
+		zfs_mntopts_free(zmo);
+		return (ERR_PTR(error));
+	}
+
+	return (mount_nodev(fs_type, flags, zmo, zpl_fill_super));
 }
 #else
 static int
 zpl_get_sb(struct file_system_type *fs_type, int flags,
     const char *osname, void *data, struct vfsmount *mnt)
 {
-	zpl_mount_data_t zmd = { osname, data };
+	zfs_mntopts_t *zmo = zfs_mntopts_alloc();
+	int error;
 
-	return (get_sb_nodev(fs_type, flags, &zmd, zpl_fill_super, mnt));
+	error = zpl_parse_options((char *)osname, (char *)data, zmo, B_FALSE);
+	if (error) {
+		zfs_mntopts_free(zmo);
+		return (error);
+	}
+
+	return (get_sb_nodev(fs_type, flags, zmo, zpl_fill_super, mnt));
 }
 #endif /* HAVE_MOUNT_NODEV */
 


### PR DESCRIPTION
Add the required kernel side infrastructure to parse arbitrary
mount options.  This enables us to support temporary mount
options is largely the same way it's handled on other platforms.

See the 'Temporary Mount Point Properties' section of zfs(8)
for complete details.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Closes #985
Closes #3351