### PR TITLE
RFC: SEEK_DATA/SEEK_HOLE should not block on transaction group commit

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1812,26 +1812,11 @@ int
 dmu_offset_next(objset_t *os, uint64_t object, boolean_t hole, uint64_t *off)
 {
 	dnode_t *dn;
-	int i, err;
+	int err;
 
 	err = dnode_hold(os, object, FTAG, &dn);
 	if (err)
 		return (err);
-	/*
-	 * Sync any current changes before
-	 * we go trundling through the block pointers.
-	 */
-	for (i = 0; i < TXG_SIZE; i++) {
-		if (list_link_active(&dn->dn_dirty_link[i]))
-			break;
-	}
-	if (i != TXG_SIZE) {
-		dnode_rele(dn, FTAG);
-		txg_wait_synced(dmu_objset_pool(os), 0);
-		err = dnode_hold(os, object, FTAG, &dn);
-		if (err)
-			return (err);
-	}
 
 	err = dnode_next_offset(dn, (hole ? DNODE_FIND_HOLE : 0), off, 1, 1, 0);
 	dnode_rele(dn, FTAG);


### PR DESCRIPTION
The original implementation of `SEEK_DATA` and `SEEK_HOLE` for `lseek()`
in OpenSolaris would block on the transaction group commit when called
on files that have dirty data. This was an attempt to ensure that any
holes that are made by zero detection are reported. However, there is
nothing stopping userland from redirtying the dnode with additional
writes while the transaction group commit finishes, such that the
reported information is not necessarily up to date. The consequence is
that we can report data where holes are (or would be) present.

Reporting data where there is holes is alright because userspace would
then copy zeroes instead on a read, but the inverse of reporting holes
where there is data is not alright. Other consumers of
`dnode_next_offset` such as zvol_discard would fail to perform their
intended function if holes were reported where there is data and do not
block on the transaction group commit like we do with lseek on
`SEEK_DATA` or `SEEK_HOLE`. Consequently, it should be the case that
this code will never report a hole where there is data and there is no
need to block on the transaction group commit.

Closes zfsonlinux/zfs#4306

Signed-off-by: Richard Yao <ryao@gentoo.org>