### PR TITLE
Allow zfs_purgedir() to skip inodes undergoing eviction

### DIFF
--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -305,6 +305,7 @@ extern void	zfs_znode_init(void);
 extern void	zfs_znode_fini(void);
 extern int	zfs_znode_hold_compare(const void *, const void *);
 extern int	zfs_zget(zfs_sb_t *, uint64_t, znode_t **);
+extern int	zfs_zget_retry(zfs_sb_t *, uint64_t, znode_t **, boolean_t);
 extern int	zfs_rezget(znode_t *);
 extern void	zfs_zinactive(znode_t *);
 extern void	zfs_znode_delete(znode_t *, dmu_tx_t *);

--- a/module/zfs/zfs_dir.c
+++ b/module/zfs/zfs_dir.c
@@ -518,7 +518,7 @@ zfs_unlinked_drain(zfs_sb_t *zsb)
 		 * We need to re-mark these list entries for deletion,
 		 * so we pull them back into core and set zp->z_unlinked.
 		 */
-		error = zfs_zget(zsb, zap.za_first_integer, &zp);
+		error = zfs_zget_retry(zsb, zap.za_first_integer, &zp, B_FALSE);
 
 		/*
 		 * We may pick up znodes that are already marked for deletion.
@@ -561,8 +561,8 @@ zfs_purgedir(znode_t *dzp)
 	for (zap_cursor_init(&zc, zsb->z_os, dzp->z_id);
 	    (error = zap_cursor_retrieve(&zc, &zap)) == 0;
 	    zap_cursor_advance(&zc)) {
-		error = zfs_zget(zsb,
-		    ZFS_DIRENT_OBJ(zap.za_first_integer), &xzp);
+		error = zfs_zget_retry(zsb,
+		    ZFS_DIRENT_OBJ(zap.za_first_integer), &xzp, B_FALSE);
 		if (error) {
 			skipped += 1;
 			continue;


### PR DESCRIPTION
When destroying a file which contains xattrs the xattr directory inode
and its child inodes may be acquired with zfs_zget().  This can result
in a deadlock if these inodes are part of the same disposal list.  This
is only possible in zfs_purgedir() because it is called from evict()
while processing this disposal list.

Prevent this deadlock by allowing zfs_zget() to fail in zfs_purgedir().
The object will be left in the unlinked set and processing of it will
be deferred via the existing mechanisms.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #4816