### PR TITLE
Fix compiling with -O0 opt level

### DIFF
--- a/module/zfs/vdev_raidz_math.c
+++ b/module/zfs/vdev_raidz_math.c
@@ -271,7 +271,7 @@ init_raidz_kstat(raidz_impl_kstat_t *rs, const char *name)
 
 #define	BENCH_D_COLS	(8ULL)
 #define	BENCH_COLS	(BENCH_D_COLS + PARITY_PQR)
-#define	BENCH_ZIO_SIZE	(2ULL << 17)			/* 128 kiB */
+#define	BENCH_ZIO_SIZE	(1ULL << SPA_OLD_MAXBLOCKSHIFT)	/* 128 kiB */
 #define	BENCH_NS	MSEC2NSEC(25)			/* 25ms */
 
 typedef void (*benchmark_fn)(raidz_map_t *rm, const int fn);

--- a/module/zfs/vdev_raidz_math_scalar.c
+++ b/module/zfs/vdev_raidz_math_scalar.c
@@ -211,6 +211,14 @@ static const struct {
 
 #include "vdev_raidz_math_impl.h"
 
+/*
+ * If compiled with -O0, gcc doesn't do any stack frame coalescing
+ * and -Wframe-larger-than=1024 is triggered in debug mode.
+ * Starting with gcc 4.8, new opt level -Og is introduced for debugging, which
+ * does not trigger this warning.
+ */
+#pragma GCC diagnostic ignored "-Wframe-larger-than="
+
 DEFINE_GEN_METHODS(scalar);
 DEFINE_REC_METHODS(scalar);
 


### PR DESCRIPTION
Allow building with `CFLAGS="-O0"`

If compiled with -O0, gcc doesn't do any stack frame coalescing
and -Wframe-larger-than=1024 is triggered in debug mode.

Starting with gcc 4.8, new opt level -Og is introduced for debugging, which
does not trigger this warning.

Issue #4799

Signed-off-by: Gvozden Neskovic <neskovic@gmail.com>