### PR TITLE
module/.gitignore: Add *.dwo

### DIFF
--- a/module/.gitignore
+++ b/module/.gitignore
@@ -2,6 +2,7 @@
 *.ko.unsigned
 *.ko.out
 *.ko.out.sig
+*.dwo
 .*.cmd
 
 /.tmp_versions


### PR DESCRIPTION
These files get generated when `CONFIG_DEBUG_INFO_DWARF4` is enabled in
Linux `.config`.