### PR TITLE
Set _DATE_FMT to '%+' if not defined in libspl/timestamp.c

### DIFF
--- a/lib/libspl/timestamp.c
+++ b/lib/libspl/timestamp.c
@@ -28,6 +28,10 @@
 #include <langinfo.h>
 #include "statcommon.h"
 
+#ifndef _DATE_FMT
+#define	_DATE_FMT "%+"
+#endif
+
 /*
  * Print timestamp as decimal reprentation of time_t value (-T u was specified)
  * or in date(1) format (-T d was specified).


### PR DESCRIPTION
this is needed for musl libc

Splitted from #4385