### PR TITLE
Discard on zvols should not exceed the length of a block

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -661,6 +661,7 @@ zvol_discard(struct bio *bio)
 	if (!(bio->bi_rw & REQ_SECURE)) {
 		start = P2ROUNDUP(start, zv->zv_volblocksize);
 		end = P2ALIGN(end, zv->zv_volblocksize);
+		size = end - start;
 	}
 #endif
 


### PR DESCRIPTION
37f9dac592bf5889c3efb305c48ac39b4c7dd140 replaced the end-start
calculation with a cached value, but neglected to update it on discard
operations. This can cause us to discard data not requested, causing
data loss on zvols.

Reported-by: Richard Connon <richard.connon@zynstra.com>
Signed-off-by: Richard Yao <ryao@gentoo.org>