### PR TITLE
zfs-zed cannot reload zed.rc in OpenRC

### DIFF
--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -227,7 +227,7 @@ zfs_daemon_reload()
 
 	if type start-stop-daemon > /dev/null 2>&1 ; then
 		# LSB functions
-		start-stop-daemon --stop -signal 1 --quiet \
+		start-stop-daemon --stop --signal 1 --quiet \
 		    --pidfile "$PIDFILE" --name "$DAEMON_NAME"
 		return $?
 	elif type killproc > /dev/null 2>&1 ; then

--- a/etc/init.d/zfs-zed.in
+++ b/etc/init.d/zfs-zed.in
@@ -32,6 +32,8 @@
 ZED_NAME="zed"
 ZED_PIDFILE="@runstatedir@/$ZED_NAME.pid"
 
+extra_started_commands="reload"
+
 # Exit if the package is not installed
 [ -x "$ZED" ] || exit 0
 


### PR DESCRIPTION
zfs-zed needs `extra_started_commands="reload"` because openrc-run have no reload function by default 