### PR TITLE
Fix cstyle.pl warnings

### DIFF
--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -191,7 +191,11 @@ my $no_errs = 0;		# set for CSTYLED-protected lines
 sub err($) {
 	my ($error) = @_;
 	unless ($no_errs) {
-		printf $fmt, $filename, $., $error, $line;
+		if ($verbose) {
+			printf $fmt, $filename, $., $error, $line;
+		} else {
+			printf $fmt, $filename, $., $error;
+		}	
 		$err_stat = 1;
 	}
 }
@@ -200,7 +204,11 @@ sub err_prefix($$) {
 	my ($prevline, $error) = @_;
 	my $out = $prevline."\n".$line;
 	unless ($no_errs) {
-		printf $fmt, $filename, $., $error, $out;
+		if ($verbose) {
+			printf $fmt, $filename, $., $error, $out;
+		} else {
+			printf $fmt, $filename, $., $error;
+		}
 		$err_stat = 1;
 	}
 }
@@ -208,7 +216,11 @@ sub err_prefix($$) {
 sub err_prev($) {
 	my ($error) = @_;
 	unless ($no_errs) {
-		printf $fmt, $filename, $. - 1, $error, $prev;
+		if ($verbose) {
+			printf $fmt, $filename, $. - 1, $error, $prev;
+		} else {
+			printf $fmt, $filename, $. - 1, $error;
+		}
 		$err_stat = 1;
 	}
 }
@@ -605,7 +617,7 @@ line: while (<$filehandle>) {
 	if (/^\s*\(void\)[^ ]/) {
 		err("missing space after (void) cast");
 	}
-	if (/\S{/ && !/{{/) {
+	if (/\S\{/ && !/\{\{/) {
 		err("missing space before left brace");
 	}
 	if ($in_function && /^\s+{/ &&


### PR DESCRIPTION
As of perl v5.22.1 the following warnings are generated:

* Redundant argument in printf at scripts/cstyle.pl line 194

* Unescaped left brace in regex is deprecated, passed through
  in regex; marked by <-- HERE in m/\S{ <-- HERE / at
  scripts/cstyle.pl line 608.

They have been addressed by escaping the left braces and by
providing the correct number of arguments to printf based on
the fmt specifier set by the verbose option.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>