### PR TITLE
Cleanup linking

### DIFF
--- a/cmd/zdb/Makefile.am
+++ b/cmd/zdb/Makefile.am
@@ -18,5 +18,3 @@ zdb_LDADD = \
 	$(top_builddir)/lib/libzpool/libzpool.la \
 	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la
-
-zdb_LDADD += $(ZLIB)

--- a/cmd/zfs/Makefile.am
+++ b/cmd/zfs/Makefile.am
@@ -19,5 +19,4 @@ zfs_LDADD = \
 	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 
-zfs_LDADD += $(ZLIB)
 zfs_LDFLAGS = -pthread

--- a/cmd/zhack/Makefile.am
+++ b/cmd/zhack/Makefile.am
@@ -15,5 +15,3 @@ zhack_LDADD = \
 	$(top_builddir)/lib/libzpool/libzpool.la \
 	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la
-
-zhack_LDADD += $(ZLIB)

--- a/cmd/zstreamdump/Makefile.am
+++ b/cmd/zstreamdump/Makefile.am
@@ -15,5 +15,3 @@ zstreamdump_LDADD = \
 	$(top_builddir)/lib/libzpool/libzpool.la \
 	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la
-
-zstreamdump_LDADD += $(ZLIB)

--- a/cmd/ztest/Makefile.am
+++ b/cmd/ztest/Makefile.am
@@ -19,4 +19,4 @@ ztest_LDADD = \
 	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 
-ztest_LDADD += -lm -ldl
+ztest_LDADD += -lm

--- a/config/user-libuuid.m4
+++ b/config/user-libuuid.m4
@@ -7,10 +7,10 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBUUID], [
 	AC_CHECK_HEADER([uuid/uuid.h], [], [AC_MSG_FAILURE([
 	*** uuid/uuid.h missing, libuuid-devel package required])])
 
-	AC_CHECK_LIB([uuid], [uuid_generate], [], [AC_MSG_FAILURE([
+	AC_SEARCH_LIBS([uuid_generate], [uuid], [], [AC_MSG_FAILURE([
 	*** uuid_generate() missing, libuuid-devel package required])])
 
-	AC_CHECK_LIB([uuid], [uuid_is_null], [], [AC_MSG_FAILURE([
+	AC_SEARCH_LIBS([uuid_is_null], [uuid], [], [AC_MSG_FAILURE([
 	*** uuid_is_null() missing, libuuid-devel package required])])
 
 	AC_SUBST([LIBUUID], ["-luuid"])

--- a/config/user-zlib.m4
+++ b/config/user-zlib.m4
@@ -7,13 +7,13 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_ZLIB], [
 	AC_CHECK_HEADER([zlib.h], [], [AC_MSG_FAILURE([
 	*** zlib.h missing, zlib-devel package required])])
 
-	AC_CHECK_LIB([z], [compress2], [], [AC_MSG_FAILURE([
+	AC_SEARCH_LIBS([compress2], [z], [], [AC_MSG_FAILURE([
 	*** compress2() missing, zlib-devel package required])])
 
-	AC_CHECK_LIB([z], [uncompress], [], [AC_MSG_FAILURE([
+	AC_SEARCH_LIBS([uncompress], [z], [], [AC_MSG_FAILURE([
 	*** uncompress() missing, zlib-devel package required])])
 
-	AC_CHECK_LIB([z], [crc32], [], [AC_MSG_FAILURE([
+	AC_SEARCH_LIBS([crc32], [z], [], [AC_MSG_FAILURE([
 	*** crc32() missing, zlib-devel package required])])
 
 	AC_SUBST([ZLIB], ["-lz"])

--- a/lib/libefi/Makefile.am
+++ b/lib/libefi/Makefile.am
@@ -17,6 +17,6 @@ nodist_libefi_la_SOURCES = \
 	$(USER_C) \
 	$(KERNEL_C)
 
-libefi_la_LIBADD = $(LIBUUID) $(ZLIB)
+libefi_la_LIBADD = $(LIBUUID)
 
 EXTRA_DIST = $(USER_C)

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -36,7 +36,7 @@ libzfs_la_LIBADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libzpool/libzpool.la
 
-libzfs_la_LIBADD += -lm -ldl $(LIBBLKID)
+libzfs_la_LIBADD += -lm $(LIBBLKID)
 libzfs_la_LDFLAGS = -version-info 2:0:0
 
 EXTRA_DIST = $(libzfs_pc_DATA) $(USER_C)


### PR DESCRIPTION
I noticed during code review of zfsonlinux/zfs#4385 that the author of a
commit had peppered the various Makefile.am files with `$(TIRPC_LIBS)`
when putting it into `lib/libspl/Makefile.am` should have sufficed. Upon
further examination, it seems that he had copied what we do with
`$(ZLIB)`. We also have a bit of that with `-ldl` too.  Unfortunately,
what we do is wrong, so lets fix it to set a good example for future
contributors.

In addition, we have multiple `-lz` and `-lblkid` passed to the compiler
because each `AC_CHECK_LIB` adds it to `$LIBS`. That is somewhat
annoying to see, so we switch to `AC_SEARCH_LIBS` to avoid it.  This is
consistent with the recommendation to use `AC_SEARCH_LIBS` over
`AC_CHECK_LIB` by autotools upstream:

https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/Libraries.html

In an ideal world, this would translate into improvements in ELF's
DT_NEEDED entries, but that is not the case because of a couple of bugs
in libtool.

The first bug causes libtool to overlink by using static link 
dependencies for dynamic linking:

https://wiki.mageia.org/en/Overlinking_issues_in_packaging#libtool_issues

The workaround for this should be to pass `-Wl,--as-needed` in
`LDFLAGS`. That leads us to the second bug, where libtool passes
`LDFLAGS` after the libraries are specified and `ld` will only honor
`--as-needed` on libraries specified before it:

https://sigquit.wordpress.com/2011/02/16/why-asneeded-doesnt-work-as-expected-for-your-libraries-on-your-autotools-project/

There are a few possible workarounds for the second bug. One is to
either patch the compiler spec file to specify `-Wl,--as-needed` or pass
`-Wl,--as-needed` via `CC` like `CC='gcc -Wl,--as-needed'` so that it is
specified early. Another is to patch ltmain.sh like Gentoo does:

https://gitweb.gentoo.org/repo/gentoo.git/tree/eclass/ELT-patches/as-needed

Without one of those workarounds, this cleanup provides no benefit in
terms of DT_NEEDED entry generation. It should still be an improvement
because it nicely simplifies the code while encouraging good habits when
patching autotools scripts.

Signed-off-by: Richard Yao <ryao@gentoo.org>