### PR TITLE
Linux 4.3 compat: bio_end_io_t / BIO_UPTODATE

### DIFF
--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -408,16 +408,12 @@ BIO_END_IO_PROTO(vdev_disk_physio_completion, bio, error)
 	dio_request_t *dr = bio->bi_private;
 	int rc;
 
-	if (dr->dr_error == 0) {
+	if (dr->dr_error == 0)
 #ifdef HAVE_1ARG_BIO_END_IO_T
 		dr->dr_error = -(bio->bi_error);
 #else
-		if (error)
-			dr->dr_error = -(error);
-		else if (!test_bit(BIO_UPTODATE, &bio->bi_flags))
-			dr->dr_error = EIO;
+		dr->dr_error = -(error);
 #endif
-	}
 
 	/* Drop reference aquired by __vdev_disk_physio */
 	rc = vdev_disk_dio_put(dr);


### PR DESCRIPTION
This seems to be the only compat issue with 4.3 so far, I have it running fine now with 4.3-rc2. Let's see what the build bot says.

I refactored the code in `vdev_disk_physio_completion()` a bit in an attempt to retain readability. If you want anything changed do not hesitate to post a comment. Thanks.

One thing that struck me as odd is that `dio_request_t->dr_error` (and consequently `zio->io_error`) stores a *positive* errno. Is this a Solaris convention?

Fixes #3799