### PR TITLE
SET_ERROR should print strings

### DIFF
--- a/include/sys/trace_dbgmsg.h
+++ b/include/sys/trace_dbgmsg.h
@@ -51,19 +51,20 @@ DECLARE_EVENT_CLASS(zfs_dprintf_class,
 	    const char *msg),
 	TP_ARGS(file, function, line, msg),
 	TP_STRUCT__entry(
-	    __field(const char *,	file)
-	    __field(const char *,	function)
+	    __string(file, file)
+	    __string(function, function)
 	    __field(int,		line)
 	    __string(msg, msg)
 	),
 	TP_fast_assign(
-	    __entry->file		= file;
-	    __entry->function		= function;
+	    __assign_str(file, strchr(file, '/') ?
+		strrchr(file, '/') + 1 : file)
+	    __assign_str(function, function);
 	    __entry->line		= line;
 	    __assign_str(msg, msg);
 	),
-	TP_printk("%s:%d:%s(): %s", __entry->file, __entry->line,
-	    __entry->function, __get_str(msg))
+	TP_printk("%s:%d:%s(): %s", __get_str(file), __entry->line,
+	    __get_str(function), __get_str(msg))
 );
 
 #define	DEFINE_DPRINTF_EVENT(name) \
@@ -88,19 +89,20 @@ DECLARE_EVENT_CLASS(zfs_set_error_class,
 	    uintptr_t error),
 	TP_ARGS(file, function, line, error),
 	TP_STRUCT__entry(
-	    __field(const char *,	file)
-	    __field(const char *,	function)
+	    __string(file, file)
+	    __string(function, function)
 	    __field(int,		line)
 	    __field(uintptr_t,		error)
 	),
 	TP_fast_assign(
-	    __entry->file = strchr(file, '/') ? strrchr(file, '/') + 1 : file;
-	    __entry->function		= function;
+	    __assign_str(file, strchr(file, '/') ?
+		strrchr(file, '/') + 1 : file)
+	    __assign_str(function, function);
 	    __entry->line		= line;
 	    __entry->error		= error;
 	),
-	TP_printk("%s:%d:%s(): error 0x%lx", __entry->file, __entry->line,
-	    __entry->function, __entry->error)
+	TP_printk("%s:%d:%s(): error 0x%lx", __get_str(file), __entry->line,
+	    __get_str(function), __entry->error)
 );
 
 #ifdef TP_CONDITION

--- a/include/sys/trace_dbuf.h
+++ b/include/sys/trace_dbuf.h
@@ -42,7 +42,8 @@
  */
 
 #define	DBUF_TP_STRUCT_ENTRY					\
-	__field(const char *,	os_spa)				\
+	__string(os_spa,					\
+	    spa_name(DB_DNODE(db)->dn_objset->os_spa))		\
 	__field(uint64_t,	ds_object)			\
 	__field(uint64_t,	db_object)			\
 	__field(uint64_t,	db_level)			\
@@ -53,8 +54,8 @@
 	__field(int64_t,	db_holds)			\
 
 #define	DBUF_TP_FAST_ASSIGN					\
-	__entry->os_spa =					\
-	    spa_name(DB_DNODE(db)->dn_objset->os_spa);		\
+	__assign_str(os_spa,					\
+	    spa_name(DB_DNODE(db)->dn_objset->os_spa));		\
 								\
 	__entry->ds_object = db->db_objset->os_dsl_dataset ?	\
 	    db->db_objset->os_dsl_dataset->ds_object : 0;	\
@@ -72,7 +73,7 @@
 	"blkid %llu offset %llu size %llu state %llu holds %lld }"
 
 #define	DBUF_TP_PRINTK_ARGS					\
-	__entry->os_spa, __entry->ds_object,			\
+	__get_str(os_spa), __entry->ds_object,			\
 	__entry->db_object, __entry->db_level,			\
 	__entry->db_blkid, __entry->db_offset,			\
 	__entry->db_size, __entry->db_state, __entry->db_holds

