### PR TITLE
Remove wrong ASSERT in annotate_ecksum

### DIFF
--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -457,7 +457,8 @@ update_histogram(uint64_t value_arg, uint16_t *hist, uint32_t *count)
 	/* We store the bits in big-endian (largest-first) order */
 	for (i = 0; i < 64; i++) {
 		if (value & (1ull << i)) {
-			hist[63 - i]++;
+			if (hist[63 - i] < UINT16_MAX)
+				hist[63 - i]++;
 			++bits;
 		}
 	}
@@ -615,7 +616,6 @@ annotate_ecksum(nvlist_t *ereport, zio_bad_cksum_t *info,
 	if (badbuf == NULL || goodbuf == NULL)
 		return (eip);
 
-	ASSERT3U(nui64s, <=, UINT16_MAX);
 	ASSERT3U(size, ==, nui64s * sizeof (uint64_t));
 	ASSERT3U(size, <=, SPA_MAXBLOCKSIZE);
 	ASSERT3U(size, <=, UINT32_MAX);


### PR DESCRIPTION
When using large blocks like 1M, this ASSERT would go off.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>