### PR TITLE
issue-4023: partial overwrite of metadata holes results in loss of hole birth info

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -337,6 +337,7 @@ ztest_func_t ztest_vdev_aux_add_remove;
 ztest_func_t ztest_split_pool;
 ztest_func_t ztest_reguid;
 ztest_func_t ztest_spa_upgrade;
+ztest_func_t ztest_dmu_free_long_range;
 
 uint64_t zopt_always = 0ULL * NANOSEC;		/* all the time */
 uint64_t zopt_incessant = 1ULL * NANOSEC / 10;	/* every 1/10 second */
@@ -382,6 +383,7 @@ ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_vdev_LUN_growth, 1, &zopt_rarely),
 	ZTI_INIT(ztest_vdev_add_remove, 1, &ztest_opts.zo_vdevtime),
 	ZTI_INIT(ztest_vdev_aux_add_remove, 1, &ztest_opts.zo_vdevtime),
+	ZTI_INIT(ztest_dmu_free_long_range, 1, &zopt_always),
 };
 
 #define	ZTEST_FUNCS	(sizeof (ztest_info) / sizeof (ztest_info_t))
@@ -4205,6 +4207,182 @@ ztest_dmu_write_parallel(ztest_ds_t *zd, uint64_t id)
 	while (ztest_random(10) != 0)
 		ztest_io(zd, od->od_object, offset);
 
