### PR TITLE
Fix --enable-linux-builtin

### DIFF
--- a/copy-builtin
+++ b/copy-builtin
@@ -55,6 +55,8 @@ adjust_obj_paths()
 for MODULE in "${MODULES[@]}"
 do
 	adjust_obj_paths "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
+	sed -i.bak '/obj =/d' "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
+	sed -i.bak '/src =/d' "$KERNEL_DIR/fs/zfs/$MODULE/Makefile"
 done
 
 cat > "$KERNEL_DIR/fs/zfs/Kconfig" <<"EOF"


### PR DESCRIPTION
Adding VPATH support, commit 47a4a6f, required that a `src`
and `obj` line be added to the top of the Makefiles.  They
must be removed from the Makefiles when builtin.

Requires-spl: refs/pull/503/head
Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue zfsonlinux/spl#481
Issue zfsonlinux/spl#498