### PR TITLE
Enable history test cases

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -428,16 +428,11 @@ tests = ['large_dnode_001_pos', 'large_dnode_002_pos', 'large_dnode_003_pos',
 #pre =
 #post =
 
-# DISABLED:
-# history_001_pos - export commands missing from history
-# history_003_pos - nested pool
-# history_006_neg - needs investigation
-# history_007_pos - needs investigation
-# history_008_pos - needs investigation
-# history_010_pos - needs investigation
 [tests/functional/history]
-tests = ['history_002_pos', 'history_004_pos', 'history_005_neg',
-    'history_009_pos']
+tests = ['history_001_pos', 'history_002_pos', 'history_003_pos',
+    'history_004_pos', 'history_005_neg', 'history_006_neg',
+    'history_007_pos', 'history_008_pos', 'history_009_pos',
+    'history_010_pos']
 
 [tests/functional/inheritance]
 tests = ['inherit_001_pos']

--- a/tests/zfs-tests/tests/functional/history/Makefile.am
+++ b/tests/zfs-tests/tests/functional/history/Makefile.am
@@ -13,10 +13,7 @@ dist_pkgdata_SCRIPTS = \
 	history_007_pos.ksh \
 	history_008_pos.ksh \
 	history_009_pos.ksh \
-	history_010_pos.ksh
-
-
-EXTRA_DIST = \
+	history_010_pos.ksh \
 	i386.migratedpool.DAT.Z \
 	i386.orig_history.txt \
 	sparc.migratedpool.DAT.Z \

--- a/tests/zfs-tests/tests/functional/history/history_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_001_pos.ksh
@@ -92,10 +92,21 @@ for i in 0 2; do
 	$ZPOOL history $MPOOL > $TMP_HISTORY 2>/dev/null
 	$DIFF $OLD_HISTORY $TMP_HISTORY | $GREP "^> " | $SED 's/^> //g' > \
 	    $NEW_HISTORY
-	$GREP "$($ECHO "$cmd1" | $SED 's/\/usr\/sbin\///g')" $NEW_HISTORY \
-	    >/dev/null 2>&1 || log_fail "Didn't find \"$cmd1\" in pool history"
-	$GREP "$($ECHO "$cmd2" | $SED 's/\/usr\/sbin\///g')" $NEW_HISTORY \
-	    >/dev/null 2>&1 || log_fail "Didn't find \"$cmd2\" in pool history"
+        if is_linux; then
+		$GREP "$($ECHO "$cmd1" | $SED 's/^.*\/\(zpool .*\).*$/\1/')" \
+		    $NEW_HISTORY >/dev/null 2>&1 || \
+		    log_fail "Didn't find \"$cmd1\" in pool history"
+		$GREP "$($ECHO "$cmd2" | $SED 's/^.*\/\(zpool .*\).*$/\1/')" \
+		    $NEW_HISTORY >/dev/null 2>&1 || \
+		    log_fail "Didn't find \"$cmd2\" in pool history"
+        else
+		$GREP "$($ECHO "$cmd1" | $SED 's/\/usr\/sbin\///g')" \
+		    $NEW_HISTORY >/dev/null 2>&1 || \
+		    log_fail "Didn't find \"$cmd1\" in pool history"
+		$GREP "$($ECHO "$cmd2" | $SED 's/\/usr\/sbin\///g')" \
+		    $NEW_HISTORY >/dev/null 2>&1 || \
+		    log_fail "Didn't find \"$cmd2\" in pool history"
+        fi
 done
 
 run_and_verify -p "$MPOOL" "$ZPOOL split $MPOOL ${MPOOL}_split"

--- a/tests/zfs-tests/tests/functional/history/history_common.kshlib
+++ b/tests/zfs-tests/tests/functional/history/history_common.kshlib
@@ -109,8 +109,13 @@ function verify_long
 		hname=$hname:$($ZONENAME)
 	fi
 
-	$GREP "$cmd \[user $uid ($user) on $hname\]" $NEW_HISTORY >/dev/null \
-	    2>&1
+	typeset suffix=""
+	if [ is_linux ]; then
+		suffix=":linux"
+	fi
+
+	$GREP "$cmd \[user $uid ($user) on $hname$suffix\]" \
+	    $NEW_HISTORY >/dev/null 2>&1
 	if [[ $? != 0 ]]; then
 		log_note "Couldn't find long information for \"$cmd\""
 		return 1


### PR DESCRIPTION
Updated test case history_001_pos.ksh so it can run in tree.  The
original test case assumed /usr/sbin/zfs and /usr/sbin/zpool were
the only valid locations for these utilities.  The same modification
has already been made too history_common.kshlib.

The only other failing test case was history_010_pos and that was
the result of the ":linux" suffix not being appended when checking
the long output in the test case.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>