### PR TITLE
Fix zpool_scrub_* test cases

### DIFF
--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -379,6 +379,10 @@ zio_handle_io_delay(zio_t *zio)
 		if (handler->zi_record.zi_cmd != ZINJECT_DELAY_IO)
 			continue;
 
+		if (handler->zi_record.zi_freq != 0 &&
+		    spa_get_random(100) >= handler->zi_record.zi_freq);
+			continue;
+
 		if (vd->vdev_guid == handler->zi_record.zi_guid) {
 			seconds = handler->zi_record.zi_timer;
 			break;

--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -165,7 +165,7 @@ OPTIONS:
 	-k          Disable cleanup after test failure
 	-f          Use files only, disables block device tests
 	-d DIR      Use DIR for files and loopback devices
-	-s SIZE     Use vdevs of SIZE (default: 4G)
+	-s SIZE     Use vdevs of SIZE (default: 2G)
 	-r RUNFILE  Run tests in RUNFILE (default: linux.run)
 
 EXAMPLES:

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -327,11 +327,9 @@ tests = ['zpool_remove_001_neg', 'zpool_remove_002_pos']
 [tests/functional/cli_root/zpool_replace]
 tests = ['zpool_replace_001_neg']
 
-# DISABLED:
-# zpool_scrub_004_pos - needs investigation
-# zpool_scrub_005_pos - needs investigation
 [tests/functional/cli_root/zpool_scrub]
-tests = ['zpool_scrub_001_neg', 'zpool_scrub_002_pos', 'zpool_scrub_003_pos']
+tests = ['zpool_scrub_001_neg', 'zpool_scrub_002_pos', 'zpool_scrub_003_pos',
+    'zpool_scrub_004_pos', 'zpool_scrub_005_pos']
 
 [tests/functional/cli_root/zpool_set]
 tests = ['zpool_set_001_pos', 'zpool_set_002_neg', 'zpool_set_003_neg']

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_002_pos.ksh
@@ -26,6 +26,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
 
 #
 # DESCRIPTION:
@@ -36,13 +37,20 @@
 #	2. zpool scrub the pool
 #	3. Verify zpool scrub -s succeed when the system is scrubbing.
 #
+# NOTES:
+#	A 1 second delay is added to 10% of zio's in order to ensure that
+#	the scrub does not complete before it has a chance to be cancelled.
+#	This can occur when testing with small pools or very fast hardware.
+#
 
 verify_runnable "global"
 
 log_assert "Verify scrub -s works correctly."
 
+log_must $ZINJECT -d $DISK1 -f10 -D1 $TESTPOOL
 log_must $ZPOOL scrub $TESTPOOL
 log_must $ZPOOL scrub -s $TESTPOOL
 log_must is_pool_scrub_stopped $TESTPOOL
 
+log_must $ZINJECT -c all
 log_pass "Verify scrub -s works correctly."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_003_pos.ksh
@@ -26,6 +26,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
 
 #
 # DESCRIPTION:
@@ -37,6 +38,11 @@
 #	2. Kick off a scrub
 #	3. Check the completed percent and invoke another scrub
 #	4. Check the percent again, verify a new scrub started.
+#
+# NOTES:
+#	A 1 second delay is added to 10% of zio's in order to ensure that
+#	the scrub does not complete before it has a chance to be restarted.
+#	This can occur when testing with small pools or very fast hardware.
 #
 
 verify_runnable "global"
@@ -55,6 +61,7 @@ function get_scrub_percent
 log_assert "scrub command terminates the existing scrub process and starts" \
 	"a new scrub."
 
+log_must $ZINJECT -d $DISK1 -f10 -D1 $TESTPOOL
 log_must $ZPOOL scrub $TESTPOOL
 typeset -i PERCENT=30 percent=0
 while ((percent < PERCENT)) ; do
@@ -67,5 +74,6 @@ if ((percent > PERCENT)); then
 	log_fail "zpool scrub don't stop existing scrubbing process."
 fi
 
+log_must $ZINJECT -c all
 log_pass "scrub command terminates the existing scrub process and starts" \
 	"a new scrub."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
@@ -41,11 +41,16 @@
 #	2. Detach one of devices
 #	3. Verify scrub failed until the resilver completed
 #
+# NOTES:
+#	A 1 second delay is added to 10% of zio's in order to ensure that
+#	the resilver does not complete before the scrub can be issue.  This
+#	can occur when testing with small pools or very fast hardware.
 
 verify_runnable "global"
 
 log_assert "Resilver prevent scrub from starting until the resilver completes"
 
+log_must $ZINJECT -d $DISK1 -f10 -D1 $TESTPOOL
 log_must $ZPOOL detach $TESTPOOL $DISK2
 log_must $ZPOOL attach $TESTPOOL $DISK1 $DISK2
 log_must is_pool_resilvering $TESTPOOL
@@ -56,4 +61,5 @@ while ! is_pool_resilvered $TESTPOOL; do
 	$SLEEP 1
 done
 
+log_must $ZINJECT -c all
 log_pass "Resilver prevent scrub from starting until the resilver completes"


### PR DESCRIPTION
Fix zpool_scrub_* test cases
  
The zpool_scrub_002, zpool_scrub_003, zpool_scrub_004 test cases fail
reliably when running against small pools or fast storage.  This
occurs because the scrub/resilver operation completes before subsequent
commands can be run.
    
A one second delay has been added to 10% of zio's in order to ensure
the scrub/resilver operation will run for at least several seconds.