### PR TITLE
Kill znode->z_gen field

### DIFF
--- a/include/sys/trace_acl.h
+++ b/include/sys/trace_acl.h
@@ -54,7 +54,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __field(uint_t,		z_blksz)
 	    __field(uint_t,		z_seq)
 	    __field(uint64_t,		z_mapcnt)
-	    __field(uint64_t,		z_gen)
 	    __field(uint64_t,		z_size)
 	    __field(uint64_t,		z_links)
 	    __field(uint64_t,		z_pflags)
@@ -92,7 +91,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __entry->z_blksz		= zn->z_blksz;
 	    __entry->z_seq		= zn->z_seq;
 	    __entry->z_mapcnt		= zn->z_mapcnt;
-	    __entry->z_gen		= zn->z_gen;
 	    __entry->z_size		= zn->z_size;
 	    __entry->z_links		= zn->z_links;
 	    __entry->z_pflags		= zn->z_pflags;
@@ -123,17 +121,15 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	),
 	TP_printk("zn { id %llu unlinked %u atime_dirty %u "
 	    "zn_prefetch %u moved %u blksz %u seq %u "
-	    "mapcnt %llu gen %llu size %llu "
-	    "links %llu pflags %llu uid %llu gid %llu "
-	    "sync_cnt %u mode 0x%x is_sa %d is_zvol %d "
-	    "is_mapped %d is_ctldir %d is_stale %d inode { "
-	    "ino %lu nlink %u version %llu size %lli blkbits %u "
-	    "bytes %u mode 0x%x generation %x } } ace { type %u "
-	    "flags %u access_mask %u } mask_matched %u",
+	    "mapcnt %llu size %llu links %llu pflags %llu "
+	    "uid %llu gid %llu sync_cnt %u mode 0x%x is_sa %d "
+	    "is_zvol %d is_mapped %d is_ctldir %d is_stale %d "
+	    "inode { ino %lu nlink %u version %llu size %lli "
+	    "blkbits %u bytes %u mode 0x%x generation %x } } "
+	    "ace { type %u flags %u access_mask %u } mask_matched %u",
 	    __entry->z_id, __entry->z_unlinked, __entry->z_atime_dirty,
 	    __entry->z_zn_prefetch, __entry->z_moved, __entry->z_blksz,
-	    __entry->z_seq, __entry->z_mapcnt, __entry->z_gen,
-	    __entry->z_size,
+	    __entry->z_seq, __entry->z_mapcnt, __entry->z_size,
 	    __entry->z_links, __entry->z_pflags, __entry->z_uid,
 	    __entry->z_gid, __entry->z_sync_cnt, __entry->z_mode,
 	    __entry->z_is_sa, __entry->z_is_zvol, __entry->z_is_mapped,

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -25,7 +25,7 @@
 /*
  * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
- * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_ZFS_CONTEXT_H
@@ -353,6 +353,7 @@ typedef struct kcondvar {
 } kcondvar_t;
 
 #define	CV_DEFAULT	0
+#define	CALLOUT_FLAG_ABSOLUTE	0x2
 
 extern void cv_init(kcondvar_t *cv, char *name, int type, void *arg);
 extern void cv_destroy(kcondvar_t *cv);

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -196,7 +196,6 @@ typedef struct znode {
 	uint_t		z_blksz;	/* block size in bytes */
 	uint_t		z_seq;		/* modification sequence number */
 	uint64_t	z_mapcnt;	/* number of pages mapped to file */
-	uint64_t	z_gen;		/* generation (cached) */
 	uint64_t	z_size;		/* file size (cached) */
 	uint64_t	z_links;	/* file links (cached) */
 	uint64_t	z_pflags;	/* pflags (cached) */

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -477,7 +477,6 @@ zfsctl_inode_alloc(zfs_sb_t *zsb, uint64_t id,
 	zp->z_blksz = 0;
 	zp->z_seq = 0;
 	zp->z_mapcnt = 0;
-	zp->z_gen = 0;
 	zp->z_size = 0;
 	zp->z_links = 0;
 	zp->z_pflags = 0;
@@ -490,6 +489,7 @@ zfsctl_inode_alloc(zfs_sb_t *zsb, uint64_t id,
 	zp->z_is_ctldir = B_TRUE;
 	zp->z_is_sa = B_FALSE;
 	zp->z_is_stale = B_FALSE;
+	ip->i_generation = 0;
 	ip->i_ino = id;
 	ip->i_mode = (S_IFDIR | S_IRUGO | S_IXUGO);
 	ip->i_uid = SUID_TO_KUID(0);

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -276,7 +276,7 @@ zfs_sa_upgrade(sa_handle_t *hdl, dmu_tx_t *tx)
 	int count = 0;
 	sa_bulk_attr_t *bulk, *sa_attrs;
 	zfs_acl_locator_cb_t locate = { 0 };
-	uint64_t uid, gid, mode, rdev, xattr, parent;
+	uint64_t uid, gid, mode, rdev, xattr, parent, tmp_gen;
 	uint64_t crtime[2], mtime[2], ctime[2], atime[2];
 	zfs_acl_phys_t znode_acl;
 	char scanstamp[AV_SCANSTAMP_SZ];
@@ -319,6 +319,7 @@ zfs_sa_upgrade(sa_handle_t *hdl, dmu_tx_t *tx)
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_RDEV(zsb), NULL, &rdev, 8);
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_UID(zsb), NULL, &uid, 8);
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_GID(zsb), NULL, &gid, 8);
+	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_GEN(zsb), NULL, &tmp_gen, 8);
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_ZNODE_ACL(zsb), NULL,
 	    &znode_acl, 88);
 
@@ -336,8 +337,7 @@ zfs_sa_upgrade(sa_handle_t *hdl, dmu_tx_t *tx)
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_MODE(zsb), NULL, &mode, 8);
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_SIZE(zsb), NULL,
 	    &zp->z_size, 8);
-	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_GEN(zsb),
-	    NULL, &zp->z_gen, 8);
+	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_GEN(zsb), NULL, &tmp_gen, 8);
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_UID(zsb), NULL, &uid, 8);
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_GID(zsb), NULL, &gid, 8);
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_PARENT(zsb),

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2393,7 +2393,7 @@ zfs_getattr(struct inode *ip, vattr_t *vap, int flags, cred_t *cr)
 			XVA_SET_RTN(xvap, XAT_REPARSE);
 		}
 		if (XVA_ISSET_REQ(xvap, XAT_GEN)) {
-			xoap->xoa_generation = zp->z_gen;
+			xoap->xoa_generation = ip->i_generation;
 			XVA_SET_RTN(xvap, XAT_GEN);
 		}
 


### PR DESCRIPTION
This field is a duplicate of the inode->i_generation, so just kill it, take 2.

Signed-off-by: Nikolay Borisov <n.borisov.lkml@gmail.com>