### PR TITLE
Enable zpool_upgrade test cases

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -339,12 +339,13 @@ post =
 [tests/functional/cli_root/zpool_status]
 tests = ['zpool_status_001_pos', 'zpool_status_002_pos']
 
-# DISABLED: ENOSPC failure
-#[tests/functional/cli_root/zpool_upgrade]
-#tests = ['zpool_upgrade_001_pos', 'zpool_upgrade_002_pos',
-#    'zpool_upgrade_003_pos', 'zpool_upgrade_004_pos', 'zpool_upgrade_005_neg',
-#    'zpool_upgrade_006_neg', 'zpool_upgrade_007_pos', 'zpool_upgrade_008_pos',
-#    'zpool_upgrade_009_neg']
+# DISABLED:
+# zpool_upgrade_007_pos - needs investigation
+[tests/functional/cli_root/zpool_upgrade]
+tests = ['zpool_upgrade_001_pos', 'zpool_upgrade_002_pos',
+    'zpool_upgrade_003_pos', 'zpool_upgrade_004_pos', 'zpool_upgrade_005_neg',
+    'zpool_upgrade_006_neg', 'zpool_upgrade_008_pos',
+    'zpool_upgrade_009_neg']
 
 # DISABLED:
 # zfs_share_001_neg - requires additional dependencies

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/setup.ksh
@@ -35,4 +35,4 @@ verify_runnable "global"
 verify_disk_count "$DISKS" 2
 
 # give us a pool to play in
-default_mirror_setup $DISKS
+default_setup "$DISKS"


### PR DESCRIPTION
Creating the pool in a striped rather than mirrored configuration
provides enough space for all upgrade tests to run.  Test case
zpool_upgrade_007_pos still fails and must be investigated so
it has been left disabled.
