### PR TITLE
When casesensitivity=insensitive is set for the file system, zpl_lookup

### DIFF
--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -44,13 +44,24 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 	struct inode *ip;
 	int error;
 	fstrans_cookie_t cookie;
+	pathname_t *ppn = NULL;
+	pathname_t pn;
+	zfs_sb_t *zsb = dentry->d_sb->s_fs_info;
 
 	if (dlen(dentry) > ZFS_MAXNAMELEN)
 		return (ERR_PTR(-ENAMETOOLONG));
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_lookup(dir, dname(dentry), &ip, 0, cr, NULL, NULL);
+
+	/* If we are a case insensitive fs, we need the real name */
+	if (zsb->z_case == ZFS_CASE_INSENSITIVE) {
+		pn.pn_bufsize = ZFS_MAXNAMELEN;
+		pn.pn_buf = kmem_zalloc(ZFS_MAXNAMELEN, KM_SLEEP);
+		ppn = &pn;
+	}
+
+	error = -zfs_lookup(dir, dname(dentry), &ip, 0, cr, NULL, ppn);
 	spl_fstrans_unmark(cookie);
 	ASSERT3S(error, <=, 0);
 	crfree(cr);
@@ -63,13 +74,31 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 	spin_unlock(&dentry->d_lock);
 
 	if (error) {
+		if (ppn) {
+			kmem_free(pn.pn_buf, ZFS_MAXNAMELEN);
+		}
 		if (error == -ENOENT)
 			return (d_splice_alias(NULL, dentry));
 		else
 			return (ERR_PTR(error));
 	}
 
-	return (d_splice_alias(ip, dentry));
+	/*
+	 * If we are case insensitive, call the correct function
+	 * to install the name.
+	 */
+	if (ppn) {
+		struct dentry *new_dentry;
+		struct qstr ci_name;
+
+		ci_name.name = pn.pn_buf;
+		ci_name.len = strlen(pn.pn_buf);
+		new_dentry = d_add_ci(dentry, ip, &ci_name);
+		kmem_free(pn.pn_buf, ZFS_MAXNAMELEN);
+		return (new_dentry);
+	} else {
+		return (d_splice_alias(ip, dentry));
+	}
 }
 
 void


### PR DESCRIPTION
should retrieve the actual name found and add it using d_add_ci.

Signed-off-by: Richard Sharpe <realrichardsharpe@gmail.com>