### PR TITLE
Grsecurity compat: Call mount.zfs and umount.zfs directly

### DIFF
--- a/cmd/mount_zfs/.gitignore
+++ b/cmd/mount_zfs/.gitignore
@@ -1,1 +1,2 @@
 mount.zfs
+umount.zfs

--- a/cmd/mount_zfs/Makefile.am
+++ b/cmd/mount_zfs/Makefile.am
@@ -9,10 +9,12 @@ DEFAULT_INCLUDES += \
 # because this path is hardcoded in the mount(8) for security reasons.
 #
 sbindir=$(mounthelperdir)
-sbin_PROGRAMS = mount.zfs
+sbin_PROGRAMS = mount.zfs umount.zfs
 
 mount_zfs_SOURCES = \
 	mount_zfs.c
+umount_zfs_SOURCES = \
+	umount_zfs.c
 
 mount_zfs_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \

--- a/cmd/mount_zfs/umount_zfs.c
+++ b/cmd/mount_zfs/umount_zfs.c
@@ -1,0 +1,53 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2016 Stian Ellingsen.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int
+usage(void)
+{
+	fprintf(stderr, "Usage: umount.zfs [-flnrv] {directory|device}\n");
+	return (1);
+}
+
+int
+main(int argc, char **argv)
+{
+	char *cmd[] = { "/bin/umount", "-t", "zfs", "-i" };
+	char *argv2[argc + 4];
+	char c;
+	while ((c = getopt(argc, argv, "flnrv")) != -1) {
+		if (c == '?')
+			return (usage());
+	}
+	if (argc - optind != 1)
+		return (usage());
+	memcpy(argv2, cmd, sizeof (cmd));
+	memcpy(argv2 + 4, argv + 1, argc * sizeof (char *));
+	execv(*argv2, argv2);
+	return (127);
+}

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -1049,11 +1049,6 @@ zfsctl_snapshot_unmount(char *snapname, int flags)
 }
 
 #define	MOUNT_BUSY 0x80		/* Mount failed due to EBUSY (from mntent.h) */
-#define	SET_MOUNT_CMD \
-	"exec 0</dev/null " \
-	"     1>/dev/null " \
-	"     2>/dev/null; " \
-	"mount -t zfs -n '%s' '%s'"
 
 int
 zfsctl_snapshot_mount(struct path *path, int flags)
@@ -1064,7 +1059,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	zfs_sb_t *snap_zsb;
 	zfs_snapentry_t *se;
 	char *full_name, *full_path;
-	char *argv[] = { "/bin/sh", "-c", NULL, NULL };
+	char *argv[] = { "/sbin/mount.zfs", "-n", "--", NULL, NULL, NULL };
 	char *envp[] = { NULL };
 	int error;
 	struct path spath;
@@ -1109,9 +1104,9 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	 * value from call_usermodehelper() will be (exitcode << 8 + signal).
 	 */
 	dprintf("mount; name=%s path=%s\n", full_name, full_path);
-	argv[2] = kmem_asprintf(SET_MOUNT_CMD, full_name, full_path);
+	argv[3] = full_name;
+	argv[4] = full_path;
 	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
-	strfree(argv[2]);
 	if (error) {
 		if (!(error & MOUNT_BUSY << 8)) {
 			cmn_err(CE_WARN, "Unable to automount %s/%s: %d",


### PR DESCRIPTION
Grsecurity does not permit calling `/bin/sh` via `call_usermodehelper()`. Instead, call `/sbin/mount.zfs` and a new minimal helper `/sbin/umount.zfs` directly.

`umount.zfs` simply works by validating arguments and passing them to `/bin/umount -t zfs -i`.

Redirecting to `/dev/null` does not seem to be necessary. I tested by printing to `stdout` and `stderr` from a binary called by `call_usermodehelper()` and could not see the output in the console or any logs.

Fixes  #4377