### PR TITLE
Avoid integer overflow on computation of refquota_slack

### DIFF
--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -2836,7 +2836,8 @@ dsl_dataset_clone_swap_check_impl(dsl_dataset_t *clone,
 	 * "slack" factor for received datasets with refquota set on them.
 	 * See the bottom of this function for details on its use.
 	 */
-	uint64_t refquota_slack = DMU_MAX_ACCESS * spa_asize_inflation;
+	uint64_t refquota_slack = (uint64_t)DMU_MAX_ACCESS *
+				  spa_asize_inflation;
 	int64_t unused_refres_delta;
 
 	/* they should both be heads */


### PR DESCRIPTION
DMU_MAX_ACCESS should be cast to a uint64_t otherwise the
multiplication of DMU_MAX_ACCESS with spa_asize_inflation will
be 32 bit and may lead to an overflow. Currently DMU_MAX_ACCESS
is 64 * 1024 * 1024, so spa_asize_inflation being 64 or more will
lead to an overflow.

Found by static analysis with CoverityScan 0.8.5

CID 150942 (#1 of 1): Unintentional integer overflow
  (OVERFLOW_BEFORE_WIDEN)
overflow_before_widen: Potentially overflowing expression
  67108864 * spa_asize_inflation with type int (32 bits, signed)
  is evaluated using 32-bit arithmetic, and then used in a context
  that expects an expression of type uint64_t (64 bits, unsigned).

Signed-off-by: Colin Ian King <colin.king@canonical.com>