### PR TITLE
WIP: Refactor systemd and use /etc/default/zfs if available

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Import ZFS pools by cache file
+Documentation=man:zpool(8)
 DefaultDependencies=no
 Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service

--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -5,10 +5,12 @@ Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
 Before=dracut-mount.service
-ConditionPathExists=@sysconfdir@/zfs/zpool.cache
+ConditionPathExists=${ZPOOL_CACHE:-@sysconfdir@/zfs/zpool.cache}
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+EnvironmentFile=-@initconfdir@/zfs
+Environment="ZPOOL_CACHE=${ZPOOL_CACHE:-@sysconfdir@/zfs/zpool.cache}"
 ExecStartPre=/sbin/modprobe zfs
-ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
+ExecStart=@sbindir@/zpool import ${ZPOOL_CACHE:+-c "${ZPOOL_CACHE}"} -aN ${ZPOOL_IMPORT_OPTS}

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Import ZFS pools by device scanning
+Documentation=man:zpool(8)
 DefaultDependencies=no
 Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -5,10 +5,12 @@ Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
 Before=dracut-mount.service
-ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
+ConditionPathExists=!${ZPOOL_CACHE:-@sysconfdir@/zfs/zpool.cache}
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+EnvironmentFile=-@initconfdir@/zfs
+Environment="ZPOOL_CACHE=${ZPOOL_CACHE:-@sysconfdir@/zfs/zpool.cache}"
 ExecStartPre=/sbin/modprobe zfs
-ExecStart=@sbindir@/zpool import -d /dev/disk/by-id -aN
+ExecStart=@sbindir@/zpool import ${ZPOOL_IMPORT_PATH:+-d "${ZPOOL_IMPORT_PATH}"} -aN ${ZPOOL_IMPORT_OPTS}

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mount ZFS filesystems
+Documentation=man:zfs(8)
 DefaultDependencies=no
 Wants=zfs-import-cache.service
 Wants=zfs-import-scan.service

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -12,4 +12,5 @@ Before=local-fs.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=@sbindir@/zfs mount -a
+EnvironmentFile=-@initconfdir@/zfs
+ExecStart=@sbindir@/zfs mount -a ${MOUNT_EXTRA_OPTIONS}

--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=ZFS file system shares
+Documentation=man:zfs(8)
 After=nfs-server.service nfs-kernel-server.service
 After=smb.service
 After=zfs-mount.service

--- a/etc/systemd/system/zfs-zed.service.in
+++ b/etc/systemd/system/zfs-zed.service.in
@@ -5,7 +5,8 @@ After=zfs-import-cache.service
 After=zfs-import-scan.service
 
 [Service]
-ExecStart=@sbindir@/zed -F
+EnvironmentFile=-@initconfdir@/zfs
+ExecStart=@sbindir@/zed -F ${ZED_ARGS}
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
Rearrangement of some source directories.
    
* Move the systemd files into the contrib directory. This isn't really part of the ZFS/ZoL code, so it's more appropriate to put it in the contrib directory.

Use the /etc/{default,sysconfig}/zfs file in systemd service files (1of3).
    
* Instead of looing for the hardcoded @sysconfdir@/zfs/zpool.cache file, use the $ZFS_CACHE if/when set.
* Instead of using hardcoded /dev/disk/by-id dir in import, use the ZPOOL_IMPORT_PATH if/when set.
* Use ZPOOL_IMPORT_OPTS if/when applicable.

Use the /etc/{default,sysconfig}/zfs file in systemd service files (2of3).
    
* Use VERBOSE_MOUNT, DO_OVERLAY_MOUNTS and/or MOUNT_EXTRA_OPTIONS to <code>zfs mount</code> if/when applicable.

Use the /etc/{default,sysconfig}/zfs file in systemd service files (3of3).
    
* Use the ZED_ARGS variable when starting zed if/when applicable.


This whole PR is untested, so I'm tagging this **WIP**.