### PR TITLE
Fix zdb -e and zhack thread_init()

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2331,7 +2331,15 @@ zpool_do_import(int argc, char **argv)
 	idata.cachefile = cachefile;
 	idata.scan = do_scan;
 
+	/*
+	 * Under Linux the zpool_find_import_impl() function leverages the
+	 * taskq implementation to parallelize device scanning.  It is
+	 * therefore necessary to initialize this functionality for the
+	 * duration of the zpool_search_import() function.
+	 */
+	thread_init();
 	pools = zpool_search_import(g_zfs, &idata);
+	thread_fini();
 
 	if (pools != NULL && idata.exists &&
 	    (argc == 1 || strcmp(argv[0], argv[1]) == 0)) {

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1392,6 +1392,7 @@ zpool_find_import_impl(libzfs_handle_t *hdl, importargs_t *iarg)
 			slice->rn_nozpool = B_FALSE;
 			avl_add(&slice_cache, slice);
 		}
+
 		/*
 		 * create a thread pool to do all of this in parallel;
 		 * rn_nozpool is not protected, so this is racy in that
@@ -1401,7 +1402,6 @@ zpool_find_import_impl(libzfs_handle_t *hdl, importargs_t *iarg)
 		 * locks in the kernel, so going beyond this doesn't
 		 * buy us much.
 		 */
-		thread_init();
 		t = taskq_create("z_import", 2 * boot_ncpus, defclsyspri,
 		    2 * boot_ncpus, INT_MAX, TASKQ_PREPOPULATE);
 		for (slice = avl_first(&slice_cache); slice;
@@ -1411,7 +1411,6 @@ zpool_find_import_impl(libzfs_handle_t *hdl, importargs_t *iarg)
 			    TQ_SLEEP);
 		taskq_wait(t);
 		taskq_destroy(t);
-		thread_fini();
 
 		cookie = NULL;
 		while ((slice = avl_destroy_nodes(&slice_cache,

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -301,19 +301,17 @@ tests = ['zpool_history_001_neg', 'zpool_history_002_pos']
 # DISABLED:
 # zpool_import_012_pos - sharenfs issue
 # zpool_import_all_001_pos - partition issue
-# zpool_import_features_001_pos - zhack issue
-# zpool_import_features_002_neg - zhack issue
-# zpool_import_features_003_pos - zhack issue
-# zpool_import_missing_001_pos - zhack_issue
-# zpool_import_missing_002_pos - zhack_issue
-# zpool_import_missing_003_pos - zhack_issue
-# zpool_import_rename_001_pos - hack issue
+# zpool_import_features_003_pos - zhack: invalid option -- 'r'
 [tests/functional/cli_root/zpool_import]
 tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'zpool_import_003_pos', 'zpool_import_004_pos', 'zpool_import_005_pos',
     'zpool_import_006_pos', 'zpool_import_007_pos', 'zpool_import_008_pos',
     'zpool_import_009_neg', 'zpool_import_010_pos', 'zpool_import_011_neg',
-    'zpool_import_013_neg']
+    'zpool_import_013_neg',
+    'zpool_import_features_001_pos', 'zpool_import_features_002_neg',
+    'zpool_import_missing_001_pos',
+    'zpool_import_missing_002_pos', 'zpool_import_missing_003_pos',
+    'zpool_import_rename_001_pos']
 
 [tests/functional/cli_root/zpool_offline]
 tests = ['zpool_offline_001_pos', 'zpool_offline_002_neg']
@@ -486,11 +484,12 @@ tests = ['nestedfs_001_pos']
 [tests/functional/no_space]
 tests = ['enospc_001_pos']
 
-# DISABLED: needs investigation (CentOS 7 only)
-#[tests/functional/nopwrite]
-#tests = ['nopwrite_copies', 'nopwrite_mtime', 'nopwrite_negative',
-#    'nopwrite_promoted_clone', 'nopwrite_recsize', 'nopwrite_sync',
-#    'nopwrite_volume', 'nopwrite_varying_compression']
+# DISABLED:
+# nopwrite_varying_compression - needs investigation
+[tests/functional/nopwrite]
+tests = ['nopwrite_copies', 'nopwrite_mtime', 'nopwrite_negative',
+    'nopwrite_promoted_clone', 'nopwrite_recsize', 'nopwrite_sync',
+    'nopwrite_volume']
 
 # DISABLED: needs investigation
 #[tests/functional/online_offline]
@@ -536,9 +535,8 @@ tests = ['refreserv_001_pos', 'refreserv_002_pos', 'refreserv_003_pos',
 #[tests/functional/rename_dirs]
 #tests = ['rename_dirs_001_pos']
 
-# DISABLED: nested pool
-#[tests/functional/replacement]
-#tests = ['replacement_001_pos', 'replacement_002_pos']
+[tests/functional/replacement]
+tests = ['replacement_001_pos', 'replacement_002_pos', 'replacement_003_pos']
 
 # DISABLED:
 # reservation_012_pos - needs investigation


### PR DESCRIPTION
This issue was caused by calling `thread_init()` and `thread_fini()`
multiple times resulting in `kthread_key` being invalid.  To resolve
the issue the explicit calls to `thread_init()` and `thread_fini()`
required by the `zpool` command have been moved in to the command.
Consumers such as `zdb` and `zhack` perform the same initialized
through `kernel_init()` and `kernel_fini()`.

Resolving this issue allows multiple additional test cases to
be enabled.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #4331