### PR TITLE
arc_meta_limit should be updated correctly when arc_max is changed.

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5364,7 +5364,7 @@ arc_tuning_update(void)
 		arc_c_max = zfs_arc_max;
 		arc_c = arc_c_max;
 		arc_p = (arc_c >> 1);
-		arc_meta_limit = MIN(arc_meta_limit, (3 * arc_c_max) / 4);
+		arc_meta_limit = (3 * arc_c_max) / 4;
 		arc_dnode_limit = arc_meta_limit / 10;
 	}
 


### PR DESCRIPTION
When arc_max is increased, arc_meta_limit will not be updated to 3/4 of the new arc_c_max value. This fix takes care of it.
If zfs_arc_meta_min is non-default, it will be picked up later in the ARC tuning function.