### PR TITLE
Userland should busy-wait briefly before using usleep()

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -41,6 +41,7 @@
 #include <sys/vtoc.h>
 #include <sys/zfs_ioctl.h>
 #include <dlfcn.h>
+#include <sched.h>
 
 #include "zfs_namecheck.h"
 #include "zfs_prop.h"
@@ -4116,7 +4117,11 @@ int
 zpool_label_disk_wait(char *path, int timeout)
 {
 	struct stat64 statbuf;
-	int i;
+	hrtime_t start = gethrtime(), now;
+	long busy_timeout = 10; /* milliseconds */
+	long sleep_period = 1; /* milliseconds */
+
+	errno = 0;
 
 	/*
 	 * Wait timeout miliseconds for a newly created device to be available
@@ -4124,13 +4129,21 @@ zpool_label_disk_wait(char *path, int timeout)
 	 * will exist and the udev link will not, so we must wait for the
 	 * symlink.  Depending on the udev rules this may take a few seconds.
 	 */
-	for (i = 0; i < timeout; i++) {
-		usleep(1000);
-
-		errno = 0;
-		if ((stat64(path, &statbuf) == 0) && (errno == 0))
+	do {
+		if ((stat64(path, &statbuf) == 0) && (errno == 0)) {
 			return (0);
-	}
+		} else if (errno != ENOENT) {
+			return (errno);
+		} else if (NSEC2MSEC((now = gethrtime()) - start) <
+		    busy_timeout) {
+			sched_yield();
+		} else if (NSEC2MSEC(now - start) +
+		    (sleep_period * MILLISEC) >= (timeout * MILLISEC)) {
+			break;
+		} else {
+			usleep(sleep_period * MILLISEC);
+		}
+	} while (NSEC2MSEC(gethrtime() - start) < (timeout * MILLISEC));
 
 	return (ENOENT);
 }


### PR DESCRIPTION
The userland code uses the `do {usleep()} while (unavaliable)` pattern
for closing races in asynchronous device initialization. However, the
normal case is that calling `usleep()` introduces an unnecessarily long
delay because the other side typically finishes what it was doing *much*
faster than the period in which we sleep. The periods in which we
`usleep()` are short, but they can add to a significant period of time
when scripts trigger the codepaths using `usleep()` in a loop.

`libzfs_load_module` uses the alternative pattern of `do {sched_yield()}
while (unavaliable)` for 10ms before falling back to the `do {usleep()}
while (unavaliable)` pattern, which is much better for latencies. As a
general principle, I would like to encourage contributors to avoid the
`do {usleep()} while (unavaliable)` pattern for closing asynchronous
races. Modifying the places that use it to do what `libzfs_load_module`
does should achieve that.

There are some minor behavior changes worth noting.

One is that reusing the exact code structure from `libzfs_load_module`
meant that `zpool_label_disk_wait()` will return the error code passed
by `stat64()`. I had considered altering it to maintaining the current
error behavior, but after looking at its consumers, I felt that they
would benefit from a more accurate error code.

Another is that while I used the same timeouts, time spent in the
kernel no longer can extend the timeouts, so the maximum timeouts should
be somewhat shorter. That should be more noticeable on a heavily loaded
system. One might consider the busy-wait to be a cause for concern
there, but the use of `sched_yield()` should lower the number of
iterations in which we busy-wait before falling back to `usleep()`.

The last is that I made a slight improvement to the original algorithm
where if we would timeout after returning from `usleep()`, we will now
skip the call and timeout early.

Signed-off-by: Richard Yao <ryao@gentoo.org>