### PR TITLE
Rotor vector allocation (small records favour SSD)

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -153,8 +153,9 @@ enum iostat_type {
 	IOS_DEFAULT = 0,
 	IOS_LATENCY = 1,
 	IOS_QUEUES = 2,
-	IOS_L_HISTO = 3,
-	IOS_RQ_HISTO = 4,
+	IOS_MEDIA_TYPE = 3,
+	IOS_L_HISTO = 4,
+	IOS_RQ_HISTO = 5,
 	IOS_COUNT,	/* always last element */
 };
 
@@ -162,6 +163,7 @@ enum iostat_type {
 #define	IOS_DEFAULT_M	(1ULL << IOS_DEFAULT)
 #define	IOS_LATENCY_M	(1ULL << IOS_LATENCY)
 #define	IOS_QUEUES_M	(1ULL << IOS_QUEUES)
+#define	IOS_MEDIA_TYPE_M	(1ULL << IOS_MEDIA_TYPE)
 #define	IOS_L_HISTO_M	(1ULL << IOS_L_HISTO)
 #define	IOS_RQ_HISTO_M	(1ULL << IOS_RQ_HISTO)
 
@@ -197,6 +199,9 @@ static const char *vsx_type_to_nvlist[IOS_COUNT][11] = {
 	    ZPOOL_CONFIG_VDEV_ASYNC_R_ACTIVE_QUEUE,
 	    ZPOOL_CONFIG_VDEV_ASYNC_W_ACTIVE_QUEUE,
 	    ZPOOL_CONFIG_VDEV_SCRUB_ACTIVE_QUEUE,
+	    NULL},
+	[IOS_MEDIA_TYPE] = {
+	    ZPOOL_CONFIG_VDEV_MEDIA_TYPE,
 	    NULL},
 	[IOS_RQ_HISTO] = {
 	    ZPOOL_CONFIG_VDEV_SYNC_IND_R_HISTO,
@@ -314,7 +319,7 @@ get_usage(zpool_help_t idx)
 		    "[-R root] [-F [-n]]\n"
 		    "\t    <pool | id> [newpool]\n"));
 	case HELP_IOSTAT:
