### PR TITLE
Fix zfs_copies_001_pos/zfs_copies_004_neg

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_001_pos.ksh
@@ -72,6 +72,7 @@ for val in 1 2 3; do
 	log_must $ZFS create -o copies=$val $fs1
 	if is_global_zone; then
 		log_must $ZFS create -V $VOLSIZE -o copies=$val $vol1
+		block_device_wait
 	else
 		log_must $ZFS create -o copies=$val $vol1
 	fi
@@ -83,17 +84,20 @@ for val in 1 2 3; do
 		log_must $ZFS create -o copies=$val2 $fs2
 		if is_global_zone; then
 			log_must $ZFS create -V $VOLSIZE -o copies=$val2 $vol2
+			block_device_wait
 		else
 			log_must $ZFS create -o copies=$val2 $vol2
 		fi
 		for ds in $fs2 $vol2; do
 			cmp_prop $ds $val2
 			log_must $ZFS destroy $ds
+			block_device_wait
 		done
 	done
 
 	for ds in $fs1 $vol1; do
 		log_must $ZFS destroy $ds
+		block_device_wait
 	done
 
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_004_neg.ksh
@@ -48,6 +48,7 @@ for val in ${badval[@]}; do
 	log_mustnot $ZFS create -V $VOLSIZE -o copies=$val $TESTPOOL/$TESTVOL1
 	log_mustnot $ZFS set copies=$val $TESTPOOL/$TESTFS
 	log_mustnot $ZFS set copies=$val $TESTPOOL/$TESTVOL
+	block_device_wait
 done
 
 log_pass "The copies property cannot be set to any value other than 1,2 or 3 as expected"


### PR DESCRIPTION
Call block_device_wait when creating/destroying volumes in order
to make the operations synchronous as expected by the test cases.