### PR TITLE
Improved libblkid/libudev integration

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -6055,6 +6055,7 @@ main(int argc, char **argv)
 
 	(void) setlocale(LC_ALL, "");
 	(void) textdomain(TEXT_DOMAIN);
+	srand(time(NULL));
 
 	dprintf_setup(&argc, argv);
 

--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -171,11 +171,7 @@ struct dk_map2  default_vtoc_map[NDKMAP] = {
 #endif			/* defined(_SUNOS_VTOC_16) */
 };
 
-#ifdef DEBUG
-int efi_debug = 1;
-#else
 int efi_debug = 0;
-#endif
 
 static int efi_read(int, struct dk_gpt *);
 

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -99,14 +99,14 @@ typedef struct pool_list {
 	name_entry_t		*names;
 } pool_list_t;
 
+#define	DEV_BYID_PATH	"/dev/disk/by-id/"
+
 /*
  * Linux persistent device strings for vdev labels
  *
  * based on libudev for consistency with libudev disk add/remove events
  */
 #ifdef HAVE_LIBUDEV
-
-#define	DEV_BYID_PATH	"/dev/disk/by-id/"
 
 typedef struct vdev_dev_strs {
 	char	vds_devid[128];
@@ -536,7 +536,6 @@ update_vdev_config_dev_strs(nvlist_t *nv)
 
 #endif /* HAVE_LIBUDEV */
 
-
 /*
  * Go through and fix up any path and/or devid information for the given vdev
  * configuration.
@@ -577,7 +576,6 @@ fix_paths(nvlist_t *nv, name_entry_t *names)
 	best = NULL;
 	for (ne = names; ne != NULL; ne = ne->ne_next) {
 		if (ne->ne_guid == guid) {
-
 			if (path == NULL) {
 				best = ne;
 				break;
@@ -760,6 +758,116 @@ add_config(libzfs_handle_t *hdl, pool_list_t *pl, const char *path,
 	pl->names = ne;
 
 	return (0);
+}
+
+static int
+add_path(libzfs_handle_t *hdl, pool_list_t *pools, uint64_t pool_guid,
+    uint64_t vdev_guid, const char *path, int order)
+{
+	nvlist_t *label;
+	uint64_t guid;
+	int error, fd, num_labels;
+
+	fd = open64(path, O_RDONLY);
+	if (fd < 0)
+		return (errno);
+
+	error = zpool_read_label(fd, &label, &num_labels);
+	close(fd);
+
+	if (error || label == NULL)
+		return (ENOENT);
+
+	error = nvlist_lookup_uint64(label, ZPOOL_CONFIG_POOL_GUID, &guid);
+	if (error || guid != pool_guid) {
+		nvlist_free(label);
+		return (EINVAL);
+	}
+
+	error = nvlist_lookup_uint64(label, ZPOOL_CONFIG_GUID, &guid);
+	if (error || guid != vdev_guid) {
+		nvlist_free(label);
+		return (EINVAL);
+	}
+
+	error = add_config(hdl, pools, path, order, num_labels, label);
+
+	return (error);
+}
+
+static int
+add_configs_from_label_impl(libzfs_handle_t *hdl, pool_list_t *pools,
+    nvlist_t *nvroot, uint64_t pool_guid, uint64_t vdev_guid)
+{
+	char udevpath[MAXPATHLEN];
+	char *path;
+	nvlist_t **child;
+	uint_t c, children;
+	uint64_t guid;
+	int error;
+
+	if (nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
+	    &child, &children) == 0) {
+		for (c = 0; c < children; c++) {
+			error  = add_configs_from_label_impl(hdl, pools,
+			    child[c], pool_guid, vdev_guid);
+			if (error)
+				return (error);
+		}
+		return (0);
+	}
+
+	if (nvroot == NULL)
+		return (0);
+
+	error = nvlist_lookup_uint64(nvroot, ZPOOL_CONFIG_GUID, &guid);
+	if ((error != 0) || (guid != vdev_guid))
+		return (0);
+
+	error = nvlist_lookup_string(nvroot, ZPOOL_CONFIG_PATH, &path);
+	if (error == 0)
+		(void) add_path(hdl, pools, pool_guid, vdev_guid, path, 0);
+
+	error = nvlist_lookup_string(nvroot, ZPOOL_CONFIG_DEVID, &path);
+	if (error == 0) {
+		sprintf(udevpath, "%s%s", DEV_BYID_PATH, path);
+		(void) add_path(hdl, pools, pool_guid, vdev_guid, udevpath, 1);
+	}
+
+	return (0);
+}
+
+/*
+ * Given a disk label call add_config() for all known paths to the device
+ * as described by the label itself.  The paths are added in the following
+ * priority order: 'path', 'devid', 'devnode'.  As these alternate paths are
+ * added the labels are verified to make sure they refer to the same device.
+ */
+static int
+add_configs_from_label(libzfs_handle_t *hdl, pool_list_t *pools,
+    char *devname, int num_labels, nvlist_t *label)
+{
+	nvlist_t *nvroot;
+	uint64_t pool_guid;
+	uint64_t vdev_guid;
+	int error;
+
+	if (nvlist_lookup_nvlist(label, ZPOOL_CONFIG_VDEV_TREE, &nvroot) ||
+	    nvlist_lookup_uint64(label, ZPOOL_CONFIG_POOL_GUID, &pool_guid) ||
+	    nvlist_lookup_uint64(label, ZPOOL_CONFIG_GUID, &vdev_guid))
+		return (ENOENT);
+
+	/* Allow devlinks to stabilize so all paths are available. */
+	zpool_label_disk_wait(devname, DISK_LABEL_WAIT);
+
+	/* Add alternate paths as described by the label vdev_tree. */
+	(void) add_configs_from_label_impl(hdl, pools, nvroot,
+	    pool_guid, vdev_guid);
+
+	/* Add the device node /dev/sdX path as a last resort. */
+	error = add_config(hdl, pools, devname, 100, num_labels, label);
+
+	return (error);
 }
 
 /*
@@ -1609,9 +1717,7 @@ zpool_find_import_blkid(libzfs_handle_t *hdl, pool_list_t *pools)
 	blkid_cache cache;
 	blkid_dev_iterate iter;
 	blkid_dev dev;
-	const char *devname;
-	nvlist_t *config;
-	int fd, err, num_labels;
+	int err;
 
 	err = blkid_get_cache(&cache, NULL);
 	if (err != 0) {
@@ -1642,25 +1748,23 @@ zpool_find_import_blkid(libzfs_handle_t *hdl, pool_list_t *pools)
 	}
 
 	while (blkid_dev_next(iter, &dev) == 0) {
-		devname = blkid_dev_devname(dev);
+		nvlist_t *label;
+		char *devname;
+		int fd, num_labels;
+
+		devname = (char *) blkid_dev_devname(dev);
 		if ((fd = open64(devname, O_RDONLY)) < 0)
 			continue;
 
-		err = zpool_read_label(fd, &config, &num_labels);
+		err = zpool_read_label(fd, &label, &num_labels);
 		(void) close(fd);
 
-		if (err != 0) {
-			(void) no_memory(hdl);
-			goto err_blkid3;
-		}
+		if (err || label == NULL)
+			continue;
 
-		if (config != NULL) {
-			err = add_config(hdl, pools, devname, 0,
-			    num_labels, config);
-			if (err != 0)
-				goto err_blkid3;
-		}
+		add_configs_from_label(hdl, pools, devname, num_labels, label);
 	}
+	err = 0;
 
 err_blkid3:
 	blkid_dev_iterate_end(iter);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4122,30 +4122,7 @@ find_start_block(nvlist_t *config)
 	return (MAXOFFSET_T);
 }
 
-int
-zpool_label_disk_wait(char *path, int timeout)
-{
-	struct stat64 statbuf;
-	int i;
-
-	/*
-	 * Wait timeout miliseconds for a newly created device to be available
-	 * from the given path.  There is a small window when a /dev/ device
-	 * will exist and the udev link will not, so we must wait for the
-	 * symlink.  Depending on the udev rules this may take a few seconds.
-	 */
-	for (i = 0; i < timeout; i++) {
-		usleep(1000);
-
-		errno = 0;
-		if ((stat64(path, &statbuf) == 0) && (errno == 0))
-			return (0);
-	}
-
-	return (ENOENT);
-}
-
-int
+static int
 zpool_label_disk_check(char *path)
 {
 	struct dk_gpt *vtoc;
@@ -4310,12 +4287,11 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 	(void) close(fd);
 	efi_free(vtoc);
 
-	/* Wait for the first expected partition to appear. */
-
 	(void) snprintf(path, sizeof (path), "%s/%s", DISK_ROOT, name);
 	(void) zfs_append_partition(path, MAXPATHLEN);
 
-	rval = zpool_label_disk_wait(path, 3000);
+	/* Wait to udev to signal use the device has settled. */
+	rval = zpool_label_disk_wait(path, DISK_LABEL_WAIT);
 	if (rval) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "failed to "
 		    "detect device partitions on '%s': %d"), path, rval);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4171,6 +4171,32 @@ zpool_label_disk_check(char *path)
 }
 
 /*
+ * Generate a unique partition name for the ZFS member.  Partitions must
+ * have unique names to ensure udev will be able to create symlinks under
+ * /dev/disk/by-partlabel/ for all pool members.  The partition names are
+ * of the form <pool>-<unique-id>.
+ */
+static void
+zpool_label_name(char *label_name, int label_size)
+{
+	uint64_t id = 0;
+	int fd;
+
+	fd = open("/dev/urandom", O_RDONLY);
+	if (fd > 0) {
+		if (read(fd, &id, sizeof (id)) != sizeof (id))
+			id = 0;
+
+		close(fd);
+	}
+
+	if (id == 0)
+		id = (((uint64_t)rand()) << 32) | (uint64_t)rand();
+
+	snprintf(label_name, label_size, "zfs-%016llx", (u_longlong_t) id);
+}
+
+/*
  * Label an individual disk.  The name provided is the short name,
  * stripped of any leading /dev path.
  */
