### PR TITLE
Illumos 3465, 3466, 3467, 3468, 3470, 3473

### DIFF
--- a/include/sys/refcount.h
+++ b/include/sys/refcount.h
@@ -53,8 +53,8 @@ typedef struct refcount {
 	boolean_t rc_tracked;
 	list_t rc_list;
 	list_t rc_removed;
-	int64_t rc_count;
-	int64_t rc_removed_count;
+	uint64_t rc_count;
+	uint64_t rc_removed_count;
 } refcount_t;
 
 /* Note: refcount_t must be initialized with refcount_create[_untracked]() */


### PR DESCRIPTION
3465 ::walk ... | ::<dcmd> misinterprets input as symbol names
3466 ::tsd should handle missing/NULL values better
3467 mdb_ctf_vread() could be more useful
3468 mdb enhancements for zfs development
3470 ::whatis does not print callers from KMF_LITE
3473 mdb_get_module() returns wrong module
Reviewed by: Adam Leventhal <ahl@delphix.com>
Reviewed by: Eric Schrock <eric.schrock@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Robert Mustacchi <rm@joyent.com>
Approved by: Dan McDonald <danmcd@nexenta.com>

References:
  https://www.illumos.org/issues/3468
  https://github.com/illumos/illumos-gate/commit/28e4da2

Porting notes:
- The only portion of this patch which applies to ZoL is a small
  change to types used in the refcount structure.

Ported-by: Brian Behlendorf <behlendorf1@llnl.gov>