### PR TITLE
Adjustments to compile with musl libc 1.1.14

### DIFF
--- a/cmd/raidz_test/raidz_bench.c
+++ b/cmd/raidz_test/raidz_bench.c
@@ -42,6 +42,11 @@
 #define	MIN_CS_SHIFT		BENCH_ASHIFT
 #define	MAX_CS_SHIFT		SPA_MAXBLOCKSHIFT
 
+// Musl libc in versions up to and including 1.1.14 does not define this value
+#ifndef RUSAGE_THREAD
+#define RUSAGE_THREAD 1
+#endif
+
 
 static zio_t zio_bench;
 static raidz_map_t *rm_bench;

--- a/cmd/zed/zed_log.c
+++ b/cmd/zed/zed_log.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
+#include <unistd.h>
 #include "zed_log.h"
 
 #define	ZED_LOG_MAX_LOG_LEN	1024

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -92,7 +92,7 @@
 #include <sys/dbuf.h>
 #include <sys/zap.h>
 #include <sys/dmu_objset.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/wait.h>

--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -28,7 +28,7 @@
 
 #include <sys/types.h>
 #include <sys/time.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/va_list.h>
 
 #if defined(_KERNEL) && !defined(_BOOT)

--- a/include/sys/u8_textprep.h
+++ b/include/sys/u8_textprep.h
@@ -30,7 +30,7 @@
 
 #include <sys/isa_defs.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -29,7 +29,7 @@
 #include <sys/xvattr.h>
 #include <sys/uio.h>
 #include <sys/cred.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/pathname.h>
 #include <sys/zpl.h>
 

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -43,7 +43,7 @@
 #include <sys/mnttab.h>
 #include <sys/mntent.h>
 #include <sys/types.h>
-#include <wait.h>
+#include <sys/wait.h>
 
 #include <libzfs.h>
 #include <libzfs_core.h>

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <zlib.h>
 #include <libgen.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <sys/spa.h>
 #include <sys/stat.h>
 #include <sys/processor.h>

--- a/module/unicode/u8_textprep.c
+++ b/module/unicode/u8_textprep.c
@@ -49,7 +49,7 @@
 #include <strings.h>
 #endif	/* _KERNEL */
 #include <sys/byteorder.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/u8_textprep_data.h>
 
 

--- a/module/unicode/uconv.c
+++ b/module/unicode/uconv.c
@@ -46,7 +46,7 @@
 #include <sys/u8_textprep.h>
 #endif	/* _KERNEL */
 #include <sys/byteorder.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 
 /*

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -41,7 +41,7 @@
 #include <sys/sunddi.h>
 #include <sys/sa_impl.h>
 #include <sys/dnode.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/zfs_context.h>
 
 /*

--- a/module/zfs/zfs_acl.c
+++ b/module/zfs/zfs_acl.c
@@ -37,7 +37,7 @@
 #include <sys/stat.h>
 #include <sys/kmem.h>
 #include <sys/cmn_err.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/unistd.h>
 #include <sys/sdt.h>
 #include <sys/fs/zfs.h>

--- a/module/zfs/zfs_dir.c
+++ b/module/zfs/zfs_dir.c
@@ -38,7 +38,7 @@
 #include <sys/uio.h>
 #include <sys/pathname.h>
 #include <sys/cmn_err.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/stat.h>
 #include <sys/unistd.h>
 #include <sys/sunddi.h>

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -135,7 +135,7 @@
 
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/uio.h>
 #include <sys/buf.h>
 #include <sys/modctl.h>

--- a/module/zfs/zfs_onexit.c
+++ b/module/zfs/zfs_onexit.c
@@ -25,7 +25,7 @@
 
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/open.h>
 #include <sys/kmem.h>
 #include <sys/conf.h>

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -32,7 +32,7 @@
 #include <sys/kmem.h>
 #include <sys/thread.h>
 #include <sys/file.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/vfs.h>
 #include <sys/fs/zfs.h>
 #include <sys/zfs_znode.h>

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -47,7 +47,7 @@
 #include <vm/pvn.h>
 #include <sys/pathname.h>
 #include <sys/cmn_err.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/unistd.h>
 #include <sys/zfs_dir.h>
 #include <sys/zfs_acl.h>

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -41,7 +41,7 @@
 #include <sys/vnode.h>
 #include <sys/file.h>
 #include <sys/kmem.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/unistd.h>
 #include <sys/mode.h>
 #include <sys/atomic.h>

--- a/tests/zfs-tests/cmd/file_trunc/file_trunc.c
+++ b/tests/zfs-tests/cmd/file_trunc/file_trunc.c
@@ -35,10 +35,10 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/types.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/time.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>

--- a/tests/zfs-tests/cmd/mktree/mktree.c
+++ b/tests/zfs-tests/cmd/mktree/mktree.c
@@ -32,7 +32,7 @@
 #include <attr/xattr.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/param.h>
 
 #define	TYPE_D 'D'


### PR DESCRIPTION
raidz_bench.c defines RUSAGE_THREAD if not previously defined
This may be fixed in a forthcoming musl version.

zed_log.c includes unistd.h so that read, close, pipe and getpid
are not implicitly defined.

remaining files are corrected to include headers poll.h,
errno.h, signal.h and fcntl.h from the POSIX locations. This
reduces the warnings significantly when building under musl,
allowing more subtle and serious warnings about implicitly
defined functions to stand out.