### PR TITLE
fixes based on gcc 6.x warnings

### DIFF
--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -599,7 +599,7 @@ fix_paths(nvlist_t *nv, name_entry_t *names)
 			}
 
 			/* Prefer paths earlier in the search order. */
-			if (best->ne_num_labels == best->ne_num_labels &&
+			if (ne->ne_num_labels == best->ne_num_labels &&
 			    ne->ne_order < best->ne_order) {
 				best = ne;
 				continue;

--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -380,8 +380,9 @@ zio_handle_io_delay(zio_t *zio)
 			continue;
 
 		if (handler->zi_record.zi_freq != 0 &&
-		    spa_get_random(100) >= handler->zi_record.zi_freq);
+		    spa_get_random(100) >= handler->zi_record.zi_freq) {
 			continue;
+		}
 
 		if (vd->vdev_guid == handler->zi_record.zi_guid) {
 			seconds = handler->zi_record.zi_timer;


### PR DESCRIPTION
The changes in the files should be self explanatory.

But there's another warning I was not able to fix due to fairly complicated indirections and bit manipulations. Here is the compiler output:

```
In file included from ../../include/sys/spa.h:588:0,
                 from zdb.c:34:
zdb.c: In function ‘dump_object’:
../../include/sys/dmu.h:130:8: warning: array subscript is outside array bounds [-Warray-bounds]
  dmu_ot[(int)(ot)].ot_byteswap)
  ~~~~~~^~~~~~~~~~~
zdb.c:72:18: note: in expansion of macro ‘DMU_OT_BYTESWAP’
  dmu_ot_byteswap[DMU_OT_BYTESWAP(idx)].ob_name : "UNKNOWN")
                  ^~~~~~~~~~~~~~~
zdb.c:1931:26: note: in expansion of macro ‘ZDB_OT_NAME’
      asize, lsize, fill, ZDB_OT_NAME(doi.doi_type), aux);
                          ^~~~~~~~~~~
../../include/sys/dmu.h:130:8: warning: array subscript is outside array bounds [-Warray-bounds]
  dmu_ot[(int)(ot)].ot_byteswap)
  ~~~~~~^~~~~~~~~~~
zdb.c:72:18: note: in expansion of macro ‘DMU_OT_BYTESWAP’
  dmu_ot_byteswap[DMU_OT_BYTESWAP(idx)].ob_name : "UNKNOWN")
                  ^~~~~~~~~~~~~~~
zdb.c:1936:7: note: in expansion of macro ‘ZDB_OT_NAME’
       ZDB_OT_NAME(doi.doi_bonus_type));
       ^~~~~~~~~~~
```