### PR TITLE
This is the parity generation/rebuild using 128-bits NEON for Aarch64.

### DIFF
--- a/cmd/raidz_test/raidz_test.h
+++ b/cmd/raidz_test/raidz_test.h
@@ -34,6 +34,8 @@ static const char *raidz_impl_names[] = {
 	"sse2",
 	"ssse3",
 	"avx2",
+	"aarch64_neon",
+	"aarch64_neonx2",
 	NULL
 };
 

--- a/include/linux/Makefile.am
+++ b/include/linux/Makefile.am
@@ -8,6 +8,7 @@ KERNEL_H = \
 	$(top_srcdir)/include/linux/utsname_compat.h \
 	$(top_srcdir)/include/linux/kmap_compat.h \
 	$(top_srcdir)/include/linux/simd_x86.h \
+	$(top_srcdir)/include/linux/simd_aarch64.h \
 	$(top_srcdir)/include/linux/mod_compat.h
 
 USER_H =

--- a/include/linux/simd_aarch64.h
+++ b/include/linux/simd_aarch64.h
@@ -1,0 +1,62 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (C) 2016 Romain Dolbeau <romain@dolbeau.org>.
+ */
+
+/*
+ * USER API:
+ *
+ * Kernel fpu methods:
+ * 	kfpu_begin()
+ * 	kfpu_end()
+ */
+
+#ifndef _SIMD_AARCH64_H
+#define	_SIMD_AARCH64_H
+
+#include <sys/isa_defs.h>
+
+#if defined(__aarch64__)
+
+#include <sys/types.h>
+
+#if defined(_KERNEL)
+#include <asm/neon.h>
+#define	kfpu_begin()		\
+{					\
+	kernel_neon_begin();		\
+}
+#define	kfpu_end()			\
+{					\
+	kernel_neon_end();		\
+}
+#else
+/*
+ * fpu dummy methods for userspace
+ */
+#define	kfpu_begin() 	do {} while (0)
+#define	kfpu_end() 		do {} while (0)
+#endif /* defined(_KERNEL) */
+
+#endif /* __aarch64__ */
+
+#endif /* _SIMD_AARCH64_H */

--- a/include/sys/vdev_raidz_impl.h
+++ b/include/sys/vdev_raidz_impl.h
@@ -141,6 +141,10 @@ extern const raidz_impl_ops_t vdev_raidz_ssse3_impl;
 #if defined(__x86_64) && defined(HAVE_AVX2)	/* only x86_64 for now */
 extern const raidz_impl_ops_t vdev_raidz_avx2_impl;
 #endif
+#if defined(__aarch64__)
+extern const raidz_impl_ops_t vdev_raidz_aarch64_neon_impl;
+extern const raidz_impl_ops_t vdev_raidz_aarch64_neonx2_impl;
+#endif
 
 /*
  * Commonly used raidz_map helpers

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -99,6 +99,8 @@ KERNEL_C = \
 	vdev_raidz_math_sse2.c \
 	vdev_raidz_math_ssse3.c \
 	vdev_raidz_math_avx2.c \
+	vdev_raidz_math_aarch64_neon.c \
+	vdev_raidz_math_aarch64_neonx2.c \
 	vdev_root.c \
 	zap.c \
 	zap_leaf.c \

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1763,6 +1763,8 @@ Possible options are:
   sse2     - implementation using SSE2 instruction set (64bit x86 only)
   ssse3    - implementation using SSSE3 instruction set (64bit x86 only)
   avx2     - implementation using AVX2 instruction set (64bit x86 only)
+  aarch64_neon - implementation using NEON (Aarch64/64 bit ARMv8 only)
+  aarch64_neonx2 - implementation using NEON with more unrolling (Aarch64/64 bit ARMv8 only)
 .sp
 Default value: \fBfastest\fR.
 .RE

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -115,3 +115,6 @@ $(MODULE)-objs += dsl_userhold.o
 $(MODULE)-$(CONFIG_X86) += vdev_raidz_math_sse2.o
 $(MODULE)-$(CONFIG_X86) += vdev_raidz_math_ssse3.o
 $(MODULE)-$(CONFIG_X86) += vdev_raidz_math_avx2.o
+
+$(MODULE)-$(CONFIG_ARM64) += vdev_raidz_math_aarch64_neon.o
+$(MODULE)-$(CONFIG_ARM64) += vdev_raidz_math_aarch64_neonx2.o

--- a/module/zfs/vdev_raidz_math.c
+++ b/module/zfs/vdev_raidz_math.c
@@ -55,7 +55,11 @@ const raidz_impl_ops_t *raidz_all_maths[] = {
 	&vdev_raidz_ssse3_impl,
 #endif
 #if defined(__x86_64) && defined(HAVE_AVX2)	/* only x86_64 for now */
-	&vdev_raidz_avx2_impl
+	&vdev_raidz_avx2_impl,
+#endif
+#if defined(__aarch64__)
+	&vdev_raidz_aarch64_neon_impl,
+	&vdev_raidz_aarch64_neonx2_impl,
 #endif
 };
 

--- a/module/zfs/vdev_raidz_math.c
+++ b/module/zfs/vdev_raidz_math.c
@@ -279,11 +279,11 @@ raidz_math_kstat_headers(char *buf, size_t size)
 	off = snprintf(buf, size, "%-17s", "implementation");
 
 	for (i = 0; i < ARRAY_SIZE(raidz_gen_name); i++)
