### PR TITLE
Add missing RPM BuildRequires

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -84,6 +84,8 @@ Conflicts:      zfs-fuse
 BuildRequires:  zlib-devel
 BuildRequires:  libuuid-devel
 BuildRequires:  libblkid-devel
+BuildRequires:  libudev-devel
+BuildRequires:  libattr-devel
 %endif
 %if 0%{?_systemd}
 Requires(post): systemd


### PR DESCRIPTION
Both libudev and libattr are recommended build requirements.  As
such their development headers should lists in the rpm spec file
so those dependencies are pulled in when building rpm packages.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>