@@ -4260,7 +4286,7 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 	 * can get, in the absence of V_OTHER.
 	 */
 	vtoc->efi_parts[0].p_tag = V_USR;
-	(void) strcpy(vtoc->efi_parts[0].p_name, "zfs");
+	zpool_label_name(vtoc->efi_parts[0].p_name, EFI_PART_NAME_LEN);
 
 	vtoc->efi_parts[8].p_start = slice_size + start_block;
 	vtoc->efi_parts[8].p_size = resv;

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -244,12 +244,12 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 {
 	struct block_device *bdev = ERR_PTR(-ENXIO);
 	vdev_disk_t *vd;
-	int mode, block_size;
+	int count = 0, mode, block_size;
 
 	/* Must have a pathname and it must be absolute. */
 	if (v->vdev_path == NULL || v->vdev_path[0] != '/') {
 		v->vdev_stat.vs_aux = VDEV_AUX_BAD_LABEL;
-		return (EINVAL);
+		return (SET_ERROR(EINVAL));
 	}
 
 	/*
@@ -264,7 +264,7 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 
 	vd = kmem_zalloc(sizeof (vdev_disk_t), KM_SLEEP);
 	if (vd == NULL)
-		return (ENOMEM);
+		return (SET_ERROR(ENOMEM));
 
 	/*
 	 * Devices are always opened by the path provided at configuration
@@ -279,16 +279,35 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 	 * /dev/[hd]d devices which may be reordered due to probing order.
 	 * Devices in the wrong locations will be detected by the higher
 	 * level vdev validation.
+	 *
+	 * The specified paths may be briefly removed and recreated in
+	 * response to udev events.  This should be exceptionally unlikely
+	 * because the zpool command makes every effort to verify these paths
+	 * have already settled prior to reaching this point.  Therefore,
+	 * a ENOENT failure at this point is highly likely to be transient
+	 * and it is reasonable to sleep and retry before giving up.  In
+	 * practice delays have been observed to be on the order of 100ms.
 	 */
 	mode = spa_mode(v->vdev_spa);
 	if (v->vdev_wholedisk && v->vdev_expanding)
 		bdev = vdev_disk_rrpart(v->vdev_path, mode, vd);
-	if (IS_ERR(bdev))
+
+	while (IS_ERR(bdev) && count < 50) {
 		bdev = vdev_bdev_open(v->vdev_path,
 		    vdev_bdev_mode(mode), zfs_vdev_holder);
+		if (unlikely(PTR_ERR(bdev) == -ENOENT)) {
+			msleep(10);
+			count++;
+		} else if (IS_ERR(bdev)) {
+			break;
+		}
+	}
+
 	if (IS_ERR(bdev)) {
+		dprintf("failed open v->vdev_path=%s, error=%d count=%d\n",
+		    v->vdev_path, -PTR_ERR(bdev), count);
 		kmem_free(vd, sizeof (vdev_disk_t));
-		return (-PTR_ERR(bdev));
+		return (SET_ERROR(-PTR_ERR(bdev)));
 	}
 
 	v->vdev_tsd = vd;


### PR DESCRIPTION
When partitioning a device a name may be specified for each partion.
Internally zfs doesn't use this partition name for anything so it
has always just been set to "zfs".

However this isn't optimal because udev will create symlinks using
this name in /dev/disk/by-partlabel/.  If the name isn't unique
then all the links cannot be created.

Therefore a random 64-bit value has been added to the partition
label, i.e "zfs-1234567890abcdef".  Additional information could
be encoded here since partitions may be reused that could result
in confusion and was decided against.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #4517