### PR TITLE
Increase default user space stack size

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -222,7 +222,7 @@ extern int aok;
  */
 #define	TS_MAGIC		0x72f158ab4261e538ull
 #define	TS_RUN			0x00000002
-#define	TS_STACK_MIN		PTHREAD_STACK_MIN
+#define	TS_STACK_MIN		MAX(PTHREAD_STACK_MIN, 32768)
 #define	TS_STACK_MAX		(256 * 1024)
 
 /* in libzpool, p0 exists only to have its address taken */

--- a/man/man1/ztest.1
+++ b/man/man1/ztest.1
@@ -149,11 +149,10 @@ ztest -f / -V -T 120
 .TP
 .B "ZFS_STACK_SIZE=stacksize"
 Limit the default stack size to \fBstacksize\fR bytes for the purpose of
-detecting and debugging kernel stack overflows.  For x86_64 platforms this
-value should be set as follows to simulate these platforms: \fB8192\fR
-(Linux), \fB20480\fR (Illumos), \fB16384\fR (FreeBSD).
+detecting and debugging kernel stack overflows.  This value defaults to
+\fB32K\fR which is double the default \fB16K\fR Linux kernel stack size.
 
-In practice you may need to set these value slightly higher because
+In practice, setting the stack size slightly higher is needed because
 differences in stack usage between kernel and user space can lead to spurious
 stack overflows (especially when debugging is enabled).  The specified value
 will be rounded up to a floor of PTHREAD_STACK_MIN which is the minimum stack

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -212,7 +212,7 @@ txg_sync_start(dsl_pool_t *dp)
 	 * 32-bit x86.  This is due in part to nested pools and
 	 * scrub_visitbp() recursion.
 	 */
-	tx->tx_sync_thread = thread_create(NULL, 32<<10, txg_sync_thread,
+	tx->tx_sync_thread = thread_create(NULL, 0, txg_sync_thread,
 	    dp, 0, &p0, TS_RUN, defclsyspri);
 
 	mutex_exit(&tx->tx_sync_lock);


### PR DESCRIPTION
Under RHEL6/CentOS6 the default stack size must be increased to 32K
to prevent overflowing the stack when running ztest.  This isn't an
issue for other distributions due to either the version of pthreads
or perhaps the compiler.  Doubling the stack size resolves the
issue safely for all distribution and leaves us some headroom.

$ sudo -E ztest -V -T 300 -f /var/tmp/
5 vdevs, 7 datasets, 23 threads, 300 seconds...

loading space map for vdev 0 of 1, metaslab 0 of 30 ...
...
loading space map for vdev 0 of 1, metaslab 14 of 30 ...
child died with signal 11
Exited ztest with error 3

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>