### PR TITLE
kobj_read_file: Return -1 on vn_rdwr() error

### DIFF
--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -966,8 +966,9 @@ kobj_read_file(struct _buf *file, char *buf, unsigned size, unsigned off)
 {
 	ssize_t resid;
 
-	vn_rdwr(UIO_READ, (vnode_t *)file->_fd, buf, size, (offset_t)off,
-	    UIO_SYSSPACE, 0, 0, 0, &resid);
+	if (vn_rdwr(UIO_READ, (vnode_t *)file->_fd, buf, size, (offset_t)off,
+	    UIO_SYSSPACE, 0, 0, 0, &resid) != 0)
+		return (-1);
 
 	return (size - resid);
 }


### PR DESCRIPTION
LLVM's static analyzer showed that we could subtract using an
uninitialized value on an error from vn_rdwr().
    
The correct behavior is to return -1 on an error, so lets do that
instead.

Signed-off-by: Richard Yao <ryao@gentoo.org>