### PR TITLE
Grsecurity compat: Add dedicated usermode helper

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,3 +1,3 @@
 SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest zpios
 SUBDIRS += mount_zfs fsck_zfs zvol_id vdev_id arcstat dbufstat zed
-SUBDIRS += arc_summary
+SUBDIRS += arc_summary z_usermodehelper

--- a/cmd/z_usermodehelper/.gitignore
+++ b/cmd/z_usermodehelper/.gitignore
@@ -1,0 +1,1 @@
+/z_usermodehelper

--- a/cmd/z_usermodehelper/Makefile.am
+++ b/cmd/z_usermodehelper/Makefile.am
@@ -1,0 +1,6 @@
+include $(top_srcdir)/config/Rules.am
+
+pkglibexec_PROGRAMS = z_usermodehelper
+
+z_usermodehelper_SOURCES = \
+	z_usermodehelper.c

--- a/cmd/z_usermodehelper/z_usermodehelper.c
+++ b/cmd/z_usermodehelper/z_usermodehelper.c
@@ -1,0 +1,83 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2016 Stian Ellingsen.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int
+mount(int argc, char **argv) {
+	char *argv2[] = { "/sbin/mount.zfs", "--", NULL, NULL, NULL };
+	if (argc != 3)
+		return (1);
+	argv2[2] = argv[1];
+	argv2[3] = argv[2];
+	execv(*argv2, argv2);
+	return (127);
+}
+
+int
+umount(int argc, char **argv) {
+	char *argv2[] = { "/bin/umount", "-t", "zfs", "-f", NULL, NULL, NULL };
+	int i = 3;
+	char c;
+	while ((c = getopt(argc, argv, "f")) != -1) {
+		switch (c) {
+		case 'f':
+			i = 4;
+			break;
+		default:
+			return (1);
+		}
+	}
+	if (argc - optind != 1)
+		return (1);
+	argv2[i] = "--";
+	argv2[i + 1] = argv[optind];
+	execv(*argv2, argv2);
+	return (127);
+}
+
+	int
+main(int argc, char **argv)
+{
+	int (*cmd)(int, char **);
+
+	if (argc < 2)
+		return (1);
+
+	if (strcmp(argv[1], "mount") == 0)
+		cmd = mount;
+	else if (strcmp(argv[1], "umount") == 0)
+		cmd = umount;
+	else
+		return (1);
+
+	freopen("/dev/null", "r", stdin);
+	freopen("/dev/null", "w", stdout);
+	freopen("/dev/null", "w", stderr);
+
+	return (cmd(argc - 1, argv + 1));
+}

--- a/cmd/z_usermodehelper/z_usermodehelper.c
+++ b/cmd/z_usermodehelper/z_usermodehelper.c
@@ -75,9 +75,10 @@ main(int argc, char **argv)
 	else
 		return (1);
 
-	freopen("/dev/null", "r", stdin);
-	freopen("/dev/null", "w", stdout);
-	freopen("/dev/null", "w", stderr);
+	if (freopen("/dev/null", "r", stdin) == NULL ||
+	    freopen("/dev/null", "w", stdout) == NULL ||
+	    freopen("/dev/null", "w", stderr) == NULL)
+		return (127);
 
 	return (cmd(argc - 1, argv + 1));
 }

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,7 @@ AC_CONFIG_FILES([
 	cmd/dbufstat/Makefile
 	cmd/arc_summary/Makefile
 	cmd/zed/Makefile
+	cmd/z_usermodehelper/Makefile
 	contrib/Makefile
 	contrib/bash_completion.d/Makefile
 	contrib/dracut/Makefile

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -1008,19 +1008,14 @@ out:
  * best effort.  In the case where it does fail, perhaps because
  * it's in use, the unmount will fail harmlessly.
  */
-#define	SET_UNMOUNT_CMD \
-	"exec 0</dev/null " \
-	"     1>/dev/null " \
-	"     2>/dev/null; " \
-	"umount -t zfs -n %s'%s'"
-
 int
 zfsctl_snapshot_unmount(char *snapname, int flags)
 {
-	char *argv[] = { "/bin/sh", "-c", NULL, NULL };
+	char *argv[] = { "/usr/libexec/zfs/z_usermodehelper", "umount",
+	    NULL, NULL, NULL };
 	char *envp[] = { NULL };
 	zfs_snapentry_t *se;
-	int error;
+	int error, i = 2;
 
 	rw_enter(&zfs_snapshot_lock, RW_READER);
 	if ((se = zfsctl_snapshot_find_by_name(snapname)) == NULL) {
@@ -1029,12 +1024,12 @@ zfsctl_snapshot_unmount(char *snapname, int flags)
 	}
 	rw_exit(&zfs_snapshot_lock);
 
-	argv[2] = kmem_asprintf(SET_UNMOUNT_CMD,
-	    flags & MNT_FORCE ? "-f " : "", se->se_path);
-	zfsctl_snapshot_rele(se);
+	if (flags & MNT_FORCE)
+		argv[i++] = "-f";
+	argv[i] = se->se_path;
 	dprintf("unmount; path=%s\n", se->se_path);
 	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
-	strfree(argv[2]);
+	zfsctl_snapshot_rele(se);
 
 
 	/*
@@ -1049,11 +1044,6 @@ zfsctl_snapshot_unmount(char *snapname, int flags)
 }
 
 #define	MOUNT_BUSY 0x80		/* Mount failed due to EBUSY (from mntent.h) */
-#define	SET_MOUNT_CMD \
-	"exec 0</dev/null " \
-	"     1>/dev/null " \
-	"     2>/dev/null; " \
-	"mount -t zfs -n '%s' '%s'"
 
 int
 zfsctl_snapshot_mount(struct path *path, int flags)
@@ -1064,7 +1054,8 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	zfs_sb_t *snap_zsb;
 	zfs_snapentry_t *se;
 	char *full_name, *full_path;
-	char *argv[] = { "/bin/sh", "-c", NULL, NULL };
+	char *argv[] = { "/usr/libexec/zfs/z_usermodehelper", "mount",
+	    NULL, NULL, NULL };
 	char *envp[] = { NULL };
 	int error;
 	struct path spath;
@@ -1109,9 +1100,9 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	 * value from call_usermodehelper() will be (exitcode << 8 + signal).
 	 */
 	dprintf("mount; name=%s path=%s\n", full_name, full_path);
-	argv[2] = kmem_asprintf(SET_MOUNT_CMD, full_name, full_path);
+	argv[2] = full_name;
+	argv[3] = full_path;
 	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
-	strfree(argv[2]);
 	if (error) {
 		if (!(error & MOUNT_BUSY << 8)) {
 			cmn_err(CE_WARN, "Unable to automount %s/%s: %d",


### PR DESCRIPTION
Add executable z_usermodehelper in /usr/libexec. This usermode helper is
used in place of the calls to /bin/sh in zfs_ctldir.c, which were not
permitted by grsecurity.

Fixes #4377