### PR TITLE
Fixes for issues found with cppcheck tool

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -4553,7 +4553,7 @@ parse_fs_perm(fs_perm_t *fsperm, nvlist_t *nvl)
 				who_perm = &node->who_perm;
 			}
 		}
-
+		VERIFY3P(who_perm, !=, NULL);
 		(void) parse_who_perm(who_perm, nvl2, perm_locality);
 	}
 

--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -663,8 +663,8 @@ main(int argc, char **argv)
 	err_type_t type = TYPE_INVAL;
 	err_type_t label = TYPE_INVAL;
 	zinject_record_t record = { 0 };
-	char pool[MAXNAMELEN];
-	char dataset[MAXNAMELEN];
+	char pool[MAXNAMELEN] = "";
+	char dataset[MAXNAMELEN] = "";
 	zfs_handle_t *zhp = NULL;
 	int nowrites = 0;
 	int dur_txg = 0;

--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -308,7 +308,7 @@ for_each_vdev_cb(zpool_handle_t *zhp, nvlist_t *nv, pool_vdev_iter_f func,
 int
 for_each_vdev(zpool_handle_t *zhp, pool_vdev_iter_f func, void *data)
 {
-	nvlist_t *config, *nvroot;
+	nvlist_t *config, *nvroot = NULL;
 
 	if ((config = zpool_get_config(zhp, NULL)) != NULL) {
 		verify(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -1522,8 +1522,13 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 				if (child == NULL)
 					zpool_no_memory();
 				if ((nv = make_leaf_vdev(props, argv[c],
-				    B_FALSE)) == NULL)
+				    B_FALSE)) == NULL) {
+					for (c = 0; c < children - 1; c++)
+						nvlist_free(child[c]);
+					free(child);
 					return (NULL);
+				}
+
 				child[children - 1] = nv;
 			}
 
@@ -1531,6 +1536,9 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 				(void) fprintf(stderr, gettext("invalid vdev "
 				    "specification: %s requires at least %d "
 				    "devices\n"), argv[0], mindev);
+				for (c = 0; c < children; c++)
+					nvlist_free(child[c]);
+				free(child);
 				return (NULL);
 			}
 
@@ -1538,6 +1546,9 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 				(void) fprintf(stderr, gettext("invalid vdev "
 				    "specification: %s supports no more than "
 				    "%d devices\n"), argv[0], maxdev);
+				for (c = 0; c < children; c++)
+					nvlist_free(child[c]);
+				free(child);
 				return (NULL);
 			}
 

--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -1106,7 +1106,7 @@ check_input(struct dk_gpt *vtoc)
 int
 efi_use_whole_disk(int fd)
 {
-	struct dk_gpt		*efi_label;
+	struct dk_gpt		*efi_label = NULL;
 	int			rval;
 	int			i;
 	uint_t			resv_index = 0, data_index = 0;
@@ -1115,6 +1115,8 @@ efi_use_whole_disk(int fd)
 
 	rval = efi_alloc_and_read(fd, &efi_label);
 	if (rval < 0) {
+		if (efi_label != NULL)
+			efi_free(efi_label);
 		return (rval);
 	}
 

--- a/lib/libuutil/uu_misc.c
+++ b/lib/libuutil/uu_misc.c
@@ -199,6 +199,8 @@ uu_panic(const char *format, ...)
 
 	(void) vfprintf(stderr, format, args);
 
+	va_end(args);
+
 	if (uu_panic_thread == pthread_self())
 		abort();
 	else

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1551,6 +1551,7 @@ check_slices(avl_tree_t *r, int fd, const char *sname)
 	int i;
 
 	(void) strncpy(diskname, sname, MAXNAMELEN);
+	diskname[MAXNAMELEN - 1] = '\0';
 	if ((ptr = strrchr(diskname, 's')) == NULL || !isdigit(ptr[1]))
 		return;
 	ptr[1] = '\0';

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3264,8 +3264,9 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		 * specified only the pool name (i.e. if the destination name
 		 * contained no slash character).
 		 */
-		if (!stream_wantsnewfs ||
-		    (cp = strrchr(name, '/')) == NULL) {
+		cp = strrchr(name, '/');
+
+		if (!stream_wantsnewfs || cp == NULL) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 			    "destination '%s' does not exist"), name);
 			err = zfs_error(hdl, EZFS_NOENT, errbuf);

--- a/tests/zfs-tests/cmd/file_write/file_write.c
+++ b/tests/zfs-tests/cmd/file_write/file_write.c
@@ -127,7 +127,10 @@ main(int argc, char **argv)
 		err++;
 	}
 
-	if (err) usage(prog);
+	if (err) {
+		usage(prog); /* no return */
+		return (1);
+	}
 
 	/*
 	 * Prepare the buffer and determine the requested operation

--- a/tests/zfs-tests/cmd/randfree_file/randfree_file.c
+++ b/tests/zfs-tests/cmd/randfree_file/randfree_file.c
@@ -83,16 +83,20 @@ main(int argc, char *argv[])
 	else
 		usage(argv[0]);
 
-	buf = (char *)malloc(filesize);
-
 	if ((fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, mode)) < 0) {
 		perror("open");
 		return (1);
 	}
+
+	buf = (char *)malloc(filesize);
+
 	if (write(fd, buf, filesize) < filesize) {
+		free(buf);
 		perror("write");
 		return (1);
 	}
+
+	free(buf);
 
 	if (fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
 	    start_off, off_len) < 0) {
@@ -100,6 +104,5 @@ main(int argc, char *argv[])
 		return (1);
 	}
 
-	free(buf);
 	return (0);
 }


### PR DESCRIPTION
The patch fixes small number of errors/false positives reported by `cppcheck` static analysis tool for C/C++.

List of errors:
```
[cmd/zfs/zfs_main.c:4444]: (error) Possible null pointer dereference: who_perm
[cmd/zfs/zfs_main.c:4445]: (error) Possible null pointer dereference: who_perm
[cmd/zfs/zfs_main.c:4446]: (error) Possible null pointer dereference: who_perm
[cmd/zpool/zpool_iter.c:317]: (error) Uninitialized variable: nvroot
[cmd/zpool/zpool_vdev.c:1526]: (error) Memory leak: child
[lib/libefi/rdwr_efi.c:1118]: (error) Memory leak: efi_label
[lib/libuutil/uu_misc.c:207]: (error) va_list 'args' was opened but not closed by va_end().
[lib/libzfs/libzfs_import.c:1554]: (error) Dangerous usage of 'diskname' (strncpy doesn't always null-terminate it).
[lib/libzfs/libzfs_sendrecv.c:3279]: (error) Dereferencing 'cp' after it is deallocated / released
[tests/zfs-tests/cmd/file_write/file_write.c:154]: (error) Possible null pointer dereference: operation
[tests/zfs-tests/cmd/randfree_file/randfree_file.c:90]: (error) Memory leak: buf
```

Issue #1392