### PR TITLE
[RFC] Kill znode->z_gen field

### DIFF
--- a/include/sys/trace_acl.h
+++ b/include/sys/trace_acl.h
@@ -54,7 +54,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __field(uint_t,		z_blksz)
 	    __field(uint_t,		z_seq)
 	    __field(uint64_t,		z_mapcnt)
-	    __field(uint64_t,		z_gen)
 	    __field(uint64_t,		z_size)
 	    __field(uint64_t,		z_links)
 	    __field(uint64_t,		z_pflags)
@@ -92,7 +91,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __entry->z_blksz		= zn->z_blksz;
 	    __entry->z_seq		= zn->z_seq;
 	    __entry->z_mapcnt		= zn->z_mapcnt;
-	    __entry->z_gen		= zn->z_gen;
 	    __entry->z_size		= zn->z_size;
 	    __entry->z_links		= zn->z_links;
 	    __entry->z_pflags		= zn->z_pflags;
@@ -123,17 +121,15 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	),
 	TP_printk("zn { id %llu unlinked %u atime_dirty %u "
 	    "zn_prefetch %u moved %u blksz %u seq %u "
-	    "mapcnt %llu gen %llu size %llu "
-	    "links %llu pflags %llu uid %llu gid %llu "
-	    "sync_cnt %u mode 0x%x is_sa %d is_zvol %d "
-	    "is_mapped %d is_ctldir %d is_stale %d inode { "
-	    "ino %lu nlink %u version %llu size %lli blkbits %u "
-	    "bytes %u mode 0x%x generation %x } } ace { type %u "
-	    "flags %u access_mask %u } mask_matched %u",
+	    "mapcnt %llu size %llu links %llu pflags %llu "
+		"uid %llu gid %llu sync_cnt %u mode 0x%x is_sa %d "
+		"is_zvol %d is_mapped %d is_ctldir %d is_stale %d "
+		"inode { ino %lu nlink %u version %llu size %lli "
+		"blkbits %u bytes %u mode 0x%x generation %x } } "
+		"ace { type %u flags %u access_mask %u } mask_matched %u",
 	    __entry->z_id, __entry->z_unlinked, __entry->z_atime_dirty,
 	    __entry->z_zn_prefetch, __entry->z_moved, __entry->z_blksz,
-	    __entry->z_seq, __entry->z_mapcnt, __entry->z_gen,
-	    __entry->z_size,
+	    __entry->z_seq, __entry->z_mapcnt, __entry->z_size,
 	    __entry->z_links, __entry->z_pflags, __entry->z_uid,
 	    __entry->z_gid, __entry->z_sync_cnt, __entry->z_mode,
 	    __entry->z_is_sa, __entry->z_is_zvol, __entry->z_is_mapped,

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -196,7 +196,6 @@ typedef struct znode {
 	uint_t		z_blksz;	/* block size in bytes */
 	uint_t		z_seq;		/* modification sequence number */
 	uint64_t	z_mapcnt;	/* number of pages mapped to file */
-	uint64_t	z_gen;		/* generation (cached) */
 	uint64_t	z_size;		/* file size (cached) */
 	uint64_t	z_links;	/* file links (cached) */
 	uint64_t	z_pflags;	/* pflags (cached) */

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -476,7 +476,6 @@ zfsctl_inode_alloc(zfs_sb_t *zsb, uint64_t id,
 	zp->z_blksz = 0;
 	zp->z_seq = 0;
 	zp->z_mapcnt = 0;
-	zp->z_gen = 0;
 	zp->z_size = 0;
 	zp->z_links = 0;
 	zp->z_pflags = 0;
@@ -489,6 +488,7 @@ zfsctl_inode_alloc(zfs_sb_t *zsb, uint64_t id,
 	zp->z_is_ctldir = B_TRUE;
 	zp->z_is_sa = B_FALSE;
 	zp->z_is_stale = B_FALSE;
+	ip->i_generation = 0;
 	ip->i_ino = id;
 	ip->i_mode = (S_IFDIR | S_IRUGO | S_IXUGO);
 	ip->i_uid = SUID_TO_KUID(0);

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -337,7 +337,7 @@ zfs_sa_upgrade(sa_handle_t *hdl, dmu_tx_t *tx)
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_SIZE(zsb), NULL,
 	    &zp->z_size, 8);
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_GEN(zsb),
-	    NULL, &zp->z_gen, 8);
+	    NULL, &(ZTOI(zp)->i_generation), 8);
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_UID(zsb), NULL, &uid, 8);
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_GID(zsb), NULL, &gid, 8);
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_PARENT(zsb),

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2405,7 +2405,7 @@ zfs_getattr(struct inode *ip, vattr_t *vap, int flags, cred_t *cr)
 			XVA_SET_RTN(xvap, XAT_REPARSE);
 		}
 		if (XVA_ISSET_REQ(xvap, XAT_GEN)) {
-			xoap->xoa_generation = zp->z_gen;
+			xoap->xoa_generation = ip->i_generation;
 			XVA_SET_RTN(xvap, XAT_GEN);
 		}
 

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -542,7 +542,6 @@ zfs_inode_update_impl(znode_t *zp, boolean_t new)
 	dmu_object_size_from_db(sa_get_db(zp->z_sa_hdl), &blksize, &i_blocks);
 
 	spin_lock(&ip->i_lock);
