### PR TITLE
Ensure zed _finish_daemonize() leaves fds 0-2 open

### DIFF
--- a/cmd/zed/zed.c
+++ b/cmd/zed/zed.c
@@ -199,7 +199,7 @@ _finish_daemonize(void)
 		zed_log_die("Failed to dup /dev/null onto stderr: %s",
 		    strerror(errno));
 
-	if (close(devnull) < 0)
+	if ((devnull > STDERR_FILENO) && (close(devnull) < 0))
 		zed_log_die("Failed to close /dev/null: %s", strerror(errno));
 
 	/* Notify parent that daemonization is complete. */


### PR DESCRIPTION
In zed's `_finish_daemonize()`, /dev/null is open()d onto a temporary file descriptor which is then dup()d onto stdin, stdout, and stderr.  But if file descriptors 0, 1, or 2 are not already open at the start of this function, then the temporary file descriptor will fall within this range and be inadvertently closed when the function cleans up.

This commit adds a check to prevent inadvertently closing this (presumably temporary) file descriptor when it shouldn't.

This fixes an issue noted by Seth Arnold in <https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1532198/>:
> - _finish_daemonize() if devnull is 0, 1, 2, the close(devnull) call will leave the program without that fd

But this isn't something we'll hit in practice.  systemd runs zed in the foreground which bypasses the daemonization code path.