### PR TITLE
Illumos 4448 zfs diff misprints unicode characters

### DIFF
--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
- * Copyright 2015 Joyent, Inc.
+ * Copyright 2016 Joyent, Inc.
  */
 
 /*
@@ -130,11 +130,14 @@ get_stats_for_obj(differ_info_t *di, const char *dsname, uint64_t obj,
 static void
 stream_bytes(FILE *fp, const char *string)
 {
-	while (*string) {
-		if (*string > ' ' && *string != '\\' && *string < '\177')
-			(void) fprintf(fp, "%c", *string++);
-		else
-			(void) fprintf(fp, "\\%04o", (unsigned char)*string++);
+	char c;
+
+	while ((c = *string++) != '\0') {
+		if (c > ' ' && c != '\\' && c < '\177') {
+			(void) fprintf(fp, "%c", c);
+		} else {
+			(void) fprintf(fp, "\\%04o", (uint8_t)c);
+		}
 	}
 }
 


### PR DESCRIPTION
Reviewed by: Igor Kozhukhov <ikozhukhov@gmail.com>
Reviewed by: Toomas Soome <tsoome@me.com>
Approved by: Matthew Ahrens <mahrens@delphix.com>

References:
https://www.illumos.org/issues/4448
illumos/illumos-gate@b211eb9

unya@572e285 Update to onnv_147

diverged code base from Illumos:

[lib/libzfs/libzfs_diff.c]
zfsonlinux#1172
zfsonlinux@38145d6 Ensure that zfs diff prints unicode safely.
zfsonlinux@141b638 Change 3-digit octal escapes to 4-digit ones

Ported-by: kernelOfTruth kerneloftruth@gmail.com