### PR TITLE
SPL 521 - Workaround for failure in vdev_open_children under stress

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1168,11 +1168,16 @@ vdev_open_children(vdev_t *vd)
 	tq = taskq_create("vdev_open", children, minclsyspri,
 	    children, children, TASKQ_PREPOPULATE);
 
-	for (c = 0; c < children; c++)
-		VERIFY(taskq_dispatch(tq, vdev_open_child, vd->vdev_child[c],
-		    TQ_SLEEP) != 0);
+	if (tq != NULL) {
+		for (c = 0; c < children; c++)
+			VERIFY(taskq_dispatch(tq, vdev_open_child,
+				vd->vdev_child[c], TQ_SLEEP) != 0);
 
-	taskq_destroy(tq);
+		taskq_destroy(tq);
+	} else {
+		for (c = 0; c < children; c++)
+			vdev_open_child(vd->vdev_child[c]);
+	}
 
 	for (c = 0; c < children; c++)
 		vd->vdev_nonrot &= vd->vdev_child[c]->vdev_nonrot;


### PR DESCRIPTION
It is possible for taskq_create to return NULL under stress when running in kernel space.
In this case the code executes the work in its own thread.

Sorry, but I am not yet ready to write a stress test as I am not familiar enough with the test framework.