### PR TITLE
Per-vdev ZAP tests must use $ZPOOL and $ZDB

### DIFF
--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps.kshlib
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps.kshlib
@@ -69,7 +69,7 @@ function assert_zap_common # pool vd lvl zapobj
 
         if [[ -z "$zapobj" ]]; then
                 log_fail "$vd on $pool has no $lvl ZAP in config"
-        elif [[ -z "$(zdb -d $pool $zapobj | grep 'zap')" ]]; then
+        elif [[ -z "$($ZDB -d $pool $zapobj | grep 'zap')" ]]; then
                 log_fail "$vd on $pool has no $lvl ZAP in MOS"
         fi
 }
@@ -101,13 +101,13 @@ function assert_leaf_zap # pool vd conf
 function cleanup
 {
         if datasetexists $TESTPOOL ; then
-                log_must zpool destroy -f $TESTPOOL
+                log_must $ZPOOL destroy -f $TESTPOOL
         fi
         if [[ -e $conf ]]; then
                 log_must $RM -f "$conf"
         fi
         if [[ -e $POOL2 ]]; then
-                log_must zpool destroy -f $POOL2
+                log_must $ZPOOL destroy -f $POOL2
         fi
 }
 

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_001_pos.ksh
@@ -31,9 +31,9 @@ log_assert "Per-vdev ZAPs are created on pool creation with one disk."
 
 DISK=${DISKS%% *}
 
-log_must zpool create -f $TESTPOOL $DISK
+log_must $ZPOOL create -f $TESTPOOL $DISK
 conf="$TESTDIR/vz001"
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZDB -PC $TESTPOOL > $conf
 
 assert_top_zap $TESTPOOL $DISK "$conf"
 assert_leaf_zap $TESTPOOL $DISK "$conf"

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_002_pos.ksh
@@ -30,10 +30,10 @@
 
 log_assert "Per-vdev ZAPs are created on pool creation with many disks."
 
-log_must zpool create -f $TESTPOOL $DISKS
+log_must $ZPOOL create -f $TESTPOOL $DISKS
 
 conf="$TESTDIR/vz002"
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZDB -PC $TESTPOOL > $conf
 
 assert_has_sentinel "$conf"
 for DISK in $DISKS; do

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_003_pos.ksh
@@ -31,10 +31,10 @@
 log_assert "Per-vdev ZAPs are created on pool creation with multi-level vdev "\
         "trees."
 
-log_must zpool create -f $TESTPOOL mirror $DISKS
+log_must $ZPOOL create -f $TESTPOOL mirror $DISKS
 
 conf="$TESTDIR/vz003"
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZDB -PC $TESTPOOL > $conf
 
 assert_has_sentinel "$conf"
 assert_top_zap $TESTPOOL "type: 'mirror'" "$conf"

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_004_pos.ksh
@@ -34,11 +34,11 @@
 log_assert "Per-vdev ZAPs are transferred properly on attach/detach"
 
 DISK=${DISKS%% *}
-log_must zpool create -f $TESTPOOL $DISK
+log_must $ZPOOL create -f $TESTPOOL $DISK
 
 # Make the pool.
 conf="$TESTDIR/vz004"
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZDB -PC $TESTPOOL > $conf
 assert_has_sentinel "$conf"
 orig_top=$(get_top_vd_zap $DISK $conf)
 orig_leaf=$(get_leaf_vd_zap $DISK $conf)
@@ -49,8 +49,8 @@ assert_zap_common $TESTPOOL $DISK "top" $orig_top
 #
 
 disk2=$(echo $DISKS | awk '{print $2}')
-log_must zpool attach $TESTPOOL $DISK $disk2
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZPOOL attach $TESTPOOL $DISK $disk2
+log_must $ZDB -PC $TESTPOOL > $conf
 
 # Ensure top-level ZAP was transferred successfully.
 new_top=$(get_top_vd_zap "type: 'mirror'" $conf)
@@ -78,8 +78,8 @@ dsk2_leaf=$(get_leaf_vd_zap $disk2 $conf)
 # Detach original disk.
 #
 
-log_must zpool detach $TESTPOOL $DISK
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZPOOL detach $TESTPOOL $DISK
+log_must $ZDB -PC $TESTPOOL > $conf
 
 final_top=$(get_top_vd_zap $disk2 $conf)
 final_leaf=$(get_leaf_vd_zap $disk2 $conf)

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_005_pos.ksh
@@ -31,11 +31,11 @@
 log_assert "Per-vdev ZAPs persist across export/import."
 
 DISK=${DISKS%% *}
