### PR TITLE
libspl sys/sysmacros.h: Fix P2ROUNDUP_TYPED to not trigger integer overflow

### DIFF
--- a/lib/libspl/include/sys/sysmacros.h
+++ b/lib/libspl/include/sys/sysmacros.h
@@ -49,9 +49,7 @@
  */
 #define	P2ALIGN(x, align)	((x) & -(align))
 #define	P2CROSS(x, y, align)	(((x) ^ (y)) > (align) - 1)
-#define	P2ROUNDUP(x, align)	(-(-(x) & -(align)))
-#define	P2ROUNDUP_TYPED(x, align, type) \
-				(-(-(type)(x) & -(type)(align)))
+#define	P2ROUNDUP(x, align)	((((x) - 1) | ((align) - 1)) + 1)
 #define	P2BOUNDARY(off, len, align) \
 				(((off) ^ ((off) + (len) - 1)) > (align) - 1)
 #define	P2PHASE(x, align)	((x) & ((align) - 1))
@@ -79,7 +77,7 @@
 #define	P2NPHASE_TYPED(x, align, type)		\
 	(-(type)(x) & ((type)(align) - 1))
 #define	P2ROUNDUP_TYPED(x, align, type)		\
-	(-(-(type)(x) & -(type)(align)))
+	((((type)(x) - 1) | ((type)(align) - 1)) + 1)
 #define	P2END_TYPED(x, align, type)		\
 	(-(~(type)(x) & -(type)(align)))
 #define	P2PHASEUP_TYPED(x, align, phase, type)	\


### PR DESCRIPTION
The original P2ROUNDUP_TYPED macro contains a -x which triggers PaX's
integer overflow detection for unsigned integers. Replace the macro with
an equivalent version that does not trigger the overflow.

Signed-off-by: Jason Zaman <jason@perfinion.com>

fixes https://github.com/zfsonlinux/zfs/issues/2505