### PR TITLE
Unconditionally build zdb and ztest with -DDEBUG

### DIFF
--- a/cmd/zdb/Makefile.am
+++ b/cmd/zdb/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/config/Rules.am
 
+AM_CPPFLAGS += -DDEBUG
+
 DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/lib/libspl/include

--- a/cmd/ztest/Makefile.am
+++ b/cmd/ztest/Makefile.am
@@ -1,6 +1,7 @@
 include $(top_srcdir)/config/Rules.am
 
 AM_CFLAGS += $(DEBUG_STACKFLAGS) $(FRAME_LARGER_THAN)
+AM_CPPFLAGS += -DDEBUG
 
 DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -6185,7 +6185,7 @@ setup_hdr(void)
 
 	hdr = (void *)mmap(0, P2ROUNDUP(sizeof (*hdr), getpagesize()),
 	    PROT_READ | PROT_WRITE, MAP_SHARED, ztest_fd_data, 0);
-	VERIFY3P(hdr, !=, MAP_FAILED);
+	ASSERT(hdr != MAP_FAILED);
 
 	VERIFY3U(0, ==, ftruncate(ztest_fd_data, sizeof (ztest_shared_hdr_t)));
 
@@ -6212,14 +6212,14 @@ setup_data(void)
 
 	hdr = (void *)mmap(0, P2ROUNDUP(sizeof (*hdr), getpagesize()),
 	    PROT_READ, MAP_SHARED, ztest_fd_data, 0);
-	VERIFY3P(hdr, !=, MAP_FAILED);
+	ASSERT(hdr != MAP_FAILED);
 
 	size = shared_data_size(hdr);
 
 	(void) munmap((caddr_t)hdr, P2ROUNDUP(sizeof (*hdr), getpagesize()));
 	hdr = ztest_shared_hdr = (void *)mmap(0, P2ROUNDUP(size, getpagesize()),
 	    PROT_READ | PROT_WRITE, MAP_SHARED, ztest_fd_data, 0);
-	VERIFY3P(hdr, !=, MAP_FAILED);
+	ASSERT(hdr != MAP_FAILED);
 	buf = (uint8_t *)hdr;
 
 	offset = hdr->zh_hdr_size;


### PR DESCRIPTION
Illumos unconditionally builds zdb and ztest with -DDEBUG. This helps
catch bugs and eliminates the need for commits like
2026196, which changed ASSERTs to
VERIFYs. The following files in the illumos tree show this:

usr/src/cmd/zdb/Makefile.com
usr/src/cmd/ztest/Makefile.com

Given the usefulness of having early failure in these tools, we should
do it too.

Signed-off-by: Richard Yao <ryao@gentoo.org>