### PR TITLE
Remove dummy znode from zvol_state

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -101,6 +101,7 @@
 #include <sys/zio.h>
 #include <sys/zil.h>
 #include <sys/zil_impl.h>
+#include <sys/zfs_rlock.h>
 #include <sys/vdev_impl.h>
 #include <sys/vdev_file.h>
 #include <sys/spa_impl.h>
@@ -231,15 +232,6 @@ typedef struct bufwad {
 	uint64_t	bw_data;
 } bufwad_t;
 
-/*
- * XXX -- fix zfs range locks to be generic so we can use them here.
- */
-typedef enum {
-	RL_READER,
-	RL_WRITER,
-	RL_APPEND
-} rl_type_t;
-
 typedef struct rll {
 	void		*rll_writer;
 	int		rll_readers;
@@ -247,12 +239,10 @@ typedef struct rll {
 	kcondvar_t	rll_cv;
 } rll_t;
 
-typedef struct rl {
-	uint64_t	rl_object;
-	uint64_t	rl_offset;
-	uint64_t	rl_size;
-	rll_t		*rl_lock;
-} rl_t;
+typedef struct zll {
+	list_t z_list;
+	kmutex_t z_lock;
+} zll_t;
 
 #define	ZTEST_RANGE_LOCKS	64
 #define	ZTEST_OBJECT_LOCKS	64
@@ -284,7 +274,7 @@ typedef struct ztest_ds {
 	char		zd_name[MAXNAMELEN];
 	kmutex_t	zd_dirobj_lock;
 	rll_t		zd_object_lock[ZTEST_OBJECT_LOCKS];
-	rll_t		zd_range_lock[ZTEST_RANGE_LOCKS];
+	zll_t		zd_range_lock[ZTEST_RANGE_LOCKS];
 } ztest_ds_t;
 
 /*
@@ -1133,6 +1123,100 @@ ztest_spa_prop_set_uint64(zpool_prop_t prop, uint64_t value)
 	return (error);
 }
 
+
+/*
+ * Object and range lock mechanics
+ */
+typedef struct {
+	list_node_t z_lnode;
+	refcount_t z_refcnt;
+	uint64_t z_object;
+	zfs_rlock_t z_range_lock;
+} ztest_znode_t;
+
+typedef struct {
+	rl_t *z_rl;
+	ztest_znode_t *z_ztznode;
+} ztest_zrl_t;
+
+static ztest_znode_t *
+ztest_znode_init(uint64_t object)
+{
+	ztest_znode_t *zp = umem_alloc(sizeof (*zp), UMEM_NOFAIL);
+
+	list_link_init(&zp->z_lnode);
+	refcount_create(&zp->z_refcnt);
+	zp->z_object = object;
+	zfs_rlock_init(&zp->z_range_lock);
+
+	return (zp);
+}
+
+static void
+ztest_znode_fini(ztest_znode_t *zp)
+{
+	ASSERT(refcount_is_zero(&zp->z_refcnt));
+	zfs_rlock_destroy(&zp->z_range_lock);
+	zp->z_object = 0;
+	refcount_destroy(&zp->z_refcnt);
+	list_link_init(&zp->z_lnode);
+	umem_free(zp, sizeof (*zp));
+}
+
+static void
+ztest_zll_init(zll_t *zll)
+{
+	mutex_init(&zll->z_lock, NULL, MUTEX_DEFAULT, NULL);
+	list_create(&zll->z_list, sizeof (ztest_znode_t),
+	    offsetof(ztest_znode_t, z_lnode));
+}
+
+static void
+ztest_zll_destroy(zll_t *zll)
+{
+	list_destroy(&zll->z_list);
+	mutex_destroy(&zll->z_lock);
+}
+
+#define	RL_TAG "range_lock"
+static ztest_znode_t *
+ztest_znode_get(ztest_ds_t *zd, uint64_t object)
+{
+	zll_t *zll = &zd->zd_range_lock[object & (ZTEST_OBJECT_LOCKS - 1)];
+	ztest_znode_t *zp = NULL;
+	mutex_enter(&zll->z_lock);
+	for (zp = list_head(&zll->z_list); (zp);
+	    zp = list_next(&zll->z_list, zp)) {
+		if (zp->z_object == object) {
+			refcount_add(&zp->z_refcnt, RL_TAG);
+			break;
+		}
+	}
+	if (zp == NULL) {
+		zp = ztest_znode_init(object);
+		refcount_add(&zp->z_refcnt, RL_TAG);
+		list_insert_head(&zll->z_list, zp);
+	}
+	mutex_exit(&zll->z_lock);
+	return (zp);
+}
+
+static void
+ztest_znode_put(ztest_ds_t *zd, ztest_znode_t *zp)
+{
+	zll_t *zll = NULL;
+	ASSERT3U(zp->z_object, !=, 0);
+	zll = &zd->zd_range_lock[zp->z_object & (ZTEST_OBJECT_LOCKS - 1)];
+	mutex_enter(&zll->z_lock);
+	refcount_remove(&zp->z_refcnt, RL_TAG);
+	if (refcount_is_zero(&zp->z_refcnt)) {
+		list_remove(&zll->z_list, zp);
+		ztest_znode_fini(zp);
+	}
+	mutex_exit(&zll->z_lock);
+}
+
+
 static void
 ztest_rll_init(rll_t *rll)
 {
@@ -1205,33 +1289,37 @@ ztest_object_unlock(ztest_ds_t *zd, uint64_t object)
 	ztest_rll_unlock(rll);
 }
 
-static rl_t *
-ztest_range_lock(ztest_ds_t *zd, uint64_t object, uint64_t offset,
-    uint64_t size, rl_type_t type)
+static ztest_zrl_t *
+ztest_zrl_init(rl_t *rl, ztest_znode_t *zp)
 {
-	uint64_t hash = object ^ (offset % (ZTEST_RANGE_LOCKS + 1));
-	rll_t *rll = &zd->zd_range_lock[hash & (ZTEST_RANGE_LOCKS - 1)];
-	rl_t *rl;
-
-	rl = umem_alloc(sizeof (*rl), UMEM_NOFAIL);
-	rl->rl_object = object;
-	rl->rl_offset = offset;
-	rl->rl_size = size;
-	rl->rl_lock = rll;
-
-	ztest_rll_lock(rll, type);
-
-	return (rl);
+	ztest_zrl_t *zrl = umem_alloc(sizeof (*zrl), UMEM_NOFAIL);
+	zrl->z_rl = rl;
+	zrl->z_ztznode = zp;
+	return (zrl);
 }
 
 static void
-ztest_range_unlock(rl_t *rl)
+ztest_zrl_fini(ztest_zrl_t *zrl)
 {
-	rll_t *rll = rl->rl_lock;
+	umem_free(zrl, sizeof (*zrl));
+}
 
-	ztest_rll_unlock(rll);
+static ztest_zrl_t *
+ztest_range_lock(ztest_ds_t *zd, uint64_t object, uint64_t offset,
+    uint64_t size, rl_type_t type)
+{
+	ztest_znode_t *zp = ztest_znode_get(zd, object);
+	rl_t *rl = zfs_range_lock(&zp->z_range_lock, offset,
+	    size, type);
+	return (ztest_zrl_init(rl, zp));
+}
 
-	umem_free(rl, sizeof (*rl));
+static void
+ztest_range_unlock(ztest_ds_t *zd, ztest_zrl_t *zrl)
+{
+	zfs_range_unlock(zrl->z_rl);
+	ztest_znode_put(zd, zrl->z_ztznode);
+	ztest_zrl_fini(zrl);
 }
 
 static void
@@ -1253,7 +1341,7 @@ ztest_zd_init(ztest_ds_t *zd, ztest_shared_ds_t *szd, objset_t *os)
 		ztest_rll_init(&zd->zd_object_lock[l]);
 
 	for (l = 0; l < ZTEST_RANGE_LOCKS; l++)
-		ztest_rll_init(&zd->zd_range_lock[l]);
+		ztest_zll_init(&zd->zd_range_lock[l]);
 }
 
 static void
