### PR TITLE
A collection of patches for pool recovery

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1997,6 +1997,14 @@ show_import(nvlist_t *config)
 			    "imported. Attach the missing\n\tdevices and try "
 			    "again.\n"));
 			break;
+		case ZPOOL_STATUS_CORRUPT_LABEL_R:
+		case ZPOOL_STATUS_CORRUPT_LABEL_NR:
+			(void) printf(gettext(" action: The pool cannot be "
+			    "imported due to a corrupt or missing label.\n\t"
+			    "It may be possible to reconstruct the label "
+			    "from the cache file.\n\tImport the pool with "
+			    "\"-F -o readonly=on -c <cache-file>\".\n"));
+			break;
 		default:
 			(void) printf(gettext(" action: The pool cannot be "
 			    "imported due to damaged devices or data.\n"));

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1422,7 +1422,13 @@ vdev_validate(vdev_t *vd, boolean_t strict)
 		uint64_t txg = spa_last_synced_txg(spa) != 0 ?
 		    spa_last_synced_txg(spa) : -1ULL;
 
-		if ((label = vdev_label_read_config(vd, txg)) == NULL) {
+		label = vdev_label_read_config(vd, txg);
+		if (label == NULL && spa->spa_load_state == SPA_LOAD_RECOVER) {
+			dprintf("generating label for %s\n", vd->vdev_path);
+			label = spa_config_generate(spa, vd, -1ULL, 0);
+		}
+
+		if (label == NULL) {
 			vdev_set_state(vd, B_FALSE, VDEV_STATE_CANT_OPEN,
 			    VDEV_AUX_BAD_LABEL);
 			return (0);
@@ -2239,6 +2245,7 @@ vdev_load(vdev_t *vd)
 int
 vdev_validate_aux(vdev_t *vd)
 {
+	spa_t *spa = vd->vdev_spa;
 	nvlist_t *label;
 	uint64_t guid, version;
 	uint64_t state;
@@ -2246,7 +2253,13 @@ vdev_validate_aux(vdev_t *vd)
 	if (!vdev_readable(vd))
 		return (0);
 
-	if ((label = vdev_label_read_config(vd, -1ULL)) == NULL) {
+	label = vdev_label_read_config(vd, -1ULL);
+	if (label == NULL && spa->spa_load_state == SPA_LOAD_RECOVER) {
+		dprintf("generating label for %s\n", vd->vdev_path);
+		label = spa_config_generate(spa, vd, -1ULL, 0);
+	}
+
+	if (label == NULL) {
 		vdev_set_state(vd, B_TRUE, VDEV_STATE_CANT_OPEN,
 		    VDEV_AUX_CORRUPT_DATA);
 		return (-1);

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1116,8 +1116,15 @@ vdev_uberblock_load(vdev_t *rvd, uberblock_t *ub, nvlist_t **config)
 	 * Search all labels on this vdev to find the configuration that
 	 * matches the txg for our uberblock.
 	 */
-	if (cb.ubl_vd != NULL)
+	if (cb.ubl_vd != NULL) {
 		*config = vdev_label_read_config(cb.ubl_vd, ub->ub_txg);
+		if (*config == NULL &&
+		    spa->spa_load_state == SPA_LOAD_RECOVER) {
+			dprintf("generating label for %s, txg=%llu\n",
+			    cb.ubl_vd->vdev_path, ub->ub_txg);
+			*config = spa_config_generate(spa, cb.ubl_vd, -1ULL, 0);
+		}
+	}
 	spa_config_exit(spa, SCL_ALL, FTAG);
 }
 

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -624,7 +624,7 @@ retry:
 			if ((error || label_txg == 0) && !config) {
 				config = label;
 				break;
-			} else if (label_txg <= txg && label_txg > best_txg) {
+			} else if (label_txg > best_txg) {
 				best_txg = label_txg;
 				nvlist_free(config);
 				config = fnvlist_dup(label);


### PR DESCRIPTION
The per-vdev nvlist configuration information can be automatically
regenerated given a valid zpool.cache file.  Extend the existing
'-F' recovery option to add this behavior for missing or corrupt
labels.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>