### PR TITLE
SPL-521

### DIFF
--- a/lib/libzpool/taskq.c
+++ b/lib/libzpool/taskq.c
@@ -308,7 +308,7 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 
 	for (t = 0; t < nthreads; t++)
 		VERIFY((tq->tq_threadlist[t] = thread_create(NULL, 0,
-		    taskq_thread, tq, TS_RUN, NULL, 0, pri)) != NULL);
+		    taskq_thread, tq, 0, &p0, TS_RUN, pri)) != NULL);
 
 	return (tq);
 }


### PR DESCRIPTION
Under stress taskq_create may fail. So when it happens the code should do the same job in its current thread.
This is related to issue https://github.com/zfsonlinux/spl/issues/521