### PR TITLE
libzfs: Fix missing va_end call on ENOSPC and EDQUOT cases

### DIFF
--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -390,7 +390,7 @@ zfs_standard_error_fmt(libzfs_handle_t *hdl, int error, const char *fmt, ...)
 	case ENOSPC:
 	case EDQUOT:
 		zfs_verror(hdl, EZFS_NOSPC, fmt, ap);
-		return (-1);
+		break;
 
 	case EEXIST:
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -862,7 +862,12 @@ libzfs_init(void)
 		return (NULL);
 	}
 
-	hdl->libzfs_sharetab = fopen("/etc/dfs/sharetab", "r");
+	if ((hdl->libzfs_sharetab = fopen("/etc/dfs/sharetab", "r")) == NULL) {
+		(void) close(hdl->libzfs_fd);
+		(void) fclose(hdl->libzfs_mnttab);
+		free(hdl);
+		return (NULL);
+	}
 
 	if (libzfs_core_init() != 0) {
 		(void) close(hdl->libzfs_fd);


### PR DESCRIPTION
The switch statement in function zfs_standard_error_fmt for the
ENOSPC and EDQUOT cases returns immediately and unlike all other
cases in the switch this does not perform the va_end call.

Perform a break which ends up calling va_end rather than retutning
immediately.

Found by static analysis with CoverityScan 0.8.5

Closes #4900

Signed-off-by: Colin Ian King <colin.king@canonical.com>