### PR TITLE
Illumos 5704 libzfs can only handle 255 file descriptors

### DIFF
--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -783,16 +783,16 @@ libzfs_init(void)
 	}
 
 #ifdef HAVE_SETMNTENT
-	if ((hdl->libzfs_mnttab = setmntent(MNTTAB, "r")) == NULL) {
+	if ((hdl->libzfs_mnttab = setmntent(MNTTAB, "rF")) == NULL) {
 #else
-	if ((hdl->libzfs_mnttab = fopen(MNTTAB, "r")) == NULL) {
+	if ((hdl->libzfs_mnttab = fopen(MNTTAB, "rF")) == NULL) {
 #endif
 		(void) close(hdl->libzfs_fd);
 		free(hdl);
 		return (NULL);
 	}
 
-	hdl->libzfs_sharetab = fopen("/etc/dfs/sharetab", "r");
+	hdl->libzfs_sharetab = fopen("/etc/dfs/sharetab", "rF");
 
 	if (libzfs_core_init() != 0) {
 		(void) close(hdl->libzfs_fd);
@@ -875,7 +875,7 @@ zfs_path_to_zhandle(libzfs_handle_t *hdl, char *path, zfs_type_t argtype)
 	}
 
 	/* Reopen MNTTAB to prevent reading stale data from open file */
-	if (freopen(MNTTAB, "r", hdl->libzfs_mnttab) == NULL)
+	if (freopen(MNTTAB, "rF", hdl->libzfs_mnttab) == NULL)
 		return (NULL);
 
 	while ((ret = getextmntent(hdl->libzfs_mnttab, &entry, 0)) == 0) {


### PR DESCRIPTION
Reviewed by: Josef 'Jeff' Sipek <josef.sipek@nexenta.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>
Approved by: Richard Lowe <richlowe@richlowe.net>

References:
https://www.illumos.org/issues/5704
https://github.com/illumos/illumos-gate/commit/bde3d61

Porting notes:
the tests in usr/src/test/zfs-tests
and usr/src/pkg/manifests/system-test-zfstest.mf
weren't merged (7 files)

This fix was also applied to the freopen case and setmntent

diverged code base from Illumos:

[lib/libzfs/libzfs_util.c]
https://github.com/zfsonlinux/zfs/commit/2eadf037f5ae2735bcbc61e3bb2974c6d3235b8e Add linux mntent support
https://github.com/zfsonlinux/zfs/commit/fb5c53ea65b75c67c23f90ebbbb1134a5bb6c140 Fix for re-reading /etc/mtab in zfs_is_mounted()
https://github.com/zfsonlinux/zfs/commit/cbca6076b33e3d1af330e0e1f00cbf1baaf26d82 This is a continuation of fb5c53ea65b75c67c23f90ebbbb1134a5bb6c140

Ported-by: kernelOfTruth kerneloftruth@gmail.com