@@ -1268,7 +1356,7 @@ ztest_zd_fini(ztest_ds_t *zd)
 		ztest_rll_destroy(&zd->zd_object_lock[l]);
 
 	for (l = 0; l < ZTEST_RANGE_LOCKS; l++)
-		ztest_rll_destroy(&zd->zd_range_lock[l]);
+		ztest_zll_destroy(&zd->zd_range_lock[l]);
 }
 
 #define	TXG_MIGHTWAIT	(ztest_random(10) == 0 ? TXG_NOWAIT : TXG_WAIT)
@@ -1625,7 +1713,7 @@ ztest_replay_write(ztest_ds_t *zd, lr_write_t *lr, boolean_t byteswap)
 	dmu_tx_t *tx;
 	dmu_buf_t *db;
 	arc_buf_t *abuf = NULL;
-	rl_t *rl;
+	ztest_zrl_t *rl;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -1674,7 +1762,7 @@ ztest_replay_write(ztest_ds_t *zd, lr_write_t *lr, boolean_t byteswap)
 		if (abuf != NULL)
 			dmu_return_arcbuf(abuf);
 		dmu_buf_rele(db, FTAG);
-		ztest_range_unlock(rl);
+		ztest_range_unlock(zd, rl);
 		ztest_object_unlock(zd, lr->lr_foid);
 		return (ENOSPC);
 	}
@@ -1731,7 +1819,7 @@ ztest_replay_write(ztest_ds_t *zd, lr_write_t *lr, boolean_t byteswap)
 
 	dmu_tx_commit(tx);
 
-	ztest_range_unlock(rl);
+	ztest_range_unlock(zd, rl);
 	ztest_object_unlock(zd, lr->lr_foid);
 
 	return (0);
@@ -1743,7 +1831,7 @@ ztest_replay_truncate(ztest_ds_t *zd, lr_truncate_t *lr, boolean_t byteswap)
 	objset_t *os = zd->zd_os;
 	dmu_tx_t *tx;
 	uint64_t txg;
