### PR TITLE
Fix inverted logic on none elevator comparison

### DIFF
--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -139,7 +139,7 @@ vdev_elevator_switch(vdev_t *v, char *elevator)
 		return (0);
 
 	/* Leave existing scheduler when set to "none" */
-	if (strncmp(elevator, "none", 4) && (strlen(elevator) == 4) == 0)
+	if ((strncmp(elevator, "none", 4) == 0) && (strlen(elevator) == 4))
 		return (0);
 
 #ifdef HAVE_ELEVATOR_CHANGE


### PR DESCRIPTION
Commit d1d7e2689db9e03f1 ("cstyle: Resolve C style issues") inverted
the logic on the none elevator comparison.  Fix this and make it
cstyle warning clean.

Signed-off-by: Colin Ian King <colin.king@canonical.com>
Closes #4507