### PR TITLE
make zfs test easier to run in local install

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -177,7 +177,7 @@ $0 -r linux-fast
 
 # Cleanup a previous run of the test suite prior to testing, run the
 # default (linux) suite of tests and perform no cleanup on exit.
-$0 -c
+$0 -x
 
 EOF
 }
@@ -248,6 +248,13 @@ fi
 
 if [ $(sudo whoami) != "root" ]; then
 	fail "Passwordless sudo access required."
+fi
+
+#
+# Check if ksh exists
+#
+if [ -z "$(which ksh 2>/dev/null)" ]; then
+	fail "This test suite requires ksh."
 fi
 
 #

--- a/tests/zfs-tests/include/default.cfg.in
+++ b/tests/zfs-tests/include/default.cfg.in
@@ -29,6 +29,20 @@
 #
 
 . $STF_SUITE/include/commands.cfg
+
+# Common paths
+bindir=@bindir@
+sbindir=@sbindir@
+
+# ZFS Commands
+export ZDB=${ZDB:-${sbindir}/zdb}
+export ZFS=${ZFS:-${sbindir}/zfs}
+export ZHACK=${ZHACK:-${sbindir}/zhack}
+export ZINJECT=${ZINJECT:-${sbindir}/zinject}
+export ZPOOL=${ZPOOL:-${sbindir}/zpool}
+export ZTEST=${ZTEST:-${sbindir}/ztest}
+export ZPIOS=${ZPIOS:-${sbindir}/zpios}
+
 . $STF_SUITE/include/libtest.shlib
 
 # Optionally override the installed ZFS commands to run in-tree
@@ -45,21 +59,8 @@ export RT_SHORT="1"
 export ZONE_POOL="zonepool"
 export ZONE_CTR="zonectr"
 
-# Common paths
-bindir=@bindir@
-sbindir=@sbindir@
-helperdir=@datarootdir@/@PACKAGE@/zfs-tests/bin
-
-# ZFS Commands
-ZDB=${ZDB:-${sbindir}/zdb}
-ZFS=${ZFS:-${sbindir}/zfs}
-ZHACK=${ZHACK:-${sbindir}/zhack}
-ZINJECT=${ZINJECT:-${sbindir}/zinject}
-ZPOOL=${ZPOOL:-${sbindir}/zpool}
-ZTEST=${ZTEST:-${sbindir}/ztest}
-ZPIOS=${ZPIOS:-${sbindir}/zpios}
-
 # Test Suite Specific Commands
+helperdir=@datarootdir@/@PACKAGE@/zfs-tests/bin
 export CHG_USR_EXEC=${CHG_USR_EXEC:-${helperdir}/chg_usr_exec}
 export DEVNAME2DEVID=${DEVNAME2DEVID:-${helperdir}/devname2devid}
 export DIR_RD_UPDATE=${DIR_RD_UPDATE:-${helperdir}/dir_rd_update}

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -31,13 +31,6 @@
 
 . ${STF_TOOLS}/include/logapi.shlib
 
-ZDB=${ZDB:-/sbin/zdb}
-ZFS=${ZFS:-/sbin/zfs}
-ZINJECT=${ZINJECT:-/sbin/zinject}
-ZHACK=${ZHACK:-/sbin/zhack}
-ZPOOL=${ZPOOL:-/sbin/zpool}
-ZTEST=${ZTEST:-/sbin/ztest}
-
 # Determine if this is a Linux test system
 #
 # Return 0 if platform Linux, 1 if otherwise


### PR DESCRIPTION
When ZFS is installed by 'make install', programs will be installed
into '/usr/local'. ZFS test scripts can't locate programs 'zpool'
that caused tests failure.

Signed-off-by: Jinshan Xiong <jinshan.xiong@intel.com>