### PR TITLE
Issue #3892 - Updated paths to scan when importing zpool(s)

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -64,7 +64,7 @@ extern "C" {
  */
 #define	DISK_LABEL_WAIT		(30 * 1000)  /* 30 seconds */
 
-#define	DEFAULT_IMPORT_PATH_SIZE	7
+#define	DEFAULT_IMPORT_PATH_SIZE	9
 extern char *zpool_default_import_path[DEFAULT_IMPORT_PATH_SIZE];
 
 /*

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1277,23 +1277,14 @@ err_blkid1:
 
 char *
 zpool_default_import_path[DEFAULT_IMPORT_PATH_SIZE] = {
-	/* Custom hard rules */
 	"/dev/disk/by-vdev",	/* Custom rules, use first if they exist */
 	"/dev/mapper",		/* Use multipath devices before components */
-
-	/* Partitions > Devices */
 	"/dev/disk/by-partlabel", /* Single unique entry set by user, always better than generated */
 	"/dev/disk/by-partuuid", /* Single unique entry, persistant, and better than device id's */
-
-	/* Devices (Custom Labeled)*/
 	"/dev/disk/by-label",	/* Custom persistent labels */
-
-  /* Devices (Generated) */
 	"/dev/disk/by-uuid",	/* Single unique entry and persistent */
 	"/dev/disk/by-id",	/* May be multiple entries and persistent */
 	"/dev/disk/by-path",	/* Encodes physical location and persistent */
-
-	/* Legacy Fallback */
 	"/dev"			/* UNSAFE device names will change */
 };
 

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1279,8 +1279,8 @@ char *
 zpool_default_import_path[DEFAULT_IMPORT_PATH_SIZE] = {
 	"/dev/disk/by-vdev",	/* Custom rules, use first if they exist */
 	"/dev/mapper",		/* Use multipath devices before components */
-	"/dev/disk/by-partlabel", /* Single unique entry set by user, always better than generated */
-	"/dev/disk/by-partuuid", /* Single unique entry, persistant, and better than device id's */
+	"/dev/disk/by-partlabel", /* Single unique entry set by user */
+	"/dev/disk/by-partuuid", /* Generated partition UUid */
 	"/dev/disk/by-label",	/* Custom persistent labels */
 	"/dev/disk/by-uuid",	/* Single unique entry and persistent */
 	"/dev/disk/by-id",	/* May be multiple entries and persistent */

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1277,12 +1277,23 @@ err_blkid1:
 
 char *
 zpool_default_import_path[DEFAULT_IMPORT_PATH_SIZE] = {
+	/* Custom hard rules */
 	"/dev/disk/by-vdev",	/* Custom rules, use first if they exist */
 	"/dev/mapper",		/* Use multipath devices before components */
+
+	/* Partitions > Devices */
+	"/dev/disk/by-partlabel", /* Single unique entry set by user, always better than generated */
+	"/dev/disk/by-partuuid", /* Single unique entry, persistant, and better than device id's */
+
+	/* Devices (Custom Labeled)*/
+	"/dev/disk/by-label",	/* Custom persistent labels */
+
+  /* Devices (Generated) */
 	"/dev/disk/by-uuid",	/* Single unique entry and persistent */
 	"/dev/disk/by-id",	/* May be multiple entries and persistent */
 	"/dev/disk/by-path",	/* Encodes physical location and persistent */
-	"/dev/disk/by-label",	/* Custom persistent labels */
+
+	/* Legacy Fallback */
 	"/dev"			/* UNSAFE device names will change */
 };
 


### PR DESCRIPTION
I've reworked the directories that zpool import scans in to make it more BSD like.
This fixes some problems when importing and exporting pools when using GPT style partition labels.