### PR TITLE
Want tunable to ignore hole_birth

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -27,6 +27,19 @@ Description of the different parameters to the ZFS module.
 .sp
 .ne 2
 .na
+\fBignore_hole_birth\fR (int)
+.ad
+.RS 12n
+When set, the hole_birth optimization will not be used, and all holes will
+always be sent on zfs send. Useful if you suspect your datasets are affected
+by a bug in hole_birth.
+.sp
+Use \fB1\fR for on and \fB0\fR (default) for off.
+.RE
+
+.sp
+.ne 2
+.na
 \fBl2arc_feed_again\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -39,7 +39,7 @@
 #include <sys/zfeature.h>
 
 int32_t zfs_pd_bytes_max = 50 * 1024 * 1024;	/* 50MB */
-int32_t ignore_hole_birth = 1;
+int32_t ignore_hole_birth = 0;
 
 typedef struct prefetch_data {
 	kmutex_t pd_mtx;

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -39,6 +39,7 @@
 #include <sys/zfeature.h>
 
 int32_t zfs_pd_bytes_max = 50 * 1024 * 1024;	/* 50MB */
+int32_t ignore_hole_birth = 1;
 
 typedef struct prefetch_data {
 	kmutex_t pd_mtx;
@@ -251,7 +252,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		 *
 		 * Note that the meta-dnode cannot be reallocated.
 		 */
-		if ((!td->td_realloc_possible ||
+		if (!ignore_hole_birth && (!td->td_realloc_possible ||
 			zb->zb_object == DMU_META_DNODE_OBJECT) &&
 			td->td_hole_birth_enabled_txg <= td->td_min_txg)
 			return (0);
@@ -727,4 +728,7 @@ EXPORT_SYMBOL(traverse_pool);
 
 module_param(zfs_pd_bytes_max, int, 0644);
 MODULE_PARM_DESC(zfs_pd_bytes_max, "Max number of bytes to prefetch");
+
+module_param(ignore_hole_birth, int, 0644);
+MODULE_PARM_DESC(ignore_hole_birth, "Ignore hole_birth txg for send");
 #endif


### PR DESCRIPTION
Between 0.6.5.7 and prior still being affected by illumos #6513, and the newly-discovered Illumos #7176, a tunable to ignore hole_birth for safe sends seems a reasonable tool.

This is just a minor improvement on @pcd1193182's [patch](https://gist.github.com/pcd1193182/2c0cd47211f3aee623958b4698836c48) to make it a runtime-tunable module parameter.

I tested it, and it functions correctly on ignoring hole_birth at least on the test dataset I have from #4809.