-		off += snprintf(buf + off, size - off, "%-12s",
+		off += snprintf(buf + off, size - off, "%-16s",
 		    raidz_gen_name[i]);
 
 	for (i = 0; i < ARRAY_SIZE(raidz_rec_name); i++)
-		off += snprintf(buf + off, size - off, "%-12s",
+		off += snprintf(buf + off, size - off, "%-16s",
 		    raidz_rec_name[i]);
 
 	(void) snprintf(buf + off, size - off, "\n");
@@ -306,12 +306,12 @@ raidz_math_kstat_data(char *buf, size_t size, void *data)
 
 		for (i = 0; i < ARRAY_SIZE(raidz_gen_name); i++) {
 			int id = fstat->gen[i];
-			off += snprintf(buf + off, size - off, "%-12s",
+			off += snprintf(buf + off, size - off, "%-16s",
 			    raidz_supp_impl[id]->name);
 		}
 		for (i = 0; i < ARRAY_SIZE(raidz_rec_name); i++) {
 			int id = fstat->rec[i];
-			off += snprintf(buf + off, size - off, "%-12s",
+			off += snprintf(buf + off, size - off, "%-16s",
 			    raidz_supp_impl[id]->name);
 		}
 	} else {
@@ -321,11 +321,11 @@ raidz_math_kstat_data(char *buf, size_t size, void *data)
 		    raidz_supp_impl[id]->name);
 
 		for (i = 0; i < ARRAY_SIZE(raidz_gen_name); i++)
-			off += snprintf(buf + off, size - off, "%-12llu",
+			off += snprintf(buf + off, size - off, "%-16llu",
 			    (u_longlong_t) cstat->gen[i]);
 
 		for (i = 0; i < ARRAY_SIZE(raidz_rec_name); i++)
-			off += snprintf(buf + off, size - off, "%-12llu",
+			off += snprintf(buf + off, size - off, "%-16llu",
 			    (u_longlong_t) cstat->rec[i]);
 	}
 

--- a/module/zfs/vdev_raidz_math_aarch64_neon_common.h
+++ b/module/zfs/vdev_raidz_math_aarch64_neon_common.h
@@ -1,0 +1,685 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (C) 2016 Romain Dolbeau. All rights reserved.
+ */
+
+#include <sys/types.h>
+#include <linux/simd_aarch64.h>
+
+#define	__asm __asm__ __volatile__
+
+#define	_REG_CNT(_0, _1, _2, _3, _4, _5, _6, _7, N, ...) N
+#define	REG_CNT(r...) _REG_CNT(r, 8, 7, 6, 5, 4, 3, 2, 1)
+
+#define	VR0_(REG, ...) "%[w"#REG"]"
+#define	VR1_(_1, REG, ...) "%[w"#REG"]"
+#define	VR2_(_1, _2, REG, ...) "%[w"#REG"]"
+#define	VR3_(_1, _2, _3, REG, ...) "%[w"#REG"]"
+#define	VR4_(_1, _2, _3, _4, REG, ...) "%[w"#REG"]"
+#define	VR5_(_1, _2, _3, _4, _5, REG, ...) "%[w"#REG"]"
+#define	VR6_(_1, _2, _3, _4, _5, _6, REG, ...) "%[w"#REG"]"
+#define	VR7_(_1, _2, _3, _4, _5, _6, _7, REG, ...) "%[w"#REG"]"
+
+/*
+ * Here we need registers not used otherwise.
+ * They will be used in unused ASM for the case
+ * with more registers than required... but GGC
+ * will still need to make sure the constraints
+ * are correct, and duplicate constraints are illegal
+ * ... and we use the "register" number as a name
+ */
+
+#define	VR0(r...) VR0_(r)
+#define	VR1(r...) VR1_(r)
+#define	VR2(r...) VR2_(r, 36)
+#define	VR3(r...) VR3_(r, 36, 35)
+#define	VR4(r...) VR4_(r, 36, 35, 34, 33)
+#define	VR5(r...) VR5_(r, 36, 35, 34, 33, 32)
+#define	VR6(r...) VR6_(r, 36, 35, 34, 33, 32, 31)
+#define	VR7(r...) VR7_(r, 36, 35, 34, 33, 32, 31, 30)
+
+#define	VR(X) "%[w"#X"]"
+
+#define	RVR0_(REG, ...) [w##REG] "w" (w##REG)
+#define	RVR1_(_1, REG, ...) [w##REG] "w" (w##REG)
+#define	RVR2_(_1, _2, REG, ...) [w##REG] "w" (w##REG)
+#define	RVR3_(_1, _2, _3, REG, ...) [w##REG] "w" (w##REG)
+#define	RVR4_(_1, _2, _3, _4, REG, ...) [w##REG] "w" (w##REG)
+#define	RVR5_(_1, _2, _3, _4, _5, REG, ...) [w##REG] "w" (w##REG)
+#define	RVR6_(_1, _2, _3, _4, _5, _6, REG, ...) [w##REG] "w" (w##REG)
+#define	RVR7_(_1, _2, _3, _4, _5, _6, _7, REG, ...) [w##REG] "w" (w##REG)
+
+#define	RVR0(r...) RVR0_(r)
+#define	RVR1(r...) RVR1_(r)
+#define	RVR2(r...) RVR2_(r, 36)
+#define	RVR3(r...) RVR3_(r, 36, 35)
+#define	RVR4(r...) RVR4_(r, 36, 35, 34, 33)
+#define	RVR5(r...) RVR5_(r, 36, 35, 34, 33, 32)
+#define	RVR6(r...) RVR6_(r, 36, 35, 34, 33, 32, 31)
+#define	RVR7(r...) RVR7_(r, 36, 35, 34, 33, 32, 31, 30)
+
+#define	RVR(X) [w##X] "w" (w##X)
+
+#define	WVR0_(REG, ...) [w##REG] "=w" (w##REG)
+#define	WVR1_(_1, REG, ...) [w##REG] "=w" (w##REG)
+#define	WVR2_(_1, _2, REG, ...) [w##REG] "=w" (w##REG)
+#define	WVR3_(_1, _2, _3, REG, ...) [w##REG] "=w" (w##REG)
+#define	WVR4_(_1, _2, _3, _4, REG, ...) [w##REG] "=w" (w##REG)
+#define	WVR5_(_1, _2, _3, _4, _5, REG, ...) [w##REG] "=w" (w##REG)
+#define	WVR6_(_1, _2, _3, _4, _5, _6, REG, ...) [w##REG] "=w" (w##REG)
+#define	WVR7_(_1, _2, _3, _4, _5, _6, _7, REG, ...) [w##REG] "=w" (w##REG)
+
+#define	WVR0(r...) WVR0_(r)
+#define	WVR1(r...) WVR1_(r)
+#define	WVR2(r...) WVR2_(r, 36)
+#define	WVR3(r...) WVR3_(r, 36, 35)
+#define	WVR4(r...) WVR4_(r, 36, 35, 34, 33)
+#define	WVR5(r...) WVR5_(r, 36, 35, 34, 33, 32)
+#define	WVR6(r...) WVR6_(r, 36, 35, 34, 33, 32, 31)
+#define	WVR7(r...) WVR7_(r, 36, 35, 34, 33, 32, 31, 30)
+
+#define	WVR(X) [w##X] "=w" (w##X)
+
+#define	UVR0_(REG, ...) [w##REG] "+&w" (w##REG)
+#define	UVR1_(_1, REG, ...) [w##REG] "+&w" (w##REG)
+#define	UVR2_(_1, _2, REG, ...) [w##REG] "+&w" (w##REG)
+#define	UVR3_(_1, _2, _3, REG, ...) [w##REG] "+&w" (w##REG)
+#define	UVR4_(_1, _2, _3, _4, REG, ...) [w##REG] "+&w" (w##REG)
+#define	UVR5_(_1, _2, _3, _4, _5, REG, ...) [w##REG] "+&w" (w##REG)
+#define	UVR6_(_1, _2, _3, _4, _5, _6, REG, ...) [w##REG] "+&w" (w##REG)
+#define	UVR7_(_1, _2, _3, _4, _5, _6, _7, REG, ...) [w##REG] "+&w" (w##REG)
+
+#define	UVR0(r...) UVR0_(r)
+#define	UVR1(r...) UVR1_(r)
+#define	UVR2(r...) UVR2_(r, 36)
+#define	UVR3(r...) UVR3_(r, 36, 35)
+#define	UVR4(r...) UVR4_(r, 36, 35, 34, 33)
+#define	UVR5(r...) UVR5_(r, 36, 35, 34, 33, 32)
+#define	UVR6(r...) UVR6_(r, 36, 35, 34, 33, 32, 31)
+#define	UVR7(r...) UVR7_(r, 36, 35, 34, 33, 32, 31, 30)
+
+#define	UVR(X) [w##X] "+&w" (w##X)
+
+#define	R_01(REG1, REG2, ...) REG1, REG2
+#define	_R_23(_0, _1, REG2, REG3, ...) REG2, REG3
+#define	R_23(REG...) _R_23(REG, 1, 2, 3)
+
+#define	ASM_BUG()	ASSERT(0)
+
+#define	OFFSET(ptr, val)	(((unsigned char *)ptr)+val)
+
+extern const uint8_t gf_clmul_mod_lt[4*256][16];
+
+#define	ELEM_SIZE 16
+
+typedef struct v {
+	uint8_t b[ELEM_SIZE] __attribute__((aligned(ELEM_SIZE)));
+} v_t;
+
+#define	PREFETCHNTA(ptr, offset) 					\
+{									\
+	__asm(								\
+	    "prfm pstl1strm, %[MEM]\n"					\
+	    :	:	[MEM] "Q" (*(ptr + offset)));			\
+}
+
+#define	PREFETCH(ptr, offset) 						\
+{									\
+	__asm(								\
+	    "prfm pldl1keep, %[MEM]\n"					\
+	    :	:	[MEM] "Q" (*(ptr + offset)));			\
+}
+
+#define	XOR_ACC(src, r...)						\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 8:								\
+		__asm(							\
+		"ld1 { v21.4s },%[SRC0]\n"				\
+		"ld1 { v20.4s },%[SRC1]\n"				\
+		"ld1 { v19.4s },%[SRC2]\n"				\
+		"ld1 { v18.4s },%[SRC3]\n"				\
+		"eor " VR0(r) ".16b," VR0(r) ".16b,v21.16b\n"		\
+		"eor " VR1(r) ".16b," VR1(r) ".16b,v20.16b\n"		\
+		"eor " VR2(r) ".16b," VR2(r) ".16b,v19.16b\n"		\
+		"eor " VR3(r) ".16b," VR3(r) ".16b,v18.16b\n"		\
+		"ld1 { v21.4s },%[SRC4]\n"				\
+		"ld1 { v20.4s },%[SRC5]\n"				\
+		"ld1 { v19.4s },%[SRC6]\n"				\
+		"ld1 { v18.4s },%[SRC7]\n"				\
+		"eor " VR4(r) ".16b," VR4(r) ".16b,v21.16b\n"		\
+		"eor " VR5(r) ".16b," VR5(r) ".16b,v20.16b\n"		\
+		"eor " VR6(r) ".16b," VR6(r) ".16b,v19.16b\n"		\
+		"eor " VR7(r) ".16b," VR7(r) ".16b,v18.16b\n"		\
+		:	UVR0(r), UVR1(r), UVR2(r), UVR3(r),		\
+			UVR4(r), UVR5(r), UVR6(r), UVR7(r)		\
+		:	[SRC0] "Q" (*(OFFSET(src, 0))),			\
+		[SRC1] "Q" (*(OFFSET(src, 16))),			\
+		[SRC2] "Q" (*(OFFSET(src, 32))),			\
+		[SRC3] "Q" (*(OFFSET(src, 48))),			\
+		[SRC4] "Q" (*(OFFSET(src, 64))),			\
+		[SRC5] "Q" (*(OFFSET(src, 80))),			\
+		[SRC6] "Q" (*(OFFSET(src, 96))),			\
+		[SRC7] "Q" (*(OFFSET(src, 112)))			\
+		:	"v18", "v19", "v20", "v21");			\
+		break;							\
+	case 4:								\
+		__asm(							\
+		"ld1 { v21.4s },%[SRC0]\n"				\
+		"ld1 { v20.4s },%[SRC1]\n"				\
+		"ld1 { v19.4s },%[SRC2]\n"				\
+		"ld1 { v18.4s },%[SRC3]\n"				\
+		"eor " VR0(r) ".16b," VR0(r) ".16b,v21.16b\n"		\
+		"eor " VR1(r) ".16b," VR1(r) ".16b,v20.16b\n"		\
+		"eor " VR2(r) ".16b," VR2(r) ".16b,v19.16b\n"		\
+		"eor " VR3(r) ".16b," VR3(r) ".16b,v18.16b\n"		\
+		:	UVR0(r), UVR1(r), UVR2(r), UVR3(r)		\
+		:	[SRC0] "Q" (*(OFFSET(src, 0))),			\
+		[SRC1] "Q" (*(OFFSET(src, 16))),			\
+		[SRC2] "Q" (*(OFFSET(src, 32))),			\
+		[SRC3] "Q" (*(OFFSET(src, 48)))				\
+		:	"v18", "v19", "v20", "v21");			\
+		break;							\
+	case 2:								\
+		__asm(							\
+		"ld1 { v21.4s },%[SRC0]\n"				\
+		"ld1 { v20.4s },%[SRC1]\n"				\
+		"eor " VR0(r) ".16b," VR0(r) ".16b,v21.16b\n"		\
+		"eor " VR1(r) ".16b," VR1(r) ".16b,v20.16b\n"		\
+		:	UVR0(r), UVR1(r)				\
+		:	[SRC0] "Q" (*(OFFSET(src, 0))),			\
+		[SRC1] "Q" (*(OFFSET(src, 16)))				\
+		:	"v20", "v21");					\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
+#define	XOR(r...)							\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 8:								\
+		__asm(							\
+		"eor " VR4(r) ".16b," VR4(r) ".16b," VR0(r) ".16b\n"	\
+		"eor " VR5(r) ".16b," VR5(r) ".16b," VR1(r) ".16b\n"	\
+		"eor " VR6(r) ".16b," VR6(r) ".16b," VR2(r) ".16b\n"	\
+		"eor " VR7(r) ".16b," VR7(r) ".16b," VR3(r) ".16b\n"	\
+		:	UVR4(r), UVR5(r), UVR6(r), UVR7(r)		\
+		:	RVR0(r), RVR1(r), RVR2(r), RVR3(r));		\
+		break;							\
+	case 4:								\
+		__asm(							\
+		"eor " VR2(r) ".16b," VR2(r) ".16b," VR0(r) ".16b\n"	\
+		"eor " VR3(r) ".16b," VR3(r) ".16b," VR1(r) ".16b\n"	\
+		:	UVR2(r), UVR3(r)				\
+		:	RVR0(r), RVR1(r));				\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
+#define	ZERO(r...)							\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 4:								\
+		__asm(							\
+		"eor " VR0(r) ".16b," VR0(r) ".16b," VR0(r) ".16b\n"	\
+		"eor " VR1(r) ".16b," VR1(r) ".16b," VR1(r) ".16b\n"	\
+		"eor " VR2(r) ".16b," VR2(r) ".16b," VR2(r) ".16b\n"	\
+		"eor " VR3(r) ".16b," VR3(r) ".16b," VR3(r) ".16b\n"	\
+		:	WVR0(r), WVR1(r), WVR2(r), WVR3(r));		\
+		break;							\
+	case 2:								\
+		__asm(							\
+		"eor " VR0(r) ".16b," VR0(r) ".16b," VR0(r) ".16b\n"	\
+		"eor " VR1(r) ".16b," VR1(r) ".16b," VR1(r) ".16b\n"	\
+		:	WVR0(r), WVR1(r));				\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
+#define	COPY(r...)							\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 8:								\
+		__asm(							\
+		"mov " VR4(r) ".16b," VR0(r) ".16b\n"			\
+		"mov " VR5(r) ".16b," VR1(r) ".16b\n"			\
+		"mov " VR6(r) ".16b," VR2(r) ".16b\n"			\
+		"mov " VR7(r) ".16b," VR3(r) ".16b\n"			\
+		:	WVR4(r), WVR5(r), WVR6(r), WVR7(r)		\
+		:	RVR0(r), RVR1(r), RVR2(r), RVR3(r));		\
+		break;							\
+	case 4:								\
+		__asm(							\
+		"mov " VR2(r) ".16b," VR0(r) ".16b\n"			\
+		"mov " VR3(r) ".16b," VR1(r) ".16b\n"			\
+		:	WVR2(r), WVR3(r)				\
+		:	RVR0(r), RVR1(r));				\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
+#define	LOAD(src, r...)							\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 8:								\
+		__asm(							\
+		"ld1 { " VR0(r) ".4s },%[SRC0]\n"			\
+		"ld1 { " VR1(r) ".4s },%[SRC1]\n"			\
+		"ld1 { " VR2(r) ".4s },%[SRC2]\n"			\
+		"ld1 { " VR3(r) ".4s },%[SRC3]\n"			\
+		"ld1 { " VR4(r) ".4s },%[SRC4]\n"			\
+		"ld1 { " VR5(r) ".4s },%[SRC5]\n"			\
+		"ld1 { " VR6(r) ".4s },%[SRC6]\n"			\
+		"ld1 { " VR7(r) ".4s },%[SRC7]\n"			\
+		:	WVR0(r), WVR1(r), WVR2(r), WVR3(r),		\
+			WVR4(r), WVR5(r), WVR6(r), WVR7(r)		\
+		:	[SRC0] "Q" (*(OFFSET(src, 0))),			\
+		[SRC1] "Q" (*(OFFSET(src, 16))),			\
+		[SRC2] "Q" (*(OFFSET(src, 32))),			\
+		[SRC3] "Q" (*(OFFSET(src, 48))),			\
+		[SRC4] "Q" (*(OFFSET(src, 64))),			\
+		[SRC5] "Q" (*(OFFSET(src, 80))),			\
+		[SRC6] "Q" (*(OFFSET(src, 96))),			\
+		[SRC7] "Q" (*(OFFSET(src, 112))));			\
+		break;							\
+	case 4:								\
+		__asm(							\
+		"ld1 { " VR0(r) ".4s },%[SRC0]\n"			\
+		"ld1 { " VR1(r) ".4s },%[SRC1]\n"			\
+		"ld1 { " VR2(r) ".4s },%[SRC2]\n"			\
+		"ld1 { " VR3(r) ".4s },%[SRC3]\n"			\
+		:	WVR0(r), WVR1(r), WVR2(r), WVR3(r)		\
+		:	[SRC0] "Q" (*(OFFSET(src, 0))),			\
+		[SRC1] "Q" (*(OFFSET(src, 16))),			\
+		[SRC2] "Q" (*(OFFSET(src, 32))),			\
+		[SRC3] "Q" (*(OFFSET(src, 48))));			\
+		break;							\
+	case 2:								\
+		__asm(							\
+		"ld1 { " VR0(r) ".4s },%[SRC0]\n"			\
+		"ld1 { " VR1(r) ".4s },%[SRC1]\n"			\
+		:	WVR0(r), WVR1(r)				\
+		:	[SRC0] "Q" (*(OFFSET(src, 0))),			\
+		[SRC1] "Q" (*(OFFSET(src, 16))));			\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
+#define	STORE(dst, r...)						\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 8:								\
+		__asm(							\
+		"st1 { " VR0(r) ".4s },%[DST0]\n"			\
+		"st1 { " VR1(r) ".4s },%[DST1]\n"			\
+		"st1 { " VR2(r) ".4s },%[DST2]\n"			\
+		"st1 { " VR3(r) ".4s },%[DST3]\n"			\
+		"st1 { " VR4(r) ".4s },%[DST4]\n"			\
+		"st1 { " VR5(r) ".4s },%[DST5]\n"			\
+		"st1 { " VR6(r) ".4s },%[DST6]\n"			\
+		"st1 { " VR7(r) ".4s },%[DST7]\n"			\
+		:	[DST0] "=Q" (*(OFFSET(dst, 0))),		\
+		[DST1] "=Q" (*(OFFSET(dst, 16))),			\
+		[DST2] "=Q" (*(OFFSET(dst, 32))),			\
+		[DST3] "=Q" (*(OFFSET(dst, 48))),			\
+		[DST4] "=Q" (*(OFFSET(dst, 64))),			\
+		[DST5] "=Q" (*(OFFSET(dst, 80))),			\
+		[DST6] "=Q" (*(OFFSET(dst, 96))),			\
+		[DST7] "=Q" (*(OFFSET(dst, 112)))			\
+		:	RVR0(r), RVR1(r), RVR2(r), RVR3(r),		\
+			RVR4(r), RVR5(r), RVR6(r), RVR7(r));		\
+		break;							\
+	case 4:								\
+		__asm(							\
+		"st1 { " VR0(r) ".4s },%[DST0]\n"			\
+		"st1 { " VR1(r) ".4s },%[DST1]\n"			\
+		"st1 { " VR2(r) ".4s },%[DST2]\n"			\
+		"st1 { " VR3(r) ".4s },%[DST3]\n"			\
+		:	[DST0] "=Q" (*(OFFSET(dst, 0))),		\
+		[DST1] "=Q" (*(OFFSET(dst, 16))),			\
+		[DST2] "=Q" (*(OFFSET(dst, 32))),			\
+		[DST3] "=Q" (*(OFFSET(dst, 48)))			\
+		:	RVR0(r), RVR1(r), RVR2(r), RVR3(r));		\
+		break;							\
+	case 2:								\
+		__asm(							\
+		"st1 { " VR0(r) ".4s },%[DST0]\n"			\
+		"st1 { " VR1(r) ".4s },%[DST1]\n"			\
+		:	[DST0] "=Q" (*(OFFSET(dst, 0))),		\
+		[DST1] "=Q" (*(OFFSET(dst, 16)))			\
+		:	RVR0(r), RVR1(r));				\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
+/*
+ * Unfortunately cannot use the macro, because GCC
+ * will try to use the macro name and not value
+ * later on...
+ * Kept as a reference to what a numbered variable is
+ */
+#define	_00	"v17"
+#define	_1d	"v16"
+#define	_temp0	"v19"
+#define	_temp1	"v18"
+
+#define	MUL2_SETUP()							\
+{									\
+	__asm(								\
+	"eor " VR(17) ".16b," VR(17) ".16b," VR(17) ".16b\n"		\
+	"movi " VR(16) ".16b,#0x1d\n"					\
+	:	WVR(16), WVR(17));					\
+}
+
+#define	MUL2(r...)							\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 4:								\
+		__asm(							\
+		"cmgt v19.16b," VR(17) ".16b," VR0(r) ".16b\n"		\
+		"cmgt v18.16b," VR(17) ".16b," VR1(r) ".16b\n"		\
+		"cmgt v21.16b," VR(17) ".16b," VR2(r) ".16b\n"		\
+		"cmgt v20.16b," VR(17) ".16b," VR3(r) ".16b\n"		\
+		"and v19.16b,v19.16b," VR(16) ".16b\n"			\
+		"and v18.16b,v18.16b," VR(16) ".16b\n"			\
+		"and v21.16b,v21.16b," VR(16) ".16b\n"			\
+		"and v20.16b,v20.16b," VR(16) ".16b\n"			\
+		"shl " VR0(r) ".16b," VR0(r) ".16b,#1\n"		\
+		"shl " VR1(r) ".16b," VR1(r) ".16b,#1\n"		\
+		"shl " VR2(r) ".16b," VR2(r) ".16b,#1\n"		\
+		"shl " VR3(r) ".16b," VR3(r) ".16b,#1\n"		\
+		"eor " VR0(r) ".16b,v19.16b," VR0(r) ".16b\n"		\
+		"eor " VR1(r) ".16b,v18.16b," VR1(r) ".16b\n"		\
+		"eor " VR2(r) ".16b,v21.16b," VR2(r) ".16b\n"		\
+		"eor " VR3(r) ".16b,v20.16b," VR3(r) ".16b\n"		\
+		:	UVR0(r), UVR1(r), UVR2(r), UVR3(r)		\
+		:	RVR(17), RVR(16)				\
+		:	"v18", "v19", "v20", "v21");			\
+		break;							\
+	case 2:								\
+		__asm(							\
+		"cmgt v19.16b," VR(17) ".16b," VR0(r) ".16b\n"		\
+		"cmgt v18.16b," VR(17) ".16b," VR1(r) ".16b\n"		\
+		"and v19.16b,v19.16b," VR(16) ".16b\n"			\
+		"and v18.16b,v18.16b," VR(16) ".16b\n"			\
+		"shl " VR0(r) ".16b," VR0(r) ".16b,#1\n"		\
+		"shl " VR1(r) ".16b," VR1(r) ".16b,#1\n"		\
+		"eor " VR0(r) ".16b,v19.16b," VR0(r) ".16b\n"		\
+		"eor " VR1(r) ".16b,v18.16b," VR1(r) ".16b\n"		\
+		:	UVR0(r), UVR1(r)				\
+		:	RVR(17), RVR(16)				\
+		:	"v18", "v19");					\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
+#define	MUL4(r...)							\
+{									\
+	MUL2(r);							\
+	MUL2(r);							\
+}
+
+/*
+ * Unfortunately cannot use the macro, because GCC
+ * will try to use the macro name and not value
+ * later on...
+ * Kept as a reference to what a register is
+ * (here we're using actual registers for the
+ * clobbered ones)
+ */
+#define	_0f		"v15"
+#define	_a_save		"v14"
+#define	_b_save		"v13"
+#define	_lt_mod_a	"v12"
+#define	_lt_clmul_a	"v11"
+#define	_lt_mod_b	"v10"
+#define	_lt_clmul_b	"v15"
+
+#define	_MULx2(c, r...)							\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 2:								\
+		__asm(							\
+		/* lts for upper part */				\
+		"movi v15.16b,#0x0f\n"					\
+		"ld1 { v10.4s },%[lt0]\n"				\
+		"ld1 { v11.4s },%[lt1]\n"				\
+		/* upper part */					\
+		"and v14.16b," VR0(r) ".16b,v15.16b\n"			\
+		"and v13.16b," VR1(r) ".16b,v15.16b\n"			\
+		"sshr " VR0(r) ".8h," VR0(r) ".8h,#4\n"			\
+		"sshr " VR1(r) ".8h," VR1(r) ".8h,#4\n"			\
+		"and " VR0(r) ".16b," VR0(r) ".16b,v15.16b\n"		\
+		"and " VR1(r) ".16b," VR1(r) ".16b,v15.16b\n"		\
+									\
+		"tbl v12.16b,{v10.16b}," VR0(r) ".16b\n"		\
+		"tbl v10.16b,{v10.16b}," VR1(r) ".16b\n"		\
+		"tbl v15.16b,{v11.16b}," VR0(r) ".16b\n"		\
+		"tbl v11.16b,{v11.16b}," VR1(r) ".16b\n"		\
+									\
+		"eor " VR0(r) ".16b,v15.16b,v12.16b\n"			\
+		"eor " VR1(r) ".16b,v11.16b,v10.16b\n"			\
+		/* lts for lower part */				\
+		"ld1 { v10.4s },%[lt2]\n"				\
+		"ld1 { v15.4s },%[lt3]\n"				\
+		/* lower part */					\
+		"tbl v12.16b,{v10.16b},v14.16b\n"			\
+		"tbl v10.16b,{v10.16b},v13.16b\n"			\
+		"tbl v11.16b,{v15.16b},v14.16b\n"			\
+		"tbl v15.16b,{v15.16b},v13.16b\n"			\
+									\
+		"eor " VR0(r) ".16b," VR0(r) ".16b,v12.16b\n"		\
+		"eor " VR1(r) ".16b," VR1(r) ".16b,v10.16b\n"		\
+		"eor " VR0(r) ".16b," VR0(r) ".16b,v11.16b\n"		\
+		"eor " VR1(r) ".16b," VR1(r) ".16b,v15.16b\n"		\
+		:	UVR0(r), UVR1(r)				\
+		:	[lt0] "Q" ((gf_clmul_mod_lt[4*(c)+0][0])),	\
+		[lt1] "Q" ((gf_clmul_mod_lt[4*(c)+1][0])),		\
+		[lt2] "Q" ((gf_clmul_mod_lt[4*(c)+2][0])),		\
+		[lt3] "Q" ((gf_clmul_mod_lt[4*(c)+3][0]))		\
+		:	"v10", "v11", "v12", "v13", "v14", "v15");	\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
+#define	MUL(c, r...)							\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 4:								\
+		_MULx2(c, R_23(r));					\
+		_MULx2(c, R_01(r));					\
+		break;							\
+	case 2:								\
+		_MULx2(c, R_01(r));					\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
+#define	raidz_math_begin()	kfpu_begin()
+#define	raidz_math_end()	kfpu_end()
+
+/* Overkill... */
+#if defined(_KERNEL)
+#define	GEN_X_DEFINE_0_3()	\
+register unsigned char w0 asm("v0") __attribute__((vector_size(16)));	\
+register unsigned char w1 asm("v1") __attribute__((vector_size(16)));	\
+register unsigned char w2 asm("v2") __attribute__((vector_size(16)));	\
+register unsigned char w3 asm("v3") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_4_5()	\
+register unsigned char w4 asm("v4") __attribute__((vector_size(16)));	\
+register unsigned char w5 asm("v5") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_6_7()	\
+register unsigned char w6 asm("v6") __attribute__((vector_size(16)));	\
+register unsigned char w7 asm("v7") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_8_9()	\
+register unsigned char w8 asm("v8") __attribute__((vector_size(16)));	\
+register unsigned char w9 asm("v9") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_10_11()	\
+register unsigned char w10 asm("v10") __attribute__((vector_size(16)));	\
+register unsigned char w11 asm("v11") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_12_15()	\
+register unsigned char w12 asm("v12") __attribute__((vector_size(16)));	\
+register unsigned char w13 asm("v13") __attribute__((vector_size(16)));	\
+register unsigned char w14 asm("v14") __attribute__((vector_size(16)));	\
+register unsigned char w15 asm("v15") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_16()	\
+register unsigned char w16 asm("v16") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_17()	\
+register unsigned char w17 asm("v17") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_18_21()	\
+register unsigned char w18 asm("v18") __attribute__((vector_size(16)));	\
+register unsigned char w19 asm("v19") __attribute__((vector_size(16)));	\
+register unsigned char w20 asm("v20") __attribute__((vector_size(16)));	\
+register unsigned char w21 asm("v21") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_22_23()	\
+register unsigned char w22 asm("v22") __attribute__((vector_size(16)));	\
+register unsigned char w23 asm("v23") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_24_27()	\
+register unsigned char w24 asm("v24") __attribute__((vector_size(16)));	\
+register unsigned char w25 asm("v25") __attribute__((vector_size(16)));	\
+register unsigned char w26 asm("v26") __attribute__((vector_size(16)));	\
+register unsigned char w27 asm("v27") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_28_30()	\
+register unsigned char w28 asm("v28") __attribute__((vector_size(16)));	\
+register unsigned char w29 asm("v29") __attribute__((vector_size(16)));	\
+register unsigned char w30 asm("v30") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_31()	\
+register unsigned char w31 asm("v31") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_32()	\
+register unsigned char w32 asm("v31") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_33_36()	\
+register unsigned char w33 asm("v31") __attribute__((vector_size(16)));	\
+register unsigned char w34 asm("v31") __attribute__((vector_size(16)));	\
+register unsigned char w35 asm("v31") __attribute__((vector_size(16)));	\
+register unsigned char w36 asm("v31") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_37_38()	\
+register unsigned char w37 asm("v31") __attribute__((vector_size(16)));	\
+register unsigned char w38 asm("v31") __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_ALL()	\
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_4_5()	\
+	GEN_X_DEFINE_6_7()	\
+	GEN_X_DEFINE_8_9()	\
+	GEN_X_DEFINE_10_11()	\
+	GEN_X_DEFINE_12_15()	\
+	GEN_X_DEFINE_16()	\
+	GEN_X_DEFINE_17()	\
+	GEN_X_DEFINE_18_21()	\
+	GEN_X_DEFINE_22_23()	\
+	GEN_X_DEFINE_24_27()	\
+	GEN_X_DEFINE_28_30()	\
+	GEN_X_DEFINE_31()	\
+	GEN_X_DEFINE_32()	\
+	GEN_X_DEFINE_33_36() 	\
+	GEN_X_DEFINE_37_38()
+#else
+#define	GEN_X_DEFINE_0_3()	\
+	unsigned char w0 __attribute__((vector_size(16)));	\
+	unsigned char w1 __attribute__((vector_size(16)));	\
+	unsigned char w2 __attribute__((vector_size(16)));	\
+	unsigned char w3 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_4_5()	\
+	unsigned char w4 __attribute__((vector_size(16)));	\
+	unsigned char w5 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_6_7()	\
+	unsigned char w6 __attribute__((vector_size(16)));	\
+	unsigned char w7 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_8_9()	\
+	unsigned char w8 __attribute__((vector_size(16)));	\
+	unsigned char w9 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_10_11()	\
+	unsigned char w10 __attribute__((vector_size(16)));	\
+	unsigned char w11 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_12_15()	\
+	unsigned char w12 __attribute__((vector_size(16)));	\
+	unsigned char w13 __attribute__((vector_size(16)));	\
+	unsigned char w14 __attribute__((vector_size(16)));	\
+	unsigned char w15 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_16()	\
+	unsigned char w16 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_17()	\
+	unsigned char w17 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_18_21()	\
+	unsigned char w18 __attribute__((vector_size(16)));	\
+	unsigned char w19 __attribute__((vector_size(16)));	\
+	unsigned char w20 __attribute__((vector_size(16)));	\
+	unsigned char w21 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_22_23()	\
+	unsigned char w22 __attribute__((vector_size(16)));	\
+	unsigned char w23 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_24_27()	\
+	unsigned char w24 __attribute__((vector_size(16)));	\
+	unsigned char w25 __attribute__((vector_size(16)));	\
+	unsigned char w26 __attribute__((vector_size(16)));	\
+	unsigned char w27 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_28_30()	\
+	unsigned char w28 __attribute__((vector_size(16)));	\
+	unsigned char w29 __attribute__((vector_size(16)));	\
+	unsigned char w30 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_31()	\
+	unsigned char w31 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_32()	\
+	unsigned char w32 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_33_36()	\
+	unsigned char w33 __attribute__((vector_size(16)));	\
+	unsigned char w34 __attribute__((vector_size(16)));	\
+	unsigned char w35 __attribute__((vector_size(16)));	\
+	unsigned char w36 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_37_38()	\
+	unsigned char w37 __attribute__((vector_size(16)));	\
+	unsigned char w38 __attribute__((vector_size(16)));
+#define	GEN_X_DEFINE_ALL()	\
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_4_5()	\
+	GEN_X_DEFINE_6_7()	\
+	GEN_X_DEFINE_8_9()	\
+	GEN_X_DEFINE_10_11()	\
+	GEN_X_DEFINE_12_15()	\
+	GEN_X_DEFINE_16()	\
+	GEN_X_DEFINE_17()	\
+	GEN_X_DEFINE_18_21()	\
+	GEN_X_DEFINE_22_23()	\
+	GEN_X_DEFINE_24_27()	\
+	GEN_X_DEFINE_28_30()	\
+	GEN_X_DEFINE_31()	\
+	GEN_X_DEFINE_32()	\
+	GEN_X_DEFINE_33_36()	\
+	GEN_X_DEFINE_37_38()
+#endif

--- a/module/zfs/vdev_raidz_math_aarch64_neonx2.c
+++ b/module/zfs/vdev_raidz_math_aarch64_neonx2.c
@@ -1,0 +1,164 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (C) 2016 Romain Dolbeau. All rights reserved.
+ */
+
+#include <sys/isa_defs.h>
+
+#if defined(__aarch64__)
+
+#include "vdev_raidz_math_aarch64_neon_common.h"
+
+#define	GEN_P_DEFINE() \
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_4_5()	\
+	GEN_X_DEFINE_6_7()
+#define	GEN_P_STRIDE		8
+#define	GEN_P_P			0, 1, 2, 3, 4, 5, 6, 7
+
+#define	GEN_PQ_DEFINE()	\
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_4_5()	\
+	GEN_X_DEFINE_6_7()	\
+	GEN_X_DEFINE_8_9()	\
+	GEN_X_DEFINE_10_11()	\
+	GEN_X_DEFINE_16()	\
+	GEN_X_DEFINE_17()	\
+	GEN_X_DEFINE_33_36()
+#define	GEN_PQ_STRIDE		4
+#define	GEN_PQ_D		0, 1, 2, 3
+#define	GEN_PQ_P		4, 5, 6, 7
+#define	GEN_PQ_Q		8, 9, 10, 11
+
+#define	GEN_PQR_DEFINE() \
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_4_5()	\
+	GEN_X_DEFINE_6_7()	\
+	GEN_X_DEFINE_8_9()	\
+	GEN_X_DEFINE_22_23()	\
+	GEN_X_DEFINE_24_27()	\
+	GEN_X_DEFINE_16()	\
+	GEN_X_DEFINE_17()	\
+	GEN_X_DEFINE_33_36()
+#define	GEN_PQR_STRIDE		4
+#define	GEN_PQR_D		0, 1, 2, 3
+#define	GEN_PQR_P		4, 5, 6, 7
+#define	GEN_PQR_Q		8, 9, 22, 23
+#define	GEN_PQR_R		24, 25, 26, 27
+
+#define	REC_P_DEFINE() \
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_33_36()
+#define	REC_P_STRIDE		4
+#define	REC_P_X			0, 1, 2, 3
+
+#define	REC_Q_DEFINE() \
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_16()	\
+	GEN_X_DEFINE_17()	\
+	GEN_X_DEFINE_33_36()
+#define	REC_Q_STRIDE		4
+#define	REC_Q_X			0, 1, 2, 3
+
+#define	REC_R_DEFINE() \
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_16()	\
+	GEN_X_DEFINE_17()	\
+	GEN_X_DEFINE_33_36()
+#define	REC_R_STRIDE		4
+#define	REC_R_X			0, 1, 2, 3
+
+#define	REC_PQ_DEFINE() \
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_4_5()	\
+	GEN_X_DEFINE_6_7()	\
+	GEN_X_DEFINE_8_9()	\
+	GEN_X_DEFINE_16()	\
+	GEN_X_DEFINE_17()	\
+	GEN_X_DEFINE_22_23()	\
+	GEN_X_DEFINE_33_36()
+#define	REC_PQ_STRIDE		4
+#define	REC_PQ_X		0, 1, 2, 3
+#define	REC_PQ_Y		4, 5, 6, 7
+#define	REC_PQ_D		8, 9, 22, 23
+
+#define	REC_PR_DEFINE()	REC_PQ_DEFINE()
+#define	REC_PR_STRIDE		4
+#define	REC_PR_X		0, 1, 2, 3
+#define	REC_PR_Y		4, 5, 6, 7
+#define	REC_PR_D		8, 9, 22, 23
+
+#define	REC_QR_DEFINE()	REC_PQ_DEFINE()
+#define	REC_QR_STRIDE		4
+#define	REC_QR_X		0, 1, 2, 3
+#define	REC_QR_Y		4, 5, 6, 7
+#define	REC_QR_D		8, 9, 22, 23
+
+#define	REC_PQR_DEFINE() \
+	GEN_X_DEFINE_0_3()	\
+	GEN_X_DEFINE_4_5()	\
+	GEN_X_DEFINE_6_7()	\
+	GEN_X_DEFINE_8_9()	\
+	GEN_X_DEFINE_16()	\
+	GEN_X_DEFINE_17()	\
+	GEN_X_DEFINE_22_23()	\
+	GEN_X_DEFINE_24_27()	\
+	GEN_X_DEFINE_28_30()	\
+	GEN_X_DEFINE_31()	\
+	GEN_X_DEFINE_33_36()
+#define	REC_PQR_STRIDE		4
+#define	REC_PQR_X		0, 1, 2, 3
+#define	REC_PQR_Y		4, 5, 6, 7
+#define	REC_PQR_Z		8, 9, 22, 23
+#define	REC_PQR_D		24, 25, 26, 27
+#define	REC_PQR_XS		24, 25, 26, 27
+#define	REC_PQR_YS		28, 29, 30, 31
+
+
+#include <sys/vdev_raidz_impl.h>
+#include "vdev_raidz_math_impl.h"
+
+DEFINE_GEN_METHODS(aarch64_neonx2);
+/*
+ * If compiled with -O0, gcc doesn't do any stack frame coalescing
+ * and -Wframe-larger-than=1024 is triggered in debug mode.
+ */
+#pragma GCC diagnostic ignored "-Wframe-larger-than="
+DEFINE_REC_METHODS(aarch64_neonx2);
+#pragma GCC diagnostic pop
+
+static boolean_t
+raidz_will_aarch64_neonx2_work(void)
+{
+	return (B_TRUE); // __arch64__ requires NEON
+}
+
+const raidz_impl_ops_t vdev_raidz_aarch64_neonx2_impl = {
+	.init = NULL,
+	.fini = NULL,
+	.gen = RAIDZ_GEN_METHODS(aarch64_neonx2),
+	.rec = RAIDZ_REC_METHODS(aarch64_neonx2),
+	.is_supported = &raidz_will_aarch64_neonx2_work,
+	.name = "aarch64_neonx2"
+};
+
+#endif /* defined(__aarch64__) */

--- a/module/zfs/vdev_raidz_math_avx2.c
+++ b/module/zfs/vdev_raidz_math_avx2.c
@@ -122,6 +122,26 @@ typedef struct v {
 	}								\
 }
 
+#define	ZERO(r...)							\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 4:								\
+		__asm(							\
+		    "vpxor %" VR0(r) ", %" VR0(r)", %" VR0(r) "\n"	\
+		    "vpxor %" VR1(r) ", %" VR1(r)", %" VR1(r) "\n"	\
+		    "vpxor %" VR2(r) ", %" VR2(r)", %" VR2(r) "\n"	\
+		    "vpxor %" VR3(r) ", %" VR3(r)", %" VR3(r));		\
+		break;							\
+	case 2:								\
+		__asm(							\
+		    "vpxor %" VR0(r) ", %" VR0(r)", %" VR0(r) "\n"	\
+		    "vpxor %" VR1(r) ", %" VR1(r)", %" VR1(r));		\
+		break;							\
+	default:							\
+		ASM_BUG();						\
+	}								\
+}
+
 #define	COPY(r...) 							\
 {									\
 	switch (REG_CNT(r)) {						\

--- a/module/zfs/vdev_raidz_math_impl.h
+++ b/module/zfs/vdev_raidz_math_impl.h
@@ -490,7 +490,7 @@ REC_Q_BLOCK(raidz_map_t * const rm, const size_t off, const size_t end,
 	for (ioff = off; ioff < end; ioff += (REC_Q_STRIDE * sizeof (v_t))) {
 		MUL2_SETUP();
 
-		XOR(REC_Q_X, REC_Q_X);
+		ZERO(REC_Q_X);
 
 		if (ncols == nbigcols) {
 			for (c = firstdc; c < x; c++)
@@ -587,7 +587,7 @@ REC_R_BLOCK(raidz_map_t * const rm, const size_t off, const size_t end,
 	for (ioff = off; ioff < end; ioff += (REC_R_STRIDE * sizeof (v_t))) {
 		MUL2_SETUP();
 
-		XOR(REC_R_X, REC_R_X);
+		ZERO(REC_R_X);
 
 		if (ncols == nbigcols) {
 			for (c = firstdc; c < x; c++)
@@ -690,7 +690,7 @@ REC_PQ_BLOCK(raidz_map_t * const rm, const size_t off, const size_t end,
 
 	for (ioff = off; ioff < end; ioff += (REC_PQ_STRIDE * sizeof (v_t))) {
 		LOAD(COL_OFF(pcol, ioff), REC_PQ_X);
-		XOR(REC_PQ_Y, REC_PQ_Y);
+		ZERO(REC_PQ_Y);
 		MUL2_SETUP();
 
 		if (ncols == nbigcols) {
@@ -816,7 +816,7 @@ REC_PR_BLOCK(raidz_map_t * const rm, const size_t off, const size_t end,
 
 	for (ioff = off; ioff < end; ioff += (REC_PR_STRIDE * sizeof (v_t))) {
 		LOAD(COL_OFF(pcol, ioff), REC_PR_X);
-		XOR(REC_PR_Y, REC_PR_Y);
+		ZERO(REC_PR_Y);
 		MUL2_SETUP();
 
 		if (ncols == nbigcols) {
@@ -949,8 +949,8 @@ REC_QR_BLOCK(raidz_map_t * const rm, const size_t off, const size_t end,
 
 	for (ioff = off; ioff < end; ioff += (REC_QR_STRIDE * sizeof (v_t))) {
 		MUL2_SETUP();
-		XOR(REC_QR_X, REC_QR_X);
-		XOR(REC_QR_Y, REC_QR_Y);
+		ZERO(REC_QR_X);
+		ZERO(REC_QR_Y);
 
 		if (ncols == nbigcols) {
 			for (c = firstdc; c < x; c++)
@@ -1090,8 +1090,8 @@ REC_PQR_BLOCK(raidz_map_t * const rm, const size_t off, const size_t end,
 	for (ioff = off; ioff < end; ioff += (REC_PQR_STRIDE * sizeof (v_t))) {
 		MUL2_SETUP();
 		LOAD(COL_OFF(pcol, ioff), REC_PQR_X);
-		XOR(REC_PQR_Y, REC_PQR_Y);
-		XOR(REC_PQR_Z, REC_PQR_Z);
+		ZERO(REC_PQR_Y);
+		ZERO(REC_PQR_Z);
 
 		if (ncols == nbigcols) {
 			for (c = firstdc; c < x; c++)

--- a/module/zfs/vdev_raidz_math_scalar.c
+++ b/module/zfs/vdev_raidz_math_scalar.c
@@ -91,6 +91,7 @@ raidz_init_scalar(void)
 
 #define	XOR_ACC(src, acc)	acc.e ^= ((v_t *)src)[0].e
 #define	XOR(src, acc)		acc.e ^= src.e
+#define	ZERO(acc)		acc.e = 0
 #define	COPY(src, dst)		dst = src
 #define	LOAD(src, val) 		val = ((v_t *)src)[0]
 #define	STORE(dst, val)		((v_t *)dst)[0] = val

--- a/module/zfs/vdev_raidz_math_sse2.c
+++ b/module/zfs/vdev_raidz_math_sse2.c
@@ -106,6 +106,27 @@ typedef struct v {
 		break;							\
 	}								\
 }
+#define	ZERO(r...)							\
+{									\
+	switch (REG_CNT(r)) {						\
+	case 4:								\
+		__asm(							\
+		    "pxor %" VR0(r) ", %" VR0(r) "\n"			\
+		    "pxor %" VR1(r) ", %" VR1(r) "\n"			\
+		    "pxor %" VR2(r) ", %" VR2(r) "\n"			\
+		    "pxor %" VR3(r) ", %" VR3(r));			\
+		break;							\
+	case 2:								\
+		__asm(							\
+		    "pxor %" VR0(r) ", %" VR0(r) "\n"			\
+		    "pxor %" VR1(r) ", %" VR1(r));			\
+		break;							\
+	case 1:								\
+		__asm(							\
+		    "pxor %" VR0(r) ", %" VR0(r));			\
+		break;							\
+	}								\
+}
 
 #define	COPY(r...) 							\
 {									\


### PR DESCRIPTION
This re-use the framework established for SSE and AVX2.
However, GCC is using FP registers on Aarch64, so unlike
SSE/AVX2 we can't rely on the registers being left alone
between ASM statements. So instead, the NEON code uses
C variables and GCC extended ASM syntax.

As we use the variable's number to define the symbolic
name, and GCC won't allow duplicate symbolic names,
numbers have to be unique. Even when the code is not
going to be used (e.g. the case for 4 registers when
using the macro with only 2).

This requires the replacement of the XOR(X,X) syntax
by a new ZERO(X) macro, which does the same thing but
without repeating the argument. And perhaps someday
there will be a machine where there is a more efficient
way to zero a register than XOR with itself. This affects
scalar, SSE and AVX2 as they need the new macro.

It's possible to write faster implementations (different
scheduling, different unrolling, interleaving NEON and
scalar, ...) for various cores, but this one has the
advantage of fitting in the current state of the code,
and thus is likely easier to review/check/merge.