### PR TITLE
Only trigger SET_ERROR tracepoint event on error

### DIFF
--- a/include/sys/trace_dbgmsg.h
+++ b/include/sys/trace_dbgmsg.h
@@ -103,9 +103,18 @@ DECLARE_EVENT_CLASS(zfs_set_error_class,
 	    __entry->function, __entry->error)
 );
 
+#ifdef TP_CONDITION
+#define	DEFINE_SET_ERROR_EVENT(name) \
+DEFINE_EVENT_CONDITION(zfs_set_error_class, name, \
+	TP_PROTO(const char *file, const char *function, int line, \
+	    uintptr_t error), \
+	TP_ARGS(file, function, line, error), \
+	TP_CONDITION(error))
+#else
 #define	DEFINE_SET_ERROR_EVENT(name) \
 DEFINE_EVENT(zfs_set_error_class, name, \
 	TP_PROTO(const char *file, const char *function, int line, \
 	    uintptr_t error), \
 	TP_ARGS(file, function, line, error))
+#endif
 DEFINE_SET_ERROR_EVENT(zfs_set__error);


### PR DESCRIPTION
Currently, the SET_ERROR tracepoint triggers regardless of whether there
is an error or not. On Illumos, SET_ERROR only triggers on an actual
error, which is avoids irrelevant noise. Linux 2.6.38 added support for
conditional tracepoints, so we modify SET_ERROR to use them when they
are avaliable for functionality equivalent to the Illumos functionality.

Signed-off-by: Richard Yao <ryao@gentoo.org>