### PR TITLE
Fix get_zfs_sb race and misc fixes

### DIFF
--- a/config/kernel-xattr-handler.m4
+++ b/config/kernel-xattr-handler.m4
@@ -89,6 +89,7 @@ AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_GET], [
 		dnl # attr_handler, and handler_flags argument was removed and
 		dnl # should be accessed by handler->flags.
 		dnl #
+		AC_MSG_RESULT(no)
 		AC_MSG_CHECKING([whether xattr_handler->get() wants xattr_handler])
 		ZFS_LINUX_TRY_COMPILE([
 			#include <linux/xattr.h>
@@ -192,6 +193,7 @@ AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_SET], [
 		dnl # xattr_handler, and handler_flags argument was removed and
 		dnl # should be accessed by handler->flags.
 		dnl #
+		AC_MSG_RESULT(no)
 		AC_MSG_CHECKING([whether xattr_handler->set() wants xattr_handler])
 		ZFS_LINUX_TRY_COMPILE([
 			#include <linux/xattr.h>

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -892,11 +892,11 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 
 	ASSERT(oldc <= newc);
 
-	mspp = kmem_zalloc(newc * sizeof (*mspp), KM_SLEEP);
+	mspp = vmem_zalloc(newc * sizeof (*mspp), KM_SLEEP);
 
 	if (oldc != 0) {
 		bcopy(vd->vdev_ms, mspp, oldc * sizeof (*mspp));
-		kmem_free(vd->vdev_ms, oldc * sizeof (*mspp));
+		vmem_free(vd->vdev_ms, oldc * sizeof (*mspp));
 	}
 
 	vd->vdev_ms = mspp;
@@ -950,7 +950,7 @@ vdev_metaslab_fini(vdev_t *vd)
 			if (msp != NULL)
 				metaslab_fini(msp);
 		}
-		kmem_free(vd->vdev_ms, count * sizeof (metaslab_t *));
+		vmem_free(vd->vdev_ms, count * sizeof (metaslab_t *));
 		vd->vdev_ms = NULL;
 	}
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1393,9 +1393,9 @@ get_zfs_sb(const char *dsname, zfs_sb_t **zsbp)
 
 	mutex_enter(&os->os_user_ptr_lock);
 	*zsbp = dmu_objset_get_user(os);
-	if (*zsbp && (*zsbp)->z_sb) {
-		atomic_inc(&((*zsbp)->z_sb->s_active));
-	} else {
+	/* bump s_active only when non-zero to prevent umount race */
+	if (*zsbp == NULL || (*zsbp)->z_sb == NULL ||
+	    !atomic_inc_not_zero(&((*zsbp)->z_sb->s_active))) {
 		error = SET_ERROR(ESRCH);
 	}
 	mutex_exit(&os->os_user_ptr_lock);

--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -1540,6 +1540,14 @@ zfs_vget(struct super_block *sb, struct inode **ipp, fid_t *fidp)
 		ZFS_EXIT(zsb);
 		return (err);
 	}
+
+	/* Don't export xattr stuff */
+	if (zp->z_pflags & ZFS_XATTR) {
+		iput(ZTOI(zp));
+		ZFS_EXIT(zsb);
+		return (SET_ERROR(ENOENT));
+	}
+
 	(void) sa_lookup(zp->z_sa_hdl, SA_ZPL_GEN(zsb), &zp_gen,
 	    sizeof (uint64_t));
 	zp_gen = zp_gen & gen_mask;

--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -1560,7 +1560,7 @@ zfs_vget(struct super_block *sb, struct inode **ipp, fid_t *fidp)
 		    fid_gen);
 		iput(ZTOI(zp));
 		ZFS_EXIT(zsb);
-		return (SET_ERROR(EINVAL));
+		return (SET_ERROR(ENOENT));
 	}
 
 	*ipp = ZTOI(zp);


### PR DESCRIPTION
1. Don't allow accessing XATTR via export handle
2. Fix Large kmem_alloc in vdev_metaslab_init
3. Add configure result for xattr_handler
4. fh_to_dentry should return ESTALE when generation mismatch
5. Fix get_zfs_sb race with concurrent umount