### PR TITLE
Consistently use parsable instead of parseable.

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -172,7 +172,7 @@ usage(void)
 	    "-e to specify path to vdev dir\n");
 	(void) fprintf(stderr, "        -x <dumpdir> -- "
 	    "dump all read blocks into specified directory\n");
-	(void) fprintf(stderr, "        -P print numbers in parseable form\n");
+	(void) fprintf(stderr, "        -P print numbers in parsable form\n");
 	(void) fprintf(stderr, "        -t <txg> -- highest txg to use when "
 	    "searching for uberblocks\n");
 	(void) fprintf(stderr, "        -I <number of inflight I/Os> -- "

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3852,7 +3852,7 @@ zpool_do_iostat(int argc, char **argv)
 	zpool_list_t *list;
 	boolean_t verbose = B_FALSE;
 	boolean_t latency = B_FALSE, histo = B_FALSE;
-	boolean_t queues = B_FALSE, parseable = B_FALSE, scripted = B_FALSE;
+	boolean_t queues = B_FALSE, parsable = B_FALSE, scripted = B_FALSE;
 	boolean_t omit_since_boot = B_FALSE;
 	boolean_t guid = B_FALSE;
 	boolean_t follow_links = B_FALSE;
@@ -3884,7 +3884,7 @@ zpool_do_iostat(int argc, char **argv)
 			verbose = B_TRUE;
 			break;
 		case 'p':
-			parseable = B_TRUE;
+			parsable = B_TRUE;
 			break;
 		case 'l':
 			latency = B_TRUE;
@@ -3914,7 +3914,7 @@ zpool_do_iostat(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	cb.cb_literal = parseable;
+	cb.cb_literal = parsable;
 	cb.cb_scripted = scripted;
 
 	if (guid)

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1125,7 +1125,7 @@ Scripted mode. Do not display headers, and separate fields by a single tab inste
 \fB\fB-p\fR\fR
 .ad
 .RS 6n
-Display numbers in parseable (exact) values.
+Display numbers in parsable (exact) values.
 .RE
 
 .sp
@@ -1570,7 +1570,7 @@ Display real paths for vdevs resolving all symbolic links. This can be used to l
 \fB\fB-p\fR\fR
 .ad
 .RS 12n
-Display numbers in parseable (exact) values.  Time values are in nanoseconds.
+Display numbers in parsable (exact) values.  Time values are in nanoseconds.
 .RE
 
 .sp

--- a/tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/zpool_iostat/zpool_iostat_004_pos.ksh
@@ -36,7 +36,7 @@
 #
 # DESCRIPTION:
 # Executing 'zpool iostat' command with various combinations of extended
-# stats (-vqL), parseable/script options (-pH), and misc lists of pools
+# stats (-vqL), parsable/script options (-pH), and misc lists of pools
 # and vdevs.
 #
 # STRATEGY:


### PR DESCRIPTION
This is a purely cosmetical change, to consistently prefer one of
two (both acceptable) choises for the word parsable in documentation and
code. I don't really care which to use, but acording to wiktionary
https://en.wiktionary.org/wiki/parsable#English parsable is preferred.