### PR TITLE
Move hrtime_t timestruc_t and timespec_t and change longlong_t to long long

### DIFF
--- a/lib/libspl/include/sys/time.h
+++ b/lib/libspl/include/sys/time.h
@@ -58,6 +58,11 @@
 #define	NSEC2MSEC(n)    ((n) / (NANOSEC / MILLISEC))
 #endif
 
+typedef	long long		hrtime_t;
+typedef	struct	timespec	timestruc_t;
+typedef	struct	timespec	timespec_t;
+
+
 extern hrtime_t gethrtime(void);
 extern void gethrestime(timestruc_t *);
 

--- a/lib/libspl/include/sys/types.h
+++ b/lib/libspl/include/sys/types.h
@@ -55,10 +55,6 @@ typedef longlong_t	diskaddr_t;
 typedef ulong_t		pgcnt_t;	/* number of pages */
 typedef long		spgcnt_t;	/* signed number of pages */
 
-typedef longlong_t	hrtime_t;
-typedef struct timespec	timestruc_t;
-typedef struct timespec timespec_t;
-
 typedef short		pri_t;
 
 typedef int		zoneid_t;


### PR DESCRIPTION
hrtime_t timestruc_t and timespec_t should have originally be included in
sys/time.h so lets move them.

longlong_t is not defined by any standard so change it to long long

Splitted from #4385