### PR TITLE
Reduce overhead in zvol_write/zvol_read via existing hold

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -731,7 +731,7 @@ zvol_read(zvol_state_t *zv, uio_t *uio)
 		if (bytes > volsize - uio->uio_loffset)
 			bytes = volsize - uio->uio_loffset;
 
-		error =  dmu_read_uio(zv->zv_objset, ZVOL_OBJ, uio, bytes);
+		error = dmu_read_uio_dbuf(zv->zv_dbuf, uio, bytes);
 		if (error) {
 			/* convert checksum errors into IO errors */
 			if (error == ECKSUM)


### PR DESCRIPTION
Our `zvol_write` function had severely diverged with illumos-gate in a
manner that caused multiple regressions:
    
1. We did `dnode_hold()` on each IO when we already had a hold.
2. We would attempt to send writes that exceeded `DMU_MAX_ACCESS` to the
DMU.
3. We could call `zil_commit()` twice. In this case, this is because
Linux uses the `->write` function to send flushes and can aggregate the
flush with a write. If a synchronous write occurred with the flush, we
effectively flushed twice when there is no need to do that.
    
Signed-off-by: Richard Yao <ryao@gentoo.org>