-		return (gettext("\tiostat [-c CMD] [-T d | u] [-ghHLpPvy] "
+		return (gettext("\tiostat [-c CMD] [-T d | u] [-ghHLMpPvy] "
 		    "[[-lq]|[-r|-w]]\n"
 		    "\t    [[pool ...]|[pool vdev ...]|[vdev ...]] "
 		    "[interval [count]]\n"));
@@ -337,7 +342,7 @@ get_usage(zpool_help_t idx)
 	case HELP_SCRUB:
 		return (gettext("\tscrub [-s] <pool> ...\n"));
 	case HELP_STATUS:
-		return (gettext("\tstatus [-c CMD] [-gLPvxD] [-T d|u] [pool]"
+		return (gettext("\tstatus [-c CMD] [-gLMPvxD] [-T d|u] [pool]"
 		    " ... [interval [count]]\n"));
 	case HELP_UPGRADE:
 		return (gettext("\tupgrade\n"
@@ -1457,6 +1462,30 @@ max_width(zpool_handle_t *zhp, nvlist_t *nv, int depth, int max,
 	return (max);
 }
 
+static const char *
+media_type_mark(nvlist_t *nv)
+{
+	nvlist_t *nvx;
+	uint64_t type = VDEV_MEDIA_TYPE_UNKNOWN;
+
+	if (nvlist_lookup_nvlist(nv, ZPOOL_CONFIG_VDEV_STATS_EX, &nvx) == 0)
+		nvlist_lookup_uint64(nvx, ZPOOL_CONFIG_VDEV_MEDIA_TYPE,
+		    &type);
+
+	switch (type) {
+	case VDEV_MEDIA_TYPE_SSD:
+		return ("ssd");
+	case VDEV_MEDIA_TYPE_FILE:
+		return ("file");
+	case VDEV_MEDIA_TYPE_MIXED:
+		return ("mix");
+	case VDEV_MEDIA_TYPE_HDD:
+		return ("hdd");
+	default:
+		return ("-");
+	}
+}
+
 typedef struct spare_cbdata {
 	uint64_t	cb_guid;
 	zpool_handle_t	*cb_zhp;
@@ -1511,6 +1540,7 @@ typedef struct status_cbdata {
 	boolean_t	cb_explain;
 	boolean_t	cb_first;
 	boolean_t	cb_dedup_stats;
+	boolean_t	cb_media_type;
 	boolean_t	cb_print_status;
 	vdev_cmd_data_list_t	*vcdl;
 } status_cbdata_t;
@@ -1574,7 +1604,12 @@ print_status_config(zpool_handle_t *zhp, status_cbdata_t *cb, const char *name,
 		zfs_nicenum(vs->vs_write_errors, wbuf, sizeof (wbuf));
 		zfs_nicenum(vs->vs_checksum_errors, cbuf, sizeof (cbuf));
 		(void) printf(" %5s %5s %5s", rbuf, wbuf, cbuf);
+	} else {
+		(void) printf("                  ");
 	}
+
+	if (cb->cb_media_type)
+		(void) printf(" %5s", media_type_mark(nv));
 
 	if (nvlist_lookup_uint64(nv, ZPOOL_CONFIG_NOT_PRESENT,
 	    &notpresent) == 0) {
@@ -2630,6 +2665,7 @@ static const name_and_columns_t iostat_top_labels[][IOSTAT_MAX_LABELS] =
 	[IOS_QUEUES] = {{"syncq_read", 2}, {"syncq_write", 2},
 	    {"asyncq_read", 2}, {"asyncq_write", 2}, {"scrubq_read", 2},
 	    {NULL}},
+	[IOS_MEDIA_TYPE] = {{"", 1}, {NULL}},
 	[IOS_L_HISTO] = {{"total_wait", 2}, {"disk_wait", 2},
 	    {"sync_queue", 2}, {"async_queue", 2}, {NULL}},
 	[IOS_RQ_HISTO] = {{"sync_read", 2}, {"sync_write", 2},
@@ -2646,6 +2682,7 @@ static const name_and_columns_t iostat_bottom_labels[][IOSTAT_MAX_LABELS] =
 	    {"write"}, {"read"}, {"write"}, {"wait"}, {NULL}},
 	[IOS_QUEUES] = {{"pend"}, {"activ"}, {"pend"}, {"activ"}, {"pend"},
 	    {"activ"}, {"pend"}, {"activ"}, {"pend"}, {"activ"}, {NULL}},
+	[IOS_MEDIA_TYPE] = {{"media"}, {NULL}},
 	[IOS_L_HISTO] = {{"read"}, {"write"}, {"read"}, {"write"}, {"read"},
 	    {"write"}, {"read"}, {"write"}, {"scrub"}, {NULL}},
 	[IOS_RQ_HISTO] = {{"ind"}, {"agg"}, {"ind"}, {"agg"}, {"ind"}, {"agg"},
@@ -2708,9 +2745,10 @@ default_column_width(iostat_cbdata_t *cb, enum iostat_type type)
 		[IOS_DEFAULT] = 15, /* 1PB capacity */
 		[IOS_LATENCY] = 10, /* 1B ns = 10sec */
 		[IOS_QUEUES] = 6,   /* 1M queue entries */
+		[IOS_MEDIA_TYPE] = 5, /* type/file/ssd/hdd/mix */
 	};
 
-	if (cb->cb_literal)
+	if (cb->cb_literal || type == IOS_MEDIA_TYPE)
 		column_width = widths[type];
 
 	return (column_width);
@@ -3415,6 +3453,9 @@ print_vdev_stats(zpool_handle_t *zhp, const char *name, nvlist_t *oldnv,
 		print_iostat_latency(cb, oldnv, newnv, scale);
 	if (cb->cb_flags & IOS_QUEUES_M)
 		print_iostat_queues(cb, oldnv, newnv, scale);
+	if (cb->cb_flags & IOS_MEDIA_TYPE_M)
+		printf("%s%5s", cb->cb_scripted ? "\t" : "  ",
+		    media_type_mark(newnv));
 	if (cb->cb_flags & IOS_ANYHISTO_M) {
 		printf("\n");
 		print_iostat_histos(cb, oldnv, newnv, scale, name);
@@ -3965,7 +4006,7 @@ fsleep(float sec)
 
 
 /*
- * zpool iostat [-c CMD] [-ghHLpPvy] [[-lq]|[-r|-w]] [-n name] [-T d|u]
+ * zpool iostat [-c CMD] [-ghHLMpPvy] [[-lq]|[-r|-w]] [-n name] [-T d|u]
  *		[[ pool ...]|[pool vdev ...]|[vdev ...]]
  *		[interval [count]]
  *
@@ -3979,6 +4020,7 @@ fsleep(float sec)
  *	-H	Scripted mode.  Don't display headers, and separate properties
  *		by a single tab.
  *	-l	Display average latency
+ *	-M      Display media type of device, e.g. solid-state or mixed.
  *	-q	Display queue depths
  *	-w	Display latency histograms
  *	-r	Display request size histogram
@@ -4006,6 +4048,7 @@ zpool_do_iostat(int argc, char **argv)
 	boolean_t guid = B_FALSE;
 	boolean_t follow_links = B_FALSE;
 	boolean_t full_name = B_FALSE;
+	boolean_t media_type = B_FALSE;
 	iostat_cbdata_t cb = { 0 };
 	char *cmd = NULL;
 
@@ -4016,7 +4059,7 @@ zpool_do_iostat(int argc, char **argv)
 	uint64_t unsupported_flags;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "c:gLPT:vyhplqrwH")) != -1) {
+	while ((c = getopt(argc, argv, "c:gLPT:vyhplMqrwH")) != -1) {
 		switch (c) {
 		case 'c':
 			cmd = optarg;
@@ -4026,6 +4069,9 @@ zpool_do_iostat(int argc, char **argv)
 			break;
 		case 'L':
 			follow_links = B_TRUE;
+			break;
+		case 'M':
+			media_type = B_TRUE;
 			break;
 		case 'P':
 			full_name = B_TRUE;
@@ -4194,6 +4240,8 @@ zpool_do_iostat(int argc, char **argv)
 			cb.cb_flags |= IOS_LATENCY_M;
 		if (queues)
 			cb.cb_flags |= IOS_QUEUES_M;
+		if (media_type)
+			cb.cb_flags |= IOS_MEDIA_TYPE_M;
 	}
 
 	/*
@@ -6012,9 +6060,9 @@ status_callback(zpool_handle_t *zhp, void *data)
 			cbp->cb_namewidth = 10;
 
 		(void) printf(gettext("config:\n\n"));
-		(void) printf(gettext("\t%-*s  %-8s %5s %5s %5s\n"),
+		(void) printf(gettext("\t%-*s  %-8s %5s %5s %5s%s\n"),
 		    cbp->cb_namewidth, "NAME", "STATE", "READ", "WRITE",
-		    "CKSUM");
+		    "CKSUM", cbp->cb_media_type ? " MEDIA" : "");
 		print_status_config(zhp, cbp, zpool_get_name(zhp), nvroot, 0,
 		    B_FALSE);
 
@@ -6074,11 +6122,12 @@ status_callback(zpool_handle_t *zhp, void *data)
 }
 
 /*
- * zpool status [-c CMD] [-gLPvx] [-T d|u] [pool] ... [interval [count]]
+ * zpool status [-c CMD] [-gLMPvx] [-T d|u] [pool] ... [interval [count]]
  *
  *	-c CMD	For each vdev, run command CMD
  *	-g	Display guid for individual vdev name.
  *	-L	Follow links when resolving vdev path name.
+ *	-M      Display media type of device, e.g. solid-state or mixed.
  *	-P	Display full path for vdev name.
  *	-v	Display complete error logs
  *	-x	Display only pools with potential problems
@@ -6098,7 +6147,7 @@ zpool_do_status(int argc, char **argv)
 	char *cmd = NULL;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "c:gLPvxDT:")) != -1) {
+	while ((c = getopt(argc, argv, "c:gLMPvxDT:")) != -1) {
 		switch (c) {
 		case 'c':
 			cmd = optarg;
@@ -6108,6 +6157,9 @@ zpool_do_status(int argc, char **argv)
 			break;
 		case 'L':
 			cb.cb_name_flags |= VDEV_NAME_FOLLOW_LINKS;
+			break;
+		case 'M':
+			cb.cb_media_type = B_TRUE;
 			break;
 		case 'P':
 			cb.cb_name_flags |= VDEV_NAME_PATH;

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -1001,6 +1001,20 @@ make_vdev_root(char *path, char *aux, char *pool, size_t size, uint64_t ashift,
 	return (root);
 }
 
+boolean_t ztest_vdev_nonrot(void);
+
+boolean_t
+ztest_vdev_nonrot()
+{
+	boolean_t nonrot;
+
+	nonrot = ztest_random(2) == 1 ? B_TRUE : B_FALSE;
+
+	printf("NONROT: %d\n", nonrot);
+
+	return (nonrot);
+}
+
 /*
  * Find a random spa version. Returns back a random spa version in the
  * range [initial_version, SPA_VERSION_FEATURES].
@@ -6539,6 +6553,14 @@ ztest_init(ztest_shared_t *zs)
 		VERIFY3S(-1, !=, asprintf(&buf, "feature@%s",
 		    spa_feature_table[i].fi_uname));
 		VERIFY3U(0, ==, nvlist_add_uint64(props, buf, 0));
+		free(buf);
+	}
+	{
+		char *buf;
+		VERIFY3S(-1, !=, asprintf(&buf, "ssd<=meta:%d,%d;mixed<=%d;hdd",
+		    32, 4, 64));
+		VERIFY3U(0, ==, nvlist_add_string(props,
+		    ZPOOL_CONFIG_ROTORVECTOR, buf));
 		free(buf);
 	}
 	VERIFY3U(0, ==, spa_create(ztest_opts.zo_pool, nvroot, props, NULL));

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -603,6 +603,7 @@ typedef struct zpool_rewind_policy {
 
 /* Type (ssd, file, mix, hdd) (part of vdev_stat_ex_t) */
 #define	ZPOOL_CONFIG_VDEV_MEDIA_TYPE	"media_type"
+#define	ZPOOL_CONFIG_VDEV_NROTOR	"nrotor"
 
 #define	ZPOOL_CONFIG_WHOLE_DISK		"whole_disk"
 #define	ZPOOL_CONFIG_ERRCOUNT		"error_count"
@@ -910,6 +911,8 @@ typedef struct vdev_stat_ex {
 	 * Exported as one value.
 	 */
 	uint64_t vsx_media_type;
+	/* Allocation rotor */
+	uint64_t vsx_nrotor;
 } vdev_stat_ex_t;
 
 /*

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -601,6 +601,9 @@ typedef struct zpool_rewind_policy {
 /* vdev enclosure sysfs path */
 #define	ZPOOL_CONFIG_VDEV_ENC_SYSFS_PATH	"vdev_enc_sysfs_path"
 
+/* Type (ssd, file, mix, hdd) (part of vdev_stat_ex_t) */
+#define	ZPOOL_CONFIG_VDEV_MEDIA_TYPE	"media_type"
+
 #define	ZPOOL_CONFIG_WHOLE_DISK		"whole_disk"
 #define	ZPOOL_CONFIG_ERRCOUNT		"error_count"
 #define	ZPOOL_CONFIG_NOT_PRESENT	"not_present"
@@ -736,6 +739,14 @@ typedef enum vdev_aux {
 	VDEV_AUX_EXTERNAL,	/* external diagnosis			*/
 	VDEV_AUX_SPLIT_POOL	/* vdev was split off into another pool	*/
 } vdev_aux_t;
+
+typedef enum vdev_media_type_info {
+	VDEV_MEDIA_TYPE_UNKNOWN = 0,	/* not set yet			*/
+	VDEV_MEDIA_TYPE_SSD,		/* device is solid state	*/
+	VDEV_MEDIA_TYPE_FILE,		/* device is file backed	*/
+	VDEV_MEDIA_TYPE_MIXED,		/* device has both types	*/
+	VDEV_MEDIA_TYPE_HDD		/* device is not solid state	*/
+} vdev_media_type_info_t;
 
 /*
  * pool state.  The following states are written to disk as part of the normal
@@ -894,6 +905,11 @@ typedef struct vdev_stat_ex {
 	uint64_t vsx_agg_histo[ZIO_PRIORITY_NUM_QUEUEABLE]
 	    [VDEV_RQ_HISTO_BUCKETS];
 
+	/*
+	 * Rotational type of vdev (ssd, file, mixed, hdd).
+	 * Exported as one value.
+	 */
+	uint64_t vsx_media_type;
 } vdev_stat_ex_t;
 
 /*

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -220,6 +220,7 @@ typedef enum {
 	ZPOOL_PROP_MAXBLOCKSIZE,
 	ZPOOL_PROP_TNAME,
 	ZPOOL_PROP_MAXDNODESIZE,
+	ZPOOL_PROP_ROTORVECTOR,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -641,6 +642,7 @@ typedef struct zpool_rewind_policy {
 #define	ZPOOL_CONFIG_VDEV_TOP_ZAP	"com.delphix:vdev_zap_top"
 #define	ZPOOL_CONFIG_VDEV_LEAF_ZAP	"com.delphix:vdev_zap_leaf"
 #define	ZPOOL_CONFIG_HAS_PER_VDEV_ZAPS	"com.delphix:has_per_vdev_zaps"
+#define	ZPOOL_CONFIG_ROTORVECTOR	"rotorvector"
 /*
  * The persistent vdev state is stored as separate values rather than a single
  * 'vdev_state' entry.  This is because a device can be in multiple states, such

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -95,6 +95,8 @@ uint64_t metaslab_class_get_space(metaslab_class_t *);
 uint64_t metaslab_class_get_dspace(metaslab_class_t *);
 uint64_t metaslab_class_get_deferred(metaslab_class_t *);
 
+int metaslab_parse_rotor_config(metaslab_class_t *, char *);
+
 metaslab_group_t *metaslab_group_create(metaslab_class_t *, vdev_t *);
 void metaslab_group_destroy(metaslab_group_t *);
 void metaslab_group_activate(metaslab_group_t *);

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -78,7 +78,7 @@ void metaslab_alloc_trace_fini(void);
 void metaslab_trace_init(zio_alloc_list_t *);
 void metaslab_trace_fini(zio_alloc_list_t *);
 
-metaslab_class_t *metaslab_class_create(spa_t *, metaslab_ops_t *);
+metaslab_class_t *metaslab_class_create(spa_t *, metaslab_ops_t *, char *);
 void metaslab_class_destroy(metaslab_class_t *);
 int metaslab_class_validate(metaslab_class_t *);
 void metaslab_class_histogram_verify(metaslab_class_t *);

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -88,7 +88,7 @@ boolean_t metaslab_class_throttle_reserve(metaslab_class_t *, int,
     zio_t *, int);
 void metaslab_class_throttle_unreserve(metaslab_class_t *, int, zio_t *);
 
-void metaslab_class_space_update(metaslab_class_t *, int64_t, int64_t,
+void metaslab_class_space_update(metaslab_class_t *, int, int64_t, int64_t,
     int64_t, int64_t);
 uint64_t metaslab_class_get_alloc(metaslab_class_t *);
 uint64_t metaslab_class_get_space(metaslab_class_t *);

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -99,6 +99,7 @@ int metaslab_parse_rotor_config(metaslab_class_t *, char *);
 
 metaslab_group_t *metaslab_group_create(metaslab_class_t *, vdev_t *);
 void metaslab_group_destroy(metaslab_group_t *);
+void metaslab_group_set_rotor_category(metaslab_group_t *, boolean_t);
 void metaslab_group_activate(metaslab_group_t *);
 void metaslab_group_passivate(metaslab_group_t *);
 boolean_t metaslab_group_initialized(metaslab_group_t *);

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -155,7 +155,7 @@ typedef enum trace_alloc_type {
  * big and less expensive.  Depending on the size of an allocation,
  * a rotor will be chosen.
  */
-#define	METASLAB_CLASS_ROTORS	1
+#define	METASLAB_CLASS_ROTORS	5
 
 struct metaslab_class {
 	kmutex_t		mc_lock;
@@ -163,6 +163,7 @@ struct metaslab_class {
 	metaslab_group_t	*mc_rotorv[METASLAB_CLASS_ROTORS];
 	metaslab_ops_t		*mc_ops;
 	uint64_t		mc_aliquotv[METASLAB_CLASS_ROTORS];
+	int			mc_max_nrot;    /* highest rotor with member */
 
 	/*
 	 * Track the number of metaslab groups that have been initialized

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -157,6 +157,15 @@ typedef enum trace_alloc_type {
  */
 #define	METASLAB_CLASS_ROTORS	5
 
+/*
+ * Number of different categories of allocations.  Currently data and
+ * metadata.
+ */
+#define	METASLAB_ROTOR_ALLOC_CLASS_DATA		0
+#define	METASLAB_ROTOR_ALLOC_CLASS_METADATA	1
+
+#define	METASLAB_ROTOR_ALLOC_CLASSES		2
+
 struct metaslab_class {
 	kmutex_t		mc_lock;
 	spa_t			*mc_spa;
@@ -206,7 +215,8 @@ struct metaslab_class {
 	uint64_t		mc_histogram[RANGE_TREE_HISTOGRAM_SIZE];
 
 	/* Maximum allocation size in each rotor vector category. */
-	uint64_t		mc_rotvec_threshold[METASLAB_CLASS_ROTORS];
+	uint64_t		mc_rotvec_threshold[METASLAB_CLASS_ROTORS]
+	    [METASLAB_ROTOR_ALLOC_CLASSES];
 	/* List of vdev guids to place in each rotor vector category. */
 	/* Should be a dynamic list. */
 	uint64_t		mc_rotvec_vdev_guids[METASLAB_CLASS_ROTORS][5];

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -195,10 +195,14 @@ struct metaslab_class {
 
 	uint64_t		mc_alloc_groups; /* # of allocatable groups */
 
-	uint64_t		mc_alloc;	/* total allocated space */
-	uint64_t		mc_deferred;	/* total deferred frees */
-	uint64_t		mc_space;	/* total space (alloc + free) */
-	uint64_t		mc_dspace;	/* total deflated space */
+	/* total allocated space */
+	uint64_t		mc_allocv[METASLAB_CLASS_ROTORS];
+	/* total deferred frees */
+	uint64_t		mc_deferredv[METASLAB_CLASS_ROTORS];
+	/* total space (alloc + free) */
+	uint64_t		mc_spacev[METASLAB_CLASS_ROTORS];
+	/* total deflated space */
+	uint64_t		mc_dspacev[METASLAB_CLASS_ROTORS];
 	uint64_t		mc_histogram[RANGE_TREE_HISTOGRAM_SIZE];
 
 	/* Maximum allocation size in each rotor vector category. */

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -199,6 +199,14 @@ struct metaslab_class {
 	uint64_t		mc_space;	/* total space (alloc + free) */
 	uint64_t		mc_dspace;	/* total deflated space */
 	uint64_t		mc_histogram[RANGE_TREE_HISTOGRAM_SIZE];
+
+	/* Maximum allocation size in each rotor vector category. */
+	uint64_t		mc_rotvec_threshold[METASLAB_CLASS_ROTORS];
+	/* List of vdev guids to place in each rotor vector category. */
+	/* Should be a dynamic list. */
+	uint64_t		mc_rotvec_vdev_guids[METASLAB_CLASS_ROTORS][5];
+	/* vdev types to place in rotor vector category, if no guid match. */
+	int			mc_rotvec_categories[METASLAB_CLASS_ROTORS];
 };
 
 /*

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -130,6 +130,7 @@ struct spa {
 	 */
 	char		spa_name[ZFS_MAX_DATASET_NAME_LEN];	/* pool name */
 	char		*spa_comment;		/* comment */
+	char		*spa_rotorvector;	/* rotorvector categories */
 	avl_node_t	spa_avl;		/* node in spa_namespace_avl */
 	nvlist_t	*spa_config;		/* last synced config */
 	nvlist_t	*spa_config_syncing;	/* currently syncing config */

--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -94,7 +94,7 @@ extern void vdev_propagate_state(vdev_t *vd);
 extern void vdev_set_state(vdev_t *vd, boolean_t isopen, vdev_state_t state,
     vdev_aux_t aux);
 
-extern void vdev_space_update(vdev_t *vd,
+extern void vdev_space_update(vdev_t *vd, int nrot,
     int64_t alloc_delta, int64_t defer_delta, int64_t space_delta);
 
 extern uint64_t vdev_psize_to_asize(vdev_t *vd, uint64_t psize);

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -159,6 +159,7 @@ struct vdev {
 	boolean_t	vdev_expanding;	/* expand the vdev?		*/
 	boolean_t	vdev_reopening;	/* reopen in progress?		*/
 	boolean_t	vdev_nonrot;	/* true if solid state		*/
+	boolean_t	vdev_nonrot_mix; /* true if partial solid state	*/
 	int		vdev_open_error; /* error on last open		*/
 	kthread_t	*vdev_open_thread; /* thread opening children	*/
 	uint64_t	vdev_crtxg;	/* txg when top-level was added */

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -983,9 +983,11 @@ get_configs(libzfs_handle_t *hdl, pool_list_t *pl, boolean_t active_ok)
 				 *	pool state
 				 *	hostid (if available)
 				 *	hostname (if available)
+				 *	rotorvector (if available)
 				 */
 				uint64_t state, version;
 				char *comment = NULL;
+				char *rotvec = NULL;
 
 				version = fnvlist_lookup_uint64(tmp,
 				    ZPOOL_CONFIG_VERSION);
@@ -1004,6 +1006,11 @@ get_configs(libzfs_handle_t *hdl, pool_list_t *pl, boolean_t active_ok)
 				    ZPOOL_CONFIG_COMMENT, &comment) == 0)
 					fnvlist_add_string(config,
 					    ZPOOL_CONFIG_COMMENT, comment);
+
+				if (nvlist_lookup_string(tmp,
+				    ZPOOL_CONFIG_ROTORVECTOR, &rotvec) == 0)
+					fnvlist_add_string(config,
+					    ZPOOL_CONFIG_ROTORVECTOR, rotvec);
 
 				state = fnvlist_lookup_uint64(tmp,
 				    ZPOOL_CONFIG_POOL_STATE);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -724,6 +724,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			break;
 
 		case ZPOOL_PROP_ROTORVECTOR:
+			/* TODO: syntax check property. */
 			break;
 		}
 	}

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -268,6 +268,7 @@ zpool_get_prop(zpool_handle_t *zhp, zpool_prop_t prop, char *buf,
 		case ZPOOL_PROP_ALTROOT:
 		case ZPOOL_PROP_CACHEFILE:
 		case ZPOOL_PROP_COMMENT:
+		case ZPOOL_PROP_ROTORVECTOR:
 			if (zhp->zpool_props != NULL ||
 			    zpool_get_all_props(zhp) == 0) {
 				(void) strlcpy(buf,
@@ -720,6 +721,9 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
+			break;
+
+		case ZPOOL_PROP_ROTORVECTOR:
 			break;
 		}
 	}

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -96,7 +96,7 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
-\fB\fBzpool iostat\fR [\fB-c\fR \fBCMD\fR] [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-ghHLpPvy\fR] [\fB-lq\fR]|[\fB-r\fR|-\fBw\fR]]
+\fB\fBzpool iostat\fR [\fB-c\fR \fBCMD\fR] [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-ghHLMpPvy\fR] [\fB-lq\fR]|[\fB-r\fR|-\fBw\fR]]
      [[\fIpool\fR ...]|[\fIpool vdev\fR ...]|[\fIvdev\fR ...]] [\fIinterval\fR[\fIcount\fR]]\fR
 
 .fi
@@ -159,7 +159,7 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
-\fBzpool status\fR [\fB-c\fR \fBCMD\fR] [\fB-gLPvxD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
+\fBzpool status\fR [\fB-c\fR \fBCMD\fR] [\fB-gLMPvxD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
 .fi
 
 .LP
@@ -1523,7 +1523,7 @@ Scan using the default search path, the libblkid cache will not be consulted.  A
 .sp
 .ne 2
 .na
-\fB\fBzpool iostat\fR [\fB-c\fR \fBCMD\fR] [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-ghHLpPvy\fR] [[\fB-lq\fR]|[\fB-r\fR|\fB-w\fR]] [[\fIpool\fR ...]|[\fIpool vdev\fR ...]|[\fIvdev\fR ...]] [\fIinterval\fR[\fIcount\fR]]\fR
+\fB\fBzpool iostat\fR [\fB-c\fR \fBCMD\fR] [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-ghHLMpPvy\fR] [[\fB-lq\fR]|[\fB-r\fR|\fB-w\fR]] [[\fIpool\fR ...]|[\fIpool vdev\fR ...]|[\fIvdev\fR ...]] [\fIinterval\fR[\fIcount\fR]]\fR
 
 .ad
 .sp .6
@@ -1592,6 +1592,15 @@ Scripted mode. Do not display headers, and separate fields by a single tab inste
 .ad
 .RS 12n
 Display real paths for vdevs resolving all symbolic links. This can be used to look up the current block device name regardless of the /dev/disk/ path used to open it.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-M\fR\fR
+.ad
+.RS 12n
+Display the media type of device a pool or vdev is based on: ssd, hdd or file.  Mixed mirror vdevs that have both ssd (or file) and hdd members are marked "mix".  A pool is considered mixed if all members are at least mixed, i.e. no pure hdd.
 .RE
 
 .sp
@@ -2099,7 +2108,7 @@ Sets the specified property for \fInewpool\fR. See the “Properties” section 
 .sp
 .ne 2
 .na
-\fBzpool status\fR [\fB-c\fR \fBCMD\fR] [\fB-gLPvxD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
+\fBzpool status\fR [\fB-c\fR \fBCMD\fR] [\fB-gLMPvxD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
 .ad
 .sp .6
 .RS 4n
@@ -2140,6 +2149,15 @@ Display vdev GUIDs instead of the normal device names. These GUIDs can be used i
 .ad
 .RS 12n
 Display real paths for vdevs resolving all symbolic links. This can be used to look up the current block device name regardless of the /dev/disk/ path used to open it.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-M\fR\fR
+.ad
+.RS 12n
+Display the media type of device a pool or vdev is based on: ssd, hdd or file.  Mixed mirror vdevs that have both ssd (or file) and hdd members are marked "mix".  A pool is considered mixed if all members are at least mixed, i.e. no pure hdd.
 .RE
 
 .sp

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -753,6 +753,79 @@ This property can also be referred to by its shortened name, \fBlistsnaps\fR.
 The current on-disk version of the pool. This can be increased, but never decreased. The preferred method of updating pools is with the "\fBzpool upgrade\fR" command, though this property can be used when a specific version is needed for backwards compatibility. Once feature flags are enabled on a pool this property will no longer have a value.
 .RE
 
+.sp
+.ne 2
+.na
+\fB\fBrotorvector\fR=(unset) | \fIconfiguration\fR\fR
+.ad
+.sp .6
+.RS 4n
+Controls to which \fBvdev\fR each written block is allocated.  The primary use of this property is to allocate meta-data on faster devices (such as SSDs), while allocating all other (bulk) data on cheaper devices (HDDs).  It can also be used to allocate small data blocks on faster devices.
+.sp
+With this option set, all \fBvdev\fRs are assigned to an allocaton category (= given a rotor vector index).  The categories should be ordered from fast to slow, which would (presumably) also correspond to an ordering from expensive to cheap.  Associated with each category is a description of what kind of data blocks it accepts.  (Kind is currently \fBdata\fR or \fBmetadata\fR, and its size.)  Each written block is allocated to a \fBvdev\fR of the first (fastest) category that accepts it.
+.sp
+If a category is completely full, a slower category will be used.  And as a last resort, faster categories are used.  Note however that generally the entire pool will be reported as full and not allow further user writes before any category becomes completely full.  The rationale is that rather than filling up expensive fast \fBvdev\fRs with some last bulk data when a pool is close to full, the pool shall act as full when the cheaper categories are full.  Likewise, this strategy avoids storing metadata on slow \fBvdev\fRs, which would hamper performance for this metadata even after the full condition of the faster categories has been resolved.
+.sp
+The configuration is a semicolon-separated list of (up to 5) categories:
+.sp
+[\fIspec\fR\fB<=\fR\fIlimit\fR]\fB;\fR...\fB;\fR\fIspec\fR\fR
+.sp
+where \fIspec\fR is a comma-separated list of \fIvdev-guid\fRs and generic media type specifiers: \fBssd\fR, \fBssd-raidz\fR, \fBmixed\fR, \fBhdd\fR, and \fBhdd-raidz\fR.  (\fBmixed\fR denotes mirrors vith both ssd and hdd drives.)  Expecilitly assigned \fBvdev\fR \fIguid\fRs takes precendece over generic assignments.  Any \fBvdev\fRs which are not matched by \fIguid\fR or the generic media types are placed in the last category.
+.sp
+\fIlimit\fR is a comma-separated list of block size limits in KiB that are allowed within the category.  To specify a limit that applies to metadata only, add \fBmeta:\fR before the value.  The last category has no limit.
+.sp
+Examples:
+.sp
+.ne 2
+.na
+\fB\fBssd<=meta:16;hdd\fR\fR
+.ad
+.RS 10n
+Metadata block less than 16 KiB are allocated on ssd-only \fBvdev\fRs.  Other allocations go to remaining disks.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBssd<=16;hdd\fR\fR
+.ad
+.RS 10n
+Any block less than 16 KiB is allocated on ssd-only \fBvdev\fRs.  Other allocations go to remaining disks.  This uses more ssd space than the previous example, but gives full ssd-like performance for small files.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBssd<=4;mixed<=64;123,hdd\fR\fR
+.ad
+.RS 10n
+Blocks less than 4 KiB are allocated on ssd-only \fBvdev\fRs. Allocations less than 64 KiB end up on ssd/hdd mixed mirror  \fBvdev\fRs). Other allocations go to remaining disks. 123 represents av \fBvdev\fR \fIguid\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB123,ssd<=meta:4;mixed<=64;hdd\fR\fR
+.ad
+.RS 10n
+Pure ssd (and explicit \fBvdev\fR \fIguid\fR 123) takes metadata <= 4 KiB.
+Mixed (mirror ssd+hdd) takes data (including metadata) <= 64 KiB.
+Others (hdd) take remainder.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBssd<=meta:128,4;mixed<=64;hdd\fR\fR
+.ad
+.RS 10n
+Pure ssd \fBvdev\fR takes metadata <= 128 KiB and data <= 4 KiB.
+Mixed (mirror) takes data <= 64 KiB (this metadata already taken by ssd).
+Others (hdd) takes remainder.
+.RE
+
+.RE
+
 .SS "Subcommands"
 .sp
 .LP

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -73,6 +73,8 @@ zpool_prop_init(void)
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "<file> | none", "CACHEFILE");
 	zprop_register_string(ZPOOL_PROP_COMMENT, "comment", NULL,
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "<comment-string>", "COMMENT");
+	zprop_register_string(ZPOOL_PROP_ROTORVECTOR, "rotorvector", NULL,
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "<rotvec-categories>", "ROTORVECTOR");
 
 	/* readonly number properties */
 	zprop_register_number(ZPOOL_PROP_SIZE, "size", 0, PROP_READONLY,

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2962,7 +2962,7 @@ arc_hdr_l2hdr_destroy(arc_buf_hdr_t *hdr)
 	ARCSTAT_INCR(arcstat_l2_asize, -asize);
 	ARCSTAT_INCR(arcstat_l2_size, -HDR_GET_LSIZE(hdr));
 
-	vdev_space_update(dev->l2ad_vdev, -asize, 0, 0);
+	vdev_space_update(dev->l2ad_vdev, -1, -asize, 0, 0);
 
 	(void) refcount_remove_many(&dev->l2ad_alloc, asize, hdr);
 	arc_hdr_clear_flags(hdr, ARC_FLAG_HAS_L2HDR);
@@ -6963,7 +6963,7 @@ top:
 	kmem_cache_free(hdr_l2only_cache, head);
 	mutex_exit(&dev->l2ad_mtx);
 
-	vdev_space_update(dev->l2ad_vdev, -bytes_dropped, 0, 0);
+	vdev_space_update(dev->l2ad_vdev, -1, -bytes_dropped, 0, 0);
 
 	l2arc_do_free_on_write();
 
@@ -7398,7 +7398,7 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 	ARCSTAT_INCR(arcstat_l2_write_bytes, write_asize);
 	ARCSTAT_INCR(arcstat_l2_size, write_sz);
 	ARCSTAT_INCR(arcstat_l2_asize, write_asize);
-	vdev_space_update(dev->l2ad_vdev, write_asize, 0, 0);
+	vdev_space_update(dev->l2ad_vdev, -1, write_asize, 0, 0);
 
 	/*
 	 * Bump device hand to the device start if it is approaching the end.
@@ -7564,7 +7564,7 @@ l2arc_add_vdev(spa_t *spa, vdev_t *vd)
 	list_create(&adddev->l2ad_buflist, sizeof (arc_buf_hdr_t),
 	    offsetof(arc_buf_hdr_t, b_l2hdr.b_l2node));
 
-	vdev_space_update(vd, 0, 0, adddev->l2ad_end - adddev->l2ad_hand);
+	vdev_space_update(vd, -1, 0, 0, adddev->l2ad_end - adddev->l2ad_hand);
 	refcount_create(&adddev->l2ad_alloc);
 
 	/*

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -213,9 +213,11 @@ kmem_cache_t *metaslab_alloc_trace_cache;
  * ==========================================================================
  */
 metaslab_class_t *
-metaslab_class_create(spa_t *spa, metaslab_ops_t *ops)
+metaslab_class_create(spa_t *spa, metaslab_ops_t *ops, char *rvconfig)
 {
 	metaslab_class_t *mc;
+
+	(void) rvconfig;
 
 	mc = kmem_zalloc(sizeof (metaslab_class_t), KM_SLEEP);
 

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -978,6 +978,10 @@ metaslab_group_set_rotor_category(metaslab_group_t *mg, boolean_t failed_dev)
 		mg->mg_nrot = METASLAB_CLASS_ROTORS-1;
 	else
 		mg->mg_nrot = metaslab_vdev_rotor_category(mc, mg->mg_vd);
+
+#ifndef _KERNEL
+	printf("SET mg->mg_nrot = %d\n", mg->mg_nrot);
+#endif
 }
 
 void

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -3247,7 +3247,7 @@ metaslab_alloc_dva(spa_t *spa, metaslab_class_t *mc, uint64_t psize,
 	vdev_t *vd;
 	boolean_t try_hard = B_FALSE;
 	int nrot;
-	int i;
+	int i, j;
 
 	ASSERT(!DVA_IS_VALID(&dva[d]));
 
@@ -3342,11 +3342,16 @@ metaslab_alloc_dva(spa_t *spa, metaslab_class_t *mc, uint64_t psize,
 	if (mg->mg_class != mc || mg->mg_activation_count <= 0 ||
 	    mg->mg_nrot < nrot) {
 		for (i = nrot; i < METASLAB_CLASS_ROTORS; i++) {
-			if (mc->mc_rotorv[i] != NULL) {
-				mg = mc->mc_rotorv[i];
+			/* Better than failing we try the better options. */
+			j = (i + nrot) % METASLAB_CLASS_ROTORS;
+			if (mc->mc_rotorv[j] != NULL) {
+				mg = mc->mc_rotorv[j];
 				break;
 			}
 		}
+		ASSERT(mg->mg_class == mc);
+		ASSERT(mg->mg_activation_count > 0);
+		/* VERIFY3U(mg->mg_nrot, >=, nrot); */
 	}
 
 top1:
@@ -3513,9 +3518,12 @@ next:
 	 * (Not earlier ones, to not waste expensive space for the
 	 * future for data that is not worth it.)
 	 */
-	for (i = mg->mg_nrot+1; i < METASLAB_CLASS_ROTORS; i++) {
-		if (mc->mc_rotorv[i] != NULL) {
-			mg = mc->mc_rotorv[i];
+	for (i = (mg->mg_nrot - nrot + METASLAB_CLASS_ROTORS + 1) %
+	    METASLAB_CLASS_ROTORS; i && i < METASLAB_CLASS_ROTORS; i++) {
+		/* Better than failing we try the better options. */
+		j = (i + nrot) % METASLAB_CLASS_ROTORS;
+		if (mc->mc_rotorv[j] != NULL) {
+			mg = mc->mc_rotorv[j];
 			goto top1;
 		}
 	}

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1097,13 +1097,20 @@ spa_thread(void *arg)
 static void
 spa_activate(spa_t *spa, int mode)
 {
+	char *rvconfig;
+
 	ASSERT(spa->spa_state == POOL_STATE_UNINITIALIZED);
 
 	spa->spa_state = POOL_STATE_ACTIVE;
 	spa->spa_mode = mode;
 
-	spa->spa_normal_class = metaslab_class_create(spa, zfs_metaslab_ops);
-	spa->spa_log_class = metaslab_class_create(spa, zfs_metaslab_ops);
+	if (nvlist_lookup_string(spa->spa_config, ZPOOL_CONFIG_ROTORVECTOR,
+	    &rvconfig) != 0)
+		rvconfig = NULL;
+
+	spa->spa_normal_class = metaslab_class_create(spa, zfs_metaslab_ops,
+	    rvconfig);
+	spa->spa_log_class = metaslab_class_create(spa, zfs_metaslab_ops, NULL);
 
 	/* Try to create a covering process */
 	mutex_enter(&spa->spa_proc_lock);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -433,6 +433,7 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 		char *strval, *slash, *check, *fname;
 		const char *propname = nvpair_name(elem);
 		zpool_prop_t prop = zpool_name_to_prop(propname);
+		metaslab_class_t *mc_tmp;
 
 		switch ((int)prop) {
 		case ZPROP_INVAL:
@@ -625,6 +626,18 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 			break;
 
 		case ZPOOL_PROP_ROTORVECTOR:
+			/*
+			 * Hack?: using temporary structure to allow
+			 * simplistic verification before accepting
+			 * rotor vector pool property.
+			 */
+			if ((error = nvpair_value_string(elem, &strval)) != 0)
+				break;
+			mc_tmp = kmem_zalloc(sizeof (metaslab_class_t),
+			    KM_SLEEP);
+			if (!metaslab_parse_rotor_config(mc_tmp, strval))
+				error = SET_ERROR(EINVAL);
+			kmem_free(mc_tmp, sizeof (metaslab_class_t));
 			break;
 
 		default:
@@ -6343,6 +6356,10 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			if (spa->spa_rotorvector != NULL)
 				spa_strfree(spa->spa_rotorvector);
 			spa->spa_rotorvector = spa_strdup(strval);
+			/*
+			 * TODO:
+			 * VERIFY(metaslab_parse_rotor_config(...));
+			 */
 			/* Same as for ZPOOL_PROP_COMMENT below. */
 			if (tx->tx_txg != TXG_INITIAL)
 				vdev_config_dirty(spa->spa_root_vdev);

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -434,6 +434,9 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 	if (spa->spa_comment != NULL)
 		fnvlist_add_string(config, ZPOOL_CONFIG_COMMENT,
 		    spa->spa_comment);
+	if (spa->spa_rotorvector != NULL)
+		fnvlist_add_string(config, ZPOOL_CONFIG_ROTORVECTOR,
+		    spa->spa_rotorvector);
 
 #ifdef	_KERNEL
 	hostid = zone_get_hostid(NULL);

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1887,7 +1887,12 @@ spa_fini(void)
 boolean_t
 spa_has_slogs(spa_t *spa)
 {
-	return (spa->spa_log_class->mc_rotor != NULL);
+	int i;
+
+	for (i = 0; i < METASLAB_CLASS_ROTORS; i++)
+		if (spa->spa_log_class->mc_rotorv[i] != NULL)
+			return (B_TRUE);
+	return (B_FALSE);
 }
 
 spa_log_state_t

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -2928,6 +2928,17 @@ vdev_get_stats_ex_impl(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 			    &vd->vdev_queue.vq_class[t].vqc_queued_tree);
 		}
 	}
+	if (vsx) {
+		if (vd->vdev_nonrot) {
+			if (vd->vdev_ops == &vdev_file_ops)
+				vsx->vsx_media_type = VDEV_MEDIA_TYPE_FILE;
+			else
+				vsx->vsx_media_type = VDEV_MEDIA_TYPE_SSD;
+		} else if (vd->vdev_nonrot_mix)
+			vsx->vsx_media_type = VDEV_MEDIA_TYPE_MIXED;
+		else
+			vsx->vsx_media_type = VDEV_MEDIA_TYPE_HDD;
+	}
 }
 
 void

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -2938,6 +2938,10 @@ vdev_get_stats_ex_impl(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 			vsx->vsx_media_type = VDEV_MEDIA_TYPE_MIXED;
 		else
 			vsx->vsx_media_type = VDEV_MEDIA_TYPE_HDD;
+		if (vd->vdev_mg)
+			vsx->vsx_nrotor = vd->vdev_mg->mg_nrot;
+		else
+			vsx->vsx_nrotor = -1;
 	}
 }
 

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1173,6 +1173,7 @@ vdev_open_children(vdev_t *vd)
 	taskq_t *tq;
 	int children = vd->vdev_children;
 	int c;
+	boolean_t nonrot_some;
 
 	/*
 	 * in order to handle pools on top of zvols, do the opens
@@ -1198,9 +1199,19 @@ retry_sync:
 	}
 
 	vd->vdev_nonrot = B_TRUE;
+	vd->vdev_nonrot_mix = B_TRUE;
+	nonrot_some = B_FALSE;
 
-	for (c = 0; c < children; c++)
+	for (c = 0; c < children; c++) {
 		vd->vdev_nonrot &= vd->vdev_child[c]->vdev_nonrot;
+		vd->vdev_nonrot_mix &= vd->vdev_child[c]->vdev_nonrot_mix |
+		    vd->vdev_child[c]->vdev_nonrot;
+		nonrot_some |= vd->vdev_child[c]->vdev_nonrot;
+	}
+	if (vd->vdev_ops == &vdev_mirror_ops)
+		vd->vdev_nonrot_mix |= nonrot_some;
+	if (vd->vdev_nonrot)
+		vd->vdev_nonrot_mix = B_FALSE;
 }
 
 /*

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3155,7 +3155,8 @@ vdev_stat_update(zio_t *zio, uint64_t psize)
  * and the root vdev.
  */
 void
-vdev_space_update(vdev_t *vd, int64_t alloc_delta, int64_t defer_delta,
+vdev_space_update(vdev_t *vd, int nrot,
+    int64_t alloc_delta, int64_t defer_delta,
     int64_t space_delta)
 {
 	int64_t dspace_delta = space_delta;
@@ -3195,7 +3196,7 @@ vdev_space_update(vdev_t *vd, int64_t alloc_delta, int64_t defer_delta,
 		ASSERT(rvd == vd->vdev_parent);
 		ASSERT(vd->vdev_ms_count != 0);
 
-		metaslab_class_space_update(mc,
+		metaslab_class_space_update(mc, nrot,
 		    alloc_delta, defer_delta, space_delta, dspace_delta);
 	}
 }

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -321,6 +321,7 @@ skip_open:
 
 	/* Inform the ZIO pipeline that we are non-rotational */
 	v->vdev_nonrot = blk_queue_nonrot(bdev_get_queue(vd->vd_bdev));
+	v->vdev_nonrot_mix = B_FALSE;
 
 	/* Physical volume size in bytes */
 	*psize = bdev_capacity(vd->vd_bdev);

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -62,6 +62,7 @@ vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 
 	/* Rotational optimizations only make sense on block devices */
 	vd->vdev_nonrot = B_TRUE;
+	vd->vdev_nonrot_mix = B_FALSE;
 
 	/*
 	 * We must have a pathname, and it must be absolute.

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -51,6 +51,16 @@ vdev_file_rele(vdev_t *vd)
 	ASSERT(vd->vdev_path != NULL);
 }
 
+#ifndef _KERNEL
+boolean_t ztest_vdev_nonrot(void);
+
+boolean_t
+__attribute__((weak)) ztest_vdev_nonrot()
+{
+	return (B_TRUE);
+}
+#endif
+
 static int
 vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
     uint64_t *ashift)
@@ -60,9 +70,14 @@ vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	vattr_t vattr;
 	int error;
 
+#ifdef _KERNEL
 	/* Rotational optimizations only make sense on block devices */
 	vd->vdev_nonrot = B_TRUE;
 	vd->vdev_nonrot_mix = B_FALSE;
+#else
+	vd->vdev_nonrot = ztest_vdev_nonrot();
+	vd->vdev_nonrot_mix = B_FALSE;
+#endif
 
 	/*
 	 * We must have a pathname, and it must be absolute.

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -344,6 +344,9 @@ vdev_config_generate_stats(vdev_t *vd, nvlist_t *nv)
 	    vsx->vsx_agg_histo[ZIO_PRIORITY_SCRUB],
 	    ARRAY_SIZE(vsx->vsx_agg_histo[ZIO_PRIORITY_SCRUB]));
 
+	fnvlist_add_uint64(nvx, ZPOOL_CONFIG_VDEV_MEDIA_TYPE,
+	    vsx->vsx_media_type);
+
 	/* Add extended stats nvlist to main nvlist */
 	fnvlist_add_nvlist(nv, ZPOOL_CONFIG_VDEV_STATS_EX, nvx);
 

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -347,6 +347,8 @@ vdev_config_generate_stats(vdev_t *vd, nvlist_t *nv)
 	fnvlist_add_uint64(nvx, ZPOOL_CONFIG_VDEV_MEDIA_TYPE,
 	    vsx->vsx_media_type);
 
+	fnvlist_add_uint64(nvx, ZPOOL_CONFIG_VDEV_NROTOR, vsx->vsx_nrotor);
+
 	/* Add extended stats nvlist to main nvlist */
 	fnvlist_add_nvlist(nv, ZPOOL_CONFIG_VDEV_STATS_EX, nvx);
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -33,7 +33,7 @@ if is_linux; then
 typeset -a properties=("size" "capacity" "altroot" "health" "guid" "version"
     "bootfs" "delegation" "autoreplace" "cachefile" "dedupditto" "dedupratio"
     "free" "allocated" "readonly" "comment" "expandsize" "freeing" "failmode"
-    "listsnapshots" "autoexpand" "fragmentation" "leaked" "ashift"
+    "listsnapshots" "autoexpand" "fragmentation" "leaked" "ashift" "rotorvector"
     "feature@async_destroy" "feature@empty_bpobj" "feature@lz4_compress"
     "feature@large_blocks" "feature@large_dnode" "feature@filesystem_limits"
     "feature@spacemap_histogram" "feature@enabled_txg" "feature@hole_birth"


### PR DESCRIPTION
~~Proof-of-concept!  This is not a pull request as such, but~~ (Update: operational) for review / intended to spur discussion, and show some possible performance increases.

These commits implement a simplistic strategy to make small records (e.g. metadata, but also file data) end up on faster non-rotating storage when a pool consist of two vdevs with different characteristics e.g. an SSD (mirror) and a HDD (raidzn).

For a test case (see commit log) with many small files, times for 'find' were cut by a factor 8, and scrub with a factor 3.  More details in the commit log.

Note: Although I tried to search the web and read various articles etc, I have not really understood all the intricacies of space allocation, so presume there are unhandled cases, and possibly other issues with the approach.  Feel free to point such out.

The purpose is the same as #3779.
