### PR TITLE
zfs allow log destroy parameter NULL

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3347,9 +3347,7 @@ zfs_ioc_log_history(const char *unused, nvlist_t *innvl, nvlist_t *outnvl)
 	poolname = tsd_get(zfs_allow_log_key);
 	if (poolname == NULL)
 	    return (SET_ERROR(EINVAL));
-	    
 	(void) tsd_set(zfs_allow_log_key, NULL);
-	
 	error = spa_open(poolname, &spa, FTAG);
 	strfree(poolname);
 	if (error != 0)
@@ -6301,7 +6299,6 @@ static void
 zfs_allow_log_destroy(void *arg)
 {
 	char *poolname = arg;
-	
 	if (poolname != NULL)
 	    strfree(poolname);
 }

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3346,7 +3346,7 @@ zfs_ioc_log_history(const char *unused, nvlist_t *innvl, nvlist_t *outnvl)
 	 */
 	poolname = tsd_get(zfs_allow_log_key);
 	if (poolname == NULL)
-	    return (SET_ERROR(SET_ERROR));
+	    return (SET_ERROR(EINVAL));
 	    
 	(void) tsd_set(zfs_allow_log_key, NULL);
 	

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3345,7 +3345,11 @@ zfs_ioc_log_history(const char *unused, nvlist_t *innvl, nvlist_t *outnvl)
 	 * we clear the TSD here.
 	 */
 	poolname = tsd_get(zfs_allow_log_key);
+	if (poolname == NULL)
+	    return (SET_ERROR(SET_ERROR));
+	    
 	(void) tsd_set(zfs_allow_log_key, NULL);
+	
 	error = spa_open(poolname, &spa, FTAG);
 	strfree(poolname);
 	if (error != 0)
@@ -6297,7 +6301,9 @@ static void
 zfs_allow_log_destroy(void *arg)
 {
 	char *poolname = arg;
-	strfree(poolname);
+	
+	if (poolname != NULL)
+	    strfree(poolname);
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
issues: please see  zfsonlinux#4872
Observed during Linux 2.6.32.41 automated testing while running the ZFS Test Suite. Cause ZFS software to produce coredump.

Cause analysis：
In zfs_ioc_log_history function, the implementation of tsd_set function, will he_value of the TSD module is set to null, 
resulting in TSD module remove a entry, so he_value of the entry is null, 
casue to implement zfs_allow_log_key private function zfs_allow_log_destroy.
zfs_allow_log_destroy parameter is null, the strfree a null. Produce coredump.

Solution：
1, in order to safety, 
in the zfs_ioc_log_history function,from the TSD module to get to the poolName, 
it is possible for the NULL, so whether the processing of NULL.
if poolname is NULL,return error.

2, zfs_allow_log_key of the private function zfs_allow_log_destroy in the Senate,
   it is possible for the emergence of NULL, 
   so for arg release when the judge for the NULL and then strfree it.