### PR TITLE
Sync DMU_BACKUP_FEATURE_* flags

### DIFF
--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -98,7 +98,8 @@ typedef enum drr_headertype {
 #define	DMU_BACKUP_FEATURE_EMBED_DATA_LZ4	(1<<17)
 /* flag #18 is reserved for a Delphix feature */
 #define	DMU_BACKUP_FEATURE_LARGE_BLOCKS		(1<<19)
-#define	DMU_BACKUP_FEATURE_LARGE_DNODE		(1<<20)
+/* flag #20 is reserved for a resuming */
+#define	DMU_BACKUP_FEATURE_LARGE_DNODE		(1<<21)
 
 /*
  * Mask of all supported backup features


### PR DESCRIPTION
Flag #20 was used in OpenZFS as DMU_BACKUP_FEATURE_RESUMING, the
DMU_BACKUP_FEATURE_LARGE_DNODE flag must be shifted to #21 and
reserved in the  OpenZFS implementation.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>