### PR TITLE
Disable Linux readahead on zvols (for buildbot)

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1283,6 +1283,11 @@ zvol_alloc(dev_t dev, const char *name)
 	if (zv->zv_disk == NULL)
 		goto out_queue;
 
+	/*
+	 * NOTE: Linux read-ahead is disabled in favor of zfs read-ahead.
+	 */
+	zv->zv_queue->backing_dev_info.ra_pages = 0;
+
 	zv->zv_queue->queuedata = zv;
 	zv->zv_dev = dev;
 	zv->zv_open_count = 0;


### PR DESCRIPTION
Linux has a readahead logic designed to accelerate sequential workloads.
ZFS has its own readahead logic called zprefetch that operates on both
zvols and datasets. Having two prefetchers active at the same time
causes overprefetching, which unnecessarily reduces IOPS performance on
CoW filesystems like ZFS.

We currently disable the Linux readahead logic on datasets in the belief
that zprefetch is superior because it is aware of the internal geometry
used in ZFS while the Linux readahead logic is not. In particular,
zprefetch aligns readahead to ZFS' internal geometry and is integrated
with ARC to ensure that prefetches are not considered hits. This makes
zprefetch more desireable than the Linux readahead logic on both
datasets and zvols.

This patch disables Linux's readahead logic on zvols to be consistent
with datasets. This has the side benefit of making the behavior of ZFS
more consistent across platforms.

Signed-off-by: Richard Yao <ryao@gentoo.org>