### PR TITLE
zloop.sh requires bash

### DIFF
--- a/scripts/zloop.sh
+++ b/scripts/zloop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # CDDL HEADER START


### PR DESCRIPTION
The zloop.sh script requires bash.  It will require further improvements
to be compatible with the alternatives such as dash.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>