### PR TITLE
Revert "Remove fastwrite mutex"

### DIFF
--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -69,6 +69,7 @@ struct metaslab_class {
 	uint64_t		mc_space;	/* total space (alloc + free) */
 	uint64_t		mc_dspace;	/* total deflated space */
 	uint64_t		mc_histogram[RANGE_TREE_HISTOGRAM_SIZE];
+	kmutex_t		mc_fastwrite_lock;
 };
 
 /*

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -198,6 +198,7 @@ metaslab_class_create(spa_t *spa, metaslab_ops_t *ops)
 	mc->mc_spa = spa;
 	mc->mc_rotor = NULL;
 	mc->mc_ops = ops;
+	mutex_init(&mc->mc_fastwrite_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	return (mc);
 }
@@ -211,6 +212,7 @@ metaslab_class_destroy(metaslab_class_t *mc)
 	ASSERT(mc->mc_space == 0);
 	ASSERT(mc->mc_dspace == 0);
 
+	mutex_destroy(&mc->mc_fastwrite_lock);
 	kmem_free(mc, sizeof (metaslab_class_t));
 }
 
@@ -2212,6 +2214,9 @@ metaslab_alloc_dva(spa_t *spa, metaslab_class_t *mc, uint64_t psize,
 	if (psize >= metaslab_gang_bang && (ddi_get_lbolt() & 3) == 0)
 		return (SET_ERROR(ENOSPC));
 
+	if (flags & METASLAB_FASTWRITE)
+		mutex_enter(&mc->mc_fastwrite_lock);
+
 	/*
 	 * Start at the rotor and loop through all mgs until we find something.
 	 * Note that there's no locking on mc_rotor or mc_aliquot because
@@ -2397,6 +2402,7 @@ top:
 			if (flags & METASLAB_FASTWRITE) {
 				atomic_add_64(&vd->vdev_pending_fastwrite,
 				    psize);
+				mutex_exit(&mc->mc_fastwrite_lock);
 			}
 
 			return (0);
@@ -2419,6 +2425,9 @@ next:
 	}
 
 	bzero(&dva[d], sizeof (dva_t));
+
+	if (flags & METASLAB_FASTWRITE)
+		mutex_exit(&mc->mc_fastwrite_lock);
 
 	return (SET_ERROR(ENOSPC));
 }


### PR DESCRIPTION
This reverts commit b10695c8f1ce317cd24d99af7998741a35a5ce48 which
very likely introduce a difficult to reproduce regression in the
vdev_pending_fastwrite accounting.  This was removed solely as
a potential optimization so it's being reverted in order to resolve
this issue.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #4267