### PR TITLE
OpenZFS 6544 - incorrect comment in libzfs.h about offline status

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -345,7 +345,7 @@ typedef enum {
 	ZPOOL_STATUS_VERSION_OLDER,	/* older legacy on-disk version */
 	ZPOOL_STATUS_FEAT_DISABLED,	/* supported features are disabled */
 	ZPOOL_STATUS_RESILVERING,	/* device being resilvered */
-	ZPOOL_STATUS_OFFLINE_DEV,	/* device online */
+	ZPOOL_STATUS_OFFLINE_DEV,	/* device offline */
 	ZPOOL_STATUS_REMOVED_DEV,	/* removed device */
 
 	/*


### PR DESCRIPTION
6544 incorrect comment in libzfs.h about offline status

Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Approved by: Dan McDonald <danmcd@omniti.com>
Ported-by: Tony Hutter <hutter2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/6544
OpenZFS-commit: https://github.com/illumos/illumos-gate/commit/cb605c4