### PR TITLE
Fix: Call zfs_get_name with invalid parameter

### DIFF
--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1094,7 +1094,7 @@ libzfs_dataset_cmp(const void *a, const void *b)
 	if (gotb)
 		return (1);
 
-	return (strcmp(zfs_get_name(a), zfs_get_name(b)));
+	return (strcmp(zfs_get_name(*za), zfs_get_name(*zb)));
 }
 
 /*


### PR DESCRIPTION
Dear all:
zfs_get_name() expect parameter of type _zfs_handle_t *zhp_ , but get an invalid parameter type of _zfs_handle_t **zhp_ actually in libzfs_dataset_cmp(), which may trigger a coredump if called.

libzfs_dataset_cmp() working normally so far, just because all the callers only give datasets whoes type is ZFS_TYPE_FILESYSTEM to it now, we compared their mountpoint and return, luckily.

It's a risk when the caller give snapshot or volume as input parameter.

Signed-off-by: GeLiXin <ge.lixin@zte.com.cn>