### PR TITLE
Wrap vdev_count_verify_zaps() with DEBUG

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2238,6 +2238,7 @@ spa_load(spa_t *spa, spa_load_state_t state, spa_import_type_t type,
 	return (error);
 }
 
+#ifdef ZFS_DEBUG
 /*
  * Count the number of per-vdev ZAPs associated with all of the vdevs in the
  * vdev tree rooted in the given vd, and ensure that each ZAP is present in the
@@ -2267,6 +2268,7 @@ vdev_count_verify_zaps(vdev_t *vd)
 
 	return (total);
 }
+#endif
 
 /*
  * Load an existing storage pool, using the pool's builtin spa_config as a
@@ -6714,6 +6716,7 @@ spa_sync(spa_t *spa, uint64_t txg)
 
 	} while (dmu_objset_is_dirty(mos, txg));
 
+#ifdef ZFS_DEBUG
 	if (!list_is_empty(&spa->spa_config_dirty_list)) {
 		/*
 		 * Make sure that the number of ZAPs for all the vdevs matches
@@ -6728,6 +6731,7 @@ spa_sync(spa_t *spa, uint64_t txg)
 		ASSERT3U(vdev_count_verify_zaps(spa->spa_root_vdev), ==,
 		    all_vdev_zap_entry_count);
 	}
+#endif
 
 	/*
 	 * Rewrite the vdev configuration (which includes the uberblock)


### PR DESCRIPTION
Commit e0ab3ab introduced two blocks of code which are only needed
when debugging is enabled.  These blocks should be wrapped with a
DEBUG for clarity and to prevent unused variable warnings during
a production build.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #4515