### PR TITLE
Changing field names of struct zfs_handle and zpool_handle.

### DIFF
--- a/include/libzfs_impl.h
+++ b/include/libzfs_impl.h
@@ -88,8 +88,8 @@ struct libzfs_handle {
 #define	ZFSSHARE_MISS	0x01	/* Didn't find entry in cache */
 
 struct zfs_handle {
-	libzfs_handle_t *zfs_hdl;
-	zpool_handle_t *zpool_hdl;
+	libzfs_handle_t *zfs_libzfs_hdl;
+	zpool_handle_t *zfs_zpool_hdl;
 	char zfs_name[ZFS_MAXNAMELEN];
 	zfs_type_t zfs_type; /* type including snapshot */
 	zfs_type_t zfs_head_type; /* type excluding snapshot */
@@ -109,7 +109,7 @@ struct zfs_handle {
 #define	ZFS_IS_VOLUME(zhp) ((zhp)->zfs_head_type == ZFS_TYPE_VOLUME)
 
 struct zpool_handle {
-	libzfs_handle_t *zpool_hdl;
+	libzfs_handle_t *zpool_libzfs_hdl;
 	zpool_handle_t *zpool_next;
 	char zpool_name[ZPOOL_MAXNAMELEN];
 	int zpool_state;

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -537,7 +537,8 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	uu_compare_fn_t *compare = NULL;
 	boolean_t legacy = B_FALSE;
 
-	if ((clp = zfs_alloc(zhp->zfs_libzfs_hdl, sizeof (prop_changelist_t))) == NULL)
+	if ((clp = zfs_alloc(zhp->zfs_libzfs_hdl,
+		sizeof (prop_changelist_t))) == NULL)
 		return (NULL);
 
 	/*
@@ -569,7 +570,8 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	    compare, 0);
 	if (clp->cl_pool == NULL) {
 		assert(uu_error() == UU_ERROR_NO_MEMORY);
-		(void) zfs_error(zhp->zfs_libzfs_hdl, EZFS_NOMEM, "internal error");
+		(void) zfs_error(zhp->zfs_libzfs_hdl,
+			EZFS_NOMEM, "internal error");
 		changelist_free(clp);
 		return (NULL);
 	}
@@ -581,7 +583,8 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 
 	if (clp->cl_list == NULL) {
 		assert(uu_error() == UU_ERROR_NO_MEMORY);
-		(void) zfs_error(zhp->zfs_libzfs_hdl, EZFS_NOMEM, "internal error");
+		(void) zfs_error(zhp->zfs_libzfs_hdl,
+			EZFS_NOMEM, "internal error");
 		changelist_free(clp);
 		return (NULL);
 	}

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -180,7 +180,7 @@ changelist_postfix(prop_changelist_t *clp)
 	 * is uninitialized here so that it will reinitialize later.
 	 */
 	if (cn->cn_handle != NULL) {
-		hdl = cn->cn_handle->zfs_hdl;
+		hdl = cn->cn_handle->zfs_libzfs_hdl;
 		assert(hdl != NULL);
 		zfs_uninit_libshare(hdl);
 	}
@@ -537,7 +537,7 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	uu_compare_fn_t *compare = NULL;
 	boolean_t legacy = B_FALSE;
 
-	if ((clp = zfs_alloc(zhp->zfs_hdl, sizeof (prop_changelist_t))) == NULL)
+	if ((clp = zfs_alloc(zhp->zfs_libzfs_hdl, sizeof (prop_changelist_t))) == NULL)
 		return (NULL);
 
 	/*
@@ -569,7 +569,7 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	    compare, 0);
 	if (clp->cl_pool == NULL) {
 		assert(uu_error() == UU_ERROR_NO_MEMORY);
-		(void) zfs_error(zhp->zfs_hdl, EZFS_NOMEM, "internal error");
+		(void) zfs_error(zhp->zfs_libzfs_hdl, EZFS_NOMEM, "internal error");
 		changelist_free(clp);
 		return (NULL);
 	}
@@ -581,7 +581,7 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 
 	if (clp->cl_list == NULL) {
 		assert(uu_error() == UU_ERROR_NO_MEMORY);
-		(void) zfs_error(zhp->zfs_hdl, EZFS_NOMEM, "internal error");
+		(void) zfs_error(zhp->zfs_libzfs_hdl, EZFS_NOMEM, "internal error");
 		changelist_free(clp);
 		return (NULL);
 	}
@@ -637,7 +637,7 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	 * We have to re-open ourselves because we auto-close all the handles
 	 * and can't tell the difference.
 	 */
-	if ((temp = zfs_open(zhp->zfs_hdl, zfs_get_name(zhp),
+	if ((temp = zfs_open(zhp->zfs_libzfs_hdl, zfs_get_name(zhp),
 	    ZFS_TYPE_DATASET)) == NULL) {
 		changelist_free(clp);
 		return (NULL);
@@ -647,7 +647,7 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	 * Always add ourself to the list.  We add ourselves to the end so that
 	 * we're the last to be unmounted.
 	 */
-	if ((cn = zfs_alloc(zhp->zfs_hdl,
+	if ((cn = zfs_alloc(zhp->zfs_libzfs_hdl,
 	    sizeof (prop_changenode_t))) == NULL) {
 		zfs_close(temp);
 		changelist_free(clp);

--- a/lib/libzfs/libzfs_config.c
+++ b/lib/libzfs/libzfs_config.c
@@ -266,7 +266,7 @@ zpool_refresh_stats(zpool_handle_t *zhp, boolean_t *missing)
 	zfs_cmd_t zc = {"\0"};
 	int error;
 	nvlist_t *config;
-	libzfs_handle_t *hdl = zhp->zpool_hdl;
+	libzfs_handle_t *hdl = zhp->zpool_libzfs_hdl;
 
 	*missing = B_FALSE;
 	(void) strcpy(zc.zc_name, zhp->zpool_name);
@@ -278,7 +278,7 @@ zpool_refresh_stats(zpool_handle_t *zhp, boolean_t *missing)
 		return (-1);
 
 	for (;;) {
-		if (ioctl(zhp->zpool_hdl->libzfs_fd, ZFS_IOC_POOL_STATS,
+		if (ioctl(zhp->zpool_libzfs_hdl->libzfs_fd, ZFS_IOC_POOL_STATS,
 		    &zc) == 0) {
 			/*
 			 * The real error is returned in the zc_cookie field.

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1761,7 +1761,8 @@ zfs_prop_inherit(zfs_handle_t *zhp, const char *propname, boolean_t received)
 		(void) strlcpy(zc.zc_name, zhp->zfs_name, sizeof (zc.zc_name));
 		(void) strlcpy(zc.zc_value, propname, sizeof (zc.zc_value));
 
-		if (zfs_ioctl(zhp->zfs_libzfs_hdl, ZFS_IOC_INHERIT_PROP, &zc) != 0)
+		if (zfs_ioctl(zhp->zfs_libzfs_hdl,
+			ZFS_IOC_INHERIT_PROP, &zc) != 0)
 			return (zfs_standard_error(hdl, errno, errbuf));
 
 		return (0);
@@ -1813,7 +1814,8 @@ zfs_prop_inherit(zfs_handle_t *zhp, const char *propname, boolean_t received)
 	if ((ret = changelist_prefix(cl)) != 0)
 		goto error;
 
-	if ((ret = zfs_ioctl(zhp->zfs_libzfs_hdl, ZFS_IOC_INHERIT_PROP, &zc)) != 0) {
+	if ((ret = zfs_ioctl(zhp->zfs_libzfs_hdl,
+		ZFS_IOC_INHERIT_PROP, &zc)) != 0) {
 		return (zfs_standard_error(hdl, errno, errbuf));
 	} else {
 
@@ -2066,14 +2068,16 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 		if (zcmd_alloc_dst_nvlist(zhp->zfs_libzfs_hdl, &zc, 0) != 0)
 			return (-1);
 		(void) strlcpy(zc.zc_name, zhp->zfs_name, sizeof (zc.zc_name));
-		if (zfs_ioctl(zhp->zfs_libzfs_hdl, ZFS_IOC_OBJSET_ZPLPROPS, &zc)) {
+		if (zfs_ioctl(zhp->zfs_libzfs_hdl,
+			ZFS_IOC_OBJSET_ZPLPROPS, &zc)) {
 			zcmd_free_nvlists(&zc);
 			if (prop == ZFS_PROP_VERSION &&
 			    zhp->zfs_type == ZFS_TYPE_VOLUME)
 				*val = zfs_prop_default_numeric(prop);
 			return (-1);
 		}
-		if (zcmd_read_dst_nvlist(zhp->zfs_libzfs_hdl, &zc, &zplprops) != 0 ||
+		if (zcmd_read_dst_nvlist(zhp->zfs_libzfs_hdl, &zc,
+			&zplprops) != 0 ||
 		    nvlist_lookup_uint64(zplprops, zfs_prop_to_name(prop),
 		    val) != 0) {
 			zcmd_free_nvlists(&zc);
@@ -3366,9 +3370,10 @@ zfs_destroy(zfs_handle_t *zhp, boolean_t defer)
 		int error = lzc_destroy_bookmarks(nv, NULL);
 		fnvlist_free(nv);
 		if (error != 0) {
-			return (zfs_standard_error_fmt(zhp->zfs_libzfs_hdl, errno,
-			    dgettext(TEXT_DOMAIN, "cannot destroy '%s'"),
-			    zhp->zfs_name));
+			return (zfs_standard_error_fmt(zhp->zfs_libzfs_hdl,
+				errno,
+				dgettext(TEXT_DOMAIN, "cannot destroy '%s'"),
+				zhp->zfs_name));
 		}
 		return (0);
 	}
@@ -3544,7 +3549,8 @@ zfs_clone(zfs_handle_t *zhp, const char *target, nvlist_t *props)
 			 */
 			zfs_error_aux(zhp->zfs_libzfs_hdl, dgettext(TEXT_DOMAIN,
 			    "no such parent '%s'"), parent);
-			return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_NOENT, errbuf));
+			return (zfs_error(zhp->zfs_libzfs_hdl,
+				EZFS_NOENT, errbuf));
 
 		case EXDEV:
 			zfs_error_aux(zhp->zfs_libzfs_hdl, dgettext(TEXT_DOMAIN,
@@ -3999,7 +4005,8 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 		}
 		delim = strchr(parentname, '@');
 		*delim = '\0';
-		zhrp = zfs_open(zhp->zfs_libzfs_hdl, parentname, ZFS_TYPE_DATASET);
+		zhrp = zfs_open(zhp->zfs_libzfs_hdl, parentname,
+			ZFS_TYPE_DATASET);
 		if (zhrp == NULL) {
 			ret = -1;
 			goto error;
@@ -4046,7 +4053,8 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 			    "with the new name"));
 			(void) zfs_error(hdl, EZFS_EXISTS, errbuf);
 		} else {
-			(void) zfs_standard_error(zhp->zfs_libzfs_hdl, errno, errbuf);
+			(void) zfs_standard_error(zhp->zfs_libzfs_hdl,
+				errno, errbuf);
 		}
 
 		/*

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -90,7 +90,8 @@ get_stats_for_obj(differ_info_t *di, const char *dsname, uint64_t obj,
 	zc.zc_obj = obj;
 
 	errno = 0;
-	error = ioctl(di->zhp->zfs_libzfs_hdl->libzfs_fd, ZFS_IOC_OBJ_TO_STATS, &zc);
+	error = ioctl(di->zhp->zfs_libzfs_hdl->libzfs_fd,
+		ZFS_IOC_OBJ_TO_STATS, &zc);
 	di->zerr = errno;
 
 	/* we can get stats even if we failed to get a path */
@@ -490,7 +491,8 @@ find_shares_object(differ_info_t *di)
 	if (stat64(fullpath, &sb) != 0) {
 		(void) snprintf(di->errbuf, sizeof (di->errbuf),
 		    dgettext(TEXT_DOMAIN, "Cannot stat %s"), fullpath);
-		return (zfs_error(di->zhp->zfs_libzfs_hdl, EZFS_DIFF, di->errbuf));
+		return (zfs_error(di->zhp->zfs_libzfs_hdl,
+			EZFS_DIFF, di->errbuf));
 	}
 
 	di->shares = (uint64_t)sb.st_ino;
@@ -670,7 +672,8 @@ get_mountpoint(differ_info_t *di, char *dsnm, char **mntpt)
 		(void) snprintf(di->errbuf, sizeof (di->errbuf),
 		    dgettext(TEXT_DOMAIN,
 		    "Cannot diff an unmounted snapshot"));
-		return (zfs_error(di->zhp->zfs_libzfs_hdl, EZFS_BADTYPE, di->errbuf));
+		return (zfs_error(di->zhp->zfs_libzfs_hdl,
+			EZFS_BADTYPE, di->errbuf));
 	}
 
 	/* Avoid a double slash at the beginning of root-mounted datasets */
@@ -764,7 +767,8 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	if (pipe(pipefd)) {
 		zfs_error_aux(zhp->zfs_libzfs_hdl, strerror(errno));
 		teardown_differ_info(&di);
-		return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_PIPEFAILED, errbuf));
+		return (zfs_error(zhp->zfs_libzfs_hdl,
+			EZFS_PIPEFAILED, errbuf));
 	}
 
 	di.scripted = (flags & ZFS_DIFF_PARSEABLE);
@@ -809,9 +813,11 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 		teardown_differ_info(&di);
 		if (di.zerr != 0 && di.zerr != EPIPE) {
 			zfs_error_aux(zhp->zfs_libzfs_hdl, strerror(di.zerr));
-			return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_DIFF, di.errbuf));
+			return (zfs_error(zhp->zfs_libzfs_hdl,
+				EZFS_DIFF, di.errbuf));
 		} else {
-			return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_DIFFDATA, errbuf));
+			return (zfs_error(zhp->zfs_libzfs_hdl,
+				EZFS_DIFFDATA, errbuf));
 		}
 	}
 

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -90,7 +90,7 @@ get_stats_for_obj(differ_info_t *di, const char *dsname, uint64_t obj,
 	zc.zc_obj = obj;
 
 	errno = 0;
-	error = ioctl(di->zhp->zfs_hdl->libzfs_fd, ZFS_IOC_OBJ_TO_STATS, &zc);
+	error = ioctl(di->zhp->zfs_libzfs_hdl->libzfs_fd, ZFS_IOC_OBJ_TO_STATS, &zc);
 	di->zerr = errno;
 
 	/* we can get stats even if we failed to get a path */
@@ -374,7 +374,7 @@ static int
 write_free_diffs(FILE *fp, differ_info_t *di, dmu_diff_record_t *dr)
 {
 	zfs_cmd_t zc = {"\0"};
-	libzfs_handle_t *lhdl = di->zhp->zfs_hdl;
+	libzfs_handle_t *lhdl = di->zhp->zfs_libzfs_hdl;
 	char fobjname[MAXPATHLEN];
 
 	(void) strlcpy(zc.zc_name, di->fromsnap, sizeof (zc.zc_name));
@@ -490,7 +490,7 @@ find_shares_object(differ_info_t *di)
 	if (stat64(fullpath, &sb) != 0) {
 		(void) snprintf(di->errbuf, sizeof (di->errbuf),
 		    dgettext(TEXT_DOMAIN, "Cannot stat %s"), fullpath);
-		return (zfs_error(di->zhp->zfs_hdl, EZFS_DIFF, di->errbuf));
+		return (zfs_error(di->zhp->zfs_libzfs_hdl, EZFS_DIFF, di->errbuf));
 	}
 
 	di->shares = (uint64_t)sb.st_ino;
@@ -500,7 +500,7 @@ find_shares_object(differ_info_t *di)
 static int
 make_temp_snapshot(differ_info_t *di)
 {
-	libzfs_handle_t *hdl = di->zhp->zfs_hdl;
+	libzfs_handle_t *hdl = di->zhp->zfs_libzfs_hdl;
 	zfs_cmd_t zc = {"\0"};
 
 	(void) snprintf(zc.zc_value, sizeof (zc.zc_value),
@@ -546,7 +546,7 @@ static int
 get_snapshot_names(differ_info_t *di, const char *fromsnap,
     const char *tosnap)
 {
-	libzfs_handle_t *hdl = di->zhp->zfs_hdl;
+	libzfs_handle_t *hdl = di->zhp->zfs_libzfs_hdl;
 	char *atptrf = NULL;
 	char *atptrt = NULL;
 	int fdslen, fsnlen;
@@ -608,7 +608,7 @@ get_snapshot_names(differ_info_t *di, const char *fromsnap,
 		zprop_source_t src;
 		zfs_handle_t *zhp;
 
-		di->ds = zfs_alloc(di->zhp->zfs_hdl, tdslen + 1);
+		di->ds = zfs_alloc(di->zhp->zfs_libzfs_hdl, tdslen + 1);
 		(void) strncpy(di->ds, tosnap, tdslen);
 		di->ds[tdslen] = '\0';
 
@@ -665,12 +665,12 @@ get_mountpoint(differ_info_t *di, char *dsnm, char **mntpt)
 {
 	boolean_t mounted;
 
-	mounted = is_mounted(di->zhp->zfs_hdl, dsnm, mntpt);
+	mounted = is_mounted(di->zhp->zfs_libzfs_hdl, dsnm, mntpt);
 	if (mounted == B_FALSE) {
 		(void) snprintf(di->errbuf, sizeof (di->errbuf),
 		    dgettext(TEXT_DOMAIN,
 		    "Cannot diff an unmounted snapshot"));
-		return (zfs_error(di->zhp->zfs_hdl, EZFS_BADTYPE, di->errbuf));
+		return (zfs_error(di->zhp->zfs_libzfs_hdl, EZFS_BADTYPE, di->errbuf));
 	}
 
 	/* Avoid a double slash at the beginning of root-mounted datasets */
@@ -693,7 +693,7 @@ get_mountpoints(differ_info_t *di)
 
 	strptr = strchr(di->tosnap, '@');
 	ASSERT3P(strptr, !=, NULL);
-	di->tomnt = zfs_asprintf(di->zhp->zfs_hdl, "%s%s%s", di->dsmnt,
+	di->tomnt = zfs_asprintf(di->zhp->zfs_libzfs_hdl, "%s%s%s", di->dsmnt,
 	    ZDIFF_SNAPDIR, ++strptr);
 
 	strptr = strchr(di->fromsnap, '@');
@@ -712,7 +712,7 @@ get_mountpoints(differ_info_t *di)
 		frommntpt = mntpt;
 	}
 
-	di->frommnt = zfs_asprintf(di->zhp->zfs_hdl, "%s%s%s", frommntpt,
+	di->frommnt = zfs_asprintf(di->zhp->zfs_libzfs_hdl, "%s%s%s", frommntpt,
 	    ZDIFF_SNAPDIR, ++strptr);
 
 	if (di->isclone)
@@ -762,9 +762,9 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	}
 
 	if (pipe(pipefd)) {
-		zfs_error_aux(zhp->zfs_hdl, strerror(errno));
+		zfs_error_aux(zhp->zfs_libzfs_hdl, strerror(errno));
 		teardown_differ_info(&di);
-		return (zfs_error(zhp->zfs_hdl, EZFS_PIPEFAILED, errbuf));
+		return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_PIPEFAILED, errbuf));
 	}
 
 	di.scripted = (flags & ZFS_DIFF_PARSEABLE);
@@ -775,11 +775,11 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	di.datafd = pipefd[0];
 
 	if (pthread_create(&tid, NULL, differ, &di)) {
-		zfs_error_aux(zhp->zfs_hdl, strerror(errno));
+		zfs_error_aux(zhp->zfs_libzfs_hdl, strerror(errno));
 		(void) close(pipefd[0]);
 		(void) close(pipefd[1]);
 		teardown_differ_info(&di);
-		return (zfs_error(zhp->zfs_hdl,
+		return (zfs_error(zhp->zfs_libzfs_hdl,
 		    EZFS_THREADCREATEFAILED, errbuf));
 	}
 
@@ -788,30 +788,30 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	(void) strlcpy(zc.zc_name, di.tosnap, strlen(di.tosnap) + 1);
 	zc.zc_cookie = pipefd[1];
 
-	iocerr = ioctl(zhp->zfs_hdl->libzfs_fd, ZFS_IOC_DIFF, &zc);
+	iocerr = ioctl(zhp->zfs_libzfs_hdl->libzfs_fd, ZFS_IOC_DIFF, &zc);
 	if (iocerr != 0) {
 		(void) snprintf(errbuf, sizeof (errbuf),
 		    dgettext(TEXT_DOMAIN, "Unable to obtain diffs"));
 		if (errno == EPERM) {
-			zfs_error_aux(zhp->zfs_hdl, dgettext(TEXT_DOMAIN,
+			zfs_error_aux(zhp->zfs_libzfs_hdl, dgettext(TEXT_DOMAIN,
 			    "\n   The sys_mount privilege or diff delegated "
 			    "permission is needed\n   to execute the "
 			    "diff ioctl"));
 		} else if (errno == EXDEV) {
-			zfs_error_aux(zhp->zfs_hdl, dgettext(TEXT_DOMAIN,
+			zfs_error_aux(zhp->zfs_libzfs_hdl, dgettext(TEXT_DOMAIN,
 			    "\n   Not an earlier snapshot from the same fs"));
 		} else if (errno != EPIPE || di.zerr == 0) {
-			zfs_error_aux(zhp->zfs_hdl, strerror(errno));
+			zfs_error_aux(zhp->zfs_libzfs_hdl, strerror(errno));
 		}
 		(void) close(pipefd[1]);
 		(void) pthread_cancel(tid);
 		(void) pthread_join(tid, NULL);
 		teardown_differ_info(&di);
 		if (di.zerr != 0 && di.zerr != EPIPE) {
-			zfs_error_aux(zhp->zfs_hdl, strerror(di.zerr));
-			return (zfs_error(zhp->zfs_hdl, EZFS_DIFF, di.errbuf));
+			zfs_error_aux(zhp->zfs_libzfs_hdl, strerror(di.zerr));
+			return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_DIFF, di.errbuf));
 		} else {
-			return (zfs_error(zhp->zfs_hdl, EZFS_DIFFDATA, errbuf));
+			return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_DIFFDATA, errbuf));
 		}
 	}
 
@@ -819,8 +819,8 @@ zfs_show_diffs(zfs_handle_t *zhp, int outfd, const char *fromsnap,
 	(void) pthread_join(tid, NULL);
 
 	if (di.zerr != 0) {
-		zfs_error_aux(zhp->zfs_hdl, strerror(di.zerr));
-		return (zfs_error(zhp->zfs_hdl, EZFS_DIFF, di.errbuf));
+		zfs_error_aux(zhp->zfs_libzfs_hdl, strerror(di.zerr));
+		return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_DIFF, di.errbuf));
 	}
 	teardown_differ_info(&di);
 	return (0);

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -46,8 +46,9 @@ zfs_iter_clones(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 
 	for (pair = nvlist_next_nvpair(nvl, NULL); pair != NULL;
 	    pair = nvlist_next_nvpair(nvl, pair)) {
-		zfs_handle_t *clone = zfs_open(zhp->zfs_libzfs_hdl, nvpair_name(pair),
-		    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);
+		zfs_handle_t *clone = zfs_open(zhp->zfs_libzfs_hdl,
+			nvpair_name(pair),
+			ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);
 		if (clone != NULL) {
 			int err = func(clone, data);
 			if (err != 0)
@@ -72,7 +73,8 @@ top:
 		switch (errno) {
 		case ENOMEM:
 			/* expand nvlist memory and try again */
-			if (zcmd_expand_dst_nvlist(zhp->zfs_libzfs_hdl, zc) != 0) {
+			if (zcmd_expand_dst_nvlist(zhp->zfs_libzfs_hdl,
+				zc) != 0) {
 				zcmd_free_nvlists(zc);
 				return (-1);
 			}

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -46,7 +46,7 @@ zfs_iter_clones(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 
 	for (pair = nvlist_next_nvpair(nvl, NULL); pair != NULL;
 	    pair = nvlist_next_nvpair(nvl, pair)) {
-		zfs_handle_t *clone = zfs_open(zhp->zfs_hdl, nvpair_name(pair),
+		zfs_handle_t *clone = zfs_open(zhp->zfs_libzfs_hdl, nvpair_name(pair),
 		    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);
 		if (clone != NULL) {
 			int err = func(clone, data);
@@ -66,13 +66,13 @@ zfs_do_list_ioctl(zfs_handle_t *zhp, int arg, zfs_cmd_t *zc)
 	orig_cookie = zc->zc_cookie;
 top:
 	(void) strlcpy(zc->zc_name, zhp->zfs_name, sizeof (zc->zc_name));
-	rc = ioctl(zhp->zfs_hdl->libzfs_fd, arg, zc);
+	rc = ioctl(zhp->zfs_libzfs_hdl->libzfs_fd, arg, zc);
 
 	if (rc == -1) {
 		switch (errno) {
 		case ENOMEM:
 			/* expand nvlist memory and try again */
-			if (zcmd_expand_dst_nvlist(zhp->zfs_hdl, zc) != 0) {
+			if (zcmd_expand_dst_nvlist(zhp->zfs_libzfs_hdl, zc) != 0) {
 				zcmd_free_nvlists(zc);
 				return (-1);
 			}
@@ -88,7 +88,7 @@ top:
 			rc = 1;
 			break;
 		default:
-			rc = zfs_standard_error(zhp->zfs_hdl, errno,
+			rc = zfs_standard_error(zhp->zfs_libzfs_hdl, errno,
 			    dgettext(TEXT_DOMAIN,
 			    "cannot iterate filesystems"));
 			break;
@@ -110,7 +110,7 @@ zfs_iter_filesystems(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 	if (zhp->zfs_type != ZFS_TYPE_FILESYSTEM)
 		return (0);
 
-	if (zcmd_alloc_dst_nvlist(zhp->zfs_hdl, &zc, 0) != 0)
+	if (zcmd_alloc_dst_nvlist(zhp->zfs_libzfs_hdl, &zc, 0) != 0)
 		return (-1);
 
 	while ((ret = zfs_do_list_ioctl(zhp, ZFS_IOC_DATASET_LIST_NEXT,
@@ -119,7 +119,7 @@ zfs_iter_filesystems(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 		 * Silently ignore errors, as the only plausible explanation is
 		 * that the pool has since been removed.
 		 */
-		if ((nzhp = make_dataset_handle_zc(zhp->zfs_hdl,
+		if ((nzhp = make_dataset_handle_zc(zhp->zfs_libzfs_hdl,
 		    &zc)) == NULL) {
 			continue;
 		}
@@ -150,7 +150,7 @@ zfs_iter_snapshots(zfs_handle_t *zhp, boolean_t simple, zfs_iter_f func,
 
 	zc.zc_simple = simple;
 
-	if (zcmd_alloc_dst_nvlist(zhp->zfs_hdl, &zc, 0) != 0)
+	if (zcmd_alloc_dst_nvlist(zhp->zfs_libzfs_hdl, &zc, 0) != 0)
 		return (-1);
 	while ((ret = zfs_do_list_ioctl(zhp, ZFS_IOC_SNAPSHOT_LIST_NEXT,
 	    &zc)) == 0) {
@@ -158,7 +158,7 @@ zfs_iter_snapshots(zfs_handle_t *zhp, boolean_t simple, zfs_iter_f func,
 		if (simple)
 			nzhp = make_dataset_simple_handle_zc(zhp, &zc);
 		else
-			nzhp = make_dataset_handle_zc(zhp->zfs_hdl, &zc);
+			nzhp = make_dataset_handle_zc(zhp->zfs_libzfs_hdl, &zc);
 		if (nzhp == NULL)
 			continue;
 
@@ -251,7 +251,7 @@ zfs_sort_snaps(zfs_handle_t *zhp, void *data)
 		free(node);
 	}
 
-	node = zfs_alloc(zhp->zfs_hdl, sizeof (zfs_node_t));
+	node = zfs_alloc(zhp->zfs_libzfs_hdl, sizeof (zfs_node_t));
 	node->zn_handle = zhp;
 	avl_add(avl, node);
 
@@ -321,7 +321,7 @@ snapspec_cb(zfs_handle_t *zhp, void *arg) {
 
 	if (ssa->ssa_seenlast)
 		return (0);
-	shortsnapname = zfs_strdup(zhp->zfs_hdl,
+	shortsnapname = zfs_strdup(zhp->zfs_libzfs_hdl,
 	    strchr(zfs_get_name(zhp), '@') + 1);
 
 	if (!ssa->ssa_seenfirst && strcmp(shortsnapname, ssa->ssa_first) == 0)
@@ -362,7 +362,7 @@ zfs_iter_snapspec(zfs_handle_t *fs_zhp, const char *spec_orig,
 	int err = 0;
 	int ret = 0;
 
-	buf = zfs_strdup(fs_zhp->zfs_hdl, spec_orig);
+	buf = zfs_strdup(fs_zhp->zfs_libzfs_hdl, spec_orig);
 	cp = buf;
 
 	while ((comma_separated = strsep(&cp, ",")) != NULL) {
@@ -388,7 +388,7 @@ zfs_iter_snapspec(zfs_handle_t *fs_zhp, const char *spec_orig,
 				(void) snprintf(snapname, sizeof (snapname),
 				    "%s@%s", zfs_get_name(fs_zhp),
 				    ssa.ssa_last);
-				if (!zfs_dataset_exists(fs_zhp->zfs_hdl,
+				if (!zfs_dataset_exists(fs_zhp->zfs_libzfs_hdl,
 				    snapname, ZFS_TYPE_SNAPSHOT)) {
 					ret = ENOENT;
 					continue;
@@ -408,7 +408,7 @@ zfs_iter_snapspec(zfs_handle_t *fs_zhp, const char *spec_orig,
 			zfs_handle_t *snap_zhp;
 			(void) snprintf(snapname, sizeof (snapname), "%s@%s",
 			    zfs_get_name(fs_zhp), comma_separated);
-			snap_zhp = make_dataset_handle(fs_zhp->zfs_hdl,
+			snap_zhp = make_dataset_handle(fs_zhp->zfs_libzfs_hdl,
 			    snapname);
 			if (snap_zhp == NULL) {
 				ret = ENOENT;
@@ -477,11 +477,11 @@ iter_dependents_cb(zfs_handle_t *zhp, void *arg)
 					zfs_close(zhp);
 					return (0);
 				} else {
-					zfs_error_aux(zhp->zfs_hdl,
+					zfs_error_aux(zhp->zfs_libzfs_hdl,
 					    dgettext(TEXT_DOMAIN,
 					    "recursive dependency at '%s'"),
 					    zfs_get_name(zhp));
-					err = zfs_error(zhp->zfs_hdl,
+					err = zfs_error(zhp->zfs_libzfs_hdl,
 					    EZFS_RECURSIVE,
 					    dgettext(TEXT_DOMAIN,
 					    "cannot determine dependent "

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -903,7 +903,8 @@ zfs_unshare_proto(zfs_handle_t *zhp, const char *mountpoint,
 		zfs_share_proto_t *curr_proto;
 
 		if (mountpoint == NULL)
-			mntpt = zfs_strdup(zhp->zfs_libzfs_hdl, entry.mnt_mountp);
+			mntpt = zfs_strdup(zhp->zfs_libzfs_hdl,
+				entry.mnt_mountp);
 
 		for (curr_proto = proto; *curr_proto != PROTO_END;
 		    curr_proto++) {

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -219,7 +219,7 @@ is_mounted(libzfs_handle_t *zfs_hdl, const char *special, char **where)
 boolean_t
 zfs_is_mounted(zfs_handle_t *zhp, char **where)
 {
-	return (is_mounted(zhp->zfs_hdl, zfs_get_name(zhp), where));
+	return (is_mounted(zhp->zfs_libzfs_hdl, zfs_get_name(zhp), where));
 }
 
 /*
@@ -389,7 +389,7 @@ zfs_mount(zfs_handle_t *zhp, const char *options, int flags)
 	char mountpoint[ZFS_MAXPROPLEN];
 	char mntopts[MNT_LINE_MAX];
 	char overlay[ZFS_MAXPROPLEN];
-	libzfs_handle_t *hdl = zhp->zfs_hdl;
+	libzfs_handle_t *hdl = zhp->zfs_libzfs_hdl;
 	int remount = 0, rc;
 
 	if (options == NULL) {
@@ -404,7 +404,7 @@ zfs_mount(zfs_handle_t *zhp, const char *options, int flags)
 	/*
 	 * If the pool is imported read-only then all mounts must be read-only
 	 */
-	if (zpool_get_prop_int(zhp->zpool_hdl, ZPOOL_PROP_READONLY, NULL))
+	if (zpool_get_prop_int(zhp->zfs_zpool_hdl, ZPOOL_PROP_READONLY, NULL))
 		(void) strlcat(mntopts, "," MNTOPT_RO, sizeof (mntopts));
 
 	if (!zfs_is_mountable(zhp, mountpoint, sizeof (mountpoint), NULL))
@@ -535,7 +535,7 @@ unmount_one(libzfs_handle_t *hdl, const char *mountpoint, int flags)
 int
 zfs_unmount(zfs_handle_t *zhp, const char *mountpoint, int flags)
 {
-	libzfs_handle_t *hdl = zhp->zfs_hdl;
+	libzfs_handle_t *hdl = zhp->zfs_libzfs_hdl;
 	struct mnttab entry;
 	char *mntpt = NULL;
 
@@ -634,7 +634,7 @@ zfs_is_shared_proto(zfs_handle_t *zhp, char **where, zfs_share_proto_t proto)
 	if (!zfs_is_mounted(zhp, &mountpoint))
 		return (SHARED_NOT_SHARED);
 
-	if ((rc = is_shared(zhp->zfs_hdl, mountpoint, proto))) {
+	if ((rc = is_shared(zhp->zfs_libzfs_hdl, mountpoint, proto))) {
 		if (where != NULL)
 			*where = mountpoint;
 		else
@@ -737,7 +737,7 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 	char mountpoint[ZFS_MAXPROPLEN];
 	char shareopts[ZFS_MAXPROPLEN];
 	char sourcestr[ZFS_MAXPROPLEN];
-	libzfs_handle_t *hdl = zhp->zfs_hdl;
+	libzfs_handle_t *hdl = zhp->zfs_libzfs_hdl;
 	sa_share_t share;
 	zfs_share_proto_t *curr_proto;
 	zprop_source_t sourcetype;
@@ -890,7 +890,7 @@ int
 zfs_unshare_proto(zfs_handle_t *zhp, const char *mountpoint,
     zfs_share_proto_t *proto)
 {
-	libzfs_handle_t *hdl = zhp->zfs_hdl;
+	libzfs_handle_t *hdl = zhp->zfs_libzfs_hdl;
 	struct mnttab entry;
 	char *mntpt = NULL;
 
@@ -903,7 +903,7 @@ zfs_unshare_proto(zfs_handle_t *zhp, const char *mountpoint,
 		zfs_share_proto_t *curr_proto;
 
 		if (mountpoint == NULL)
-			mntpt = zfs_strdup(zhp->zfs_hdl, entry.mnt_mountp);
+			mntpt = zfs_strdup(zhp->zfs_libzfs_hdl, entry.mnt_mountp);
 
 		for (curr_proto = proto; *curr_proto != PROTO_END;
 		    curr_proto++) {
@@ -1019,7 +1019,7 @@ libzfs_add_handle(get_all_cb_t *cbp, zfs_handle_t *zhp)
 		void *ptr;
 
 		newsz = cbp->cb_alloc ? cbp->cb_alloc * 2 : 64;
-		ptr = zfs_realloc(zhp->zfs_hdl,
+		ptr = zfs_realloc(zhp->zfs_libzfs_hdl,
 		    cbp->cb_handles, cbp->cb_alloc * sizeof (void *),
 		    newsz * sizeof (void *));
 		cbp->cb_handles = ptr;
@@ -1091,7 +1091,7 @@ int
 zpool_enable_datasets(zpool_handle_t *zhp, const char *mntopts, int flags)
 {
 	get_all_cb_t cb = { 0 };
-	libzfs_handle_t *hdl = zhp->zpool_hdl;
+	libzfs_handle_t *hdl = zhp->zpool_libzfs_hdl;
 	zfs_handle_t *zfsp;
 	int i, ret = -1;
 	int *good;
@@ -1115,7 +1115,7 @@ zpool_enable_datasets(zpool_handle_t *zhp, const char *mntopts, int flags)
 	 * And mount all the datasets, keeping track of which ones
 	 * succeeded or failed.
 	 */
-	if ((good = zfs_alloc(zhp->zpool_hdl,
+	if ((good = zfs_alloc(zhp->zpool_libzfs_hdl,
 	    cb.cb_used * sizeof (int))) == NULL)
 		goto out;
 
@@ -1174,7 +1174,7 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	size_t namelen;
 	char **mountpoints = NULL;
 	zfs_handle_t **datasets = NULL;
-	libzfs_handle_t *hdl = zhp->zpool_hdl;
+	libzfs_handle_t *hdl = zhp->zpool_libzfs_hdl;
 	int i;
 	int ret = -1;
 	int flags = (force ? MS_FORCE : 0);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -780,7 +780,8 @@ zpool_set_prop(zpool_handle_t *zhp, const char *propname, const char *propval)
 	nvlist_free(nvl);
 
 	if (ret)
-		(void) zpool_standard_error(zhp->zpool_libzfs_hdl, errno, errbuf);
+		(void) zpool_standard_error(zhp->zpool_libzfs_hdl,
+			errno, errbuf);
 	else
 		(void) zpool_props_refresh(zhp);
 
@@ -1495,16 +1496,17 @@ zpool_export_common(zpool_handle_t *zhp, boolean_t force, boolean_t hardforce,
 	if (zfs_ioctl(zhp->zpool_libzfs_hdl, ZFS_IOC_POOL_EXPORT, &zc) != 0) {
 		switch (errno) {
 		case EXDEV:
-			zfs_error_aux(zhp->zpool_libzfs_hdl, dgettext(TEXT_DOMAIN,
+			zfs_error_aux(zhp->zpool_libzfs_hdl,
+				dgettext(TEXT_DOMAIN,
 			    "use '-f' to override the following errors:\n"
 			    "'%s' has an active shared spare which could be"
 			    " used by other pools once '%s' is exported."),
 			    zhp->zpool_name, zhp->zpool_name);
-			return (zfs_error(zhp->zpool_libzfs_hdl, EZFS_ACTIVE_SPARE,
-			    msg));
+			return (zfs_error(zhp->zpool_libzfs_hdl,
+				EZFS_ACTIVE_SPARE, msg));
 		default:
-			return (zpool_standard_error_fmt(zhp->zpool_libzfs_hdl, errno,
-			    msg));
+			return (zpool_standard_error_fmt(zhp->zpool_libzfs_hdl,
+				errno, msg));
 		}
 	}
 
@@ -2898,8 +2900,8 @@ find_vdev_entry(zpool_handle_t *zhp, nvlist_t **mchild, uint_t mchildren,
 		    mchild[mc], B_FALSE);
 
 		for (sc = 0; sc < schildren; sc++) {
-			char *spath = zpool_vdev_name(zhp->zpool_libzfs_hdl, zhp,
-			    schild[sc], B_FALSE);
+			char *spath = zpool_vdev_name(zhp->zpool_libzfs_hdl,
+				zhp, schild[sc], B_FALSE);
 			boolean_t result = (strcmp(mpath, spath) == 0);
 
 			free(spath);
@@ -3388,7 +3390,8 @@ set_path(zpool_handle_t *zhp, nvlist_t *nv, const char *path)
 	verify(nvlist_lookup_uint64(nv, ZPOOL_CONFIG_GUID,
 	    &zc.zc_guid) == 0);
 
-	(void) ioctl(zhp->zpool_libzfs_hdl->libzfs_fd, ZFS_IOC_VDEV_SETPATH, &zc);
+	(void) ioctl(zhp->zpool_libzfs_hdl->libzfs_fd,
+		ZFS_IOC_VDEV_SETPATH, &zc);
 }
 
 /*

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -1216,7 +1216,8 @@ dump_filesystem(zfs_handle_t *zhp, void *arg)
 
 	(void) snprintf(zc.zc_name, sizeof (zc.zc_name), "%s@%s",
 	    zhp->zfs_name, sdd->tosnap);
-	if (ioctl(zhp->zfs_libzfs_hdl->libzfs_fd, ZFS_IOC_OBJSET_STATS, &zc) != 0) {
+	if (ioctl(zhp->zfs_libzfs_hdl->libzfs_fd,
+		ZFS_IOC_OBJSET_STATS, &zc) != 0) {
 		(void) fprintf(stderr, dgettext(TEXT_DOMAIN,
 		    "WARNING: could not send %s@%s: does not exist\n"),
 		    zhp->zfs_name, sdd->tosnap);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -752,7 +752,7 @@ send_iterate_fs(zfs_handle_t *zhp, void *arg)
 	    sd->parent_fromsnap_guid));
 
 	if (zhp->zfs_dmustats.dds_origin[0]) {
-		zfs_handle_t *origin = zfs_open(zhp->zfs_hdl,
+		zfs_handle_t *origin = zfs_open(zhp->zfs_libzfs_hdl,
 		    zhp->zfs_dmustats.dds_origin, ZFS_TYPE_SNAPSHOT);
 		if (origin == NULL)
 			return (-1);
@@ -857,7 +857,7 @@ estimate_ioctl(zfs_handle_t *zhp, uint64_t fromsnap_obj,
     boolean_t fromorigin, uint64_t *sizep)
 {
 	zfs_cmd_t zc = {"\0"};
-	libzfs_handle_t *hdl = zhp->zfs_hdl;
+	libzfs_handle_t *hdl = zhp->zfs_libzfs_hdl;
 
 	assert(zhp->zfs_type == ZFS_TYPE_SNAPSHOT);
 	assert(fromsnap_obj == 0 || !fromorigin);
@@ -868,7 +868,7 @@ estimate_ioctl(zfs_handle_t *zhp, uint64_t fromsnap_obj,
 	zc.zc_fromobj = fromsnap_obj;
 	zc.zc_guid = 1;  /* estimate flag */
 
-	if (zfs_ioctl(zhp->zfs_hdl, ZFS_IOC_SEND, &zc) != 0) {
+	if (zfs_ioctl(zhp->zfs_libzfs_hdl, ZFS_IOC_SEND, &zc) != 0) {
 		char errbuf[1024];
 		(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
 		    "warning: cannot estimate space for '%s'"), zhp->zfs_name);
@@ -922,7 +922,7 @@ dump_ioctl(zfs_handle_t *zhp, const char *fromsnap, uint64_t fromsnap_obj,
     nvlist_t *debugnv)
 {
 	zfs_cmd_t zc = {"\0"};
-	libzfs_handle_t *hdl = zhp->zfs_hdl;
+	libzfs_handle_t *hdl = zhp->zfs_libzfs_hdl;
 	nvlist_t *thisdbg;
 
 	assert(zhp->zfs_type == ZFS_TYPE_SNAPSHOT);
@@ -941,7 +941,7 @@ dump_ioctl(zfs_handle_t *zhp, const char *fromsnap, uint64_t fromsnap_obj,
 		    "fromsnap", fromsnap));
 	}
 
-	if (zfs_ioctl(zhp->zfs_hdl, ZFS_IOC_SEND, &zc) != 0) {
+	if (zfs_ioctl(zhp->zfs_libzfs_hdl, ZFS_IOC_SEND, &zc) != 0) {
 		char errbuf[1024];
 		(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
 		    "warning: cannot send '%s'"), zhp->zfs_name);
@@ -1016,7 +1016,7 @@ send_progress_thread(void *arg)
 
 	zfs_cmd_t zc = {"\0"};
 	zfs_handle_t *zhp = pa->pa_zhp;
-	libzfs_handle_t *hdl = zhp->zfs_hdl;
+	libzfs_handle_t *hdl = zhp->zfs_libzfs_hdl;
 	unsigned long long bytes;
 	char buf[16];
 
@@ -1216,7 +1216,7 @@ dump_filesystem(zfs_handle_t *zhp, void *arg)
 
 	(void) snprintf(zc.zc_name, sizeof (zc.zc_name), "%s@%s",
 	    zhp->zfs_name, sdd->tosnap);
-	if (ioctl(zhp->zfs_hdl->libzfs_fd, ZFS_IOC_OBJSET_STATS, &zc) != 0) {
+	if (ioctl(zhp->zfs_libzfs_hdl->libzfs_fd, ZFS_IOC_OBJSET_STATS, &zc) != 0) {
 		(void) fprintf(stderr, dgettext(TEXT_DOMAIN,
 		    "WARNING: could not send %s@%s: does not exist\n"),
 		    zhp->zfs_name, sdd->tosnap);
@@ -1234,7 +1234,7 @@ dump_filesystem(zfs_handle_t *zhp, void *arg)
 		 */
 		(void) snprintf(zc.zc_name, sizeof (zc.zc_name), "%s@%s",
 		    zhp->zfs_name, sdd->fromsnap);
-		if (ioctl(zhp->zfs_hdl->libzfs_fd,
+		if (ioctl(zhp->zfs_libzfs_hdl->libzfs_fd,
 		    ZFS_IOC_OBJSET_STATS, &zc) != 0) {
 			missingfrom = B_TRUE;
 		}
@@ -1349,7 +1349,7 @@ again:
 			}
 		}
 
-		zhp = zfs_open(rzhp->zfs_hdl, fsname, ZFS_TYPE_DATASET);
+		zhp = zfs_open(rzhp->zfs_libzfs_hdl, fsname, ZFS_TYPE_DATASET);
 		if (zhp == NULL)
 			return (-1);
 		err = dump_filesystem(zhp, sdd);
@@ -1414,9 +1414,9 @@ zfs_send(zfs_handle_t *zhp, const char *fromsnap, const char *tosnap,
 	    "cannot send '%s'"), zhp->zfs_name);
 
 	if (fromsnap && fromsnap[0] == '\0') {
-		zfs_error_aux(zhp->zfs_hdl, dgettext(TEXT_DOMAIN,
+		zfs_error_aux(zhp->zfs_libzfs_hdl, dgettext(TEXT_DOMAIN,
 		    "zero-length incremental source"));
-		return (zfs_error(zhp->zfs_hdl, EZFS_NOENT, errbuf));
+		return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_NOENT, errbuf));
 	}
 
 	if (zhp->zfs_type == ZFS_TYPE_FILESYSTEM) {
@@ -1431,18 +1431,18 @@ zfs_send(zfs_handle_t *zhp, const char *fromsnap, const char *tosnap,
 		featureflags |= (DMU_BACKUP_FEATURE_DEDUP |
 		    DMU_BACKUP_FEATURE_DEDUPPROPS);
 		if ((err = socketpair(AF_UNIX, SOCK_STREAM, 0, pipefd))) {
-			zfs_error_aux(zhp->zfs_hdl, strerror(errno));
-			return (zfs_error(zhp->zfs_hdl, EZFS_PIPEFAILED,
+			zfs_error_aux(zhp->zfs_libzfs_hdl, strerror(errno));
+			return (zfs_error(zhp->zfs_libzfs_hdl, EZFS_PIPEFAILED,
 			    errbuf));
 		}
 		dda.outputfd = outfd;
 		dda.inputfd = pipefd[1];
-		dda.dedup_hdl = zhp->zfs_hdl;
+		dda.dedup_hdl = zhp->zfs_libzfs_hdl;
 		if ((err = pthread_create(&tid, NULL, cksummer, &dda))) {
 			(void) close(pipefd[0]);
 			(void) close(pipefd[1]);
-			zfs_error_aux(zhp->zfs_hdl, strerror(errno));
-			return (zfs_error(zhp->zfs_hdl,
+			zfs_error_aux(zhp->zfs_libzfs_hdl, strerror(errno));
+			return (zfs_error(zhp->zfs_libzfs_hdl,
 			    EZFS_THREADCREATEFAILED, errbuf));
 		}
 	}
@@ -1467,7 +1467,7 @@ zfs_send(zfs_handle_t *zhp, const char *fromsnap, const char *tosnap,
 				    "not_recursive"));
 			}
 
-			err = gather_nvlist(zhp->zfs_hdl, zhp->zfs_name,
+			err = gather_nvlist(zhp->zfs_libzfs_hdl, zhp->zfs_name,
 			    fromsnap, tosnap, flags->replicate, &fss, &fsavl);
 			if (err)
 				goto err_out;
@@ -1641,7 +1641,7 @@ zfs_send(zfs_handle_t *zhp, const char *fromsnap, const char *tosnap,
 		dmu_replay_record_t drr = { 0 };
 		drr.drr_type = DRR_END;
 		if (write(outfd, &drr, sizeof (drr)) == -1) {
-			return (zfs_standard_error(zhp->zfs_hdl,
+			return (zfs_standard_error(zhp->zfs_libzfs_hdl,
 			    errno, errbuf));
 		}
 	}
@@ -1649,7 +1649,7 @@ zfs_send(zfs_handle_t *zhp, const char *fromsnap, const char *tosnap,
 	return (err || sdd.err);
 
 stderr_out:
-	err = zfs_standard_error(zhp->zfs_hdl, err, errbuf);
+	err = zfs_standard_error(zhp->zfs_libzfs_hdl, err, errbuf);
 err_out:
 	fsavl_destroy(fsavl);
 	nvlist_free(fss);
@@ -1670,7 +1670,7 @@ zfs_send_one(zfs_handle_t *zhp, const char *from, int fd,
     enum lzc_send_flags flags)
 {
 	int err;
-	libzfs_handle_t *hdl = zhp->zfs_hdl;
+	libzfs_handle_t *hdl = zhp->zfs_libzfs_hdl;
 
 	char errbuf[1024];
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -834,19 +834,19 @@ libzfs_fini(libzfs_handle_t *hdl)
 libzfs_handle_t *
 zpool_get_handle(zpool_handle_t *zhp)
 {
-	return (zhp->zpool_hdl);
+	return (zhp->zpool_libzfs_hdl);
 }
 
 libzfs_handle_t *
 zfs_get_handle(zfs_handle_t *zhp)
 {
-	return (zhp->zfs_hdl);
+	return (zhp->zfs_libzfs_hdl);
 }
 
 zpool_handle_t *
 zfs_get_pool_handle(const zfs_handle_t *zhp)
 {
-	return (zhp->zpool_hdl);
+	return (zhp->zfs_zpool_hdl);
 }
 
 /*


### PR DESCRIPTION
Changing field names of struct zfs_handle to make them consistent and more clear.
Changing field names of struct zpool_handle to make them more clear.

This pull request addresses #4336.

Signed-off-by: Grischa Zengel <github.zfsonlinux@zengel.info>