### PR TITLE
Illumos 3604 zdb should print bpobjs more verbosely (fix zdb hang)

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1510,6 +1510,7 @@ dump_full_bpobj(bpobj_t *bpo, char *name, int indent)
 				continue;
 			}
 			dump_full_bpobj(&subbpo, "subobj", indent + 1);
+			bpobj_close(&subbpo);
 		}
 	} else {
 		(void) printf("    %*s: object %llu, %llu blkptrs, %s\n",


### PR DESCRIPTION
Illumos 3604 zdb should print bpobjs more verbosely (fix zdb hang)

References:
https://github.com/illumos/illumos-gate/commit/7706186
https://www.illumos.org/issues/3604

https://lists.freebsd.org/pipermail/svn-src-vendor/2015-August/002411.html
https://lists.freebsd.org/pipermail/svn-src-head/2015-August/075195.html

Porting notes:
in ZoL "5810 zdb should print details of bpobj" was merged
prior to this change

Ported-by: kernelOfTruth kerneloftruth@gmail.com