### PR TITLE
Either _ILP32 or _LP64 must be defined

### DIFF
--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -78,7 +78,7 @@ extern "C" {
 #define	_SUNOS_VTOC_16
 
 /* powerpc arch specific defines */
-#elif defined(__powerpc) || defined(__powerpc__)
+#elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__)
 
 #if !defined(__powerpc)
 #define	__powerpc
@@ -88,11 +88,13 @@ extern "C" {
 #define	__powerpc__
 #endif
 
+#if defined(__powerpc64__)
 #if !defined(_LP64)
-#ifdef __powerpc64__
 #define	_LP64
+#endif
 #else
-#define	_LP32
+#if !defined(_ILP32)
+#define	_ILP32
 #endif
 #endif
 
@@ -113,6 +115,16 @@ extern "C" {
 #define	__arm__
 #endif
 
+#if defined(__aarch64__)
+#if !defined(_LP64)
+#define	_LP64
+#endif
+#else
+#if !defined(_ILP32)
+#define	_ILP32
+#endif
+#endif
+
 #if defined(__ARMEL__) || defined(__AARCH64EL__)
 #define	_LITTLE_ENDIAN
 #else
@@ -122,7 +134,7 @@ extern "C" {
 #define	_SUNOS_VTOC_16
 
 /* sparc arch specific defines */
-#elif defined(__sparc) || defined(__sparc__)
+#elif defined(__sparc) || defined(__sparc__) || defined(__sparc64__)
 
 #if !defined(__sparc)
 #define	__sparc
@@ -135,19 +147,15 @@ extern "C" {
 #define	_BIG_ENDIAN
 #define	_SUNOS_VTOC_16
 
-/* sparc64 arch specific defines */
-#elif defined(__sparc64) || defined(__sparc64__)
-
-#if !defined(__sparc64)
-#define	__sparc64
+#if defined(__sparc64__)
+#if !defined(_LP64)
+#define	_LP64
 #endif
-
-#if !defined(__sparc64__)
-#define	__sparc64__
+#else
+#if !defined(_ILP32)
+#define	_ILP32
 #endif
-
-#define	_BIG_ENDIAN
-#define	_SUNOS_VTOC_16
+#endif
 
 #else /* Currently x86_64, i386, arm, powerpc, and sparc are supported */
 #error "Unsupported ISA type"
@@ -155,6 +163,10 @@ extern "C" {
 
 #if defined(_ILP32) && defined(_LP64)
 #error "Both _ILP32 and _LP64 are defined"
+#endif
+
+#if !defined(_ILP32) && !defined(_LP64)
+#error "Neither _ILP32 and _LP64 are defined"
 #endif
 
 #if defined(_LITTLE_ENDIAN) && defined(_BIG_ENDIAN)


### PR DESCRIPTION
For some arm, powerpc, and sparc platforms it was possible that
neither _ILP32 of _LP64 would be defined.  Update the isa_defs.h
header to explicitly set these macros and generate a compile error
in the case neither are defined.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #4048
Requires-spl: refs/pull/508/head