### PR TITLE
Set proper dependency for string replacement targets

### DIFF
--- a/contrib/dracut/02zfsexpandknowledge/Makefile.am
+++ b/contrib/dracut/02zfsexpandknowledge/Makefile.am
@@ -5,7 +5,7 @@ pkgdracut_SCRIPTS = \
 EXTRA_DIST = \
 	$(top_srcdir)/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
 
-$(pkgdracut_SCRIPTS):
+$(pkgdracut_SCRIPTS):%:%.in
 	-$(SED) -e 's,@bindir\@,$(bindir),g' \
 		-e 's,@sbindir\@,$(sbindir),g' \
 		-e 's,@datadir\@,$(datadir),g' \
@@ -13,7 +13,7 @@ $(pkgdracut_SCRIPTS):
 		-e 's,@udevdir\@,$(udevdir),g' \
 		-e 's,@udevruledir\@,$(udevruledir),g' \
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \
-		"$(top_srcdir)/contrib/dracut/02zfsexpandknowledge/$@.in" >'$@'
+		$< >'$@'
 
 clean-local::
 	-$(RM) $(pkgdracut_SCRIPTS)

--- a/contrib/dracut/90zfs/Makefile.am
+++ b/contrib/dracut/90zfs/Makefile.am
@@ -15,14 +15,14 @@ EXTRA_DIST = \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-generator.sh.in \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-lib.sh.in
 
-$(pkgdracut_SCRIPTS):
+$(pkgdracut_SCRIPTS):%:%.in
 	-$(SED) -e 's,@bindir\@,$(bindir),g' \
 		-e 's,@sbindir\@,$(sbindir),g' \
 		-e 's,@udevdir\@,$(udevdir),g' \
 		-e 's,@udevruledir\@,$(udevruledir),g' \
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \
 		-e 's,@systemdunitdir\@,$(systemdunitdir),g' \
-		"$(top_srcdir)/contrib/dracut/90zfs/$@.in" >'$@'
+		$< >'$@'
 
 distclean-local::
 	-$(RM) $(pkgdracut_SCRIPTS)

--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -15,7 +15,7 @@ EXTRA_DIST = \
 	$(top_srcdir)/etc/init.d/zfs-zed.in \
 	$(top_srcdir)/etc/init.d/zfs.in
 
-$(init_SCRIPTS) $(initconf_SCRIPTS) $(initcommon_SCRIPTS): $(EXTRA_DIST)
+$(init_SCRIPTS) $(initconf_SCRIPTS) $(initcommon_SCRIPTS):%:%.in
 	-(if [ -e /etc/debian_version ]; then \
 		NFS_SRV=nfs-kernel-server; \
 	  else \
@@ -36,7 +36,7 @@ $(init_SCRIPTS) $(initconf_SCRIPTS) $(initcommon_SCRIPTS): $(EXTRA_DIST)
 		 -e 's,@runstatedir\@,$(runstatedir),g' \
 		 -e "s,@SHELL\@,$$SHELL,g" \
 		 -e "s,@NFS_SRV\@,$$NFS_SRV,g" \
-		 "$(top_srcdir)/etc/init.d/$@.in" >'$@'; \
+		 $< >'$@'; \
 	  [ '$@' = 'zfs-functions' -o '$@' = 'zfs' ] || \
 		chmod +x '$@')
 

--- a/etc/modules-load.d/Makefile.am
+++ b/etc/modules-load.d/Makefile.am
@@ -4,10 +4,10 @@ modulesload_DATA = \
 EXTRA_DIST = \
 	$(top_srcdir)/etc/modules-load.d/zfs.conf.in
 
-$(modulesload_DATA):
+$(modulesload_DATA):%:%.in
 	-$(SED) \
 		-e '' \
-		"$(top_srcdir)/etc/modules-load.d/$@.in" >'$@'
+		$< >'$@'
 
 distclean-local::
 	-$(RM) $(modulesload_DATA)

--- a/etc/systemd/system/Makefile.am
+++ b/etc/systemd/system/Makefile.am
@@ -18,19 +18,12 @@ EXTRA_DIST = \
 	$(top_srcdir)/etc/systemd/system/zfs.target.in \
 	$(top_srcdir)/etc/systemd/system/50-zfs.preset.in
 
-$(systemdunit_DATA):
+$(systemdunit_DATA) $(systemdpreset_DATA):%:%.in
 	-$(SED) -e 's,@bindir\@,$(bindir),g' \
 		-e 's,@runstatedir\@,$(runstatedir),g' \
 		-e 's,@sbindir\@,$(sbindir),g' \
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \
-		"$(top_srcdir)/etc/systemd/system/$@.in" >'$@'
-
-$(systemdpreset_DATA):
-	-$(SED) -e 's,@bindir\@,$(bindir),g' \
-		-e 's,@runstatedir\@,$(runstatedir),g' \
-		-e 's,@sbindir\@,$(sbindir),g' \
-		-e 's,@sysconfdir\@,$(sysconfdir),g' \
-		"$(top_srcdir)/etc/systemd/system/$@.in" >'$@'
+		$< >'$@'
 
 distclean-local::
 	-$(RM) $(systemdunit_DATA) $(systemdpreset_DATA)

--- a/udev/rules.d/Makefile.am
+++ b/udev/rules.d/Makefile.am
@@ -8,13 +8,13 @@ EXTRA_DIST = \
 	$(top_srcdir)/udev/rules.d/60-zvol.rules.in \
 	$(top_srcdir)/udev/rules.d/90-zfs.rules.in
 
-$(udevrule_DATA):
+$(udevrule_DATA):%:%.in
 	-$(SED) -e 's,@bindir\@,$(bindir),g' \
 		-e 's,@sbindir\@,$(sbindir),g' \
 		-e 's,@udevdir\@,$(udevdir),g' \
 		-e 's,@udevruledir\@,$(udevruledir),g' \
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \
-		"$(top_srcdir)/udev/rules.d/$@.in" > '$@'
+		$< > '$@'
 
 distclean-local::
 	-$(RM) $(udevrule_DATA)


### PR DESCRIPTION
A lot of string replacement target don't have dependency or incorrect
dependency. We setup proper dependency by pattern rules.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>