### PR TITLE
Fix ZPL miswrite of default POSIX ACL

### DIFF
--- a/module/zfs/zpl_xattr.c
+++ b/module/zfs/zpl_xattr.c
@@ -969,7 +969,7 @@ zpl_set_acl(struct inode *ip, int type, struct posix_acl *acl)
 		break;
 
 	case ACL_TYPE_DEFAULT:
-		name = XATTR_NAME_POSIX_ACL_ACCESS;
+		name = XATTR_NAME_POSIX_ACL_DEFAULT;
 		if (!S_ISDIR(ip->i_mode))
 			return (acl ? -EACCES : 0);
 		break;

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -22,7 +22,7 @@ outputdir = /var/tmp/test_results
 # DISABLED:
 # posix_001_pos - needs investigation
 [tests/functional/acl/posix]
-tests = ['posix_002_pos']
+tests = ['posix_002_pos', 'posix_003_pos']
 
 [tests/functional/atime]
 tests = ['atime_001_pos', 'atime_002_neg', 'atime_003_pos']

--- a/tests/zfs-tests/tests/functional/acl/posix/Makefile.am
+++ b/tests/zfs-tests/tests/functional/acl/posix/Makefile.am
@@ -3,4 +3,5 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	setup.ksh \
 	posix_001_pos.ksh \
-	posix_002_pos.ksh
+	posix_002_pos.ksh \
+	posix_003_pos.ksh

--- a/tests/zfs-tests/tests/functional/acl/posix/posix_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/acl/posix/posix_003_pos.ksh
@@ -1,0 +1,61 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#	Verify that ACLs survive remount.
+#	Regression test for https://github.com/zfsonlinux/zfs/issues/4520
+#
+# STRATEGY:
+#	1. Test presence of default and regular ACLs after remount
+#	   a. Can set and list ACL before remount
+#	   b. Can list ACL after remount
+#
+
+verify_runnable "both"
+log_assert "Verify regular and default POSIX ACLs survive  remount"
+
+typeset output=/tmp/zfs-posixacl.$$
+typeset acl_str1="^group:${ZFS_ACL_STAFF_GROUP}:-wx$"
+typeset acl_str2="^default:group:${ZFS_ACL_STAFF_GROUP}:-wx$"
+typeset ACLDIR="${TESTDIR}/dir.1"
+
+log_note "Testing access to DIRECTORY"
+log_must $MKDIR $ACLDIR
+log_must $SETFACL -m g:${ZFS_ACL_STAFF_GROUP}:wx $ACLDIR
+log_must $SETFACL -d -m g:${ZFS_ACL_STAFF_GROUP}:wx $ACLDIR
+$GETFACL $ACLDIR 2> /dev/null | $EGREP -q "${acl_str1}"
+if [ "$?" -eq "0" ]; then
+	$GETFACL $ACLDIR 2> /dev/null | $EGREP -q "${acl_str2}"
+fi
+
+if [ "$?" -eq "0" ]; then
+	log_must $ZFS unmount $TESTPOOL/$TESTFS
+	log_must $ZFS mount $TESTPOOL/$TESTFS
+	log_must eval '$GETFACL $ACLDIR 2> /dev/null | $EGREP -q "${acl_str1}"'
+	log_must eval '$GETFACL $ACLDIR 2> /dev/null | $EGREP -q "${acl_str2}"'
+	log_pass "POSIX ACLs survive remount"
+else
+	log_fail "Group '${ZFS_ACL_STAFF_GROUP}' does not have 'rwx'"
+fi


### PR DESCRIPTION
Commit 4967a3e introduced a typo that caused the ZPL to store the
intended default ACL as an access ACL. Due to caching this problem
may not become visible until the filesystem is remounted or the inode
is evicted from the cache. Fix the typo and add a regression test.

Fixes #4520

Signed-off-by: Ned Bass <bass6@llnl.gov>