### PR TITLE
Fix zpool iostat bandwidth/ops calculation

### DIFF
--- a/lib/libzfs/libzfs_config.c
+++ b/lib/libzfs/libzfs_config.c
@@ -311,22 +311,10 @@ zpool_refresh_stats(zpool_handle_t *zhp, boolean_t *missing)
 	zhp->zpool_config_size = zc.zc_nvlist_dst_size;
 
 	if (zhp->zpool_config != NULL) {
-		uint64_t oldtxg, newtxg;
-
-		verify(nvlist_lookup_uint64(zhp->zpool_config,
-		    ZPOOL_CONFIG_POOL_TXG, &oldtxg) == 0);
-		verify(nvlist_lookup_uint64(config,
-		    ZPOOL_CONFIG_POOL_TXG, &newtxg) == 0);
-
 		if (zhp->zpool_old_config != NULL)
 			nvlist_free(zhp->zpool_old_config);
 
-		if (oldtxg != newtxg) {
-			nvlist_free(zhp->zpool_config);
-			zhp->zpool_old_config = NULL;
-		} else {
-			zhp->zpool_old_config = zhp->zpool_config;
-		}
+		zhp->zpool_old_config = zhp->zpool_config;
 	}
 
 	zhp->zpool_config = config;


### PR DESCRIPTION
print_vdev_stats() subtracts the old bandwidth/ops stats from the new stats
to calculate the bandwidth/ops numbers in "zpool iostat".  However when the
TXG numbers change between stats, zpool_refresh_stats() will incorrectly assign
a NULL to the old stats. This causes print_vdev_stats() to use zeroes for
the old bandwidth/ops numbers, resulting in an inaccurate calculation.

This fix allows the calculation to be correct even when TXGs change.