### PR TITLE
Linux 4.7 compat: handler->set() takes both dentry and inode

### DIFF
--- a/config/kernel-xattr-handler.m4
+++ b/config/kernel-xattr-handler.m4
@@ -81,7 +81,7 @@ AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_GET], [
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_XATTR_GET_DENTRY_INODE, 1,
-		    [xattr_handler->get() wants xattr_handler])
+		    [xattr_handler->get() wants both dentry and inode])
 	],[
 		dnl #
 		dnl # 4.4 API change,
@@ -163,18 +163,18 @@ dnl # Supported xattr handler set() interfaces checked newest to oldest.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_SET], [
 	dnl #
-	dnl # 4.4 API change,
-	dnl # The xattr_handler->set() callback was changed to take a
-	dnl # xattr_handler, and handler_flags argument was removed and
-	dnl # should be accessed by handler->flags.
+	dnl # 4.7 API change,
+	dnl # The xattr_handler->set() callback was changed to take both
+	dnl # dentry and inode.
 	dnl #
-	AC_MSG_CHECKING([whether xattr_handler->set() wants xattr_handler])
+	AC_MSG_CHECKING([whether xattr_handler->set() wants both dentry and inode])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/xattr.h>
 
 		int set(const struct xattr_handler *handler,
-		    struct dentry *dentry, const char *name,
-		    const void *buffer, size_t size, int flags)
+		    struct dentry *dentry, struct inode *inode,
+		    const char *name, const void *buffer,
+		    size_t size, int flags)
 		    { return 0; }
 		static const struct xattr_handler
 		    xops __attribute__ ((unused)) = {
@@ -183,23 +183,23 @@ AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_SET], [
 	],[
 	],[
 		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_XATTR_SET_HANDLER, 1,
-		    [xattr_handler->set() wants xattr_handler])
+		AC_DEFINE(HAVE_XATTR_SET_DENTRY_INODE, 1,
+		    [xattr_handler->set() wants both dentry and inode])
 	],[
 		dnl #
-		dnl # 2.6.33 API change,
+		dnl # 4.4 API change,
 		dnl # The xattr_handler->set() callback was changed to take a
-		dnl # dentry instead of an inode, and a handler_flags
-		dnl # argument was added.
+		dnl # xattr_handler, and handler_flags argument was removed and
+		dnl # should be accessed by handler->flags.
 		dnl #
-		AC_MSG_RESULT(no)
-		AC_MSG_CHECKING([whether xattr_handler->set() wants dentry])
+		AC_MSG_CHECKING([whether xattr_handler->set() wants xattr_handler])
 		ZFS_LINUX_TRY_COMPILE([
 			#include <linux/xattr.h>
 
-			int set(struct dentry *dentry, const char *name,
-			    const void *buffer, size_t size, int flags,
-			    int handler_flags) { return 0; }
+			int set(const struct xattr_handler *handler,
+			    struct dentry *dentry, const char *name,
+			    const void *buffer, size_t size, int flags)
+			    { return 0; }
 			static const struct xattr_handler
 			    xops __attribute__ ((unused)) = {
 				.set = set,
@@ -207,21 +207,23 @@ AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_SET], [
 		],[
 		],[
 			AC_MSG_RESULT(yes)
-			AC_DEFINE(HAVE_XATTR_SET_DENTRY, 1,
-			    [xattr_handler->set() wants dentry])
+			AC_DEFINE(HAVE_XATTR_SET_HANDLER, 1,
+			    [xattr_handler->set() wants xattr_handler])
 		],[
 			dnl #
-			dnl # 2.6.32 API
+			dnl # 2.6.33 API change,
+			dnl # The xattr_handler->set() callback was changed to take a
+			dnl # dentry instead of an inode, and a handler_flags
+			dnl # argument was added.
 			dnl #
 			AC_MSG_RESULT(no)
-			AC_MSG_CHECKING(
-			    [whether xattr_handler->set() wants inode])
+			AC_MSG_CHECKING([whether xattr_handler->set() wants dentry])
 			ZFS_LINUX_TRY_COMPILE([
 				#include <linux/xattr.h>
 
-				int set(struct inode *ip, const char *name,
-				    const void *buffer, size_t size, int flags)
-				    { return 0; }
+				int set(struct dentry *dentry, const char *name,
+				    const void *buffer, size_t size, int flags,
+				    int handler_flags) { return 0; }
 				static const struct xattr_handler
 				    xops __attribute__ ((unused)) = {
 					.set = set,
@@ -229,10 +231,33 @@ AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_SET], [
 			],[
 			],[
 				AC_MSG_RESULT(yes)
-				AC_DEFINE(HAVE_XATTR_SET_INODE, 1,
-				    [xattr_handler->set() wants inode])
+				AC_DEFINE(HAVE_XATTR_SET_DENTRY, 1,
+				    [xattr_handler->set() wants dentry])
 			],[
-	                        AC_MSG_ERROR([no; please file a bug report])
+				dnl #
+				dnl # 2.6.32 API
+				dnl #
+				AC_MSG_RESULT(no)
+				AC_MSG_CHECKING(
+				    [whether xattr_handler->set() wants inode])
+				ZFS_LINUX_TRY_COMPILE([
+					#include <linux/xattr.h>
+
+					int set(struct inode *ip, const char *name,
+					    const void *buffer, size_t size, int flags)
+					    { return 0; }
+					static const struct xattr_handler
+					    xops __attribute__ ((unused)) = {
+						.set = set,
+					};
+				],[
+				],[
+					AC_MSG_RESULT(yes)
+					AC_DEFINE(HAVE_XATTR_SET_INODE, 1,
+					    [xattr_handler->set() wants inode])
+				],[
+		                        AC_MSG_ERROR([no; please file a bug report])
+				])
 			])
 		])
 	])

--- a/include/linux/xattr_compat.h
+++ b/include/linux/xattr_compat.h
@@ -154,12 +154,26 @@ fn(struct inode *ip, const char *name, void *buffer, size_t size)	\
 #endif
 
 /*
+ * 4.7 API change,
+ * The xattr_handler->set() callback was changed to take a both dentry and
+ * inode, because the dentry might not be attached to an inode yet.
+ */
+#if defined(HAVE_XATTR_SET_DENTRY_INODE)
+#define	ZPL_XATTR_SET_WRAPPER(fn)					\
+static int								\
+fn(const struct xattr_handler *handler, struct dentry *dentry,		\
+    struct inode *inode, const char *name, const void *buffer,		\
+    size_t size, int flags)						\
+{									\
+	return (__ ## fn(inode, name, buffer, size, flags));		\
+}
+/*
  * 4.4 API change,
  * The xattr_handler->set() callback was changed to take a xattr_handler,
  * and handler_flags argument was removed and should be accessed by
  * handler->flags.
  */
-#if defined(HAVE_XATTR_SET_HANDLER)
+#elif defined(HAVE_XATTR_SET_HANDLER)
 #define	ZPL_XATTR_SET_WRAPPER(fn)					\
 static int								\
 fn(const struct xattr_handler *handler, struct dentry *dentry,		\


### PR DESCRIPTION
Counterpart to fd4c7b7a73fda391f94f58530c86ffa5b2ef8e6f, the same approach was taken to resolve the compatibility issue.  @tuxoko can you please review this since you wrote the `->get()` half.