### PR TITLE
Always remove during spl-dkms uninstall/update

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -62,14 +62,8 @@ echo -e "support or upgrade DKMS to a more current version."
 exit 1
 
 %preun
-# Only remove the modules if they are for this %{version}-%{release}.  A
-# package upgrade can replace them if only the %{release} is changed.
-RELEASE="/var/lib/dkms/%{module}/%{version}/build/%{module}.release"
-if [ -f $RELEASE ] && [ `cat $RELEASE`%{?dist} = "%{version}-%{release}" ]; then
-    echo -e
-    echo -e "Uninstall of %{module} module (version %{version}) beginning:"
-    dkms remove -m %{module} -v %{version} --all --rpm_safe_upgrade
-fi
+echo -e "Uninstall of %{module} module (version %{version}) beginning:"
+dkms remove -m %{module} -v %{version} --all --rpm_safe_upgrade
 exit 0
 
 %changelog


### PR DESCRIPTION
Always do a dkms remove during %preun so that no cruft is left behind after upgrade or uninstall.

Fixes zfsonlinux/spl#476

Signed-off-by: Nathaniel Clark <Nathaniel.Clark@misrule.us>