### PR TITLE
Illumos 5141 zfs minimum indirect block size is 4K

### DIFF
--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -57,7 +57,7 @@ extern "C" {
  * Fixed constants.
  */
 #define	DNODE_SHIFT		9	/* 512 bytes */
-#define	DN_MIN_INDBLKSHIFT	10	/* 1k */
+#define	DN_MIN_INDBLKSHIFT	12	/* 4k */
 #define	DN_MAX_INDBLKSHIFT	14	/* 16k */
 #define	DNODE_BLOCK_SHIFT	14	/* 16k */
 #define	DNODE_CORE_SIZE		64	/* 64 bytes for dnode sans blkptrs */


### PR DESCRIPTION
Reviewed by: Christopher Siden <christopher.siden@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Richard Elling <richard.elling@gmail.com>
Approved by: Dan McDonald <danmcd@omniti.com>

References:
https://www.illumos.org/issues/5141
https://github.com/illumos/illumos-gate/commit/e94f268

Porting notes:
GRUB  --  GRand Unified Bootloader change wasn't merged (not applicable)

Ported-by: kernelOfTruth kerneloftruth@gmail.com