### PR TITLE
Add `make lint` target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,13 @@ shellcheck:
 		 done; \
 	 fi
 
+lint: cppcheck
+
+cppcheck:
+	@if type cppcheck > /dev/null 2>&1; then \
+		cppcheck --quiet --force ${top_srcdir}; \
+	fi
+
 ctags:
 	$(RM) tags
 	find $(top_srcdir) -name .git -prune -o -name '*.[hc]' | xargs ctags


### PR DESCRIPTION
Add a `make lint` target which maps to a cppcheck target.  As with
the shellcheck target it will only run when cppcheck is installed.
This allows a `make lint` build check to be incrementally added to
the automated testing for distribution which provide cppcheck.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>