### PR TITLE
Prevent arc_c collapse

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3183,12 +3183,16 @@ arc_flush(spa_t *spa, boolean_t retry)
 void
 arc_shrink(int64_t to_free)
 {
+	uint64_t c;
+
 	if (arc_c > arc_c_min) {
 
-		if (arc_c > arc_c_min + to_free)
-			atomic_add_64(&arc_c, -to_free);
-		else
+		if (arc_c > arc_c_min + to_free &&
+		    (c = arc_c - to_free) > 2ULL << SPA_MAXBLOCKSHIFT) {
+			arc_c = c;
+		} else {
 			arc_c = arc_c_min;
+		}
 
 		atomic_add_64(&arc_p, -(arc_p >> arc_shrink_shift));
 		if (arc_c > arc_size)
@@ -3767,7 +3771,6 @@ arc_adapt(int bytes, arc_state_t *state)
 	 * cache size, increment the target cache size
 	 */
 	ASSERT3U(arc_c, >=, 2ULL << SPA_MAXBLOCKSHIFT);
-	arc_c = MAX(arc_c, 2ULL << SPA_MAXBLOCKSHIFT);
 	if (arc_size >= arc_c - (2ULL << SPA_MAXBLOCKSHIFT)) {
 		atomic_add_64(&arc_c, (int64_t)bytes);
 		if (arc_c > arc_c_max)
@@ -5160,7 +5163,9 @@ arc_tempreserve_space(uint64_t reserve, uint64_t txg)
 	int error;
 	uint64_t anon_size;
 
-	if (reserve > arc_c/4 && !arc_no_grow)
+	if (!arc_no_grow &&
+	    reserve > arc_c/4 &&
+	    reserve * 4 > (2ULL << SPA_MAXBLOCKSHIFT))
 		arc_c = MIN(arc_c_max, reserve * 4);
 
 	/*

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3183,17 +3183,10 @@ arc_flush(spa_t *spa, boolean_t retry)
 void
 arc_shrink(int64_t to_free)
 {
-	uint64_t c;
+	uint64_t c = arc_c;
 
-	if (arc_c > arc_c_min) {
-
-		if (arc_c > arc_c_min + to_free &&
-		    (c = arc_c - to_free) > 2ULL << SPA_MAXBLOCKSHIFT) {
-			arc_c = c;
-		} else {
-			arc_c = arc_c_min;
-		}
-
+	if (c > to_free && c - to_free > arc_c_min) {
+		arc_c = c - to_free;
 		atomic_add_64(&arc_p, -(arc_p >> arc_shrink_shift));
 		if (arc_c > arc_size)
 			arc_c = MAX(arc_size, arc_c_min);
@@ -3201,6 +3194,8 @@ arc_shrink(int64_t to_free)
 			arc_p = (arc_c >> 1);
 		ASSERT(arc_c >= arc_c_min);
 		ASSERT((int64_t)arc_p >= 0);
+	} else {
+		arc_c = arc_c_min;
 	}
 
 	if (arc_size > arc_c)


### PR DESCRIPTION
Adjusting arc_c directly is racy because it can happen in the context
of multiple threads.  It should always be >= 2 * maxblocksize.  Set it
to a known valid value rather than adjusting it directly.

Reverts: 935434ef
Fixes: #3904
Fixes: #4161