### PR TITLE
zfs-zed segmentation fault when running 'rc-service zfs-zed status' on Gentoo

### DIFF
--- a/etc/init.d/zfs-zed.in
+++ b/etc/init.d/zfs-zed.in
@@ -127,6 +127,5 @@ else
 	depend() { do_depend; }
 	start() { do_start; }
 	stop() { do_stop; }
-	status() { do_status; }
 	reload() { do_reload; }
 fi


### PR DESCRIPTION
* Gentoo Linux
* Gentoo Base System release 2.2
* amd64 no-multilib

When running `rc-service zfs-zed status`, segmentation fault occurs because of infinite loop.
`status` defined in `zfs-zed.in` calls `zfs_daemon_status` in `zfs-functions.sh` and `status` is called again in `zfs_daemon_status` because the condition for Fedora/RedHat function is true. So, infinite loop occurs. I should think we delete `status` in `zfs-zed.in`

`zfs-zed.in`
``` sh
else
	# Create wrapper functions since Gentoo don't use the case part.
	depend() { do_depend; }
	start() { do_start; }
	stop() { do_stop; }
	status() { do_status; }  # define
	reload() { do_reload; }
```

`zfs-functions.sh`
``` sh
# Returns status
zfs_daemon_status()
{
	local PIDFILE="$1"
	local DAEMON_BIN="$2"
	local DAEMON_NAME="$3"

	if type status_of_proc > /dev/null 2>&1 ; then
		# LSB functions
		status_of_proc "$DAEMON_NAME" "$DAEMON_BIN"
		return $?
	elif type status > /dev/null 2>&1 ; then # true
		# Fedora/RedHat functions
		status -p "$PIDFILE" "$DAEMON_NAME" #LOOP!!
		return $?
	else
		# Unsupported
		return 3
	fi

	return 0
}
```