### PR TITLE
Musl libc compatibility

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -33,6 +33,7 @@
 #include <libzfs.h>
 #include <locale.h>
 #include <getopt.h>
+#include <fcntl.h>
 
 #define	ZS_COMMENT	0x00000000	/* comment */
 #define	ZS_ZFSUTIL	0x00000001	/* caller is zfs(8) */

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -123,7 +123,7 @@
 #include <math.h>
 #include <sys/fs/zfs.h>
 #include <libnvpair.h>
-#ifdef __GNUC__
+#ifdef __GLIBC__
 #include <execinfo.h> /* for backtrace() */
 #endif
 
@@ -490,7 +490,7 @@ _umem_logging_init(void)
 static void sig_handler(int signo)
 {
 	struct sigaction action;
-#ifdef __GNUC__ /* backtrace() is a GNU extension */
+#ifdef __GLIBC__ /* backtrace() is a GNU extension */
 	int nptrs;
 	void *buffer[BACKTRACE_SZ];
 

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -637,7 +637,7 @@ extern void delay(clock_t ticks);
 #define	maxclsyspri	-20
 #define	defclsyspri	0
 
-#define	CPU_SEQID	(pthread_self() & (max_ncpus - 1))
+#define	CPU_SEQID	((uintptr_t)pthread_self() & (max_ncpus - 1))
 
 #define	kcred		NULL
 #define	CRED()		NULL

--- a/lib/libspl/include/devid.h
+++ b/lib/libspl/include/devid.h
@@ -27,6 +27,7 @@
 #ifndef _LIBSPL_DEVID_H
 #define	_LIBSPL_DEVID_H
 
+#include <sys/types.h>
 #include <stdlib.h>
 
 typedef int ddi_devid_t;

--- a/lib/libspl/include/sys/time.h
+++ b/lib/libspl/include/sys/time.h
@@ -58,6 +58,11 @@
 #define	NSEC2MSEC(n)    ((n) / (NANOSEC / MILLISEC))
 #endif
 
+typedef	long long		hrtime_t;
+typedef	struct	timespec	timestruc_t;
+typedef	struct	timespec	timespec_t;
+
+
 extern hrtime_t gethrtime(void);
 extern void gethrestime(timestruc_t *);
 

--- a/lib/libspl/include/sys/types.h
+++ b/lib/libspl/include/sys/types.h
@@ -55,10 +55,6 @@ typedef longlong_t	diskaddr_t;
 typedef ulong_t		pgcnt_t;	/* number of pages */
 typedef long		spgcnt_t;	/* signed number of pages */
 
-typedef longlong_t	hrtime_t;
-typedef struct timespec	timestruc_t;
-typedef struct timespec timespec_t;
-
 typedef short		pri_t;
 
 typedef int		zoneid_t;

--- a/lib/libspl/timestamp.c
+++ b/lib/libspl/timestamp.c
@@ -28,6 +28,10 @@
 #include <langinfo.h>
 #include "statcommon.h"
 
+#ifndef _DATE_FMT
+#define	_DATE_FMT "%+"
+#endif
+
 /*
  * Print timestamp as decimal reprentation of time_t value (-T u was specified)
  * or in date(1) format (-T d was specified).


### PR DESCRIPTION
This is a followup on #2604 (many thanks to @stef). It has some changes which were added to our alpinelinux tree. The main difference is the removal of --enable-musl as discussed before and is now replaced by --with-tirpc (done by @ncopa). If needed I can split some of these into separate PR's.