### PR TITLE
Systemd configuration fixes

### DIFF
--- a/etc/modules-load.d/zfs.conf.in
+++ b/etc/modules-load.d/zfs.conf.in
@@ -1,1 +1,3 @@
-zfs
+# Always load kernel modules at boot.  The default behavior is to load the
+# kernel modules in the zfs-import-*.service or when blkid(8) detects a pool.
+#zfs

--- a/etc/systemd/system/50-zfs.preset.in
+++ b/etc/systemd/system/50-zfs.preset.in
@@ -1,2 +1,7 @@
 # ZFS is enabled by default
-enable zfs.*
+enable zfs-import-cache.service
+disable zfs-import-scan.service
+enable zfs-mount.service
+enable zfs-share.service
+enable zfs-zed.service
+enable zfs.target

--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -4,6 +4,7 @@ DefaultDependencies=no
 Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
+After=systemd-remount-fs.service
 Before=dracut-mount.service
 ConditionPathExists=@sysconfdir@/zfs/zpool.cache
 
@@ -12,3 +13,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/sbin/modprobe zfs
 ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
+
+[Install]
+WantedBy=zfs-mount.service
+WantedBy=zfs.target

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -11,4 +11,8 @@ ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
 Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/sbin/modprobe zfs
-ExecStart=@sbindir@/zpool import -d /dev/disk/by-id -aN
+ExecStart=@sbindir@/zpool import -aN -o cachefile=none
+
+[Install]
+WantedBy=zfs-mount.service
+WantedBy=zfs.target

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -1,15 +1,17 @@
 [Unit]
 Description=Mount ZFS filesystems
 DefaultDependencies=no
-Wants=zfs-import-cache.service
-Wants=zfs-import-scan.service
-Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=zfs-import-cache.service
 After=zfs-import-scan.service
+After=systemd-remount-fs.service
 Before=local-fs.target
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@sbindir@/zfs mount -a
+
+[Install]
+WantedBy=zfs-share.service
+WantedBy=zfs.target

--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -3,7 +3,6 @@ Description=ZFS file system shares
 After=nfs-server.service nfs-kernel-server.service
 After=smb.service
 After=zfs-mount.service
-Requires=zfs-mount.service
 PartOf=nfs-server.service nfs-kernel-server.service
 PartOf=smb.service
 
@@ -12,3 +11,6 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=-@bindir@/rm /etc/dfs/sharetab
 ExecStart=@sbindir@/zfs share -a
+
+[Install]
+WantedBy=zfs.target

--- a/etc/systemd/system/zfs-zed.service.in
+++ b/etc/systemd/system/zfs-zed.service.in
@@ -10,3 +10,4 @@ Restart=on-abort
 
 [Install]
 Alias=zed.service
+WantedBy=zfs.target

--- a/etc/systemd/system/zfs.target.in
+++ b/etc/systemd/system/zfs.target.in
@@ -1,8 +1,5 @@
 [Unit]
 Description=ZFS startup target
-Requires=zfs-mount.service
-Requires=zfs-share.service
-Wants=zfs-zed.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* Disable zfs-import-scan.service by default.  This ensures that
pools will not be automatically imported unless they appear in
the cache file.  When this service is explicitly enabled pools
will be imported with the "cachefile=none" property set.  This
prevents the creation of, or update to, an existing cache file.

    $ systemctl list-unit-files | grep zfs
    zfs-import-cache.service                  enabled
    zfs-import-scan.service                   disabled
    zfs-mount.service                         enabled
    zfs-share.service                         enabled
    zfs-zed.service                           enabled
    zfs.target                                enabled

* Change services to dynamic from static by adding an [Install]
secton and adding 'WantedBy' tags in favor of 'Requires' tags.
This allows for easier customization of the boot behavior.

* Start the zfs-mount.service after the systemd-remount-fs.service
to ensure the root fs is writeable and the ZFS filesystems can
create their mount points.

* Change the default behavior to only load the ZFS kernel modules
in zfs-import-*.service or when blkid(8) detects a pool.  Users
who wish to unconditionally load the kernel modules must uncomment
the list of modules in /lib/modules-load.d/zfs.conf.