### PR TITLE
Fix for metaslab_fastwrite_unmark() assert failure

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -704,6 +704,7 @@ vdev_top_transfer(vdev_t *svd, vdev_t *tvd)
 
 	ASSERT(tvd == tvd->vdev_top);
 
+	tvd->vdev_pending_fastwrite = svd->vdev_pending_fastwrite;
 	tvd->vdev_ms_array = svd->vdev_ms_array;
 	tvd->vdev_ms_shift = svd->vdev_ms_shift;
 	tvd->vdev_ms_count = svd->vdev_ms_count;


### PR DESCRIPTION
Fixes Issue #4267 

Currently there is an issue where `metaslab_fastwrite_unmark()` unmarks fastwrites on `vdev_t`'s that have never had fastwrites marked on them. The 'fastwrite mark' is essentially a count of outstanding bytes that will be written to a vdev and is used in syncing context. The problem stems from the fact that the `vdev_pending_fastwrite` field is not being transferred over when replacing a top-level vdev. As a result, the metaslab is marked for fastwrite on the old vdev and unmarked on the new one, which brings the fastwrite count below zero. This fix simply assigns `vdev_pending_fastwrite` from the old vdev to the new one so this count is not lost.