### PR TITLE
Fix assertion failures in uio_prefaultpages()

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -653,6 +653,7 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 		xuio = (xuio_t *)uio;
 	else
 #endif
+	if (MIN(n, max_blksz) > 0)
 		uio_prefaultpages(MIN(n, max_blksz), uio);
 
 	/*
@@ -895,7 +896,7 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 		ASSERT(tx_bytes == nbytes);
 		n -= nbytes;
 
-		if (!xuio && n > 0)
+		if (!xuio && MIN(n, max_blksz) > 0)
 			uio_prefaultpages(MIN(n, max_blksz), uio);
 	}
 


### PR DESCRIPTION
5475aada9474464f973788c1b2fc6216486fb303 added assertions to the uio
code to catch callers that were passing 0 bytes to the function.
Unfortunately, zfs_write() has:

uio_prefaultpages(MIN(n, max_blksz), uio);

...

while (n > 0)
{
...
	if (!xuio && n > 0)
		uio_prefaultpages(MIN(n, max_blksz), uio);
...
}

The uio code is happy to handle the zero-length calls, but the assertion
causes a failure:

[   38.016728] VERIFY3(skip < iov->iov_len) failed (0 < 0)
[   38.016775] PANIC at zfs_uio.c:187:uio_prefaultpages()
[   38.016817] Showing stack for process 2702
[   38.016822] CPU: 3 PID: 2702 Comm: Plex Media Serv Tainted: P           O    4.1.7-FC.01 #6
[   38.016825] Hardware name: Gigabyte Technology Co., Ltd. To be filled by O.E.M./970A-DS3, BIOS FD 01/23/2013
[   38.016828]  00000000000000bb ffff880219bd38f8 ffffffff818e0e28 0000000000000000
[   38.016833]  ffffffffa0045271 ffff880219bd3908 ffffffffa0008414 ffff880219bd3a88
[   38.016837]  ffffffffa00084cc ffff880219bd3948 ffffffff00000030 ffff880219bd3a98
[   38.016841] Call Trace:
[   38.016851]  [<ffffffff818e0e28>] dump_stack+0x45/0x57
[   38.016871]  [<ffffffffa0008414>] spl_dumpstack+0x44/0x50 [spl]
[   38.016880]  [<ffffffffa00084cc>] spl_panic+0xac/0xf0 [spl]
[   38.016914]  [<ffffffffa0112fd3>] ? rrm_exit+0x53/0x90 [zfs]
[   38.016937]  [<ffffffffa0176cde>] ? zfs_setattr+0x2ae/0x20b0 [zfs]
[   38.016941]  [<ffffffff818e62c6>] ? mutex_lock+0x16/0x37
[   38.016969]  [<ffffffffa0111dab>] ? refcount_add_many+0xab/0x150 [zfs]
[   38.016978]  [<ffffffffa0041a84>] uio_prefaultpages+0x144/0x150 [zcommon]
[   38.016999]  [<ffffffffa0179f41>] zfs_write+0x201/0xe70 [zfs]
[   38.017026]  [<ffffffffa0112fd3>] ? rrm_exit+0x53/0x90 [zfs]
[   38.017031]  [<ffffffff811e3f79>] ? __kmalloc_node+0x139/0x2f0
[   38.017035]  [<ffffffff8123d5f6>] ? fsnotify+0x306/0x490
[   38.017043]  [<ffffffffa0000c10>] ? spl_kmem_zalloc+0x100/0x1b0 [spl]
[   38.017050]  [<ffffffff8121adf8>] ? notify_change+0x298/0x3b0
[   38.017055]  [<ffffffff811fc8f0>] ? do_truncate+0x80/0xa0
[   38.017059]  [<ffffffff81209271>] ? terminate_walk+0x51/0x60
[   38.017079]  [<ffffffffa019a31e>] zpl_write_common_iovec+0x7e/0x110 [zfs]
[   38.017099]  [<ffffffffa019a454>] zpl_iter_write+0xa4/0xe0 [zfs]
[   38.017104]  [<ffffffff81478333>] ? security_file_permission+0x23/0xa0
[   38.017123]  [<ffffffffa019a3b0>] ? zpl_write_common_iovec+0x110/0x110 [zfs]
[   38.017127]  [<ffffffff811fee19>] do_readv_writev+0x1e9/0x2b0
[   38.017146]  [<ffffffffa019a490>] ? zpl_iter_write+0xe0/0xe0 [zfs]
[   38.017151]  [<ffffffff8120e36f>] ? putname+0x6f/0x80
[   38.017154]  [<ffffffff811fef69>] vfs_writev+0x39/0x50
[   38.017157]  [<ffffffff811ffcea>] SyS_writev+0x4a/0xd0
[   38.017162]  [<ffffffff818e7e6e>] system_call_fastpath+0x12/0x71

This was detected by vectored writes done by plex. We could just delete the
assertions, but given that it does not make sense to call the uio code at all
if there is an assertion failure, it is better to change this to avoid calling
uio_prefaultpages().

Reported-by: Jonathan Vasquez <jvasquez1011@gmail.com>
Signed-off-by: Richard Yao <ryao@gentoo.org>