### PR TITLE
for testing only - dbuf hash mutexes to dbuf hash rwlocks

### DIFF
--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -253,12 +253,12 @@ typedef struct dmu_buf_impl {
 } dmu_buf_impl_t;
 
 /* Note: the dbuf hash table is exposed only for the mdb module */
-#define	DBUF_MUTEXES 8192
-#define	DBUF_HASH_MUTEX(h, idx) (&(h)->hash_mutexes[(idx) & (DBUF_MUTEXES-1)])
+#define	DBUF_RWLOCKS 8192
+#define	DBUF_HASH_RWLOCK(h, idx) (&(h)->hash_rwlocks[(idx) & (DBUF_RWLOCKS-1)])
 typedef struct dbuf_hash_table {
 	uint64_t hash_table_mask;
 	dmu_buf_impl_t **hash_table;
-	kmutex_t hash_mutexes[DBUF_MUTEXES];
+	krwlock_t hash_rwlocks[DBUF_RWLOCKS];
 } dbuf_hash_table_t;
 
 uint64_t dbuf_whichblock(struct dnode *di, int64_t level, uint64_t offset);


### PR DESCRIPTION
Change lock used to protect dbuf hash chains from mutexes to rwlocks.