### PR TITLE
Activate LVM volume groups before looking for zpools

### DIFF
--- a/contrib/initramfs/Makefile.am
+++ b/contrib/initramfs/Makefile.am
@@ -1,15 +1,16 @@
 initrddir = $(datarootdir)/initramfs-tools
 
-initrd_SCRIPTS = conf-hooks.d/zfs hooks/zfs scripts/zfs
+initrd_SCRIPTS = conf-hooks.d/zfs hooks/zfs scripts/zfs scripts/local-top/zfs
 
 EXTRA_DIST = \
 	$(top_srcdir)/contrib/initramfs/conf-hooks.d/zfs \
 	$(top_srcdir)/contrib/initramfs/hooks/zfs \
 	$(top_srcdir)/contrib/initramfs/scripts/zfs \
+	$(top_srcdir)/contrib/initramfs/scripts/local-top/zfs \
 	$(top_srcdir)/contrib/initramfs/README.initramfs.markdown
 
 install-initrdSCRIPTS: $(EXTRA_DIST)
-	for d in conf-hooks.d hooks scripts; do \
+	for d in conf-hooks.d hooks scripts scripts/local-top; do \
 	  $(MKDIR_P) $(DESTDIR)$(initrddir)/$$d; \
 	  cp $(top_srcdir)/contrib/initramfs/$$d/zfs \
 	    $(DESTDIR)$(initrddir)/$$d/; \

--- a/contrib/initramfs/scripts/local-top/zfs
+++ b/contrib/initramfs/scripts/local-top/zfs
@@ -1,0 +1,60 @@
+#!/bin/sh
+PREREQ="mdadm mdrun multipath"
+
+prereqs()
+{
+        echo "$PREREQ"
+}
+
+case $1 in
+# get pre-requisites
+prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+
+#
+# Helper functions
+#
+message()
+{
+        if [ -x /bin/plymouth ] && plymouth --ping; then
+                plymouth message --text="$@"
+        else
+                echo "$@" >&2
+        fi
+        return 0
+}
+
+udev_settle()
+{
+        # Wait for udev to be ready, see https://launchpad.net/bugs/85640
+        if [ -x /sbin/udevadm ]; then
+                /sbin/udevadm settle --timeout=30
+        elif [ -x /sbin/udevsettle ]; then
+                /sbin/udevsettle --timeout=30
+        fi
+        return 0
+}
+
+
+activate_vg()
+{
+        # Sanity checks
+        if [ ! -x /sbin/lvm ]; then
+                message "lvm is not available"
+                return 1
+        fi
+
+        # Detect and activate available volume groups
+        /sbin/lvm vgscan
+        /sbin/lvm vgchange -a y --sysinit
+        return $?
+}
+
+udev_settle
+activate_vg
+
+exit 0


### PR DESCRIPTION
Using the script by @jgoerzen from zfsonlinux/pkg-zfs#102.

I'm not sure, whether this should be an extra script.
Maybe it would be better to add this functionality to the main zfs initramfs script?