### PR TITLE
ZFS-4539 taskq_create() calls thread_create() with wrong arguments

### DIFF
--- a/lib/libzpool/taskq.c
+++ b/lib/libzpool/taskq.c
@@ -308,7 +308,7 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 
 	for (t = 0; t < nthreads; t++)
 		VERIFY((tq->tq_threadlist[t] = thread_create(NULL, 0,
-		    taskq_thread, tq, TS_RUN, NULL, 0, pri)) != NULL);
+		    taskq_thread, tq, 0, &p0, TS_RUN, pri)) != NULL);
 
 	return (tq);
 }


### PR DESCRIPTION
A fix for a problem found by @thegreatgazoo and reported in https://github.com/zfsonlinux/zfs/issues/4539