### PR TITLE
Fix: segmentation fault of write throttle while import

### DIFF
--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -249,20 +249,31 @@ static int
 vdev_queue_max_async_writes(spa_t *spa)
 {
 	int writes;
-	uint64_t dirty = spa->spa_dsl_pool->dp_dirty_total;
+	uint64_t dirty = 0;
+	dsl_pool_t *dp = spa_get_dsl(spa);
 	uint64_t min_bytes = zfs_dirty_data_max *
 	    zfs_vdev_async_write_active_min_dirty_percent / 100;
 	uint64_t max_bytes = zfs_dirty_data_max *
 	    zfs_vdev_async_write_active_max_dirty_percent / 100;
 
 	/*
+	 * async writes may be issued before the pool finish the process of
+	 * initialization, which means we can't get the statistics of dirty
+	 * data from the spa. typically this happens when the self-healing
+	 * zio was issued by mirror while importing. we push data out as fast
+	 * as possible to speed up the initialization.
+	 */
+	if (dp == NULL)
+		return (zfs_vdev_async_write_max_active);
+
+	/*
 	 * Sync tasks correspond to interactive user actions. To reduce the
 	 * execution time of those actions we push data out as fast as possible.
 	 */
-	if (spa_has_pending_synctask(spa)) {
+	if (spa_has_pending_synctask(spa))
 		return (zfs_vdev_async_write_max_active);
-	}
 
+	dirty = dp->dp_dirty_total;
 	if (dirty < min_bytes)
 		return (zfs_vdev_async_write_min_active);
 	if (dirty > max_bytes)


### PR DESCRIPTION
**The issue**
Async writes may be issued before the pool finish the process of initialization, which means we may access a NULL point of spa->spa_dsl_pool in function vdev_queue_max_async_writes illegality. typically this happens when the self-healing zio was issued by mirror while importing.

**The analysis**
Pool always imported with flag of FWRITE | FREAD, when we open the meta objset with ZIO error in one of our multi-DVAS(Both silent and “noisy” data corruption), the logical vdev which have mirror ops will try to use the good data it have in hand to repair damaged children. When the self-healing write zio issues to the leaf vdev, it encount the write throttle strategy which demand the statistics of dirty data in spa->spa_dsl_pool->dp_dirty_total. Unfortunately, the pointer of spa->spa_dsl_pool will keep NULL until we open the meta objset success, and then, segmentation fault comes up.

**The patch**
Do not ask for the dirty data statistics anymore in vdev_queue_max_async_writes before the pool pointer get initialized. Instead we push data out as fast as possible to speed up the self-healing process triggered by import.