### PR TITLE
Describe the fragmentation metric in zpool.8

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -516,6 +516,38 @@ any space on an EFI labeled vdev which has not been brought online
 .RS 20n
 .rt
 The amount of fragmentation in the pool.
+.sp
+.LP
+This table defines a segment size based fragmentation metric that will
+allow each metaslab to derive its own fragmentation value. This is done
+by calculating the space in each bucket of the spacemap histogram and
+multiplying that by the fragmetation metric in this table. Doing
+this for all buckets and dividing it by the total amount of free
+space in this metaslab (i.e. the total free space in all buckets) gives
+us the fragmentation metric. This means that a high fragmentation metric
+equates to most of the free space being comprised of small segments.
+Conversely, if the metric is low, then most of the free space is in
+large segments. A 10% change in fragmentation equates to approximately
+double the number of segments.
+.sp
+.LP
+This table defines 0% fragmented space using 16MB segments. Testing has
+shown that segments that are greater than or equal to 16MB do not suffer
+from drastic performance problems. Using this value, we derive the rest
+of the table. Since the fragmentation value is never stored on disk, it
+is possible to change these calculations in the future.
+.sp
+.in +2
+.nf
+metric segment   metric segment   metric segment
+0%     16M       30%    512K      80%    16K
+5%     8M        40%    256K      90%    8K
+10%    4M        50%    128K      95%    4K
+15%    2M        60%    64K       98%    2K
+20%    1M        70%    32K       100%   1K
+.fi
+.in -2
+.sp
 .RE
 
 .sp


### PR DESCRIPTION
While it's commonly understood that a larger fragmentation value
is worse than a smaller one it is never explained anywhere but
the source what this value means.  Using the comment in the source
add this information to the zpool.8 man page.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>