### PR TITLE
libzfs_import.c: Uninitialized pointer read

### DIFF
--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1695,6 +1695,7 @@ zpool_find_import_scan(libzfs_handle_t *hdl, kmutex_t *lock,
 	return (0);
 
 error:
+	cookie = NULL;
 	while ((slice = avl_destroy_nodes(cache, &cookie)) != NULL) {
 		free(slice->rn_name);
 		free(slice);


### PR DESCRIPTION
In zpool_find_import_scan: Reads an uninitialized pointer or its target
`Coverity 150966`
