### PR TITLE
Add db_mtx_contended to dmu_buf_impl_t

### DIFF
--- a/cmd/dbufstat/dbufstat.py
+++ b/cmd/dbufstat/dbufstat.py
@@ -32,9 +32,10 @@ import sys
 import getopt
 import errno
 
-bhdr = ["pool", "objset", "object", "level", "blkid", "offset", "dbsize"]
+bhdr = ["pool", "objset", "object", "level", "blkid", "offset", "dbsize",
+        "contend"]
 bxhdr = ["pool", "objset", "object", "level", "blkid", "offset", "dbsize",
-         "meta", "state", "dbholds", "list", "atype", "flags",
+         "meta", "state", "dbholds", "contend", "list", "atype", "flags",
          "count", "asize", "access", "mru", "gmru", "mfu", "gmfu", "l2",
          "l2_dattr", "l2_asize", "l2_comp", "aholds", "dtype", "btype",
          "data_bs", "meta_bs", "bsize", "lvls", "dholds", "blocks", "dsize"]
@@ -67,6 +68,7 @@ cols = {
     "blkid":      [8,    -1, "block number of buffer"],
     "offset":     [12, 1024, "offset in object of buffer"],
     "dbsize":     [7,  1024, "size of buffer"],
+    "contend":    [7,    -1, "number of times db_mtx was contended"],
     "meta":       [4,    -1, "is this buffer metadata?"],
     "state":      [5,    -1, "state of buffer (read, cached, etc)"],
     "dbholds":    [7,  1000, "number of holds on buffer"],

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -250,7 +250,22 @@ typedef struct dmu_buf_impl {
 	uint8_t db_pending_evict;
 
 	uint8_t db_dirtycnt;
+
+	uint32_t db_mtx_contended;
 } dmu_buf_impl_t;
+
+/*
+ * Below must be a macro so that linux' lockdep/lock_stats reports
+ * where the lock is taken.
+ * Returns with lock held.
+ */
+
+#define	take_dbuf_lock(db_ptr)			\
+if (!mutex_tryenter(&db_ptr->db_mtx)) {		\
+		mutex_enter(&db_ptr->db_mtx);	\
+	db_ptr->db_mtx_contended++;		\
+}
+
 
 /* Note: the dbuf hash table is exposed only for the mdb module */
 #define	DBUF_MUTEXES 8192

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1354,7 +1354,7 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 	else if (!before && dn->dn_bonuslen != 0) {
 		if (dn->dn_bonus) {
 			db = dn->dn_bonus;
-			mutex_enter(&db->db_mtx);
+			take_dbuf_lock(db);
 			data = dmu_objset_userquota_find_data(db, tx);
 		} else {
 			data = DN_BONUS(dn->dn_phys);
@@ -1368,7 +1368,7 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 			    rf | DB_RF_MUST_SUCCEED,
 			    FTAG, (dmu_buf_t **)&db);
 			ASSERT(error == 0);
-			mutex_enter(&db->db_mtx);
+			take_dbuf_lock(db);
 			data = (before) ? db->db.db_data :
 			    dmu_objset_userquota_find_data(db, tx);
 			have_spill = B_TRUE;

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -508,7 +508,7 @@ dnode_destroy(dnode_t *dn)
 		dn->dn_dirtyctx_firstset = NULL;
 	}
 	if (dn->dn_bonus != NULL) {
-		mutex_enter(&dn->dn_bonus->db_mtx);
+		take_dbuf_lock(dn->dn_bonus);
 		dbuf_evict(dn->dn_bonus);
 		dn->dn_bonus = NULL;
 	}

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -219,7 +219,7 @@ free_verify(dmu_buf_impl_t *db, uint64_t start, uint64_t end, dmu_tx_t *tx)
 		 * db_data better be zeroed unless it's dirty in a
 		 * future txg.
 		 */
-		mutex_enter(&child->db_mtx);
+		take_dbuf_lock(child);
 		buf = child->db.db_data;
 		if (buf != NULL && child->db_state != DB_FILL &&
 		    child->db_last_dirty == NULL) {
@@ -418,7 +418,7 @@ dnode_evict_dbufs(dnode_t *dn)
 		DB_DNODE_EXIT(db);
 #endif	/* DEBUG */
 
-		mutex_enter(&db->db_mtx);
+		take_dbuf_lock(db);
 		if (db->db_state != DB_EVICTING &&
 		    refcount_is_zero(&db->db_holds)) {
 			db_marker->db_level = db->db_level;
@@ -450,7 +450,7 @@ dnode_evict_bonus(dnode_t *dn)
 	rw_enter(&dn->dn_struct_rwlock, RW_WRITER);
 	if (dn->dn_bonus != NULL) {
 		if (refcount_is_zero(&dn->dn_bonus->db_holds)) {
-			mutex_enter(&dn->dn_bonus->db_mtx);
+			take_dbuf_lock(dn->dn_bonus);
 			dbuf_evict(dn->dn_bonus);
 			dn->dn_bonus = NULL;
 		} else {
@@ -472,7 +472,7 @@ dnode_undirty_dbufs(list_t *list)
 		if (db->db_level != 0)
 			dnode_undirty_dbufs(&dr->dt.di.dr_children);
 
-		mutex_enter(&db->db_mtx);
+		take_dbuf_lock(db);
 		/* XXX - use dbuf_undirty()? */
 		list_remove(list, dr);
 		ASSERT(db->db_last_dirty == dr);


### PR DESCRIPTION
Track how often db_mtx is contended, for each dbuf, and report
that via kstats.

Adds a new counter to the dbuf to accomplish this, and updates
cmd/dbufstat/dbufstat.py to handle the new field.

I made db_mtx_contended 32 bits because it never gets reset to 0, and overflow would be misleading.  For a pool mounted for a long time, if there was contention on system objects that count might get large.  On the other hand, the count is very low or 0 most of the time, so the space is mostly wasted, maybe smaller is better.
