### PR TITLE
mount.zfs: use getopt_long instead of getopt to guarantee permutation of argv.

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -32,6 +32,7 @@
 #include <sys/stat.h>
 #include <libzfs.h>
 #include <locale.h>
+#include <getopt.h>
 
 #define	ZS_COMMENT	0x00000000	/* comment */
 #define	ZS_ZFSUTIL	0x00000001	/* caller is zfs(8) */
@@ -387,7 +388,7 @@ main(int argc, char **argv)
 	opterr = 0;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "sfnvo:h?")) != -1) {
+	while ((c = getopt_long(argc, argv, "sfnvo:h?", 0, 0)) != -1) {
 		switch (c) {
 		case 's':
 			sloppy = 1;


### PR DESCRIPTION
mount.zfs is called by convention (and util-linux) with arguments
last, i.e.

  % mount.zfs <dataset> <mountpoint> -o <options>

This is not a problem on glibc since GNU getopt(3) will reorder the
arguments.  However, alternative libc such as musl libc (or glibc with
$POSIXLY_CORRECT set) will not permute argv and fail to parse the -o
<options>.  Use getopt_long so musl will permute arguments.

Fixes #4222.