### PR TITLE
Kill znode->z_links field

### DIFF
--- a/include/sys/trace_acl.h
+++ b/include/sys/trace_acl.h
@@ -55,7 +55,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __field(uint_t,		z_seq)
 	    __field(uint64_t,		z_mapcnt)
 	    __field(uint64_t,		z_size)
-	    __field(uint64_t,		z_links)
 	    __field(uint64_t,		z_pflags)
 	    __field(uint64_t,		z_uid)
 	    __field(uint64_t,		z_gid)
@@ -91,7 +90,6 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __entry->z_seq		= zn->z_seq;
 	    __entry->z_mapcnt		= zn->z_mapcnt;
 	    __entry->z_size		= zn->z_size;
-	    __entry->z_links		= zn->z_links;
 	    __entry->z_pflags		= zn->z_pflags;
 	    __entry->z_uid		= zn->z_uid;
 	    __entry->z_gid		= zn->z_gid;
@@ -119,7 +117,7 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	),
 	TP_printk("zn { id %llu unlinked %u atime_dirty %u "
 	    "zn_prefetch %u moved %u blksz %u seq %u "
-	    "mapcnt %llu size %llu links %llu pflags %llu "
+	    "mapcnt %llu size %llu pflags %llu "
 	    "uid %llu gid %llu sync_cnt %u mode 0x%x is_sa %d "
 	    "is_mapped %d is_ctldir %d is_stale %d inode { "
 	    "ino %lu nlink %u version %llu size %lli blkbits %u "
@@ -128,7 +126,7 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 	    __entry->z_id, __entry->z_unlinked, __entry->z_atime_dirty,
 	    __entry->z_zn_prefetch, __entry->z_moved, __entry->z_blksz,
 	    __entry->z_seq, __entry->z_mapcnt, __entry->z_size,
-	    __entry->z_links, __entry->z_pflags, __entry->z_uid,
+	    __entry->z_pflags, __entry->z_uid,
 	    __entry->z_gid, __entry->z_sync_cnt, __entry->z_mode,
 	    __entry->z_is_sa, __entry->z_is_mapped,
 	    __entry->z_is_ctldir, __entry->z_is_stale, __entry->i_ino,

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -187,7 +187,6 @@ typedef struct znode {
 	uint64_t	z_mapcnt;	/* number of pages mapped to file */
 	uint64_t	z_dnodesize;	/* dnode size */
 	uint64_t	z_size;		/* file size (cached) */
-	uint64_t	z_links;	/* file links (cached) */
 	uint64_t	z_pflags;	/* pflags (cached) */
 	uint64_t	z_uid;		/* uid fuid (cached) */
 	uint64_t	z_gid;		/* gid fuid (cached) */

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -478,7 +478,6 @@ zfsctl_inode_alloc(zfs_sb_t *zsb, uint64_t id,
 	zp->z_seq = 0;
 	zp->z_mapcnt = 0;
 	zp->z_size = 0;
-	zp->z_links = 0;
 	zp->z_pflags = 0;
 	zp->z_uid = 0;
 	zp->z_gid = 0;

--- a/module/zfs/zfs_dir.c
+++ b/module/zfs/zfs_dir.c
@@ -478,7 +478,7 @@ zfs_unlinked_add(znode_t *zp, dmu_tx_t *tx)
 	zfs_sb_t *zsb = ZTOZSB(zp);
 
 	ASSERT(zp->z_unlinked);
-	ASSERT(zp->z_links == 0);
+	ASSERT(ZTOI(zp)->i_nlink == 0);
 
 	VERIFY3U(0, ==,
 	    zap_add_int(zsb->z_os, zsb->z_unlinkedobj, zp->z_id, tx));
@@ -594,7 +594,7 @@ zfs_purgedir(znode_t *dzp)
 		if (error)
 			skipped += 1;
 		dmu_tx_commit(tx);
-		set_nlink(ZTOI(xzp), xzp->z_links);
+
 		zfs_iput_async(ZTOI(xzp));
 	}
 	zap_cursor_fini(&zc);
@@ -612,9 +612,10 @@ zfs_rmnode(znode_t *zp)
 	dmu_tx_t	*tx;
 	uint64_t	acl_obj;
 	uint64_t	xattr_obj;
+	uint64_t	links;
 	int		error;
 
-	ASSERT(zp->z_links == 0);
+	ASSERT(ZTOI(zp)->i_nlink == 0);
 	ASSERT(atomic_read(&ZTOI(zp)->i_count) == 0);
 
 	/*
@@ -694,10 +695,10 @@ zfs_rmnode(znode_t *zp)
 		ASSERT(error == 0);
 		mutex_enter(&xzp->z_lock);
 		xzp->z_unlinked = B_TRUE;	/* mark xzp for deletion */
-		xzp->z_links = 0;	/* no more links to it */
-		set_nlink(ZTOI(xzp), 0); /* this will let iput purge us */
+		clear_nlink(ZTOI(xzp));		/* no more links to it */
+		links = 0;
 		VERIFY(0 == sa_update(xzp->z_sa_hdl, SA_ZPL_LINKS(zsb),
-		    &xzp->z_links, sizeof (xzp->z_links), tx));
+		    &links, sizeof (links), tx));
 		mutex_exit(&xzp->z_lock);
 		zfs_unlinked_add(xzp, tx);
 	}
