### PR TITLE
[WIP] Illumos 3749 zfs event processing should work on R/O root filesystems

### DIFF
--- a/include/sys/fm/fs/zfs.h
+++ b/include/sys/fm/fs/zfs.h
@@ -61,6 +61,7 @@ extern "C" {
 #define	FM_EREPORT_ZFS_SCRUB_START		"scrub.start"
 #define	FM_EREPORT_ZFS_SCRUB_FINISH		"scrub.finish"
 #define	FM_EREPORT_ZFS_BOOTFS_VDEV_ATTACH	"bootfs.vdev.attach"
+#define	FM_EREPORT_ZFS_CONFIG_CACHE_WRITE	"config_cache_write"
 
 #define	FM_EREPORT_PAYLOAD_ZFS_POOL		"pool"
 #define	FM_EREPORT_PAYLOAD_ZFS_POOL_FAILMODE	"pool_failmode"

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -252,6 +252,7 @@ struct spa {
 	uint64_t	spa_deadman_synctime;	/* deadman expiration timer */
 	uint64_t	spa_errata;		/* errata issues detected */
 	spa_stats_t	spa_stats;		/* assorted spa statistics */
+	hrtime_t	spa_ccw_fail_time;	/* Conf cache write fail time */
 
 	/*
 	 * spa_refcount & spa_config_lock must be the last elements

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -82,6 +82,12 @@
 #include "zfs_prop.h"
 #include "zfs_comutil.h"
 
+/*
+ * The interval, in seconds, at which failed configuration cache file writes
+ * should be retried.
+ */
+static int zfs_ccw_retry_interval = 300;
+
 typedef enum zti_modes {
 	ZTI_MODE_FIXED,			/* value is # of threads (min 1) */
 	ZTI_MODE_BATCH,			/* cpu-intensive; value is ignored */
@@ -5912,13 +5918,34 @@ spa_async_resume(spa_t *spa)
 	mutex_exit(&spa->spa_async_lock);
 }
 
+static boolean_t
+spa_async_tasks_pending(spa_t *spa)
+{
+	uint_t non_config_tasks;
+	uint_t config_task;
+	boolean_t config_task_suspended;
+
+	non_config_tasks = spa->spa_async_tasks & ~SPA_ASYNC_CONFIG_UPDATE;
+	config_task = spa->spa_async_tasks & SPA_ASYNC_CONFIG_UPDATE;
+	if (spa->spa_ccw_fail_time == 0) {
+		config_task_suspended = B_FALSE;
+	} else {
+		config_task_suspended =
+		    (gethrtime() - spa->spa_ccw_fail_time) <
+		    (zfs_ccw_retry_interval * NANOSEC);
+	}
+
+	return (non_config_tasks || (config_task && !config_task_suspended));
+}
+
 static void
 spa_async_dispatch(spa_t *spa)
 {
 	mutex_enter(&spa->spa_async_lock);
-	if (spa->spa_async_tasks && !spa->spa_async_suspended &&
+	if (spa_async_tasks_pending(spa) &&
+	    !spa->spa_async_suspended &&
 	    spa->spa_async_thread == NULL &&
-	    rootdir != NULL && !vn_is_readonly(rootdir))
+	    rootdir != NULL)
 		spa->spa_async_thread = thread_create(NULL, 0,
 		    spa_async_thread, spa, 0, &p0, TS_RUN, maxclsyspri);
 	mutex_exit(&spa->spa_async_lock);


### PR DESCRIPTION
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Eric Schrock <eric.schrock@delphix.com>
Approved by: Christopher Siden <christopher.siden@delphix.com>

References:
https://www.illumos.org/issues/3749
https://github.com/illumos/illumos-gate/commit/3cb69f7

diverged code base from Illumos:

[include/sys/spa_impl.h]
https://github.com/zfsonlinux/zfs/commit/ffe9d38275f63dbd0e6a23f3dd310249684ad518 Add generic errata infrastructure
https://github.com/zfsonlinux/zfs/commit/1421c89142376bfd41e4de22ed7c7846b9e41f95 Add visibility in to arc_read

[include/sys/fm/fs/zfs.h]
https://github.com/zfsonlinux/zfs/commit/266852767f42781821c1d62544c9b9e985828304 Add linux events
https://github.com/zfsonlinux/zfs/commit/6283f55ea1b91e680386388c17d14b89e344fa8d Support custom build directories and move includes

Ported-by: kernelOfTruth kerneloftruth@gmail.com