### PR TITLE
Set arc_c_min properly in userland builds

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5403,6 +5403,9 @@ arc_init(void)
 	arc_need_free = 0;
 #endif
 
+	/* Set max to 1/2 of all memory */
+	arc_c_max = allmem / 2;
+
 	/*
 	 * In userland, there's only the memory pressure that we artificially
 	 * create (see arc_available_memory()).  Don't let arc_c get too
@@ -5410,13 +5413,10 @@ arc_init(void)
 	 * arc_c, causing arc_tempreserve_space() to fail.
 	 */
 #ifndef	_KERNEL
-	arc_c_min = arc_c_max / 2;
+	arc_c_min = MAX(arc_c_max / 2, 2ULL << SPA_MAXBLOCKSHIFT);
 #else
 	arc_c_min = 2ULL << SPA_MAXBLOCKSHIFT;
 #endif
-
-	/* Set max to 1/2 of all memory */
-	arc_c_max = allmem / 2;
 
 	arc_c = arc_c_max;
 	arc_p = (arc_c >> 1);


### PR DESCRIPTION
Since it's set to arc_c_max / 2, it must be set after arc_c_max is set.
Also added protection against it falling below 2 * maxblocksize in
userland builds.