### PR TITLE
prevent /etc/init.d/zfs-import from running with systemd

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -5,6 +5,7 @@ Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
 ConditionPathExists=@sysconfdir@/zfs/zpool.cache
+Conflicts=zfs-import.service
 
 [Service]
 Type=oneshot

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -5,6 +5,7 @@ Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
 ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
+Conflicts=zfs-import.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
zfsonlinux/zfs#3837
For systems with systemd in sysv init compatibility mode you have to prevent that services in /etc/init.d will be executed if there is a equivalent in systemd.
There is zfs-import without a corresponding systemd service.