-	ip->i_generation = zp->z_gen;
 	ip->i_uid = SUID_TO_KUID(zp->z_uid);
 	ip->i_gid = SGID_TO_KGID(zp->z_gid);
 	set_nlink(ip, zp->z_links);
@@ -623,7 +622,8 @@ zfs_znode_alloc(zfs_sb_t *zsb, dmu_buf_t *db, int blksz,
 	zfs_znode_sa_init(zsb, zp, db, obj_type, hdl);
 
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MODE(zsb), NULL, &mode, 8);
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_GEN(zsb), NULL, &zp->z_gen, 8);
+	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_GEN(zsb), NULL,
+		&ip->i_generation, 8);
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(zsb), NULL, &zp->z_size, 8);
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zsb), NULL, &zp->z_links, 8);
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zsb), NULL,
@@ -633,7 +633,9 @@ zfs_znode_alloc(zfs_sb_t *zsb, dmu_buf_t *db, int blksz,
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_UID(zsb), NULL, &zp->z_uid, 8);
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_GID(zsb), NULL, &zp->z_gid, 8);
 
-	if (sa_bulk_lookup(zp->z_sa_hdl, bulk, count) != 0 || zp->z_gen == 0) {
+	if (sa_bulk_lookup(zp->z_sa_hdl, bulk, count) != 0 ||
+		ip->i_generation == 0) {
+
 		if (hdl == NULL)
 			sa_handle_destroy(zp->z_sa_hdl);
 		zp->z_sa_hdl = NULL;
@@ -1229,7 +1231,7 @@ zfs_rezget(znode_t *zp)
 
 	zp->z_mode = mode;
 
-	if (gen != zp->z_gen) {
+	if (gen != ZTOI(zp)->i_generation) {
 		zfs_znode_dmu_fini(zp);
 		zfs_znode_hold_exit(zsb, zh);
 		return (SET_ERROR(EIO));


### PR DESCRIPTION
This field is a duplicate of the inode->i_generation, so just kill it.

So this is just an RFC, resulting from me seeing the comment above` zfs_inode_update`. So the changes are pretty obvious, however I'm not too sure about the locking. Generally I think the locking in `zfs_inode_update` is wrong since it's using inode->i_lock instead of i_mutex.  Grepping through the source code of other file systems it seems most of them are using inode_lock (which acquires the i_mutex). Anyway, I'll be happy if people can comment on whether the current locking at the sites where code has been changed is sufficient .e.g is is ok to hold `zp->z_lock` when modifying `ZTOI(zp)->` members. 

I'm happy to continue eliminating duplicate members, eventually leading to completely removing zfs_inode_update function. 


Signed-off-by: Nikolay Borisov <n.borisov.lkml@gmail.com>