### PR TITLE
Add large block support to zpios(1)

### DIFF
--- a/cmd/zpios/zpios.h
+++ b/cmd/zpios/zpios.h
@@ -29,6 +29,8 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with ZPIOS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Copyright (c) 2015, Intel Corporation.
  */
 
 #ifndef _ZPIOS_H
@@ -39,10 +41,10 @@
 #define	VERSION_SIZE		64
 
 /* Regular expressions */
-#define	REGEX_NUMBERS		"^[0-9]*[0-9]$"
+#define	REGEX_NUMBERS		"^[0-9]+$"
 #define	REGEX_NUMBERS_COMMA	"^([0-9]+,)*[0-9]+$"
-#define	REGEX_SIZE		"^[0-9][0-9]*[kmgt]$"
-#define	REGEX_SIZE_COMMA	"^([0-9][0-9]*[kmgt]+,)*[0-9][0-9]*[kmgt]$"
+#define	REGEX_SIZE		"^[0-9]+[kKmMgGtT]?$"
+#define	REGEX_SIZE_COMMA	"^([0-9]+[kKmMgGtT]?,)*[0-9]+[kKmMgGtT]?$"
 
 /* Flags for low, high, incr */
 #define	FLAG_SET		0x01
@@ -82,10 +84,12 @@ typedef struct cmd_args {
 	range_repeat_t O;		/* Offset count */
 	range_repeat_t C;		/* Chunksize */
 	range_repeat_t S;		/* Regionsize */
+	range_repeat_t B;		/* Blocksize */
 
 	const char *pool;		/* Pool */
 	const char *name;		/* Name */
 	uint32_t flags;			/* Flags */
+	uint32_t block_size;		/* ZFS block size */
 	uint32_t io_type;		/* DMUIO only */
 	uint32_t verbose;		/* Verbose */
 	uint32_t human_readable;	/* Human readable output */
@@ -105,6 +109,7 @@ typedef struct cmd_args {
 	uint64_t current_C;
 	uint64_t current_S;
 	uint64_t current_O;
+	uint64_t current_B;
 
 	uint32_t rc;
 } cmd_args_t;

--- a/cmd/zpios/zpios_util.c
+++ b/cmd/zpios/zpios_util.c
@@ -29,6 +29,8 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with ZPIOS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Copyright (c) 2015, Intel Corporation.
  */
 
 #include <stdlib.h>
@@ -185,6 +187,8 @@ int
 set_count(char *pattern1, char *pattern2, range_repeat_t *range,
     char *optarg, uint32_t *flags, char *arg)
 {
+	uint64_t count = range->val_count;
+
 	if (flags)
 		*flags |= FLAG_SET;
 
@@ -197,6 +201,9 @@ set_count(char *pattern1, char *pattern2, range_repeat_t *range,
 		fprintf(stderr, "Error: Incorrect pattern for %s, '%s'\n",
 		    arg, optarg);
 		return (EINVAL);
+	} else if (count == range->val_count) {
+		fprintf(stderr, "Error: input ignored for %s, '%s'\n",
+		    arg, optarg);
 	}
 
 	return (0);
@@ -314,14 +321,14 @@ print_stats_header(cmd_args_t *args)
 	if (args->verbose) {
 		printf(
 		    "status    name        id\tth-cnt\trg-cnt\trg-sz\t"
-		    "ch-sz\toffset\trg-no\tch-no\tth-dly\tflags\ttime\t"
+		    "ch-sz\toffset\trg-no\tch-no\tth-dly\tflags\tblksz\ttime\t"
 		    "cr-time\trm-time\twr-time\trd-time\twr-data\twr-ch\t"
 		    "wr-bw\trd-data\trd-ch\trd-bw\n");
 		printf(
-		    "------------------------------------------------"
-		    "------------------------------------------------"
-		    "------------------------------------------------"
-		    "----------------------------------------------\n");
+		    "-------------------------------------------------"
+		    "-------------------------------------------------"
+		    "-------------------------------------------------"
+		    "--------------------------------------------------\n");
 	} else {
 		printf(
 		    "status    name        id\t"
@@ -358,6 +365,7 @@ print_stats_human_readable(cmd_args_t *args, zpios_cmd_t *cmd)
 		printf("%s\t", uint64_to_kmgt(str, cmd->cmd_chunk_noise));
 		printf("%s\t", uint64_to_kmgt(str, cmd->cmd_thread_delay));
 		printf("%s\t", print_flags(str, cmd->cmd_flags));
+		printf("%s\t", uint64_to_kmgt(str, cmd->cmd_block_size));
 	}
 
 	if (args->rc) {
@@ -414,6 +422,7 @@ print_stats_table(cmd_args_t *args, zpios_cmd_t *cmd)
 		printf("%u\t", cmd->cmd_chunk_noise);
 		printf("%u\t", cmd->cmd_thread_delay);
 		printf("0x%x\t", cmd->cmd_flags);
+		printf("%u\t", cmd->cmd_block_size);
 	}
 
 	if (args->rc) {

--- a/include/zpios-ctl.h
+++ b/include/zpios-ctl.h
@@ -29,6 +29,8 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with ZPIOS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Copyright (c) 2015, Intel Corporation.
  */
 
 #ifndef _ZPIOS_CTL_H
@@ -116,6 +118,7 @@ typedef struct zpios_cmd {
 	uint32_t cmd_chunk_noise;	/* Chunk noise */
 	uint32_t cmd_thread_delay;	/* Thread delay */
 	uint32_t cmd_flags;		/* Test flags */
+	uint32_t cmd_block_size;	/* ZFS block size */
 	char cmd_pre[ZPIOS_PATH_SIZE];	/* Pre-exec hook */
 	char cmd_post[ZPIOS_PATH_SIZE];	/* Post-exec hook */
 	char cmd_log[ZPIOS_PATH_SIZE];  /* Requested log dir */

--- a/include/zpios-internal.h
+++ b/include/zpios-internal.h
@@ -29,6 +29,8 @@
  *
  *  You should have received a copy of the GNU General Public License along
  *  with ZPIOS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Copyright (c) 2015, Intel Corporation.
  */
 
 #ifndef _ZPIOS_INTERNAL_H
@@ -79,6 +81,7 @@ typedef struct run_args {
 	__u32 chunk_noise;
 	__u32 thread_delay;
 	__u32 flags;
+	__u32 block_size;
 	char pre[ZPIOS_PATH_SIZE];
 	char post[ZPIOS_PATH_SIZE];
 	char log[ZPIOS_PATH_SIZE];

--- a/man/man1/zpios.1
+++ b/man/man1/zpios.1
@@ -22,6 +22,8 @@
 .\"
 .\" Copyright 2013 Darik Horn <dajhorn@vanadac.com>. All rights reserved.
 .\"
+.\" Copyright (c) 2015, Intel Corporation.
+.\"
 .TH zpios 1 "2013 FEB 28" "ZFS on Linux" "User Commands"
 
 .SH NAME
@@ -36,10 +38,10 @@ not depend on the ZFS Posix Layer ("ZPL").
 
 .SH OPTIONS
 .HP
-.BI "\-s" " regex" ", \-\-threadcount" " regex"
+.BI "\-t" " regex" ", \-\-threadcount" " regex"
 .IP
 Start this many threads for each test series, specified as a comma
-delimited regular expression. (eg: "-s 1,2,3")
+delimited regular expression. (eg: "-t 1,2,3")
 .IP
 This option is mutually exclusive with the \fBthreadcount_*\fR
 options.
@@ -119,6 +121,35 @@ chunk size for the last test.
 .IP
 These three options must be specified together and are mutually
 exclusive with the \fBchunksize\fR option.
+.HP
+.BI "\-s" " size" ", \-\-regionsize" " size"
+.IP
+Use \fIsize\fR regions for each test, specified as a comma delimited
+regular expression with an optional unit suffix. (eg: "-s 1M" means
+one megabyte.)
+.IP
+This option is mutually exclusive with the \fBregionsize_*\fB options.
+.HP
+.BI "\-A" " size_low" ", \-\-regionsize_low" " size_low"
+.HP
+.BI "\-B" " size_high" ", \-\-regionsize_high" " size_high"
+.HP
+.BI "\-C" " size_incr" ", \-\-regionsize_incr" " size_incr"
+.IP
+Use a \fIsize_low\fR region size for the first test, add \fIsize_incr\fR
+to the region size for each subsequent test, and use a \fIsize_high\fR
+region size for the last test.
+.IP
+These three options must be specified together and are mutually
+exclusive with the \fBregionsize\fR option.
+.HP
+.BI "\-S" " size | sizes" ", \-\-blocksize" " size | sizes"
+.IP
+Use \fIsize\fR ZFS blocks for each test, specified as a comma delimited
+regular expression with an optional unit suffix. (eg: "-S 1M" means
+one megabyte.) The supported range is powers of two from 128K through 16M.
+A range of blocks can be tested as follows: "-S 128K,256K,512K,1M".
+.IP
 .HP
 .BI "\-L" " dmu_flags" ", \-\-load" " dmu_flags"
 .IP


### PR DESCRIPTION
As part of the large block support effort, it makes sense to add support for large blocks to **zpios(1)**. The specifying of a zfs block size for zpios is optional and will default to 128K if the block size is not specified.

  `zpios ... -S size | --blocksize size ...`

This will use *size* ZFS blocks for each test, specified as a comma delimited list with an optional unit suffix. The supported range is powers of two from 128K through 16M. A range of block sizes can be tested as follows: `-S 128K,256K,512K,1M`

Example run below
(non realistic results from a VM and output abbreviated for space)

```
 zpios --load=dmuio,fpp --pool=test --name=test --threadcount=4,8,16
 --regioncount=750 --regionsize=8M --chunksize=1M --offset=4K
 --threaddelay=0 --cleanup --human-readable --verbose --cleanup
 --blocksize=128K,256K,512K,1M

 th-cnt  rg-cnt  rg-sz  ch-sz  blksz  wr-data wr-bw   rd-data rd-bw
---------------------------------------------------------------------
 4       750     8m     1m     128k   5g      90.06m  5g      93.37m
 4       750     8m     1m     256k   5g      79.71m  5g      99.81m
 4       750     8m     1m     512k   5g      42.20m  5g      93.14m
 4       750     8m     1m     1m     5g      35.51m  5g      89.36m
 8       750     8m     1m     128k   5g      85.49m  5g      90.81m
 8       750     8m     1m     256k   5g      61.42m  5g      99.24m
 8       750     8m     1m     512k   5g      49.09m  5g     108.78m
 16      750     8m     1m     128k   5g      86.28m  5g      88.73m
 16      750     8m     1m     256k   5g      64.34m  5g      93.47m
 16      750     8m     1m     512k   5g      68.84m  5g     124.47m
 16      750     8m     1m     1m     5g      53.97m  5g      97.20m
---------------------------------------------------------------------
```