### PR TITLE
[buildbot checkup] Master 29.06.2016+syncfixes+balanced_meta_data

### DIFF
--- a/include/sys/vdev_disk.h
+++ b/include/sys/vdev_disk.h
@@ -37,9 +37,11 @@ typedef struct vdev_disk {
 	struct block_device	*vd_bdev;
 } vdev_disk_t;
 
+#ifndef __linux__
 extern int vdev_disk_physio(struct block_device *, caddr_t,
 			    size_t, uint64_t, int);
 extern int vdev_disk_read_rootlabel(char *, char *, nvlist_t **);
+#endif
 
 #endif /* _KERNEL */
 #endif /* _SYS_VDEV_DISK_H */

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3971,7 +3971,7 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	return (0);
 }
 
-#ifdef _KERNEL
+#if defined(_KERNEL) && !defined(__linux__)
 /*
  * Get the root pool information from the root disk, then import the root pool
  * during the system boot up time.
@@ -4174,7 +4174,7 @@ out:
 	return (error);
 }
 
-#endif
+#endif /* defined(_KERNEL) && !defined(__linux__) */
 
 /*
  * Import a non-root pool into the system.
@@ -7038,7 +7038,6 @@ EXPORT_SYMBOL(spa_open);
 EXPORT_SYMBOL(spa_open_rewind);
 EXPORT_SYMBOL(spa_get_stats);
 EXPORT_SYMBOL(spa_create);
-EXPORT_SYMBOL(spa_import_rootpool);
 EXPORT_SYMBOL(spa_import);
 EXPORT_SYMBOL(spa_tryimport);
 EXPORT_SYMBOL(spa_destroy);

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -41,10 +41,8 @@ static void *zfs_vdev_holder = VDEV_HOLDER;
  * Virtual device vector for disks.
  */
 typedef struct dio_request {
-	struct completion	dr_comp;	/* Completion for sync IO */
 	zio_t			*dr_zio;	/* Parent ZIO */
 	atomic_t		dr_ref;		/* References */
-	int			dr_wait;	/* Wait for IO */
 	int			dr_error;	/* Bio error */
 	int			dr_bio_count;	/* Count of bio's */
 	struct bio		*dr_bio[0];	/* Attached bio's */
@@ -363,7 +361,6 @@ vdev_disk_dio_alloc(int bio_count)
 	dr = kmem_zalloc(sizeof (dio_request_t) +
 	    sizeof (struct bio *) * bio_count, KM_SLEEP);
 	if (dr) {
-		init_completion(&dr->dr_comp);
 		atomic_set(&dr->dr_ref, 0);
 		dr->dr_bio_count = bio_count;
 		dr->dr_error = 0;
@@ -425,7 +422,6 @@ BIO_END_IO_PROTO(vdev_disk_physio_completion, bio, error)
 {
 	dio_request_t *dr = bio->bi_private;
 	int rc;
-	int wait;
 
 	if (dr->dr_error == 0) {
 #ifdef HAVE_1ARG_BIO_END_IO_T
@@ -438,13 +434,8 @@ BIO_END_IO_PROTO(vdev_disk_physio_completion, bio, error)
 #endif
 	}
 
-	wait = dr->dr_wait;
 	/* Drop reference aquired by __vdev_disk_physio */
 	rc = vdev_disk_dio_put(dr);
-
-	/* Wake up synchronous waiter this is the last outstanding bio */
-	if (wait && rc == 1)
-		complete(&dr->dr_comp);
 }
 
 static inline unsigned long
@@ -511,7 +502,7 @@ vdev_submit_bio(int rw, struct bio *bio)
 
 static int
 __vdev_disk_physio(struct block_device *bdev, zio_t *zio, caddr_t kbuf_ptr,
-    size_t kbuf_size, uint64_t kbuf_offset, int flags, int wait)
+    size_t kbuf_size, uint64_t kbuf_offset, int flags)
 {
 	dio_request_t *dr;
 	caddr_t bio_ptr;
@@ -531,7 +522,6 @@ retry:
 
 	rw = flags;
 	dr->dr_zio = zio;
-	dr->dr_wait = wait;
 
 	/*
 	 * When the IO size exceeds the maximum bio size for the request
@@ -593,32 +583,20 @@ retry:
 		if (dr->dr_bio[i])
 			vdev_submit_bio(rw, dr->dr_bio[i]);
 
-	/*
-	 * On synchronous blocking requests we wait for all bio the completion
-	 * callbacks to run.  We will be woken when the last callback runs
-	 * for this dio.  We are responsible for putting the last dio_request
-	 * reference will in turn put back the last bio references.  The
-	 * only synchronous consumer is vdev_disk_read_rootlabel() all other
-	 * IO originating from vdev_disk_io_start() is asynchronous.
-	 */
-	if (wait) {
-		wait_for_completion(&dr->dr_comp);
-		error = dr->dr_error;
-		ASSERT3S(atomic_read(&dr->dr_ref), ==, 1);
-	}
-
 	(void) vdev_disk_dio_put(dr);
 
 	return (error);
 }
 
+#ifndef __linux__
 int
 vdev_disk_physio(struct block_device *bdev, caddr_t kbuf,
     size_t size, uint64_t offset, int flags)
 {
 	bio_set_flags_failfast(bdev, &flags);
-	return (__vdev_disk_physio(bdev, NULL, kbuf, size, offset, flags, 1));
+	return (__vdev_disk_physio(bdev, NULL, kbuf, size, offset, flags));
 }
+#endif
 
 BIO_END_IO_PROTO(vdev_disk_io_flush_completion, bio, rc)
 {
@@ -667,7 +645,6 @@ vdev_disk_io_start(zio_t *zio)
 {
 	vdev_t *v = zio->io_vd;
 	vdev_disk_t *vd = v->vdev_tsd;
-	zio_priority_t pri = zio->io_priority;
 	int flags, error;
 
 	switch (zio->io_type) {
@@ -707,17 +684,11 @@ vdev_disk_io_start(zio_t *zio)
 		zio_execute(zio);
 		return;
 	case ZIO_TYPE_WRITE:
-		if ((pri == ZIO_PRIORITY_SYNC_WRITE) && (v->vdev_nonrot))
-			flags = WRITE_SYNC;
-		else
-			flags = WRITE;
+		flags = WRITE;
 		break;
 
 	case ZIO_TYPE_READ:
-		if ((pri == ZIO_PRIORITY_SYNC_READ) && (v->vdev_nonrot))
-			flags = READ_SYNC;
-		else
-			flags = READ;
+		flags = READ;
 		break;
 
 	default:
@@ -728,7 +699,7 @@ vdev_disk_io_start(zio_t *zio)
 
 	zio->io_target_timestamp = zio_handle_io_delay(zio);
 	error = __vdev_disk_physio(vd->vd_bdev, zio, zio->io_data,
-	    zio->io_size, zio->io_offset, flags, 0);
+	    zio->io_size, zio->io_offset, flags);
 	if (error) {
 		zio->io_error = error;
 		zio_interrupt(zio);
@@ -798,6 +769,7 @@ vdev_ops_t vdev_disk_ops = {
 	B_TRUE			/* leaf vdev */
 };
 
+#ifndef __linux__
 /*
  * Given the root disk device devid or pathname, read the label from
  * the device, and construct a configuration nvlist.
@@ -860,6 +832,7 @@ vdev_disk_read_rootlabel(char *devpath, char *devid, nvlist_t **config)
 
 	return (0);
 }
+#endif	/* __linux__ */
 
 module_param(zfs_vdev_scheduler, charp, 0644);
 MODULE_PARM_DESC(zfs_vdev_scheduler, "I/O scheduler");


### PR DESCRIPTION
I was running https://github.com/zfsonlinux/zfs/pull/4781 ([buildbot test][blob] zfs_master 17.06.2016 abd without avx2 fletcher) for some time without problems (several zfs send and receive operations, rsync, etc.)

but now while crawling through my data with recoll (a desktop search engine, based on xapian)

the PC is locking up (hardlock) reliably within only a few of minutes,

tested so far:

CFS vs. BFS (VRQ testing branch, VRQ stable)
CFQ vs. BFQ
aggressive compiler flags vs. (my) "default" compiler flags on zfs & spl
...

each time it lead to a hardlock,

thus testing this branch for safety and then migrating to it for troubleshooting (mid-heavy stress testing, everyday usage) to see whether the rebased ADB can be the cause behind the instability