### PR TITLE
Do not lose properties when creating a pool with a temporary name

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1480,9 +1480,16 @@ zfs_ioc_pool_create(zfs_cmd_t *zc)
 	/*
 	 * Set the remaining root properties
 	 */
-	if (!error && (error = zfs_set_prop_nvlist(zc->zc_name,
-	    ZPROP_SRC_LOCAL, rootprops, NULL)) != 0)
-		(void) spa_destroy(zc->zc_name);
+	if (error != 0) {
+		char *poolname;
+
+		if (nvlist_lookup_string(props, "tname", &poolname) != 0)
+			poolname = zc->zc_name;
+
+		if ((error = zfs_set_prop_nvlist(poolname,
+		    ZPROP_SRC_LOCAL, rootprops, NULL) != 0))
+			(void) spa_destroy(poolname);
+	}
 
 pool_props_bad:
 	nvlist_free(rootprops);


### PR DESCRIPTION
Some non-essential properties like mountpoint are lost during the
creation of a temporary pool because will try to set them on the pool's
permanent name, which does not exist inside the SPA namespace during
pool creation.

Most notably, the mountpoint property would be lost.

Signed-off-by: Richard Yao <ryao@gentoo.org>