### PR TITLE
Possible txg locking improvements

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -67,7 +67,6 @@
 #include <sys/fm/fs/zfs.h>
 #include <sys/sunddi.h>
 #include <sys/ctype.h>
-#include <sys/disp.h>
 #include <sys/trace.h>
 #include <linux/dcache_compat.h>
 #include <linux/utsname_compat.h>
@@ -261,9 +260,6 @@ extern kthread_t *zk_thread_create(caddr_t stk, size_t  stksize,
 	thread_func_t func, void *arg, size_t len,
 	proc_t *pp, int state, pri_t pri, int detachstate);
 extern void zk_thread_join(kt_did_t tid);
-
-#define	kpreempt_disable()	((void)0)
-#define	kpreempt_enable()	((void)0)
 
 #define	PS_NONE		-1
 

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -1515,13 +1515,7 @@ fm_ena_generate_cpu(uint64_t timestamp, processorid_t cpuid, uchar_t format)
 uint64_t
 fm_ena_generate(uint64_t timestamp, uchar_t format)
 {
-	uint64_t ena;
-
-	kpreempt_disable();
-	ena = fm_ena_generate_cpu(timestamp, getcpuid(), format);
-	kpreempt_enable();
-
-	return (ena);
+	return (fm_ena_generate_cpu(timestamp, getcpuid(), format));
 }
 
 uint64_t

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -294,18 +294,8 @@ uint64_t
 txg_hold_open(dsl_pool_t *dp, txg_handle_t *th)
 {
 	tx_state_t *tx = &dp->dp_tx;
-	tx_cpu_t *tc;
+	tx_cpu_t *tc = &tx->tx_cpu[CPU_SEQID];
 	uint64_t txg;
-
-	/*
-	 * It appears the processor id is simply used as a "random"
-	 * number to index into the array, and there isn't any other
-	 * significance to the chosen tx_cpu. Because.. Why not use
-	 * the current cpu to index into the array?
-	 */
-	kpreempt_disable();
-	tc = &tx->tx_cpu[CPU_SEQID];
-	kpreempt_enable();
 
 	mutex_enter(&tc->tc_open_lock);
 	txg = tx->tx_open_txg;

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1542,19 +1542,14 @@ zio_nowait(zio_t *zio)
 
 	if (zio->io_child_type == ZIO_CHILD_LOGICAL &&
 	    zio_unique_parent(zio) == NULL) {
-		zio_t *pio;
-
 		/*
 		 * This is a logical async I/O with no parent to wait for it.
 		 * We add it to the spa_async_root_zio "Godfather" I/O which
 		 * will ensure they complete prior to unloading the pool.
 		 */
 		spa_t *spa = zio->io_spa;
-		kpreempt_disable();
-		pio = spa->spa_async_zio_root[CPU_SEQID];
-		kpreempt_enable();
 
-		zio_add_child(pio, zio);
+		zio_add_child(spa->spa_async_zio_root[CPU_SEQID], zio);
 	}
 
 	__zio_execute(zio);


### PR DESCRIPTION
This contains a few ideas that I had when looking at code related to `txg_quiesce()`.

1. We can avoid some overhead by using atomic instructions on `->tc_count` rather than protecting it with a mutex. We have fewer points in the code where a mutex would block us and use 1 less atomic instruction in each.
2. We really do not need to hold `->tc_open_lock` when processing a DMU transaction provided that we we have incremented `->tc_count`, so we let it go early.
3. Calling `kpreempt_enable()` defeats the purpose of using `CPU_SEQID` to index into a per-CPU structure because we are then preempted, allowing another thread to contend with us on the per-CPU structure we reference. This behavior was introduced by 15a9e03368d8f186751a432740a5a281f45d712d as a means to work around scary warnings from Linux, but we can workaround them by mapping things to raw_smp_processor_id(), so lets do that to avoid unnecessary preemption.
