### PR TITLE
Add support for Alpine Linux

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -266,6 +266,8 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		VENDOR=ubuntu ;
 	elif test -f /etc/debian_version ; then
 		VENDOR=debian ;
+	elif test -f /etc/alpine-release ; then
+		VENDOR=alpine ;
 	else
 		VENDOR= ;
 	fi
@@ -278,6 +280,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		redhat)     DEFAULT_PACKAGE=rpm  ;;
 		fedora)     DEFAULT_PACKAGE=rpm  ;;
 		gentoo)     DEFAULT_PACKAGE=tgz  ;;
+		alpine)     DEFAULT_PACKAGE=tgz  ;;
 		arch)       DEFAULT_PACKAGE=tgz  ;;
 		sles)       DEFAULT_PACKAGE=rpm  ;;
 		slackware)  DEFAULT_PACKAGE=tgz  ;;
@@ -299,7 +302,8 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		toss)       DEFAULT_INIT_SCRIPT=redhat ;;
 		redhat)     DEFAULT_INIT_SCRIPT=redhat ;;
 		fedora)     DEFAULT_INIT_SCRIPT=fedora ;;
-		gentoo)     DEFAULT_INIT_SCRIPT=gentoo ;;
+		gentoo)     DEFAULT_INIT_SCRIPT=openrc ;;
+		alpine)     DEFAULT_INIT_SCRIPT=openrc ;;
 		arch)       DEFAULT_INIT_SCRIPT=lsb    ;;
 		sles)       DEFAULT_INIT_SCRIPT=lsb    ;;
 		slackware)  DEFAULT_INIT_SCRIPT=lsb    ;;
@@ -313,6 +317,7 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 
 	AC_MSG_CHECKING([default init config direectory])
 	case "$VENDOR" in
+		alpine)     DEFAULT_INITCONF_DIR=/etc/conf.d    ;;
 		gentoo)     DEFAULT_INITCONF_DIR=/etc/conf.d    ;;
 		toss)       DEFAULT_INITCONF_DIR=/etc/sysconfig ;;
 		redhat)     DEFAULT_INITCONF_DIR=/etc/sysconfig ;;

--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -21,7 +21,7 @@ $(init_SCRIPTS) $(initconf_SCRIPTS) $(initcommon_SCRIPTS): $(EXTRA_DIST)
 	  else \
 		NFS_SRV=nfs; \
 	  fi; \
-	  if [ -e /etc/gentoo-release ]; then \
+	  if [ -e /sbin/openrc-run ]; then \
 		SHELL=/sbin/runscript; \
 	  else \
 		SHELL=/bin/sh; \

--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -308,7 +308,7 @@ do_start()
 
 # ----------------------------------------------------
 
-if [ ! -e /etc/gentoo-release ]
+if [ ! -e /sbin/openrc-run ]
 then
 	case "$1" in
 		start)

--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -199,7 +199,7 @@ do_stop()
 
 # ----------------------------------------------------
 
-if [ ! -e /etc/gentoo-release ]
+if [ ! -e /sbin/openrc-run ]
 then
 	case "$1" in
 		start)

--- a/etc/init.d/zfs-share.in
+++ b/etc/init.d/zfs-share.in
@@ -58,7 +58,7 @@ do_stop()
 
 # ----------------------------------------------------
 
-if [ ! -e /etc/gentoo-release ]; then
+if [ ! -e /sbin/openrc-run ]; then
 	case "$1" in
 		start)
 			do_start

--- a/etc/init.d/zfs-zed.in
+++ b/etc/init.d/zfs-zed.in
@@ -98,7 +98,7 @@ do_reload()
 
 # ----------------------------------------------------
 
-if [ ! -e /etc/gentoo-release ]; then
+if [ ! -e /sbin/openrc-run ]; then
 	case "$1" in
 		start)
 			do_start


### PR DESCRIPTION
Both Alpine Linux and Gentoo use OpenRC as init, so we've modified it a bit to support Alpine Linux.