### PR TITLE
obey arc_meta_limit default size when change arc_max

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5245,7 +5245,7 @@ arc_tuning_update(void)
 		arc_c_max = zfs_arc_max;
 		arc_c = arc_c_max;
 		arc_p = (arc_c >> 1);
-		arc_meta_limit = MIN(arc_meta_limit, arc_c_max);
+		arc_meta_limit = MIN(arc_meta_limit, (3 * arc_c_max) / 4);
 	}
 
 	/* Valid range: 32M - <arc_c_max> */


### PR DESCRIPTION
I set zfs.zfs_arc_max as boot parameter and find out that arc_meta_limit just high as entire arc,
maybe it's better to follow the original default?