### PR TITLE
test zfsstress changes

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -6061,6 +6061,10 @@ main(int argc, char **argv)
 	opterr = 0;
 
 	/*
+	 * Spurious comment to provide commit for testing of zfsstress changes.
+	 */
+
+	/*
 	 * Make sure the user has specified some command.
 	 */
 	if (argc < 2) {


### PR DESCRIPTION
This commit just adds a comment to zpool.c:main().  Its purpose is to
test zfsstress changes against a known-good zfs codebase.

Changes tested here (in ofaaland/zfsstress branch
b_all_pulreqs_combined) are in pull requests 5, 6, 7, 8, and 9.

TEST_ZFSSTRESS_URL="https://github.com/ofaaland/zfsstress/archive/"
TEST_ZFSSTRESS_VER="b_all_pulreqs_combined.tar.gz"

Skip the other tests
TEST_FILEBENCH_SKIP="yes"
TEST_SPLAT_SKIP="yes"
TEST_XFSTESTS_SKIP="yes"
TEST_ZCONFIG_SKIP="yes"
TEST_ZFSTESTS_SKIP="yes"
TEST_ZILTEST_SKIP="yes"
TEST_ZIMPORT_SKIP="yes"
TEST_ZTEST_SKIP="yes"