@@ -736,6 +737,7 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 	int zp_is_dir = S_ISDIR(ZTOI(zp)->i_mode);
 	sa_bulk_attr_t bulk[5];
 	uint64_t mtime[2], ctime[2];
+	uint64_t links;
 	int count = 0;
 	int error;
 
@@ -747,10 +749,16 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 			mutex_exit(&zp->z_lock);
 			return (SET_ERROR(ENOENT));
 		}
-		zp->z_links++;
-		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zsb), NULL,
-		    &zp->z_links, sizeof (zp->z_links));
-
+		if (!(flag & ZNEW)) {
+			/*
+			 * ZNEW nodes come from zfs_mknode() where the link
+			 * count has already been initialised
+			 */
+			inc_nlink(ZTOI(zp));
+			links = ZTOI(zp)->i_nlink;
+			SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zsb), NULL,
+			    &links, sizeof (links));
+		}
 	}
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_PARENT(zsb), NULL,
 	    &dzp->z_id, sizeof (dzp->z_id));
@@ -770,12 +778,14 @@ zfs_link_create(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag)
 
 	mutex_enter(&dzp->z_lock);
 	dzp->z_size++;
-	dzp->z_links += zp_is_dir;
+	if (zp_is_dir)
+		inc_nlink(ZTOI(dzp));
+	links = ZTOI(dzp)->i_nlink;
 	count = 0;
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(zsb), NULL,
 	    &dzp->z_size, sizeof (dzp->z_size));
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zsb), NULL,
-	    &dzp->z_links, sizeof (dzp->z_links));
+	    &links, sizeof (links));
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(zsb), NULL,
 	    mtime, sizeof (mtime));
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zsb), NULL,
@@ -836,6 +846,7 @@ zfs_link_destroy(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag,
 	boolean_t unlinked = B_FALSE;
 	sa_bulk_attr_t bulk[5];
 	uint64_t mtime[2], ctime[2];
+	uint64_t links;
 	int count = 0;
 	int error;
 
@@ -862,15 +873,16 @@ zfs_link_destroy(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag,
 			return (error);
 		}
 
-		if (zp->z_links <= zp_is_dir) {
+		if (ZTOI(zp)->i_nlink <= zp_is_dir) {
 			zfs_panic_recover("zfs: link count on %lu is %u, "
 			    "should be at least %u", zp->z_id,
-			    (int)zp->z_links, zp_is_dir + 1);
-			zp->z_links = zp_is_dir + 1;
+			    (int)ZTOI(zp)->i_nlink, zp_is_dir + 1);
+			set_nlink(ZTOI(zp), zp_is_dir + 1);
 		}
-		if (--zp->z_links == zp_is_dir) {
+		drop_nlink(ZTOI(zp));
+		if (ZTOI(zp)->i_nlink == zp_is_dir) {
 			zp->z_unlinked = B_TRUE;
-			zp->z_links = 0;
+			clear_nlink(ZTOI(zp));
 			unlinked = B_TRUE;
 		} else {
 			SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zsb),
@@ -880,8 +892,9 @@ zfs_link_destroy(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag,
 			zfs_tstamp_update_setup(zp, STATE_CHANGED, mtime,
 			    ctime);
 		}
+		links = ZTOI(zp)->i_nlink;
 		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zsb),
-		    NULL, &zp->z_links, sizeof (zp->z_links));
+		    NULL, &links, sizeof (links));
 		error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
 		count = 0;
 		ASSERT(error == 0);
@@ -894,9 +907,11 @@ zfs_link_destroy(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag,
 
 	mutex_enter(&dzp->z_lock);
 	dzp->z_size--;		/* one dirent removed */
-	dzp->z_links -= zp_is_dir;	/* ".." link from zp */
+	if (zp_is_dir)
+		drop_nlink(ZTOI(dzp));	/* ".." link from zp */
+	links = ZTOI(dzp)->i_nlink;
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zsb),
-	    NULL, &dzp->z_links, sizeof (dzp->z_links));
+	    NULL, &links, sizeof (links));
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(zsb),
 	    NULL, &dzp->z_size, sizeof (dzp->z_size));
 	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zsb),

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -277,6 +277,7 @@ zfs_sa_upgrade(sa_handle_t *hdl, dmu_tx_t *tx)
 	zfs_acl_locator_cb_t locate = { 0 };
 	uint64_t uid, gid, mode, rdev, xattr, parent, tmp_gen;
 	uint64_t crtime[2], mtime[2], ctime[2], atime[2];
+	uint64_t links;
 	zfs_acl_phys_t znode_acl;
 	char scanstamp[AV_SCANSTAMP_SZ];
 	boolean_t drop_lock = B_FALSE;
@@ -351,8 +352,9 @@ zfs_sa_upgrade(sa_handle_t *hdl, dmu_tx_t *tx)
 	    &ctime, 16);
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_CRTIME(zsb), NULL,
 	    &crtime, 16);
+	links = ZTOI(zp)->i_nlink;
 	SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_LINKS(zsb), NULL,
-	    &zp->z_links, 8);
+	    &links, 8);
 	if (S_ISBLK(ZTOI(zp)->i_mode) || S_ISCHR(ZTOI(zp)->i_mode))
 		SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_RDEV(zsb), NULL,
 		    &rdev, 8);


### PR DESCRIPTION
Use native inode->i_nlink instead of znode->z_links.

Signed-off-by: Chris Dunlop <chris@onthe.net.au>