### PR TITLE
Create zfs-kmod-debuginfo rpm with redhat spec file

### DIFF
--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -177,6 +177,7 @@ for kernel_version in %{?kernel_versions}; do
         INSTALL_MOD_DIR=%{kmodinstdir_postfix}
     cd ..
 done
+# find-debuginfo.sh only considers executables
 chmod u+x ${RPM_BUILD_ROOT}%{kmodinstdir_prefix}/*/extra/*/*/*
 %{?akmod_install}
 

--- a/rpm/redhat/zfs-kmod.spec.in
+++ b/rpm/redhat/zfs-kmod.spec.in
@@ -25,7 +25,6 @@ Conflicts:      @PACKAGE@-dkms\n\n" > %{_sourcedir}/kmod-preamble)
 This package contains the ZFS kernel modules.
 
 %define kmod_name @PACKAGE@
-%define debug_package %{nil}
 
 %kernel_module_package -n %{kmod_name} -p %{_sourcedir}/kmod-preamble
 
@@ -78,6 +77,9 @@ make install \
         DESTDIR=${RPM_BUILD_ROOT} \
         INSTALL_MOD_DIR=extra/%{kmod_name}
 %{__rm} -f %{buildroot}/lib/modules/%{kverrel}/modules.*
+
+# find-debuginfo.sh only considers executables 
+%{__chmod} u+x  %{buildroot}/lib/modules/%{kverrel}/extra/*/*/*
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Correct the redhat specfile so that working debuginfo rpms are created
for the kernel modules.  The generic specfile already does the right
thing.

Requires-spl: refs/pull/525/head

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>
Issue zfsonlinux/zfs#4224