### PR TITLE
Skip GPL-only symbols test when cross-compiling

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -448,16 +448,18 @@ dnl # detected at configure time and cause a build failure.  Otherwise
 dnl # modules may be successfully built that behave incorrectly.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_CONFIG], [
-	AC_RUN_IFELSE([
-		AC_LANG_PROGRAM([
-			#include "$LINUX/include/linux/license.h"
+	AS_IF([test "x$cross_compiling" != xyes], [
+		AC_RUN_IFELSE([
+			AC_LANG_PROGRAM([
+				#include "$LINUX/include/linux/license.h"
+			], [
+				return !license_is_gpl_compatible("$ZFS_META_LICENSE");
+			])
 		], [
-			return !license_is_gpl_compatible("$ZFS_META_LICENSE");
+			AC_DEFINE([ZFS_IS_GPL_COMPATIBLE], [1],
+			    [Define to 1 if GPL-only symbols can be used])
+		], [
 		])
-	], [
-		AC_DEFINE([ZFS_IS_GPL_COMPATIBLE], [1],
-		    [Define to 1 if GPL-only symbols can be used])
-	], [
 	])
 
 	ZFS_AC_KERNEL_CONFIG_THREAD_SIZE


### PR DESCRIPTION
Allows clean cross-compilation just like zfsonlinux/spl#507