### PR TITLE
Use cv_timedwait_sig_hires in arc_reclaim_thread

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -365,6 +365,8 @@ extern void cv_broadcast(kcondvar_t *cv);
 #define	cv_timedwait_sig(cv, mp, at)		cv_timedwait(cv, mp, at)
 #define	cv_wait_sig(cv, mp)			cv_wait(cv, mp)
 #define	cv_wait_io(cv, mp)			cv_wait(cv, mp)
+#define	cv_timedwait_sig_hires(cv, mp, t, r, f) \
+	cv_timedwait_hires(cv, mp, t, r, f)
 
 /*
  * Thread-specific data

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3506,7 +3506,7 @@ arc_reclaim_thread(void)
 			 * even if we aren't being signalled)
 			 */
 			CALLB_CPR_SAFE_BEGIN(&cpr);
-			(void) cv_timedwait_hires(&arc_reclaim_thread_cv,
+			(void) cv_timedwait_sig_hires(&arc_reclaim_thread_cv,
 			    &arc_reclaim_lock, SEC2NSEC(1), MSEC2NSEC(1), 0);
 			CALLB_CPR_SAFE_END(&cpr, &arc_reclaim_lock);
 		}


### PR DESCRIPTION
The was originally using interruptible cv_timedwait_sig, but was changed to
uninterruptible cv_timedwait_hires in ae6d0c6. Use _sig_hires instead to allow
interruptible sleep.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>
Requires-spl:refs/pull/548/head