### PR TITLE
Issue #4116. Make zvol update volsize operation synchronous.

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -281,7 +281,6 @@ zvol_update_volsize(uint64_t volsize, objset_t *os)
 	ASSERT(MUTEX_HELD(&zvol_state_lock));
 
 	tx = dmu_tx_create(os);
-	txg = dmu_tx_get_txg(tx);
 	dmu_tx_hold_zap(tx, ZVOL_ZAP_OBJ, TRUE, NULL);
 	dmu_tx_mark_netfree(tx);
 	error = dmu_tx_assign(tx, TXG_WAIT);
@@ -289,6 +288,7 @@ zvol_update_volsize(uint64_t volsize, objset_t *os)
 		dmu_tx_abort(tx);
 		return (SET_ERROR(error));
 	}
+	txg = dmu_tx_get_txg(tx);
 
 	error = zap_update(os, ZVOL_ZAP_OBJ, "size", 8, 1,
 	    &volsize, tx);


### PR DESCRIPTION
Issue #4116. Make zvol update volsize operation synchronous.

There is a race condition when new transaction group is added
to dp->dp_dirty_datasets list by the zap_update in the zvol_update_volsize.
Meanwhile, before these dirty data are synchronized, the receive process
can cause that dmu_recv_end_sync is executed. Then finally dirty data
are going to be synchronized but the synchronization ends with the NULL
pointer dereference error.