### PR TITLE
Fix z_xattr_lock/z_teardown_lock inversion

### DIFF
--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -1012,16 +1012,7 @@ zfs_rezget(znode_t *zp)
 	}
 	mutex_exit(&zp->z_acl_lock);
 
-	/*
-	 * Lock inversion with zpl_xattr_get->__zpl_xattr_get->zfs_lookup
-	 * between z_xattr_lock and z_teardown_lock.  Detect this case and
-	 * return EBUSY so zfs_resume_fs() will mark the inode stale and it
-	 * will safely be revalidated on next access.
-	 */
-	err = rw_tryenter(&zp->z_xattr_lock, RW_WRITER);
-	if (!err)
-		return (SET_ERROR(EBUSY));
-
+	rw_enter(&zp->z_xattr_lock, RW_WRITER);
 	if (zp->z_xattr_cached) {
 		nvlist_free(zp->z_xattr_cached);
 		zp->z_xattr_cached = NULL;


### PR DESCRIPTION
This patch replaces commit 6b32ef572f754efc3f9edb20d022450f8e6b02d9.

There exists a lock inversion between the z_xattr_lock and the
z_teardown_lock.  Resolve this by taking the z_teardown_lock in
all registered xattr callbacks prior to taking the z_xattr_lock.
This ensures the locks are always taken is the same order thus
preventing a deadlock.  Note the z_teardown_lock is taken again
in zfs_lookup() and this is safe because the z_teardown lock is
a re-entrant read reader/writer lock.
    
    * process-1
    zpl_xattr_get -> Takes zp->z_xattr_lock
      __zpl_xattr_get
        zfs_lookup -> Takes zsb->z_teardown_lock in ZFS_ENTER macro
    
    * process-2
    zfs_ioc_recv -> Takes zsb->z_teardown_lock in zfs_suspend_fs()
      zfs_resume_fs
        zfs_rezget -> Takes zp->z_xattr_lock
    
Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3943
Issue #3969
Issue #4121