### PR TITLE
OpenZFS 6093 - zfsctl_shares_lookup

### DIFF
--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -28,6 +28,7 @@
  *   Rohan Puri <rohan.puri15@gmail.com>
  *   Brian Behlendorf <behlendorf1@llnl.gov>
  * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
  */
 
 /*
@@ -1245,20 +1246,15 @@ zfsctl_shares_lookup(struct inode *dip, char *name, struct inode **ipp,
 		return (SET_ERROR(ENOTSUP));
 	}
 
-	error = zfs_zget(zsb, zsb->z_shares_dir, &dzp);
-	if (error) {
-		ZFS_EXIT(zsb);
-		return (error);
+	if ((error = zfs_zget(zsb, zsb->z_shares_dir, &dzp)) == 0) {
+		error = zfs_lookup(ZTOI(dzp), name, &ip, 0, cr, NULL, NULL);
+		iput(ZTOI(dzp));
 	}
 
-	error = zfs_lookup(ZTOI(dzp), name, &ip, 0, cr, NULL, NULL);
-
-	iput(ZTOI(dzp));
 	ZFS_EXIT(zsb);
 
 	return (error);
 }
-
 
 /*
  * Initialize the various pieces we'll need to create and manipulate .zfs


### PR DESCRIPTION
6093 zfsctl_shares_lookup should only VN_RELE() on zfs_zget() success

Reviewed by: Gordon Ross <gwr@nexenta.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: Brian Behlendorf <behlendorf1@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/6093
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/0f92170

Porting notes:
This function was always implemented slightly differently under Linux
and therefore never suffered from this issue.  The patch has been
updated and applied as cleanup in order to minimize differences with
the upstream OpenZFS code.