### PR TITLE
remove sanity check in replacement test

### DIFF
--- a/tests/zfs-tests/tests/functional/replacement/replacement_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/replacement_001_pos.ksh
@@ -99,9 +99,6 @@ function replace_test
 		typeset pid=$!
 
 		$SLEEP 1
-		if ! $PS -p $pid > /dev/null 2>&1; then
-			log_fail "$FILE_TRUNC $options $TESTDIR/$TESTFILE.$i"
-		fi
 
 		child_pids="$child_pids $pid"
 		((i = i + 1))

--- a/tests/zfs-tests/tests/functional/replacement/replacement_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/replacement_002_pos.ksh
@@ -99,9 +99,6 @@ function attach_test
 		typeset pid=$!
 
 		$SLEEP 1
-		if ! $PS -p $pid > /dev/null 2>&1; then
-			log_fail "$FILE_TRUNC $options $TESTDIR/$TESTFILE.$i"
-		fi
 
 		child_pids="$child_pids $pid"
 		((i = i + 1))

--- a/tests/zfs-tests/tests/functional/replacement/replacement_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/replacement_003_pos.ksh
@@ -97,9 +97,6 @@ function detach_test
 		typeset pid=$!
 
 		$SLEEP 1
-		if ! $PS -p $pid > /dev/null 2>&1; then
-			log_fail "$FILE_TRUNC $options $TESTDIR/$TESTFILE.$i"
-		fi
 
 		child_pids="$child_pids $pid"
 		((i = i + 1))


### PR DESCRIPTION
In replacement test, it spawns a process to truncate a file background
and make sure that the process exists 1 second later. However, the
process may have finished its work and exited therefore it has the
chance to report a false alarm.

This patch just removed those sanity check.

Signed-off-by: Jinshan Xiong <jinshan.xiong@intel.com>