### PR TITLE
prevent running /etc/init.d/zfs-import if using systemd

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -5,6 +5,7 @@ Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
 ConditionPathExists=@sysconfdir@/zfs/zpool.cache
+Conflicts=zfs-import.service
 
 [Service]
 Type=oneshot

--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -12,3 +12,4 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/sbin/modprobe zfs
 ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
+ExecStop=@sbindir@/zpool export -a

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -12,3 +12,4 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/sbin/modprobe zfs
 ExecStart=@sbindir@/zpool import -d /dev/disk/by-id -aN
+ExecStop=@sbindir@/zpool export -a

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -5,6 +5,7 @@ Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
 ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
+Conflicts=zfs-import.service
 
 [Service]
 Type=oneshot

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -13,3 +13,4 @@ Before=local-fs.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@sbindir@/zfs mount -a
+ExecStop=@sbindir@/zfs unmount -a

--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -12,3 +12,4 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=-@bindir@/rm /etc/dfs/sharetab
 ExecStart=@sbindir@/zfs share -a
+ExecStop=@sbindir@/zfs unshare -a


### PR DESCRIPTION
For systems with systemd in sysv init compatibility mode you have to prevent that services in /etc/init.d will be executed if there is a equivalent in systemd.
There is zfs-import without a corresponding systemd service. You have to add 'Conflicts=zfs-import.service' to zfs-import-cache.service and zfs-import-scan.service.