### PR TITLE
sys/param.h depends on types defined in sys/types.h (hrtime_t & timestruc_t)

### DIFF
--- a/lib/libspl/include/sys/types.h
+++ b/lib/libspl/include/sys/types.h
@@ -30,7 +30,6 @@
 #include <sys/isa_defs.h>
 #include <sys/feature_tests.h>
 #include_next <sys/types.h>
-#include <sys/param.h> /* for NBBY */
 #include <sys/types32.h>
 #include <sys/va_list.h>
 
@@ -94,5 +93,7 @@ typedef union {
 	} _p;
 } lloff_t;
 #endif
+
+#include <sys/param.h> /* for NBBY */
 
 #endif


### PR DESCRIPTION
This fairly trivial patch seems to required for the build to succeed on aarch64.