### PR TITLE
Create a BIOS Boot Partition

### DIFF
--- a/lib/libspl/include/sys/vtoc.h
+++ b/lib/libspl/include/sys/vtoc.h
@@ -79,6 +79,7 @@ extern "C" {
 #define	V_ALTSCTR	0x09		/* Alternate sector partition */
 #define	V_CACHE		0x0a		/* Cache (cachefs) partition */
 #define	V_RESERVED	0x0b		/* SMI reserved data */
+#define V_BIOSBOOT	0x1d		/* BIOS Boot Partition */
 
 /*
  * Partition permission flags

--- a/lib/libspl/include/sys/vtoc.h
+++ b/lib/libspl/include/sys/vtoc.h
@@ -79,7 +79,7 @@ extern "C" {
 #define	V_ALTSCTR	0x09		/* Alternate sector partition */
 #define	V_CACHE		0x0a		/* Cache (cachefs) partition */
 #define	V_RESERVED	0x0b		/* SMI reserved data */
-#define V_BIOSBOOT	0x1d		/* BIOS Boot Partition */
+#define	V_BIOSBOOT	0x1d		/* BIOS Boot Partition */
 
 /*
  * Partition permission flags

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4262,6 +4262,20 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 	vtoc->efi_parts[0].p_tag = V_USR;
 	zpool_label_name(vtoc->efi_parts[0].p_name, EFI_PART_NAME_LEN);
 
+	/*
+	* When BIOS-booting off a disk in GPT format grub2 needs to embed itself
+	* in a BIOS Boot Partition with type 0xEF02 at least 31 KiB in size.
+	* The space between the default start block 34 and NEW_START_BLOCK is a
+	* good place for putting the BIOS Boot Partition.
+	* Only create this partition if its size is at least 62 logical sectors.
+	*/
+
+	if ((start_block - 34) >= 62) {
+		vtoc->efi_parts[1].p_start = 34;
+		vtoc->efi_parts[1].p_size = start_block - 34;
+		vtoc->efi_parts[1].p_tag = V_BIOSBOOT;
+	}
+
 	vtoc->efi_parts[8].p_start = slice_size + start_block;
 	vtoc->efi_parts[8].p_size = resv;
 	vtoc->efi_parts[8].p_tag = V_RESERVED;

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4263,13 +4263,13 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 	zpool_label_name(vtoc->efi_parts[0].p_name, EFI_PART_NAME_LEN);
 
 	/*
-	* When BIOS-booting off a disk in GPT format grub2 needs to embed itself
-	* in a BIOS Boot Partition with type 0xEF02 at least 31 KiB in size.
-	* The space between the default start block 34 and NEW_START_BLOCK is a
-	* good place for putting the BIOS Boot Partition, however we start at
-	* 48 to ensure alignment on drives with 8KB physical sectors.
-	* Only create this partition if its size is at least 62 logical sectors.
-	*/
+	 * When BIOS-booting off a disk in GPT format grub2 needs to embed itself
+	 * in a BIOS Boot Partition with type 0xEF02 at least 31 KiB in size.
+	 * The space between the default start block 34 and NEW_START_BLOCK is a
+	 * good place for putting the BIOS Boot Partition, however we start at
+	 * 48 to ensure alignment on drives with 8KB physical sectors.
+	 * Only create this partition if its size is at least 62 logical sectors.
+	 */
 
 	if ((start_block - 48) >= 62) {
 		vtoc->efi_parts[1].p_start = 48;

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4266,13 +4266,14 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 	* When BIOS-booting off a disk in GPT format grub2 needs to embed itself
 	* in a BIOS Boot Partition with type 0xEF02 at least 31 KiB in size.
 	* The space between the default start block 34 and NEW_START_BLOCK is a
-	* good place for putting the BIOS Boot Partition.
+	* good place for putting the BIOS Boot Partition, however we start at
+	* 48 to ensure alignment on drives with 8KB physical sectors.
 	* Only create this partition if its size is at least 62 logical sectors.
 	*/
 
-	if ((start_block - 34) >= 62) {
-		vtoc->efi_parts[1].p_start = 34;
-		vtoc->efi_parts[1].p_size = start_block - 34;
+	if ((start_block - 48) >= 62) {
+		vtoc->efi_parts[1].p_start = 48;
+		vtoc->efi_parts[1].p_size = start_block - 48;
 		vtoc->efi_parts[1].p_tag = V_BIOSBOOT;
 	}
 

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4263,12 +4263,12 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, char *name)
 	zpool_label_name(vtoc->efi_parts[0].p_name, EFI_PART_NAME_LEN);
 
 	/*
-	 * When BIOS-booting off a disk in GPT format grub2 needs to embed itself
+	 * When BIOS-booting off disks in GPT format grub2 needs to embed itself
 	 * in a BIOS Boot Partition with type 0xEF02 at least 31 KiB in size.
 	 * The space between the default start block 34 and NEW_START_BLOCK is a
 	 * good place for putting the BIOS Boot Partition, however we start at
 	 * 48 to ensure alignment on drives with 8KB physical sectors.
-	 * Only create this partition if its size is at least 62 logical sectors.
+	 * Only create the partition if its size is at least 62 logical sectors.
 	 */
 
 	if ((start_block - 48) >= 62) {


### PR DESCRIPTION
There is enough space for a BIOS Boot Partition between sectors 48 and 2048, so we can create it and have grub2 embed itself there. This allows BIOS platforms to boot off GPT formatted disks.

Partition start at sector 48 was chosen for alignment on disks using 8k physical sectors.

Fixes #1061