### PR TITLE
Use the correct macro to include backtrace

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -123,7 +123,7 @@
 #include <math.h>
 #include <sys/fs/zfs.h>
 #include <libnvpair.h>
-#ifdef __GNUC__
+#ifdef __GLIBC__
 #include <execinfo.h> /* for backtrace() */
 #endif
 
@@ -490,7 +490,7 @@ _umem_logging_init(void)
 static void sig_handler(int signo)
 {
 	struct sigaction action;
-#ifdef __GNUC__ /* backtrace() is a GNU extension */
+#ifdef __GLIBC__ /* backtrace() is a GNU extension */
 	int nptrs;
 	void *buffer[BACKTRACE_SZ];
 


### PR DESCRIPTION
execinfo.h and backtrace() are GNU extensions provided by glibc and not by gcc
http://www.gnu.org/software/libc/manual/html_mono/libc.html#Backtraces

Splitted from https://github.com/zfsonlinux/zfs/pull/4385