### PR TITLE
Fix zfsctl_snapshot_add panic

### DIFF
--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -1115,10 +1115,13 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	error = 0;
 
 	mutex_enter(&zfs_snapshot_lock);
-	se = zfsctl_snapshot_alloc(full_name, full_path,
-	    dmu_objset_id(snap_zsb->z_os), dentry);
-	zfsctl_snapshot_add(se);
-	zfsctl_snapshot_unmount_delay_impl(se, zfs_expire_snapshot);
+	se = zfsctl_snapshot_find_by_name(full_name);
+	if (se == NULL) {
+		se = zfsctl_snapshot_alloc(full_name, full_path,
+		    dmu_objset_id(snap_zsb->z_os), dentry);
+		zfsctl_snapshot_add(se);
+		zfsctl_snapshot_unmount_delay_impl(se, zfs_expire_snapshot);
+	}
 	mutex_exit(&zfs_snapshot_lock);
 error:
 	kmem_free(full_name, MAXNAMELEN);


### PR DESCRIPTION
There exists a race where the kernel will auto-mount a snapshot in
two different namespaces.  This can result in the zfs_snapentry_t
being added to the snapshot AVL trees twice.  In order to prevent
the panic check if it exists in the tree before inserting it.

Longer term to correctly handle multiple mounts in different
namespaces we may need to keep a list of all valid mount points
for each entry.  Otherwise we run the risk of them not automatically
unmounting.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3786
Issue #3887