### PR TITLE
Move assignment of i_blkbits field

### DIFF
--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -535,7 +535,6 @@ zfs_inode_update_impl(znode_t *zp, boolean_t new)
 	spin_lock(&ip->i_lock);
 	ip->i_mode = zp->z_mode;
 	zfs_set_inode_flags(zp, ip);
-	ip->i_blkbits = SPA_MINBLOCKSHIFT;
 	ip->i_blocks = i_blocks;
 
 	/*
@@ -634,6 +633,7 @@ zfs_znode_alloc(zfs_sb_t *zsb, dmu_buf_t *db, int blksz,
 
 	zp->z_mode = mode;
 	ip->i_generation = (uint32_t)tmp_gen;
+	ip->i_blkbits = SPA_MINBLOCKSHIFT;
 	set_nlink(ip, (uint32_t)links);
 	zfs_uid_write(ip, z_uid);
 	zfs_gid_write(ip, z_gid);


### PR DESCRIPTION
So this continues my quest in eliminating zfs_inode_update implementation. This change is trivial enough, however when researching it I observed something peculiar. In the linux kernel most filessystem don't set this field directly as its already being set from the generic layer in `inode_init_always` to `sb->s_blocksize_bits`. In zfs this field is being set to whatever the current value of the recordsize property is set to. I cannot help it but wonder shouldn't the inode shift bits be set at allocation time to whatever the current `s_blocksize_bits` is set to, since this is the size of the record that the inode is going to hold?

@behlendorf @dweeezil can you please explain why the inode's shift bits are always seto the minimum allowed shift and not to ilog2(sb->s_blocksize_bits) ? 