-log_must zpool create -f $TESTPOOL $DISK
+log_must $ZPOOL create -f $TESTPOOL $DISK
 
 # Make the pool.
 conf="$TESTDIR/vz005"
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZDB -PC $TESTPOOL > $conf
 assert_has_sentinel "$conf"
 orig_top=$(get_top_vd_zap $DISK $conf)
 orig_leaf=$(get_leaf_vd_zap $DISK $conf)
@@ -43,13 +43,13 @@ assert_zap_common $TESTPOOL $DISK "top" $orig_top
 assert_zap_common $TESTPOOL $DISK "leaf" $orig_leaf
 
 # Export the pool.
-log_must zpool export $TESTPOOL
+log_must $ZPOOL export $TESTPOOL
 
 # Import the pool.
-log_must zpool import $TESTPOOL
+log_must $ZPOOL import $TESTPOOL
 
 # Verify that ZAPs persisted.
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZDB -PC $TESTPOOL > $conf
 
 new_top=$(get_top_vd_zap $DISK $conf)
 new_leaf=$(get_leaf_vd_zap $DISK $conf)

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_006_pos.ksh
@@ -30,13 +30,13 @@
 
 DISK_ARR=($DISKS)
 DISK=${DISK_ARR[0]}
-log_must zpool create -f $TESTPOOL $DISK
+log_must $ZPOOL create -f $TESTPOOL $DISK
 
 log_assert "Per-vdev ZAPs are created for added vdevs."
 
-log_must zpool add -f $TESTPOOL ${DISK_ARR[1]}
+log_must $ZPOOL add -f $TESTPOOL ${DISK_ARR[1]}
 conf="$TESTDIR/vz006"
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZDB -PC $TESTPOOL > $conf
 
 assert_has_sentinel "$conf"
 orig_top=$(get_top_vd_zap ${DISK_ARR[1]} $conf)

--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_007_pos.ksh
@@ -32,11 +32,11 @@
 
 DISK_ARR=($DISKS)
 POOL2=${TESTPOOL}2
-log_must zpool create -f $TESTPOOL mirror ${DISK_ARR[0]} ${DISK_ARR[1]}
+log_must $ZPOOL create -f $TESTPOOL mirror ${DISK_ARR[0]} ${DISK_ARR[1]}
 
 log_assert "Per-vdev ZAPs persist correctly on the original pool after split."
 conf="$TESTDIR/vz007"
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZDB -PC $TESTPOOL > $conf
 
 assert_has_sentinel "$conf"
 orig_top=$(get_top_vd_zap "type: 'mirror'" $conf)
@@ -46,10 +46,10 @@ assert_zap_common $TESTPOOL "type: 'mirror'" "top" $orig_top
 assert_zap_common $TESTPOOL ${DISK_ARR[0]} "leaf" $orig_leaf0
 assert_zap_common $TESTPOOL ${DISK_ARR[1]} "leaf" $orig_leaf1
 
-log_must zpool split $TESTPOOL $POOL2 ${DISK_ARR[1]}
+log_must $ZPOOL split $TESTPOOL $POOL2 ${DISK_ARR[1]}
 
 # Make sure old pool's ZAPs are consistent.
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZDB -PC $TESTPOOL > $conf
 new_leaf0=$(get_leaf_vd_zap ${DISK_ARR[0]} $conf)
 new_top_s0=$(get_top_vd_zap ${DISK_ARR[0]} $conf)
 
@@ -61,8 +61,8 @@ new_top_s0=$(get_top_vd_zap ${DISK_ARR[0]} $conf)
 log_assert "Per-vdev ZAPs persist on the new pool after import."
 
 # Import the split pool.
-log_must zpool import $POOL2
-log_must zdb -PC $TESTPOOL > $conf
+log_must $ZPOOL import $POOL2
+log_must $ZDB -PC $TESTPOOL > $conf
 
 new_leaf1=$(get_leaf_vd_zap ${DISK_ARR[1]} $conf)
 new_top_s1=$(get_top_vd_zap ${DISK_ARR[1]} $conf)


### PR DESCRIPTION
Commit e0ab3ab introduced new per-vdev ZAP tests which should have
used the $ZPOOL and $ZDB variabled.  The tests passed the automated
testing since both utilities but when running in-tree all of the new
tests fail.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #4515