### PR TITLE
fix the PANIC: metaslab_free_dva(): bad DVA with zfs #3937

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2876,6 +2876,25 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 
 	if (db->db_blkid == DMU_SPILL_BLKID) {
 		mutex_enter(&dn->dn_mtx);
+		if (!(dn->dn_phys->dn_flags & DNODE_FLAG_SPILL_BLKPTR)) {
+			/*
+			 * pay attention the following scenario that would
+			 * introduce the potential problems:
+			 * in the previous transaction group, the bonus buffer
+			 * was entirely used to store the attributes for the
+			 * dnode which override the dn_spill field.
+			 * However, when adding more attributes to the file,
+			 * it will need the spill block to hold the extra
+			 * attributes overflowing the bonus buffer.
+			 * Make sure to clear the garbage left in the dn_spill
+			 * field which was the previous attributes in bonus
+			 * buffer, otherwise, after writing out the spill block
+			 * data to the new allocated dva, it will try to free
+			 * the old block pointed by the invalid dn_spill, that
+			 * would introduce the panic.
+			 */
+			db->db_blkptr = NULL;
+		}
 		dn->dn_phys->dn_flags |= DNODE_FLAG_SPILL_BLKPTR;
 		mutex_exit(&dn->dn_mtx);
 	}


### PR DESCRIPTION
the panic was introduced by the following scenario:
in the previous transaction group, the bonus buffer
was entirely used to store the attributes for the
dnode which override the dn_spill field.
however, when adding more attributes to the file,
it will need the spill block to hold the extra
attributes overflowing the bonus buffer.
make sure to clear the garbage left in the dn_spill
field which was the previous attributes in bonus
buffer, otherwise, after writing out the spill block
data to the new allocated dva, it will try to free
the old block pointed by the invalid dn_spill, that
would introduce the panic