### PR TITLE
OpenZFS 6672 - arc_reclaim_thread() should use gethrtime() instead of…

### DIFF
--- a/lib/libspl/include/sys/time.h
+++ b/lib/libspl/include/sys/time.h
@@ -58,6 +58,15 @@
 #define	NSEC2MSEC(n)    ((n) / (NANOSEC / MILLISEC))
 #endif
 
+#ifndef	NSEC2SEC
+#define	NSEC2SEC(n)	((n) / (NANOSEC / SEC))
+#endif
+
+#ifndef SEC2NSEC
+#define	SEC2NSEC(m)	((hrtime_t)(m) * (NANOSEC / SEC))
+#endif
+
+
 typedef	long long		hrtime_t;
 typedef	struct	timespec	timestruc_t;
 typedef	struct	timespec	timespec_t;


### PR DESCRIPTION
… ddi_get_lbolt()

6672 arc_reclaim_thread() should use gethrtime() instead of ddi_get_lbolt()

    Reviewed by: Matthew Ahrens <mahrens@delphix.com>
    Reviewed by: Prakash Surya <prakash.surya@delphix.com>
    Reviewed by: Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
    Reviewed by: Robert Mustacchi <rm@joyent.com>
    Approved by: Dan McDonald <danmcd@omniti.com>

    OpenZFS-issue: https://www.illumos.org/issues/6672
    OpenZFS-commit: https://github.com/openzfs/openzfs/commit/571be5c

    Requires-spl:refs/pull/546/head