### PR TITLE
Illumos 6319 assertion failed in zio_ddt_write: bp->blk_birth == txg

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1147,6 +1147,8 @@ zio_write_bp_init(zio_t *zio)
 			zio->io_pipeline |= ZIO_STAGE_DDT_WRITE;
 			return (ZIO_PIPELINE_CONTINUE);
 		}
+		zio->io_bp_override = NULL;
+		BP_ZERO(bp);
 	}
 
 	if (!BP_IS_HOLE(bp) && bp->blk_birth == zio->io_txg) {


### PR DESCRIPTION
Illumos 6319 assertion failed in zio_ddt_write: bp->blk_birth == txg
Reviewed by: George Wilson <george.wilson@delphix.com>
Approved by: Dan McDonald <danmcd@omniti.com>

References:
https://www.illumos.org/issues/6319 assertion failed in zio_ddt_write: bp->blk_birth == txg
illumos/illumos-gate@b39b744
zfsonlinux#3449 zio_ddt_write: Assertion `bp->blk_birth == txg' failed

Ported-by: kernelOfTruth kerneloftruth@gmail.com