### PR TITLE
Add isa_defs for MIPS

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -154,7 +154,8 @@ struct dk_map2  default_vtoc_map[NDKMAP] = {
 #if defined(_SUNOS_VTOC_16)
 
 #if defined(i386) || defined(__amd64) || defined(__arm) || \
-    defined(__powerpc) || defined(__sparc) || defined(__s390__)
+    defined(__powerpc) || defined(__sparc) || defined(__s390__) || \
+    defined(__mips__)
 	{	V_BOOT,		V_UNMNT	},		/* i - 8 */
 	{	V_ALTSCTR,	0	},		/* j - 9 */
 

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -190,7 +190,8 @@ extern "C" {
 #define	_SUNOS_VTOC_16
 
 #else
-/* Currently support
+/* 
+ * Currently support
  * x86_64, i386, arm, powerpc, s390, sparc, and mips
  */
 #error "Unsupported ISA type"

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -189,7 +189,7 @@ extern "C" {
 
 #define	_SUNOS_VTOC_16
 
-#else /* Currently support */
+#else /* Currently support
        * x86_64, i386, arm, powerpc, s390, sparc, and mips
        */
 #error "Unsupported ISA type"

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -184,12 +184,14 @@ extern "C" {
 #endif
 
 #ifndef _LP64
-#define _ILP32
+#define	_ILP32
 #endif
 
 #define	_SUNOS_VTOC_16
 
-#else /* Currently x86_64, i386, arm, powerpc, s390, sparc, and mips are supported */
+#else /* Currently support */
+       * x86_64, i386, arm, powerpc, s390, sparc, and mips
+       */
 #error "Unsupported ISA type"
 #endif
 

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -172,7 +172,24 @@ extern "C" {
 #define	_BIG_ENDIAN
 #define	_SUNOS_VTOC_16
 
-#else /* Currently x86_64, i386, arm, powerpc, s390, and sparc are supported */
+/* MIPS arch specific defines */
+#elif defined(__mips__)
+
+#if defined(__MIPSEB__)
+#define	_BIG_ENDIAN
+#elif defined(__MIPSEL__)
+#define	_LITTLE_ENDIAN
+#else
+#error MIPS no endian specified
+#endif
+
+#ifndef _LP64
+#define _ILP32
+#endif
+
+#define	_SUNOS_VTOC_16
+
+#else /* Currently x86_64, i386, arm, powerpc, s390, sparc, and mips are supported */
 #error "Unsupported ISA type"
 #endif
 

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -190,7 +190,7 @@ extern "C" {
 #define	_SUNOS_VTOC_16
 
 #else
-/* 
+/*
  * Currently support
  * x86_64, i386, arm, powerpc, s390, sparc, and mips
  */

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -189,9 +189,10 @@ extern "C" {
 
 #define	_SUNOS_VTOC_16
 
-#else /* Currently support
-       * x86_64, i386, arm, powerpc, s390, sparc, and mips
-       */
+#else
+/* Currently support
+ * x86_64, i386, arm, powerpc, s390, sparc, and mips
+ */
 #error "Unsupported ISA type"
 #endif
 


### PR DESCRIPTION
GCC for MIPS only defines _LP64 when 64bit,
while no _ILP32 defined when 32bit.