-	rl_t *rl;
+	ztest_zrl_t *rl;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -1758,7 +1846,7 @@ ztest_replay_truncate(ztest_ds_t *zd, lr_truncate_t *lr, boolean_t byteswap)
 
 	txg = ztest_tx_assign(tx, TXG_WAIT, FTAG);
 	if (txg == 0) {
-		ztest_range_unlock(rl);
+		ztest_range_unlock(zd, rl);
 		ztest_object_unlock(zd, lr->lr_foid);
 		return (ENOSPC);
 	}
@@ -1770,7 +1858,7 @@ ztest_replay_truncate(ztest_ds_t *zd, lr_truncate_t *lr, boolean_t byteswap)
 
 	dmu_tx_commit(tx);
 
-	ztest_range_unlock(rl);
+	ztest_range_unlock(zd, rl);
 	ztest_object_unlock(zd, lr->lr_foid);
 
 	return (0);
@@ -1873,23 +1961,30 @@ zil_replay_func_t ztest_replay_vector[TX_MAX_TYPE] = {
 /*
  * ZIL get_data callbacks
  */
+typedef struct ztest_zgd_private {
+	ztest_ds_t *z_zd;
+	ztest_zrl_t *z_rl;
+	uint64_t z_object;
+} ztest_zgd_private_t;
 
 static void
 ztest_get_done(zgd_t *zgd, int error)
 {
-	ztest_ds_t *zd = zgd->zgd_private;
-	uint64_t object = zgd->zgd_rl->rl_object;
+	ztest_zgd_private_t *zzp = zgd->zgd_private;
+	ztest_ds_t *zd = zzp->z_zd;
+	uint64_t object = zzp->z_object;
 
 	if (zgd->zgd_db)
 		dmu_buf_rele(zgd->zgd_db, zgd);
 
-	ztest_range_unlock(zgd->zgd_rl);
+	ztest_range_unlock(zd, zzp->z_rl);
 	ztest_object_unlock(zd, object);
 
 	if (error == 0 && zgd->zgd_bp)
 		zil_add_block(zgd->zgd_zilog, zgd->zgd_bp);
 
 	umem_free(zgd, sizeof (*zgd));
+	umem_free(zzp, sizeof (*zzp));
 }
 
 static int
@@ -1907,6 +2002,7 @@ ztest_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 	dmu_buf_t *db;
 	zgd_t *zgd;
 	int error;
+	ztest_zgd_private_t *zgd_private;
 
 	ztest_object_lock(zd, object, RL_READER);
 	error = dmu_bonus_hold(os, object, FTAG, &db);
@@ -1929,10 +2025,13 @@ ztest_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 
 	zgd = umem_zalloc(sizeof (*zgd), UMEM_NOFAIL);
 	zgd->zgd_zilog = zd->zd_zilog;
-	zgd->zgd_private = zd;
+	zgd_private = umem_zalloc(sizeof (ztest_zgd_private_t), UMEM_NOFAIL);
+	zgd_private->z_zd = zd;
+	zgd_private->z_object = object;
+	zgd->zgd_private = zgd_private;
 
 	if (buf != NULL) {	/* immediate write */
-		zgd->zgd_rl = ztest_range_lock(zd, object, offset, size,
+		zgd_private->z_rl = ztest_range_lock(zd, object, offset, size,
 		    RL_READER);
 
 		error = dmu_read(os, object, offset, size, buf,
@@ -1947,7 +2046,7 @@ ztest_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 			offset = 0;
 		}
 
-		zgd->zgd_rl = ztest_range_lock(zd, object, offset, size,
+		zgd_private->z_rl = ztest_range_lock(zd, object, offset, size,
 		    RL_READER);
 
 		error = dmu_buf_hold(os, object, offset, zgd, &db,
@@ -2198,7 +2297,7 @@ ztest_prealloc(ztest_ds_t *zd, uint64_t object, uint64_t offset, uint64_t size)
 	objset_t *os = zd->zd_os;
 	dmu_tx_t *tx;
 	uint64_t txg;
-	rl_t *rl;
+	ztest_zrl_t *rl;
 
 	txg_wait_synced(dmu_objset_pool(os), 0);
 
@@ -2219,7 +2318,7 @@ ztest_prealloc(ztest_ds_t *zd, uint64_t object, uint64_t offset, uint64_t size)
 		(void) dmu_free_long_range(os, object, offset, size);
 	}
 
-	ztest_range_unlock(rl);
+	ztest_range_unlock(zd, rl);
 	ztest_object_unlock(zd, object);
 }
 

--- a/include/sys/trace_acl.h
+++ b/include/sys/trace_acl.h
@@ -63,7 +63,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __field(uint32_t,		z_sync_cnt)
 	    __field(mode_t,		z_mode)
 	    __field(boolean_t,		z_is_sa)
-	    __field(boolean_t,		z_is_zvol)
 	    __field(boolean_t,		z_is_mapped)
 	    __field(boolean_t,		z_is_ctldir)
 	    __field(boolean_t,		z_is_stale)
@@ -101,7 +100,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __entry->z_sync_cnt		= zn->z_sync_cnt;
 	    __entry->z_mode		= zn->z_mode;
 	    __entry->z_is_sa		= zn->z_is_sa;
-	    __entry->z_is_zvol		= zn->z_is_zvol;
 	    __entry->z_is_mapped	= zn->z_is_mapped;
 	    __entry->z_is_ctldir	= zn->z_is_ctldir;
 	    __entry->z_is_stale		= zn->z_is_stale;
@@ -125,7 +123,7 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    "zn_prefetch %u moved %u blksz %u seq %u "
 	    "mapcnt %llu gen %llu size %llu "
 	    "links %llu pflags %llu uid %llu gid %llu "
-	    "sync_cnt %u mode 0x%x is_sa %d is_zvol %d "
+	    "sync_cnt %u mode 0x%x is_sa %d "
 	    "is_mapped %d is_ctldir %d is_stale %d inode { "
 	    "ino %lu nlink %u version %llu size %lli blkbits %u "
 	    "bytes %u mode 0x%x generation %x } } ace { type %u "
@@ -136,7 +134,7 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __entry->z_size,
 	    __entry->z_links, __entry->z_pflags, __entry->z_uid,
 	    __entry->z_gid, __entry->z_sync_cnt, __entry->z_mode,
-	    __entry->z_is_sa, __entry->z_is_zvol, __entry->z_is_mapped,
+	    __entry->z_is_sa, __entry->z_is_mapped,
 	    __entry->z_is_ctldir, __entry->z_is_stale, __entry->i_ino,
 	    __entry->i_nlink, __entry->i_version, __entry->i_size,
 	    __entry->i_blkbits, __entry->i_bytes, __entry->i_mode,

--- a/include/sys/zfs_rlock.h
+++ b/include/sys/zfs_rlock.h
@@ -30,11 +30,14 @@
 extern "C" {
 #endif
 
-#ifdef _KERNEL
-
 #include <sys/list.h>
 #include <sys/avl.h>
+
+#ifdef _KERNEL
 #include <sys/condvar.h>
+#else
+#include <sys/zfs_context.h>
+#endif
 
 typedef enum {
 	RL_READER,
@@ -106,7 +109,6 @@ zfs_rlock_destroy(zfs_rlock_t *zrl)
 	avl_destroy(&zrl->zr_avl);
 	mutex_destroy(&zrl->zr_mutex);
 }
-#endif /* _KERNEL */
 
 #ifdef	__cplusplus
 }

--- a/include/sys/zfs_rlock.h
+++ b/include/sys/zfs_rlock.h
@@ -32,7 +32,9 @@ extern "C" {
 
 #ifdef _KERNEL
 
-#include <sys/zfs_znode.h>
+#include <sys/list.h>
+#include <sys/avl.h>
+#include <sys/condvar.h>
 
 typedef enum {
 	RL_READER,
@@ -40,8 +42,16 @@ typedef enum {
 	RL_APPEND
 } rl_type_t;
 
+typedef struct zfs_rlock {
+	kmutex_t zr_mutex;	/* protects changes to zr_avl */
+	avl_tree_t zr_avl;	/* avl tree of range locks */
+	uint64_t *zr_size;	/* points to znode->z_size */
+	uint_t *zr_blksz;	/* points to znode->z_blksz */
+	uint64_t *zr_max_blksz; /* points to zsb->z_max_blksz */
+} zfs_rlock_t;
+
 typedef struct rl {
-	znode_t *r_zp;		/* znode this lock applies to */
+	zfs_rlock_t *r_zrl;
 	avl_node_t r_node;	/* avl node link */
 	uint64_t r_off;		/* file range offset */
 	uint64_t r_len;		/* file range length */
@@ -61,7 +71,8 @@ typedef struct rl {
  * is converted to RL_WRITER that specified to lock from the start of the
  * end of file.  Returns the range lock structure.
  */
-rl_t *zfs_range_lock(znode_t *zp, uint64_t off, uint64_t len, rl_type_t type);
+rl_t *zfs_range_lock(zfs_rlock_t *zrl, uint64_t off, uint64_t len,
+    rl_type_t type);
 
 /* Unlock range and destroy range lock structure. */
 void zfs_range_unlock(rl_t *rl);
@@ -78,6 +89,23 @@ void zfs_range_reduce(rl_t *rl, uint64_t off, uint64_t len);
  */
 int zfs_range_compare(const void *arg1, const void *arg2);
 
+static inline void
+zfs_rlock_init(zfs_rlock_t *zrl)
+{
+	mutex_init(&zrl->zr_mutex, NULL, MUTEX_DEFAULT, NULL);
+	avl_create(&zrl->zr_avl, zfs_range_compare,
+	    sizeof (rl_t), offsetof(rl_t, r_node));
+	zrl->zr_size = NULL;
+	zrl->zr_blksz = NULL;
+	zrl->zr_max_blksz = NULL;
+}
+
+static inline void
+zfs_rlock_destroy(zfs_rlock_t *zrl)
+{
+	avl_destroy(&zrl->zr_avl);
+	mutex_destroy(&zrl->zr_mutex);
+}
 #endif /* _KERNEL */
 
 #ifdef	__cplusplus

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -37,6 +37,7 @@
 #include <sys/rrwlock.h>
 #include <sys/zfs_sa.h>
 #include <sys/zfs_stat.h>
+#include <sys/zfs_rlock.h>
 #endif
 #include <sys/zfs_acl.h>
 #include <sys/zil.h>
@@ -187,8 +188,7 @@ typedef struct znode {
 	krwlock_t	z_parent_lock;	/* parent lock for directories */
 	krwlock_t	z_name_lock;	/* "master" lock for dirent locks */
 	zfs_dirlock_t	*z_dirlocks;	/* directory entry lock list */
-	kmutex_t	z_range_lock;	/* protects changes to z_range_avl */
-	avl_tree_t	z_range_avl;	/* avl tree of file range locks */
+	zfs_rlock_t	z_range_lock;	/* file range lock */
 	uint8_t		z_unlinked;	/* file has been unlinked */
 	uint8_t		z_atime_dirty;	/* atime needs to be synced */
 	uint8_t		z_zn_prefetch;	/* Prefetch znodes? */
@@ -212,7 +212,6 @@ typedef struct znode {
 	list_node_t	z_link_node;	/* all znodes in fs link */
 	sa_handle_t	*z_sa_hdl;	/* handle to sa data */
 	boolean_t	z_is_sa;	/* are we native sa? */
-	boolean_t	z_is_zvol;	/* are we used by the zvol */
 	boolean_t	z_is_mapped;	/* are we mmap'ed */
 	boolean_t	z_is_ctldir;	/* are we .zfs entry */
 	boolean_t	z_is_stale;	/* are we stale due to rollback? */

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -103,6 +103,7 @@ KERNEL_C = \
 	zfs_fuid.c \
 	zfs_sa.c \
 	zfs_znode.c \
+	zfs_rlock.c \
 	zil.c \
 	zio.c \
 	zio_checksum.c \

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -485,7 +485,6 @@ zfsctl_inode_alloc(zfs_sb_t *zsb, uint64_t id,
 	zp->z_gid = 0;
 	zp->z_mode = 0;
 	zp->z_sync_cnt = 0;
-	zp->z_is_zvol = B_FALSE;
 	zp->z_is_mapped = B_FALSE;
 	zp->z_is_ctldir = B_TRUE;
 	zp->z_is_sa = B_FALSE;

--- a/module/zfs/zfs_rlock.c
+++ b/module/zfs/zfs_rlock.c
@@ -101,9 +101,9 @@
  * Check if a write lock can be grabbed, or wait and recheck until available.
  */
 static void
-zfs_range_lock_writer(znode_t *zp, rl_t *new)
+zfs_range_lock_writer(zfs_rlock_t *zrl, rl_t *new)
 {
-	avl_tree_t *tree = &zp->z_range_avl;
+	avl_tree_t *tree = &zrl->zr_avl;
 	rl_t *rl;
 	avl_index_t where;
 	uint64_t end_size;
@@ -112,32 +112,32 @@ zfs_range_lock_writer(znode_t *zp, rl_t *new)
 
 	for (;;) {
 		/*
-		 * Range locking is also used by zvol and uses a
-		 * dummied up znode. However, for zvol, we don't need to
-		 * append or grow blocksize, and besides we don't have
-		 * a "sa" data or zfs_sb_t - so skip that processing.
+		 * Range locking is also used by zvol. However, for zvol, we
+		 * don't need to append or grow blocksize, so skip that
+		 * processing.
 		 *
 		 * Yes, this is ugly, and would be solved by not handling
 		 * grow or append in range lock code. If that was done then
 		 * we could make the range locking code generically available
 		 * to other non-zfs consumers.
 		 */
-		if (!zp->z_is_zvol) { /* caller is ZPL */
+		if (zrl->zr_size) { /* caller is ZPL */
 			/*
 			 * If in append mode pick up the current end of file.
 			 * This is done under z_range_lock to avoid races.
 			 */
 			if (new->r_type == RL_APPEND)
-				new->r_off = zp->z_size;
+				new->r_off = *zrl->zr_size;
 
 			/*
 			 * If we need to grow the block size then grab the whole
 			 * file range. This is also done under z_range_lock to
 			 * avoid races.
 			 */
-			end_size = MAX(zp->z_size, new->r_off + len);
-			if (end_size > zp->z_blksz && (!ISP2(zp->z_blksz) ||
-			    zp->z_blksz < ZTOZSB(zp)->z_max_blksz)) {
+			end_size = MAX(*zrl->zr_size, new->r_off + len);
+			if (end_size > *zrl->zr_blksz &&
+			    (!ISP2(*zrl->zr_blksz) ||
+			    *zrl->zr_blksz < *zrl->zr_max_blksz)) {
 				new->r_off = 0;
 				new->r_len = UINT64_MAX;
 			}
@@ -175,7 +175,7 @@ wait:
 			cv_init(&rl->r_wr_cv, NULL, CV_DEFAULT, NULL);
 			rl->r_write_wanted = B_TRUE;
 		}
-		cv_wait(&rl->r_wr_cv, &zp->z_range_lock);
+		cv_wait(&rl->r_wr_cv, &zrl->zr_mutex);
 
 		/* reset to original */
 		new->r_off = off;
@@ -353,9 +353,9 @@ zfs_range_add_reader(avl_tree_t *tree, rl_t *new, rl_t *prev, avl_index_t where)
  * Check if a reader lock can be grabbed, or wait and recheck until available.
  */
 static void
-zfs_range_lock_reader(znode_t *zp, rl_t *new)
+zfs_range_lock_reader(zfs_rlock_t *zrl, rl_t *new)
 {
-	avl_tree_t *tree = &zp->z_range_avl;
+	avl_tree_t *tree = &zrl->zr_avl;
 	rl_t *prev, *next;
 	avl_index_t where;
 	uint64_t off = new->r_off;
@@ -378,7 +378,7 @@ retry:
 				cv_init(&prev->r_rd_cv, NULL, CV_DEFAULT, NULL);
 				prev->r_read_wanted = B_TRUE;
 			}
-			cv_wait(&prev->r_rd_cv, &zp->z_range_lock);
+			cv_wait(&prev->r_rd_cv, &zrl->zr_mutex);
 			goto retry;
 		}
 		if (off + len < prev->r_off + prev->r_len)
@@ -401,7 +401,7 @@ retry:
 				cv_init(&next->r_rd_cv, NULL, CV_DEFAULT, NULL);
 				next->r_read_wanted = B_TRUE;
 			}
-			cv_wait(&next->r_rd_cv, &zp->z_range_lock);
+			cv_wait(&next->r_rd_cv, &zrl->zr_mutex);
 			goto retry;
 		}
 		if (off + len <= next->r_off + next->r_len)
@@ -423,14 +423,14 @@ got_lock:
  * previously locked as RL_WRITER).
  */
 rl_t *
-zfs_range_lock(znode_t *zp, uint64_t off, uint64_t len, rl_type_t type)
+zfs_range_lock(zfs_rlock_t *zrl, uint64_t off, uint64_t len, rl_type_t type)
 {
 	rl_t *new;
 
 	ASSERT(type == RL_READER || type == RL_WRITER || type == RL_APPEND);
 
 	new = kmem_alloc(sizeof (rl_t), KM_SLEEP);
-	new->r_zp = zp;
+	new->r_zrl = zrl;
 	new->r_off = off;
 	if (len + off < off)	/* overflow */
 		len = UINT64_MAX - off;
@@ -441,18 +441,18 @@ zfs_range_lock(znode_t *zp, uint64_t off, uint64_t len, rl_type_t type)
 	new->r_write_wanted = B_FALSE;
 	new->r_read_wanted = B_FALSE;
 
-	mutex_enter(&zp->z_range_lock);
+	mutex_enter(&zrl->zr_mutex);
 	if (type == RL_READER) {
 		/*
 		 * First check for the usual case of no locks
 		 */
-		if (avl_numnodes(&zp->z_range_avl) == 0)
-			avl_add(&zp->z_range_avl, new);
+		if (avl_numnodes(&zrl->zr_avl) == 0)
+			avl_add(&zrl->zr_avl, new);
 		else
-			zfs_range_lock_reader(zp, new);
-	} else
-		zfs_range_lock_writer(zp, new); /* RL_WRITER or RL_APPEND */
-	mutex_exit(&zp->z_range_lock);
+			zfs_range_lock_reader(zrl, new);
+	} else /* RL_WRITER or RL_APPEND */
+		zfs_range_lock_writer(zrl, new);
+	mutex_exit(&zrl->zr_mutex);
 	return (new);
 }
 
@@ -474,9 +474,9 @@ zfs_range_free(void *arg)
  * Unlock a reader lock
  */
 static void
-zfs_range_unlock_reader(znode_t *zp, rl_t *remove, list_t *free_list)
+zfs_range_unlock_reader(zfs_rlock_t *zrl, rl_t *remove, list_t *free_list)
 {
-	avl_tree_t *tree = &zp->z_range_avl;
+	avl_tree_t *tree = &zrl->zr_avl;
 	rl_t *rl, *next = NULL;
 	uint64_t len;
 
@@ -543,7 +543,7 @@ zfs_range_unlock_reader(znode_t *zp, rl_t *remove, list_t *free_list)
 void
 zfs_range_unlock(rl_t *rl)
 {
-	znode_t *zp = rl->r_zp;
+	zfs_rlock_t *zrl = rl->r_zrl;
 	list_t free_list;
 	rl_t *free_rl;
 
@@ -552,10 +552,10 @@ zfs_range_unlock(rl_t *rl)
 	ASSERT(!rl->r_proxy);
 	list_create(&free_list, sizeof (rl_t), offsetof(rl_t, rl_node));
 
-	mutex_enter(&zp->z_range_lock);
+	mutex_enter(&zrl->zr_mutex);
 	if (rl->r_type == RL_WRITER) {
 		/* writer locks can't be shared or split */
-		avl_remove(&zp->z_range_avl, rl);
+		avl_remove(&zrl->zr_avl, rl);
 		if (rl->r_write_wanted)
 			cv_broadcast(&rl->r_wr_cv);
 
@@ -568,9 +568,9 @@ zfs_range_unlock(rl_t *rl)
 		 * lock may be shared, let zfs_range_unlock_reader()
 		 * release the zp->z_range_lock lock and free the rl_t
 		 */
-		zfs_range_unlock_reader(zp, rl, &free_list);
+		zfs_range_unlock_reader(zrl, rl, &free_list);
 	}
-	mutex_exit(&zp->z_range_lock);
+	mutex_exit(&zrl->zr_mutex);
 
 	while ((free_rl = list_head(&free_list)) != NULL) {
 		list_remove(&free_list, free_rl);
@@ -588,17 +588,17 @@ zfs_range_unlock(rl_t *rl)
 void
 zfs_range_reduce(rl_t *rl, uint64_t off, uint64_t len)
 {
-	znode_t *zp = rl->r_zp;
+	zfs_rlock_t *zrl = rl->r_zrl;
 
 	/* Ensure there are no other locks */
-	ASSERT(avl_numnodes(&zp->z_range_avl) == 1);
+	ASSERT(avl_numnodes(&zrl->zr_avl) == 1);
 	ASSERT(rl->r_off == 0);
 	ASSERT(rl->r_type == RL_WRITER);
 	ASSERT(!rl->r_proxy);
 	ASSERT3U(rl->r_len, ==, UINT64_MAX);
 	ASSERT3U(rl->r_cnt, ==, 1);
 
-	mutex_enter(&zp->z_range_lock);
+	mutex_enter(&zrl->zr_mutex);
 	rl->r_off = off;
 	rl->r_len = len;
 
@@ -607,7 +607,7 @@ zfs_range_reduce(rl_t *rl, uint64_t off, uint64_t len)
 	if (rl->r_read_wanted)
 		cv_broadcast(&rl->r_rd_cv);
 
-	mutex_exit(&zp->z_range_lock);
+	mutex_exit(&zrl->zr_mutex);
 }
 
 /*

--- a/module/zfs/zfs_rlock.c
+++ b/module/zfs/zfs_rlock.c
@@ -626,3 +626,10 @@ zfs_range_compare(const void *arg1, const void *arg2)
 		return (-1);
 	return (0);
 }
+
+#ifdef _KERNEL
+EXPORT_SYMBOL(zfs_range_lock);
+EXPORT_SYMBOL(zfs_range_unlock);
+EXPORT_SYMBOL(zfs_range_reduce);
+EXPORT_SYMBOL(zfs_range_compare);
+#endif

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -483,7 +483,8 @@ zfs_read(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 	/*
 	 * Lock the range against changes.
 	 */
-	rl = zfs_range_lock(zp, uio->uio_loffset, uio->uio_resid, RL_READER);
+	rl = zfs_range_lock(&zp->z_range_lock, uio->uio_loffset, uio->uio_resid,
+	    RL_READER);
 
 	/*
 	 * If we are reading past end-of-file we can skip
@@ -673,7 +674,7 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 		 * Obtain an appending range lock to guarantee file append
 		 * semantics.  We reset the write offset once we have the lock.
 		 */
-		rl = zfs_range_lock(zp, 0, n, RL_APPEND);
+		rl = zfs_range_lock(&zp->z_range_lock, 0, n, RL_APPEND);
 		woff = rl->r_off;
 		if (rl->r_len == UINT64_MAX) {
 			/*
@@ -690,7 +691,7 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 		 * this write, then this range lock will lock the entire file
 		 * so that we can re-write the block safely.
 		 */
-		rl = zfs_range_lock(zp, woff, n, RL_WRITER);
+		rl = zfs_range_lock(&zp->z_range_lock, woff, n, RL_WRITER);
 	}
 
 	if (woff >= limit) {
@@ -1016,7 +1017,8 @@ zfs_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 	 * we don't have to write the data twice.
 	 */
 	if (buf != NULL) { /* immediate write */
-		zgd->zgd_rl = zfs_range_lock(zp, offset, size, RL_READER);
+		zgd->zgd_rl = zfs_range_lock(&zp->z_range_lock, offset, size,
+		    RL_READER);
 		/* test for truncation needs to be done while range locked */
 		if (offset >= zp->z_size) {
 			error = SET_ERROR(ENOENT);
@@ -1037,8 +1039,8 @@ zfs_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 			size = zp->z_blksz;
 			blkoff = ISP2(size) ? P2PHASE(offset, size) : offset;
 			offset -= blkoff;
-			zgd->zgd_rl = zfs_range_lock(zp, offset, size,
-			    RL_READER);
+			zgd->zgd_rl = zfs_range_lock(&zp->z_range_lock, offset,
+			    size, RL_READER);
 			if (zp->z_blksz == size)
 				break;
 			offset += blkoff;
@@ -4007,7 +4009,7 @@ zfs_putpage(struct inode *ip, struct page *pp, struct writeback_control *wbc)
 	redirty_page_for_writepage(wbc, pp);
 	unlock_page(pp);
 
-	rl = zfs_range_lock(zp, pgoff, pglen, RL_WRITER);
+	rl = zfs_range_lock(&zp->z_range_lock, pgoff, pglen, RL_WRITER);
 	lock_page(pp);
 
 	/* Page mapping changed or it was no longer dirty, we're done */

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -113,9 +113,7 @@ zfs_znode_cache_constructor(void *buf, void *arg, int kmflags)
 	mutex_init(&zp->z_acl_lock, NULL, MUTEX_DEFAULT, NULL);
 	rw_init(&zp->z_xattr_lock, NULL, RW_DEFAULT, NULL);
 
-	mutex_init(&zp->z_range_lock, NULL, MUTEX_DEFAULT, NULL);
-	avl_create(&zp->z_range_avl, zfs_range_compare,
-	    sizeof (rl_t), offsetof(rl_t, r_node));
+	zfs_rlock_init(&zp->z_range_lock);
 
 	zp->z_dirlocks = NULL;
 	zp->z_acl_cached = NULL;
@@ -137,8 +135,7 @@ zfs_znode_cache_destructor(void *buf, void *arg)
 	rw_destroy(&zp->z_name_lock);
 	mutex_destroy(&zp->z_acl_lock);
 	rw_destroy(&zp->z_xattr_lock);
-	avl_destroy(&zp->z_range_avl);
-	mutex_destroy(&zp->z_range_lock);
+	zfs_rlock_destroy(&zp->z_range_lock);
 
 	ASSERT(zp->z_dirlocks == NULL);
 	ASSERT(zp->z_acl_cached == NULL);
@@ -615,10 +612,12 @@ zfs_znode_alloc(zfs_sb_t *zsb, dmu_buf_t *db, int blksz,
 	zp->z_blksz = blksz;
 	zp->z_seq = 0x7A4653;
 	zp->z_sync_cnt = 0;
-	zp->z_is_zvol = B_FALSE;
 	zp->z_is_mapped = B_FALSE;
 	zp->z_is_ctldir = B_FALSE;
 	zp->z_is_stale = B_FALSE;
+	zp->z_range_lock.zr_size = &zp->z_size;
+	zp->z_range_lock.zr_blksz = &zp->z_blksz;
+	zp->z_range_lock.zr_max_blksz = &ZTOZSB(zp)->z_max_blksz;
 
 	zfs_znode_sa_init(zsb, zp, db, obj_type, hdl);
 
@@ -1403,7 +1402,7 @@ zfs_extend(znode_t *zp, uint64_t end)
 	/*
 	 * We will change zp_size, lock the whole file.
 	 */
-	rl = zfs_range_lock(zp, 0, UINT64_MAX, RL_WRITER);
+	rl = zfs_range_lock(&zp->z_range_lock, 0, UINT64_MAX, RL_WRITER);
 
 	/*
 	 * Nothing to do if file already at desired length.
@@ -1520,7 +1519,7 @@ zfs_free_range(znode_t *zp, uint64_t off, uint64_t len)
 	/*
 	 * Lock the range being freed.
 	 */
-	rl = zfs_range_lock(zp, off, len, RL_WRITER);
+	rl = zfs_range_lock(&zp->z_range_lock, off, len, RL_WRITER);
 
 	/*
 	 * Nothing to do if file already at desired length.
@@ -1602,7 +1601,7 @@ zfs_trunc(znode_t *zp, uint64_t end)
 	/*
 	 * We will change zp_size, lock the whole file.
 	 */
-	rl = zfs_range_lock(zp, 0, UINT64_MAX, RL_WRITER);
+	rl = zfs_range_lock(&zp->z_range_lock, 0, UINT64_MAX, RL_WRITER);
 
 	/*
 	 * Nothing to do if file already at desired length.


### PR DESCRIPTION
struct zvol_state contains a dummy znode, which is around 1KB on x64, only for
zfs_range_lock. But in reality, other than z_range_lock and z_range_avl,
zfs_range_lock only need znode on regular file, which means we add 1KB on a
structure and gain nothing.

In this patch, we remove the dummy znode for zvol_state. In order to do that,
we also need to refactor zfs_range_lock a bit. We move z_range_lock and
z_range_avl pair out of znode_t to form zfs_rlock_t. This new struct replaces
znode_t as the main handle inside the range lock functions. Since regular
files still need znode for RL_WRITER and RL_APPEND, we make znode an optional
argument in zfs_range_lock_impl.

To reduce possible merge conflict, we retain the prototype of zfs_range_lock.
And zvol now should call zvol_range_lock instead.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>