### PR TITLE
Fix dbuf_stats_hash_table_data race

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1461,15 +1461,19 @@ arc_buf_info(arc_buf_t *ab, arc_buf_info_t *abi, int state_index)
 	l2arc_buf_hdr_t *l2hdr = NULL;
 	arc_state_t *state = NULL;
 
+	memset(abi, 0, sizeof (arc_buf_info_t));
+
+	if (hdr == NULL)
+		return;
+
+	abi->abi_flags = hdr->b_flags;
+
 	if (HDR_HAS_L1HDR(hdr)) {
 		l1hdr = &hdr->b_l1hdr;
 		state = l1hdr->b_state;
 	}
 	if (HDR_HAS_L2HDR(hdr))
 		l2hdr = &hdr->b_l2hdr;
-
-	memset(abi, 0, sizeof (arc_buf_info_t));
-	abi->abi_flags = hdr->b_flags;
 
 	if (l1hdr) {
 		abi->abi_datacnt = l1hdr->b_datacnt;

--- a/module/zfs/dbuf_stats.c
+++ b/module/zfs/dbuf_stats.c
@@ -148,7 +148,6 @@ dbuf_stats_hash_table_data(char *buf, size_t size, void *data)
 		}
 
 		mutex_enter(&db->db_mtx);
-		mutex_exit(DBUF_HASH_MUTEX(h, dsh->idx));
 
 		if (db->db_state != DB_EVICTING) {
 			length = __dbuf_stats_hash_table_data(buf, size, db);
@@ -157,7 +156,6 @@ dbuf_stats_hash_table_data(char *buf, size_t size, void *data)
 		}
 
 		mutex_exit(&db->db_mtx);
-		mutex_enter(DBUF_HASH_MUTEX(h, dsh->idx));
 	}
 	mutex_exit(DBUF_HASH_MUTEX(h, dsh->idx));
 


### PR DESCRIPTION
Dropping DBUF_HASH_MUTEX when walking the hash list is unsafe. The dbuf can be
freed at any time.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>