### PR TITLE
Fix uioskip crash when skip to end

### DIFF
--- a/module/zcommon/zfs_uio.c
+++ b/module/zcommon/zfs_uio.c
@@ -236,13 +236,15 @@ uioskip(uio_t *uiop, size_t n)
 
 	uiop->uio_skip += n;
 	if (uiop->uio_segflg != UIO_BVEC) {
-		while (uiop->uio_skip >= uiop->uio_iov->iov_len) {
+		while (uiop->uio_iovcnt &&
+		    uiop->uio_skip >= uiop->uio_iov->iov_len) {
 			uiop->uio_skip -= uiop->uio_iov->iov_len;
 			uiop->uio_iov++;
 			uiop->uio_iovcnt--;
 		}
 	} else {
-		while (uiop->uio_skip >= uiop->uio_bvec->bv_len) {
+		while (uiop->uio_iovcnt &&
+		    uiop->uio_skip >= uiop->uio_bvec->bv_len) {
 			uiop->uio_skip -= uiop->uio_bvec->bv_len;
 			uiop->uio_bvec++;
 			uiop->uio_iovcnt--;


### PR DESCRIPTION
When doing uioskip to skip an iovec to the very end, the current loop
condition will falsely check pass the end of iovec. We fix this checking
uio_iovcnt first.

Signed-off-by: Chunwei Chen <tuxoko@gmail.com>