### PR TITLE
Prevent reclaim in the traverse prefetch thread

### DIFF
--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -476,6 +476,7 @@ traverse_prefetch_thread(void *arg)
 	traverse_data_t *td_main = arg;
 	traverse_data_t td = *td_main;
 	zbookmark_phys_t czb;
+	fstrans_cookie_t cookie = spl_fstrans_mark();
 
 	td.td_func = traverse_prefetcher;
 	td.td_arg = td_main->td_pfd;
@@ -489,6 +490,7 @@ traverse_prefetch_thread(void *arg)
 	td_main->td_pfd->pd_exited = B_TRUE;
 	cv_broadcast(&td_main->td_pfd->pd_cv);
 	mutex_exit(&td_main->td_pfd->pd_mtx);
+	spl_fstrans_unmark(cookie);
 }
 
 /*


### PR DESCRIPTION
Reclaim in the traverse prefetch thread, which is run on the system
taskq, can overrun the stack.