### PR TITLE
Prevent SA length overflow

### DIFF
--- a/include/sys/sa.h
+++ b/include/sys/sa.h
@@ -82,6 +82,10 @@ typedef struct sa_bulk_attr {
 	uint16_t		sa_size;
 } sa_bulk_attr_t;
 
+/*
+ * The on-disk format of sa_hdr_phys_t limits SA lengths to 16-bit values.
+ */
+#define	SA_ATTR_MAX_LEN UINT16_MAX
 
 /*
  * special macro for adding entries for bulk attr support
@@ -95,6 +99,7 @@ typedef struct sa_bulk_attr {
 
 #define	SA_ADD_BULK_ATTR(b, idx, attr, func, data, len) \
 { \
+	ASSERT3U(len, <=, SA_ATTR_MAX_LEN); \
 	b[idx].sa_attr = attr;\
 	b[idx].sa_data_func = func; \
 	b[idx].sa_data = data; \

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -1464,6 +1464,8 @@ sa_lookup(sa_handle_t *hdl, sa_attr_type_t attr, void *buf, uint32_t buflen)
 	int error;
 	sa_bulk_attr_t bulk;
 
+	VERIFY3U(buflen, <=, SA_ATTR_MAX_LEN);
+
 	bulk.sa_attr = attr;
 	bulk.sa_data = buf;
 	bulk.sa_length = buflen;
@@ -1836,6 +1838,8 @@ sa_update(sa_handle_t *hdl, sa_attr_type_t type,
 	int error;
 	sa_bulk_attr_t bulk;
 
+	VERIFY3U(buflen, <=, SA_ATTR_MAX_LEN);
+
 	bulk.sa_attr = type;
 	bulk.sa_data_func = NULL;
 	bulk.sa_length = buflen;
@@ -1853,6 +1857,8 @@ sa_update_from_cb(sa_handle_t *hdl, sa_attr_type_t attr,
 {
 	int error;
 	sa_bulk_attr_t bulk;
+
+	VERIFY3U(buflen, <=, SA_ATTR_MAX_LEN);
 
 	bulk.sa_attr = attr;
 	bulk.sa_data = userdata;


### PR DESCRIPTION
The function sa_update() accepts a 32-bit length parameter and
assigns it to a 16-bit field in sa_bulk_attr_t, potentially
truncating the passed-in value. This could lead to corrupt system
attribute (SA) records getting written to disk. Add a VERIFY to
sa_update() to detect cases where overflow would occur. The SA length
is limited to 16-bit values by the on-disk format defined by
sa_hdr_phys_t.

The function zfs_sa_set_xattr() is vulnerable to this bug if the
unpacked nvlist of xattrs is less than 64k in size but the packed
size is greater than 64k. Fix this by appropriately checking the
size of the packed nvlist before calling sa_update(). Add error
handling to zpl_xattr_set_sa() to keep the cached list of SA-based
xattrs consistent with the data on-disk.

Lastly, zfs_sa_set_xattr() calls dmu_tx_abort() on an assigned
transaction if sa_update() returns an error, but the DMU only allows
unassigned transactions to be aborted. Wrap the sa_update() call in a
VERIFY0, which is consistent practice with other callers.

Fixes #4150

Signed-off-by: Ned Bass <bass6@llnl.gov>