### PR TITLE
Zfs inode update locking

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -908,7 +908,9 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 			uio_prefaultpages(MIN(n, max_blksz), uio);
 	}
 
+	mutex_lock(&ZTOI(zp)->i_mutex);
 	zfs_inode_update(zp);
+	mutex_unlock(&ZTOI(zp)->i_mutex);
 	zfs_range_unlock(rl);
 
 	/*
@@ -1237,8 +1239,12 @@ zfs_lookup(struct inode *dip, char *nm, struct inode **ipp, int flags,
 	}
 
 	error = zfs_dirlook(zdp, nm, ipp, flags, direntflags, realpnp);
-	if ((error == 0) && (*ipp))
+	if ((error == 0) && (*ipp)) {
+		mutex_lock(&((*ipp)->i_mutex));
 		zfs_inode_update(ITOZ(*ipp));
+		mutex_unlock(&((*ipp)->i_mutex));
+	}
+
 
 	ZFS_EXIT(zsb);
 	return (error);

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1487,7 +1487,6 @@ out:
 			iput(ZTOI(zp));
 	} else {
 		zfs_inode_update(dzp);
-		zfs_inode_update(zp);
 		*ipp = ZTOI(zp);
 	}
 
@@ -1913,7 +1912,6 @@ top:
 		zil_commit(zilog, 0);
 
 	zfs_inode_update(dzp);
-	zfs_inode_update(zp);
 	ZFS_EXIT(zsb);
 	return (0);
 }

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -540,15 +540,19 @@ zfs_inode_update_impl(znode_t *zp, boolean_t new)
 	sa_lookup(zp->z_sa_hdl, SA_ZPL_CTIME(zsb), &ctime, 16);
 
 	dmu_object_size_from_db(sa_get_db(zp->z_sa_hdl), &blksize, &i_blocks);
+	if (new)
+		mutex_lock(&ip->i_mutex);
 
-	spin_lock(&ip->i_lock);
 	ip->i_uid = SUID_TO_KUID(zp->z_uid);
 	ip->i_gid = SGID_TO_KGID(zp->z_gid);
 	set_nlink(ip, zp->z_links);
 	ip->i_mode = zp->z_mode;
 	zfs_set_inode_flags(zp, ip);
 	ip->i_blkbits = SPA_MINBLOCKSHIFT;
+
+	spin_lock(&ip->i_lock);
 	ip->i_blocks = i_blocks;
+	spin_unlock(&ip->i_lock);
 
 	/*
 	 * Only read atime from SA if we are newly created inode (or rezget),
@@ -559,19 +563,23 @@ zfs_inode_update_impl(znode_t *zp, boolean_t new)
 	ZFS_TIME_DECODE(&ip->i_mtime, mtime);
 	ZFS_TIME_DECODE(&ip->i_ctime, ctime);
 
+	if (new)
+		mutex_unlock(&ip->i_mutex);
+
 	i_size_write(ip, zp->z_size);
-	spin_unlock(&ip->i_lock);
 }
 
 static void
 zfs_inode_update_new(znode_t *zp)
 {
+	ASSERT(!mutex_is_locked(&zp->z_inode.i_mutex));
 	zfs_inode_update_impl(zp, B_TRUE);
 }
 
 void
 zfs_inode_update(znode_t *zp)
 {
+	ASSERT(mutex_is_locked(&zp->z_inode.i_mutex));
 	zfs_inode_update_impl(zp, B_FALSE);
 }
 


### PR DESCRIPTION
So here is my take at fixing the issue brought up in #4578. With those changes I'm able to pass the zfs test suite without triggering the newly added asserts. 