+	umem_free(od, sizeof (ztest_od_t));
+}
+
+static void
+ztest_write_free(ztest_ds_t *zd, ztest_od_t *od, dmu_object_info_t *doi)
+{
+	objset_t *os = zd->zd_os;
+	uint64_t object = od->od_object;
+	uint64_t size = 1ULL << 40;
+	uint64_t blocksize = doi->doi_data_block_size;
+	uint64_t mblocksize = doi->doi_metadata_block_size;
+	uint64_t l1_range = (mblocksize / sizeof (blkptr_t)) *
+		blocksize;
+	void *data = umem_alloc(blocksize, UMEM_NOFAIL);
+
+	(void) memset(data, 'a' + (object + l1_range) % 5, blocksize);
+
+	while (ztest_random(10)) {
+		int i, nranges = 0, minoffset = 0, maxoffset = 0;
+		rl_t *rl;
+		struct ztest_range {
+			uint64_t offset;
+			uint64_t size;
+		} range[10];
+		/*
+		 * Touch a few L1 ranges
+		 */
+		bzero((void *)range, sizeof (struct ztest_range)*10);
+		nranges = ztest_random(10);
+		if (nranges == 0)
+			nranges = 3;
+
+		for (i = 0; i < nranges; i++) {
+			range[i].offset = ztest_random(size/l1_range)*l1_range;
+			range[i].size = ztest_random(10)*l1_range;
+		}
+
+		(void) rw_rdlock(&zd->zd_zilog_lock);
+		for (i = 0; i < nranges; i++) {
+			if ((ztest_write(zd, object, range[i].offset, blocksize,
+			    data)) ||
+			    (ztest_write(zd, object, range[i].offset +
+			    range[i].size - blocksize, blocksize, data))) {
+				fatal(0, "dmu_free_long_range() failed\n");
+			}
+		}
+		(void) rw_unlock(&zd->zd_zilog_lock);
+
+		/*
+		 * Free all ranges in a variable number of steps
+		 */
+		for (i = 0; i < nranges; i ++) {
+			minoffset = MIN(minoffset, range[i].offset);
+			maxoffset = MAX(maxoffset, range[i].offset +
+			    range[i].size);
+		}
+
+		ztest_object_lock(zd, object, RL_READER);
+		rl = ztest_range_lock(zd, object, minoffset,
+		    maxoffset-minoffset, RL_WRITER);
+
+		switch (ztest_random(4)) {
+		case 0:
+			/* Free each range separately */
+			for (i = 0; i < nranges; i++) {
+				if ((dmu_free_long_range(os, object,
+				    range[i].offset, range[i].size))) {
+					fatal(0, "dmu_free_long_range() "
+					    "failed\n");
+				}
+			}
+			break;
+		case 1:
+			/* Free two ranges at a time */
+			for (i = 0; i < ((nranges % 2) ? nranges - 1 : nranges);
+				i += 2) {
+				uint64_t start =
+				    MIN(range[i].offset, range[i+1].offset);
+				uint64_t end =
+				    MAX(range[i].offset + range[i].size,
+					range[i+1].offset + range[i+1].size);
+				if ((dmu_free_long_range(os, object, start,
+				    end-start))) {
+					fatal(0, "dmu_free_long_range() "
+					    "failed\n");
+				}
+			}
+			/* Free the last range for odd nranges */
+			if ((nranges % 2) &&
+				(dmu_free_long_range(os, object,
+				    range[nranges-1].offset,
+				    range[nranges-1].size))) {
+				fatal(0, "dmu_free_long_range() failed\n");
+			}
+			break;
+		case 2:
+		{
+			/*
+			 * Merge the ranges in two super-ranges and
+			 * free in two steps
+			 */
+			uint64_t start = 0, end = 0;
+			int inranges = ztest_random(nranges);
+
+			for (i = 0; i < inranges; i++) {
+				start = MIN(start, range[i].offset);
+				end = MAX(end, range[i].offset + range[i].size);
+			}
+			if ((inranges != 0) &&
+				(dmu_free_long_range(os, object, start,
+				    end-start))) {
+				fatal(0, "dmu_free_long_range() failed\n");
+			}
+
+			for (i = inranges; i < nranges; i++) {
+				start = MIN(start, range[i].offset);
+				end = MAX(end, range[i].offset + range[i].size);
+			}
+			if ((inranges != nranges) &&
+				(dmu_free_long_range(os, object, start,
+				    end-start))) {
+				fatal(0, "dmu_free_long_range() failed\n");
+			}
+		}
+		break;
+		case 3:
+		{
+			/* Merge in one range and free in one step */
+			uint64_t start = minoffset, end = maxoffset;
+
+			if ((dmu_free_long_range(os, object, start,
+			    end-start))) {
+				fatal(0, "dmu_free_long_range() failed\n");
+			}
+		}
+		break;
+		case 4:
+		default:
+			/* Free the whole logical range of the object */
+			if ((dmu_free_long_range(os, object, 0, size))) {
+				fatal(0, "dmu_free_long_range() failed\n");
+			}
+			break;
+		}
+
+		ztest_range_unlock(rl);
+		ztest_object_unlock(zd, object);
+	}
+
+	umem_free(data, blocksize);
+}
+
+/*
+ * Test punching holes in an object to verify consistency of
+ * the dmu structures for various corner cases
+ *
+ * Force reallocation of dnode between iterations
+ */
+void
+ztest_dmu_free_long_range(ztest_ds_t *zd, uint64_t id)
+{
+	ztest_od_t *od = NULL;
+	uint64_t blocksize = ztest_random_blocksize();
+	dmu_object_info_t doi = {0};
+
+	od = umem_alloc(sizeof (ztest_od_t), UMEM_NOFAIL);
+
+	ztest_od_init(od, ID_PARALLEL, FTAG, 0, DMU_OT_UINT64_OTHER,
+		blocksize, 0);
+	if (ztest_object_init(zd, od, sizeof (ztest_od_t), B_FALSE) != 0)
+		goto out;
+
+	VERIFY3U(0, ==, dmu_object_info(zd->zd_os, od->od_object, &doi));
+	ztest_write_free(zd, od, &doi);
+
+out:
 	umem_free(od, sizeof (ztest_od_t));
 }
 

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -121,6 +121,9 @@ typedef struct dbuf_dirty_record {
 	/* How much space was changed to dsl_pool_dirty_space() for this? */
 	unsigned int dr_accounted;
 
+	/* A copy of the bp that points to us */
+	blkptr_t dr_bp_copy;
+
 	union dirty_types {
 		struct dirty_indirect {
 

--- a/include/sys/trace_acl.h
+++ b/include/sys/trace_acl.h
@@ -63,7 +63,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __field(uint32_t,		z_sync_cnt)
 	    __field(mode_t,		z_mode)
 	    __field(boolean_t,		z_is_sa)
-	    __field(boolean_t,		z_is_zvol)
 	    __field(boolean_t,		z_is_mapped)
 	    __field(boolean_t,		z_is_ctldir)
 	    __field(boolean_t,		z_is_stale)
@@ -101,7 +100,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __entry->z_sync_cnt		= zn->z_sync_cnt;
 	    __entry->z_mode		= zn->z_mode;
 	    __entry->z_is_sa		= zn->z_is_sa;
-	    __entry->z_is_zvol		= zn->z_is_zvol;
 	    __entry->z_is_mapped	= zn->z_is_mapped;
 	    __entry->z_is_ctldir	= zn->z_is_ctldir;
 	    __entry->z_is_stale		= zn->z_is_stale;
@@ -125,7 +123,7 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    "zn_prefetch %u moved %u blksz %u seq %u "
 	    "mapcnt %llu gen %llu size %llu "
 	    "links %llu pflags %llu uid %llu gid %llu "
-	    "sync_cnt %u mode 0x%x is_sa %d is_zvol %d "
+	    "sync_cnt %u mode 0x%x is_sa %d "
 	    "is_mapped %d is_ctldir %d is_stale %d inode { "
 	    "ino %lu nlink %u version %llu size %lli blkbits %u "
 	    "bytes %u mode 0x%x generation %x } } ace { type %u "
@@ -136,7 +134,7 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __entry->z_size,
 	    __entry->z_links, __entry->z_pflags, __entry->z_uid,
 	    __entry->z_gid, __entry->z_sync_cnt, __entry->z_mode,
-	    __entry->z_is_sa, __entry->z_is_zvol, __entry->z_is_mapped,
+	    __entry->z_is_sa, __entry->z_is_mapped,
 	    __entry->z_is_ctldir, __entry->z_is_stale, __entry->i_ino,
 	    __entry->i_nlink, __entry->i_version, __entry->i_size,
 	    __entry->i_blkbits, __entry->i_bytes, __entry->i_mode,

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -37,6 +37,7 @@
 #include <sys/rrwlock.h>
 #include <sys/zfs_sa.h>
 #include <sys/zfs_stat.h>
+#include <sys/zfs_rlock.h>
 #endif
 #include <sys/zfs_acl.h>
 #include <sys/zil.h>
@@ -187,8 +188,7 @@ typedef struct znode {
 	krwlock_t	z_parent_lock;	/* parent lock for directories */
 	krwlock_t	z_name_lock;	/* "master" lock for dirent locks */
 	zfs_dirlock_t	*z_dirlocks;	/* directory entry lock list */
-	kmutex_t	z_range_lock;	/* protects changes to z_range_avl */
-	avl_tree_t	z_range_avl;	/* avl tree of file range locks */
+	zfs_rlock_t	z_range_lock;	/* file range lock */
 	uint8_t		z_unlinked;	/* file has been unlinked */
 	uint8_t		z_atime_dirty;	/* atime needs to be synced */
 	uint8_t		z_zn_prefetch;	/* Prefetch znodes? */
@@ -212,7 +212,6 @@ typedef struct znode {
 	list_node_t	z_link_node;	/* all znodes in fs link */
 	sa_handle_t	*z_sa_hdl;	/* handle to sa data */
 	boolean_t	z_is_sa;	/* are we native sa? */
-	boolean_t	z_is_zvol;	/* are we used by the zvol */
 	boolean_t	z_is_mapped;	/* are we mmap'ed */
 	boolean_t	z_is_ctldir;	/* are we .zfs entry */
 	boolean_t	z_is_stale;	/* are we stale due to rollback? */

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -27,6 +27,7 @@
 #define	_SYS_FS_ZFS_ZNODE_H
 
 #ifdef _KERNEL
+
 #include <sys/isa_defs.h>
 #include <sys/types32.h>
 #include <sys/attr.h>
@@ -38,7 +39,24 @@
 #include <sys/zfs_sa.h>
 #include <sys/zfs_stat.h>
 #include <sys/zfs_rlock.h>
+
+#else
+
+#include <sys/zfs_rlock.h>
+#include <sys/zfs_context.h>
+#include <sys/refcount.h>
+
+/* User mode znode emulation for ztest */
+#define	ZTOZSB(zp) (zp)			/* unused */
+typedef struct znode {
+	uint64_t z_size;		/* unused, zeroed out */
+	uint64_t z_blksz;		/* unused, zeroed out */
+	uint64_t z_max_blksz;		/* unused, zeroed out */
+	zfs_rlock_t z_range_lock;
+} znode_t;
+
 #endif
+
 #include <sys/zfs_acl.h>
 #include <sys/zil.h>
 

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -102,6 +102,7 @@ KERNEL_C = \
 	zfs_fuid.c \
 	zfs_sa.c \
 	zfs_znode.c \
+	zfs_rlock.c \
 	zil.c \
 	zio.c \
 	zio_checksum.c \

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -3081,7 +3081,8 @@ dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 	uint64_t fill = 0;
 	int i;
 
-	ASSERT3P(db->db_blkptr, ==, bp);
+	ASSERT3P(db->db_blkptr, !=, NULL);
+	ASSERT3P(&db->db_data_pending->dr_bp_copy, ==, bp);
 
 	DB_DNODE_ENTER(db);
 	dn = DB_DNODE(db);
@@ -3103,7 +3104,7 @@ dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 #ifdef ZFS_DEBUG
 	if (db->db_blkid == DMU_SPILL_BLKID) {
 		ASSERT(dn->dn_phys->dn_flags & DNODE_FLAG_SPILL_BLKPTR);
-		ASSERT(!(BP_IS_HOLE(db->db_blkptr)) &&
+		ASSERT(!(BP_IS_HOLE(bp)) &&
 		    db->db_blkptr == &dn->dn_phys->dn_spill);
 	}
 #endif
@@ -3144,6 +3145,10 @@ dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 		bp->blk_fill = fill;
 
 	mutex_exit(&db->db_mtx);
+
+	rw_enter(&dn->dn_struct_rwlock, RW_WRITER);
+	*db->db_blkptr = *bp;
+	rw_exit(&dn->dn_struct_rwlock);
 }
 
 /*
@@ -3322,6 +3327,8 @@ dbuf_write(dbuf_dirty_record_t *dr, arc_buf_t *data, dmu_tx_t *tx)
 	zio_t *zio;
 	int wp_flag = 0;
 
+	ASSERT(dmu_tx_is_syncing(tx));
+
 	DB_DNODE_ENTER(db);
 	dn = DB_DNODE(db);
 	os = dn->dn_objset;
@@ -3380,6 +3387,14 @@ dbuf_write(dbuf_dirty_record_t *dr, arc_buf_t *data, dmu_tx_t *tx)
 	dmu_write_policy(os, dn, db->db_level, wp_flag, &zp);
 	DB_DNODE_EXIT(db);
 
+	/*
+	 * We copy the blkptr now (rather than when we instantiate the dirty
+	 * record), because its value can change between open context and
+	 * syncing context. We do not need to hold dn_struct_rwlock to read
+	 * db_blkptr because we are in syncing context.
+	 */
+	dr->dr_bp_copy = *db->db_blkptr;
+
 	if (db->db_level == 0 &&
 	    dr->dt.dl.dr_override_state == DR_OVERRIDDEN) {
 		/*
@@ -3389,7 +3404,7 @@ dbuf_write(dbuf_dirty_record_t *dr, arc_buf_t *data, dmu_tx_t *tx)
 		void *contents = (data != NULL) ? data->b_data : NULL;
 
 		dr->dr_zio = zio_write(zio, os->os_spa, txg,
-		    db->db_blkptr, contents, db->db.db_size, &zp,
+		    &dr->dr_bp_copy, contents, db->db.db_size, &zp,
 		    dbuf_write_override_ready, NULL, dbuf_write_override_done,
 		    dr, ZIO_PRIORITY_ASYNC_WRITE, ZIO_FLAG_MUSTSUCCEED, &zb);
 		mutex_enter(&db->db_mtx);
@@ -3400,14 +3415,14 @@ dbuf_write(dbuf_dirty_record_t *dr, arc_buf_t *data, dmu_tx_t *tx)
 	} else if (db->db_state == DB_NOFILL) {
 		ASSERT(zp.zp_checksum == ZIO_CHECKSUM_OFF);
 		dr->dr_zio = zio_write(zio, os->os_spa, txg,
-		    db->db_blkptr, NULL, db->db.db_size, &zp,
+		    &dr->dr_bp_copy, NULL, db->db.db_size, &zp,
 		    dbuf_write_nofill_ready, NULL, dbuf_write_nofill_done, db,
 		    ZIO_PRIORITY_ASYNC_WRITE,
 		    ZIO_FLAG_MUSTSUCCEED | ZIO_FLAG_NODATA, &zb);
 	} else {
 		ASSERT(arc_released(data));
 		dr->dr_zio = arc_write(zio, os->os_spa, txg,
-		    db->db_blkptr, data, DBUF_IS_L2CACHEABLE(db),
+		    &dr->dr_bp_copy, data, DBUF_IS_L2CACHEABLE(db),
 		    DBUF_IS_L2COMPRESSIBLE(db), &zp, dbuf_write_ready,
 		    dbuf_write_physdone, dbuf_write_done, db,
 		    ZIO_PRIORITY_ASYNC_WRITE, ZIO_FLAG_MUSTSUCCEED, &zb);

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -484,7 +484,6 @@ zfsctl_inode_alloc(zfs_sb_t *zsb, uint64_t id,
 	zp->z_gid = 0;
 	zp->z_mode = 0;
 	zp->z_sync_cnt = 0;
-	zp->z_is_zvol = B_FALSE;
 	zp->z_is_mapped = B_FALSE;
 	zp->z_is_ctldir = B_TRUE;
 	zp->z_is_sa = B_FALSE;

--- a/module/zfs/zfs_rlock.c
+++ b/module/zfs/zfs_rlock.c
@@ -96,14 +96,15 @@
  */
 
 #include <sys/zfs_rlock.h>
+#include <sys/zfs_znode.h>
 
 /*
  * Check if a write lock can be grabbed, or wait and recheck until available.
  */
 static void
-zfs_range_lock_writer(znode_t *zp, rl_t *new)
+zfs_range_lock_writer(zfs_rlock_t *zrl, rl_t *new, znode_t *zp)
 {
-	avl_tree_t *tree = &zp->z_range_avl;
+	avl_tree_t *tree = &zrl->zr_avl;
 	rl_t *rl;
 	avl_index_t where;
 	uint64_t end_size;
@@ -112,17 +113,16 @@ zfs_range_lock_writer(znode_t *zp, rl_t *new)
 
 	for (;;) {
 		/*
-		 * Range locking is also used by zvol and uses a
-		 * dummied up znode. However, for zvol, we don't need to
-		 * append or grow blocksize, and besides we don't have
-		 * a "sa" data or zfs_sb_t - so skip that processing.
+		 * Range locking is also used by zvol. However, for zvol, we
+		 * don't need to append or grow blocksize, so skip that
+		 * processing.
 		 *
 		 * Yes, this is ugly, and would be solved by not handling
 		 * grow or append in range lock code. If that was done then
 		 * we could make the range locking code generically available
 		 * to other non-zfs consumers.
 		 */
-		if (!zp->z_is_zvol) { /* caller is ZPL */
+		if (zp) { /* caller is ZPL */
 			/*
 			 * If in append mode pick up the current end of file.
 			 * This is done under z_range_lock to avoid races.
@@ -175,7 +175,7 @@ wait:
 			cv_init(&rl->r_wr_cv, NULL, CV_DEFAULT, NULL);
 			rl->r_write_wanted = B_TRUE;
 		}
-		cv_wait(&rl->r_wr_cv, &zp->z_range_lock);
+		cv_wait(&rl->r_wr_cv, &zrl->zr_mutex);
 
 		/* reset to original */
 		new->r_off = off;
@@ -353,9 +353,9 @@ zfs_range_add_reader(avl_tree_t *tree, rl_t *new, rl_t *prev, avl_index_t where)
  * Check if a reader lock can be grabbed, or wait and recheck until available.
  */
 static void
-zfs_range_lock_reader(znode_t *zp, rl_t *new)
+zfs_range_lock_reader(zfs_rlock_t *zrl, rl_t *new)
 {
-	avl_tree_t *tree = &zp->z_range_avl;
+	avl_tree_t *tree = &zrl->zr_avl;
 	rl_t *prev, *next;
 	avl_index_t where;
 	uint64_t off = new->r_off;
@@ -378,7 +378,7 @@ retry:
 				cv_init(&prev->r_rd_cv, NULL, CV_DEFAULT, NULL);
 				prev->r_read_wanted = B_TRUE;
 			}
-			cv_wait(&prev->r_rd_cv, &zp->z_range_lock);
+			cv_wait(&prev->r_rd_cv, &zrl->zr_mutex);
 			goto retry;
 		}
 		if (off + len < prev->r_off + prev->r_len)
@@ -401,7 +401,7 @@ retry:
 				cv_init(&next->r_rd_cv, NULL, CV_DEFAULT, NULL);
 				next->r_read_wanted = B_TRUE;
 			}
-			cv_wait(&next->r_rd_cv, &zp->z_range_lock);
+			cv_wait(&next->r_rd_cv, &zrl->zr_mutex);
 			goto retry;
 		}
 		if (off + len <= next->r_off + next->r_len)
@@ -421,16 +421,20 @@ got_lock:
  * or exclusive (RL_WRITER). Returns the range lock structure
  * for later unlocking or reduce range (if entire file
  * previously locked as RL_WRITER).
+ *
+ * Filesystem should call zfs_range_lock.
+ * Zvol should call zvol_range_lock.
  */
 rl_t *
-zfs_range_lock(znode_t *zp, uint64_t off, uint64_t len, rl_type_t type)
+zfs_range_lock_impl(zfs_rlock_t *zrl, uint64_t off, uint64_t len,
+    rl_type_t type, znode_t *zp)
 {
 	rl_t *new;
 
 	ASSERT(type == RL_READER || type == RL_WRITER || type == RL_APPEND);
 
 	new = kmem_alloc(sizeof (rl_t), KM_SLEEP);
-	new->r_zp = zp;
+	new->r_zrl = zrl;
 	new->r_off = off;
 	if (len + off < off)	/* overflow */
 		len = UINT64_MAX - off;
@@ -441,18 +445,18 @@ zfs_range_lock(znode_t *zp, uint64_t off, uint64_t len, rl_type_t type)
 	new->r_write_wanted = B_FALSE;
 	new->r_read_wanted = B_FALSE;
 
-	mutex_enter(&zp->z_range_lock);
+	mutex_enter(&zrl->zr_mutex);
 	if (type == RL_READER) {
 		/*
 		 * First check for the usual case of no locks
 		 */
-		if (avl_numnodes(&zp->z_range_avl) == 0)
-			avl_add(&zp->z_range_avl, new);
+		if (avl_numnodes(&zrl->zr_avl) == 0)
+			avl_add(&zrl->zr_avl, new);
 		else
-			zfs_range_lock_reader(zp, new);
-	} else
-		zfs_range_lock_writer(zp, new); /* RL_WRITER or RL_APPEND */
-	mutex_exit(&zp->z_range_lock);
+			zfs_range_lock_reader(zrl, new);
+	} else /* RL_WRITER or RL_APPEND */
+		zfs_range_lock_writer(zrl, new, zp);
+	mutex_exit(&zrl->zr_mutex);
 	return (new);
 }
 
@@ -474,9 +478,9 @@ zfs_range_free(void *arg)
  * Unlock a reader lock
  */
 static void
-zfs_range_unlock_reader(znode_t *zp, rl_t *remove, list_t *free_list)
+zfs_range_unlock_reader(zfs_rlock_t *zrl, rl_t *remove, list_t *free_list)
 {
-	avl_tree_t *tree = &zp->z_range_avl;
+	avl_tree_t *tree = &zrl->zr_avl;
 	rl_t *rl, *next = NULL;
 	uint64_t len;
 
@@ -543,7 +547,7 @@ zfs_range_unlock_reader(znode_t *zp, rl_t *remove, list_t *free_list)
 void
 zfs_range_unlock(rl_t *rl)
 {
-	znode_t *zp = rl->r_zp;
+	zfs_rlock_t *zrl = rl->r_zrl;
 	list_t free_list;
 	rl_t *free_rl;
 
@@ -552,10 +556,10 @@ zfs_range_unlock(rl_t *rl)
 	ASSERT(!rl->r_proxy);
 	list_create(&free_list, sizeof (rl_t), offsetof(rl_t, rl_node));
 
-	mutex_enter(&zp->z_range_lock);
+	mutex_enter(&zrl->zr_mutex);
 	if (rl->r_type == RL_WRITER) {
 		/* writer locks can't be shared or split */
-		avl_remove(&zp->z_range_avl, rl);
+		avl_remove(&zrl->zr_avl, rl);
 		if (rl->r_write_wanted)
 			cv_broadcast(&rl->r_wr_cv);
 
@@ -568,9 +572,9 @@ zfs_range_unlock(rl_t *rl)
 		 * lock may be shared, let zfs_range_unlock_reader()
 		 * release the zp->z_range_lock lock and free the rl_t
 		 */
-		zfs_range_unlock_reader(zp, rl, &free_list);
+		zfs_range_unlock_reader(zrl, rl, &free_list);
 	}
-	mutex_exit(&zp->z_range_lock);
+	mutex_exit(&zrl->zr_mutex);
 
 	while ((free_rl = list_head(&free_list)) != NULL) {
 		list_remove(&free_list, free_rl);
@@ -588,17 +592,17 @@ zfs_range_unlock(rl_t *rl)
 void
 zfs_range_reduce(rl_t *rl, uint64_t off, uint64_t len)
 {
-	znode_t *zp = rl->r_zp;
+	zfs_rlock_t *zrl = rl->r_zrl;
 
 	/* Ensure there are no other locks */
-	ASSERT(avl_numnodes(&zp->z_range_avl) == 1);
+	ASSERT(avl_numnodes(&zrl->zr_avl) == 1);
 	ASSERT(rl->r_off == 0);
 	ASSERT(rl->r_type == RL_WRITER);
 	ASSERT(!rl->r_proxy);
 	ASSERT3U(rl->r_len, ==, UINT64_MAX);
 	ASSERT3U(rl->r_cnt, ==, 1);
 
-	mutex_enter(&zp->z_range_lock);
+	mutex_enter(&zrl->zr_mutex);
 	rl->r_off = off;
 	rl->r_len = len;
 
@@ -607,7 +611,7 @@ zfs_range_reduce(rl_t *rl, uint64_t off, uint64_t len)
 	if (rl->r_read_wanted)
 		cv_broadcast(&rl->r_rd_cv);
 
-	mutex_exit(&zp->z_range_lock);
+	mutex_exit(&zrl->zr_mutex);
 }
 
 /*

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -113,9 +113,7 @@ zfs_znode_cache_constructor(void *buf, void *arg, int kmflags)
 	mutex_init(&zp->z_acl_lock, NULL, MUTEX_DEFAULT, NULL);
 	rw_init(&zp->z_xattr_lock, NULL, RW_DEFAULT, NULL);
 
-	mutex_init(&zp->z_range_lock, NULL, MUTEX_DEFAULT, NULL);
-	avl_create(&zp->z_range_avl, zfs_range_compare,
-	    sizeof (rl_t), offsetof(rl_t, r_node));
+	zfs_rlock_init(&zp->z_range_lock);
 
 	zp->z_dirlocks = NULL;
 	zp->z_acl_cached = NULL;
@@ -137,8 +135,7 @@ zfs_znode_cache_destructor(void *buf, void *arg)
 	rw_destroy(&zp->z_name_lock);
 	mutex_destroy(&zp->z_acl_lock);
 	rw_destroy(&zp->z_xattr_lock);
-	avl_destroy(&zp->z_range_avl);
-	mutex_destroy(&zp->z_range_lock);
+	zfs_rlock_destroy(&zp->z_range_lock);
 
 	ASSERT(zp->z_dirlocks == NULL);
 	ASSERT(zp->z_acl_cached == NULL);
@@ -615,7 +612,6 @@ zfs_znode_alloc(zfs_sb_t *zsb, dmu_buf_t *db, int blksz,
 	zp->z_blksz = blksz;
 	zp->z_seq = 0x7A4653;
 	zp->z_sync_cnt = 0;
-	zp->z_is_zvol = B_FALSE;
 	zp->z_is_mapped = B_FALSE;
 	zp->z_is_ctldir = B_FALSE;
 	zp->z_is_stale = B_FALSE;

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1194,7 +1194,28 @@ zio_write_bp_init(zio_t *zio)
 		    spa_max_replication(spa)) == BP_GET_NDVAS(bp));
 	}
 
-	if (compress != ZIO_COMPRESS_OFF) {
+	if (zp->zp_level > 0) {
+		/*
+		 * Check if the metadata block is filled entirely with hole
+		 * bps, and set the psize to 0 so that the block will not be
+		 * allocated and written to, and the zio->io_bp will be
+		 * set properly with the birth epoch if needed
+		 */
+		blkptr_t *bpc, *bps = (blkptr_t *)zio->io_data,
+			*bpe = (blkptr_t *)((char *)zio->io_data + lsize);
+
+		for (bpc = bps; bpc < bpe; bpc++) {
+			if (!BP_IS_HOLE(bpc))
+				break;
+		}
+
+		if (bpc == bpe) {
+			psize = 0;
+			BP_ZERO(bp);
+		}
+	}
+
+	if (psize && compress != ZIO_COMPRESS_OFF) {
 		void *cbuf = zio_buf_alloc(lsize);
 		psize = zio_compress_data(compress, zio->io_data, cbuf, lsize);
 		if (psize == 0 || psize == lsize) {

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -75,7 +75,7 @@ typedef struct zvol_state {
 	uint32_t		zv_open_count;	/* open counts */
 	uint32_t		zv_changed;	/* disk changed */
 	zilog_t			*zv_zilog;	/* ZIL handle */
-	znode_t			zv_znode;	/* for range locking */
+	zfs_rlock_t		zv_range_lock;	/* range lock */
 	dmu_buf_t		*zv_dbuf;	/* bonus handle */
 	dev_t			zv_dev;		/* device id */
 	struct gendisk		*zv_disk;	/* generic disk */
@@ -633,8 +633,8 @@ zvol_write(zvol_state_t *zv, uio_t *uio, boolean_t sync)
 
 	ASSERT(zv && zv->zv_open_count > 0);
 
-	rl = zfs_range_lock(&zv->zv_znode, uio->uio_loffset, uio->uio_resid,
-	    RL_WRITER);
+	rl = zvol_range_lock(&zv->zv_range_lock, uio->uio_loffset,
+	    uio->uio_resid, RL_WRITER);
 
 	while (uio->uio_resid > 0 && uio->uio_loffset < volsize) {
 		uint64_t bytes = MIN(uio->uio_resid, DMU_MAX_ACCESS >> 1);
@@ -660,7 +660,7 @@ zvol_write(zvol_state_t *zv, uio_t *uio, boolean_t sync)
 		if (error)
 			break;
 	}
-	zfs_range_unlock(rl);
+	zvol_range_unlock(rl);
 	if (sync)
 		zil_commit(zv->zv_zilog, ZVOL_OBJ);
 	return (error);
@@ -725,7 +725,7 @@ zvol_discard(struct bio *bio)
 	if (start >= end)
 		return (0);
 
-	rl = zfs_range_lock(&zv->zv_znode, start, size, RL_WRITER);
+	rl = zvol_range_lock(&zv->zv_range_lock, start, size, RL_WRITER);
 	tx = dmu_tx_create(zv->zv_objset);
 	dmu_tx_mark_netfree(tx);
 	error = dmu_tx_assign(tx, TXG_WAIT);
@@ -738,7 +738,7 @@ zvol_discard(struct bio *bio)
 		    ZVOL_OBJ, start, size);
 	}
 
-	zfs_range_unlock(rl);
+	zvol_range_unlock(rl);
 
 	return (error);
 }
@@ -752,8 +752,8 @@ zvol_read(zvol_state_t *zv, uio_t *uio)
 
 	ASSERT(zv && zv->zv_open_count > 0);
 
-	rl = zfs_range_lock(&zv->zv_znode, uio->uio_loffset, uio->uio_resid,
-	    RL_READER);
+	rl = zvol_range_lock(&zv->zv_range_lock, uio->uio_loffset,
+	    uio->uio_resid, RL_READER);
 	while (uio->uio_resid > 0 && uio->uio_loffset < volsize) {
 		uint64_t bytes = MIN(uio->uio_resid, DMU_MAX_ACCESS >> 1);
 
@@ -769,7 +769,7 @@ zvol_read(zvol_state_t *zv, uio_t *uio)
 			break;
 		}
 	}
-	zfs_range_unlock(rl);
+	zvol_range_unlock(rl);
 	return (error);
 }
 
@@ -850,7 +850,7 @@ zvol_get_done(zgd_t *zgd, int error)
 	if (zgd->zgd_db)
 		dmu_buf_rele(zgd->zgd_db, zgd);
 
-	zfs_range_unlock(zgd->zgd_rl);
+	zvol_range_unlock(zgd->zgd_rl);
 
 	if (error == 0 && zgd->zgd_bp)
 		zil_add_block(zgd->zgd_zilog, zgd->zgd_bp);
@@ -879,7 +879,8 @@ zvol_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 
 	zgd = (zgd_t *)kmem_zalloc(sizeof (zgd_t), KM_SLEEP);
 	zgd->zgd_zilog = zv->zv_zilog;
-	zgd->zgd_rl = zfs_range_lock(&zv->zv_znode, offset, size, RL_READER);
+	zgd->zgd_rl = zvol_range_lock(&zv->zv_range_lock, offset, size,
+	    RL_READER);
 
 	/*
 	 * Write records come in two flavors: immediate and indirect.
@@ -1305,10 +1306,7 @@ zvol_alloc(dev_t dev, const char *name)
 	zv->zv_open_count = 0;
 	strlcpy(zv->zv_name, name, MAXNAMELEN);
 
-	mutex_init(&zv->zv_znode.z_range_lock, NULL, MUTEX_DEFAULT, NULL);
-	avl_create(&zv->zv_znode.z_range_avl, zfs_range_compare,
-	    sizeof (rl_t), offsetof(rl_t, r_node));
-	zv->zv_znode.z_is_zvol = TRUE;
+	zfs_rlock_init(&zv->zv_range_lock);
 
 	zv->zv_disk->major = zvol_major;
 	zv->zv_disk->first_minor = (dev & MINORMASK);
@@ -1337,8 +1335,7 @@ zvol_free(zvol_state_t *zv)
 	ASSERT(MUTEX_HELD(&zvol_state_lock));
 	ASSERT(zv->zv_open_count == 0);
 
-	avl_destroy(&zv->zv_znode.z_range_avl);
-	mutex_destroy(&zv->zv_znode.z_range_lock);
+	zfs_rlock_destroy(&zv->zv_range_lock);
 
 	zv->zv_disk->private_data = NULL;
 


### PR DESCRIPTION
When reading Ln metadata holes with non-zero birth epochs, instead of initializing the dbuf data with zeros, initialize with Ln-1 hole block pointers of same dmu type and birth epoch as Ln hole, and of
proper level and logical size, in order to make sure the new (Ln-1) holes inherit correct hole info.

This is important when generating incremental zfs send streams with hole_birth feature active, where
the proper hole birth is required in order to generate proper FREE records for the new holes.

Regression tested with ztest and verified proper assignment of hole birth epochs with zdb and by parsing the resulting send stream. 