--- a/include/sys/trace_zrlock.h
+++ b/include/sys/trace_zrlock.h
@@ -48,7 +48,7 @@ DECLARE_EVENT_CLASS(zfs_zrlock_class,
 	    __field(int32_t,		refcount)
 #ifdef	ZFS_DEBUG
 	    __field(pid_t,		owner_pid)
-	    __field(const char *,	caller)
+	    __string(caller, zrl->zr_caller)
 #endif
 	    __field(uint32_t,		n)
 	),
@@ -56,13 +56,13 @@ DECLARE_EVENT_CLASS(zfs_zrlock_class,
 	    __entry->refcount	= zrl->zr_refcount;
 #ifdef	ZFS_DEBUG
 	    __entry->owner_pid	= zrl->zr_owner ? zrl->zr_owner->pid : 0;
-	    __entry->caller	= zrl->zr_caller;
+	    __assign_str(caller, zrl->zr_caller);
 #endif
 	    __entry->n		= n;
 	),
 #ifdef	ZFS_DEBUG
 	TP_printk("zrl { refcount %d owner_pid %d caller %s } n %u",
-	    __entry->refcount, __entry->owner_pid, __entry->caller,
+	    __entry->refcount, __entry->owner_pid, __get_str(caller),
 	    __entry->n)
 #else
 	TP_printk("zrl { refcount %d } n %u",


### PR DESCRIPTION
When debugging with tracepoints, we see string pointers:

zfs  3017 [006]  8878.728915: zfs:zfs_set__error: ffffffffa0eec3fc:3013:ffffffffa0ebcd60(): error 0x2
        ffffffffa0e1ca43 spa_open_common (/lib/modules/3.12.21-gentoo-r1/extra/zfs/zfs.ko)
        ffffffffa0e1cbe3 spa_open (/lib/modules/3.12.21-gentoo-r1/extra/zfs/zfs.ko)
        ffffffffa0e6f6ef zfs_ioc_stable (/lib/modules/3.12.21-gentoo-r1/extra/zfs/zfs.ko)
        ffffffffa0e6f2a9 zfsdev_ioctl (/lib/modules/3.12.21-gentoo-r1/extra/zfs/zfs.ko)
        ffffffff811909dd do_vfs_ioctl ([kernel.kallsyms])
        ffffffff81190c41 sys_ioctl ([kernel.kallsyms])
        ffffffff8156e2e9 system_call_fastpath ([kernel.kallsyms])
            7ff7d8be69c7 __GI___ioctl (/lib64/libc-2.19.so)
            7ff7d90cac53 lzc_ioctl.constprop.3 (/lib64/libzfs_core.so.1.0.0)
        636f695f637a6c00 [unknown] ([unknown])

Printing the actual strings is more convenient:

zfs  3461 [001] 10599.847692: zfs:zfs_set__error: spa.c:3013:spa_open_common(): error 0x2
        ffffffffa116ba43 spa_open_common (/lib/modules/3.12.21-gentoo-r1/extra/zfs/zfs.ko)
        ffffffffa116bbe3 spa_open (/lib/modules/3.12.21-gentoo-r1/extra/zfs/zfs.ko)
        ffffffffa11be8df zfs_ioc_stable (/lib/modules/3.12.21-gentoo-r1/extra/zfs/zfs.ko)
        ffffffffa11be499 zfsdev_ioctl (/lib/modules/3.12.21-gentoo-r1/extra/zfs/zfs.ko)
        ffffffff811909dd do_vfs_ioctl ([kernel.kallsyms])
        ffffffff81190c41 sys_ioctl ([kernel.kallsyms])
        ffffffff8156e2e9 system_call_fastpath ([kernel.kallsyms])
            7f11b843c9c7 __GI___ioctl (/lib64/libc-2.19.so)
            7f11b8920c53 lzc_ioctl.constprop.3 (/lib64/libzfs_core.so.1.0.0)
        636f695f637a6c00 [unknown] ([unknown])

A few other tracepoints have strings as well, so switch to printing
the actual string values at the same time.

Signed-off-by: Richard Yao <ryao@gentoo.org>