### PR TITLE
Add missing fcntl.h to includes in mount_zfs.c

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -33,6 +33,7 @@
 #include <libzfs.h>
 #include <locale.h>
 #include <getopt.h>
+#include <fcntl.h>
 
 #define	ZS_COMMENT	0x00000000	/* comment */
 #define	ZS_ZFSUTIL	0x00000001	/* caller is zfs(8) */


### PR DESCRIPTION
this is needed for musl libc

This was missing from #4385