### PR TITLE
Unify license of icp module with the rest of zfs

### DIFF
--- a/module/icp/illumos-crypto.c
+++ b/module/icp/illumos-crypto.c
@@ -148,5 +148,5 @@ icp_init(void)
 #if defined(_KERNEL) && defined(HAVE_SPL)
 module_exit(icp_fini);
 module_init(icp_init);
-MODULE_LICENSE("CDDL");
+MODULE_LICENSE(ZFS_META_LICENSE);
 #endif


### PR DESCRIPTION
The newly added icp module uses a hardcoded value of CDDL for the license,
however in local development one might want to change that to something
else in order to facilitate compiling against lock debugging enabled kernel.
All modules of the zfs use the ZFS_META_LICNSE string which is replaced with
the value held in the META file. One can modify the value in the META file
once and then rerun the configure to have all modules' licenses changed.

Change the icp module license string to be ZFS_META_LICENSE so that it
falls under the same paradigm.