### PR TITLE
Fix of comment : Incorrect use of article for nvlist

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -834,7 +834,7 @@ typedef struct vdev_stat {
  *
  * These are stats which aren't included in the original iostat output.  For
  * convenience, they are grouped together in vdev_stat_ex, although each stat
- * is individually exported as a nvlist.
+ * is individually exported as an nvlist.
  */
 typedef struct vdev_stat_ex {
 	/* Number of ZIOs issued to disk and waiting to finish */

--- a/lib/libzfs/libzfs_config.c
+++ b/lib/libzfs/libzfs_config.c
@@ -212,7 +212,7 @@ namespace_reload(libzfs_handle_t *hdl)
 }
 
 /*
- * Retrieve the configuration for the given pool.  The configuration is a nvlist
+ * Retrieve the configuration for the given pool. The configuration is an nvlist
  * describing the vdevs, as well as the statistics associated with each one.
  */
 nvlist_t *

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -391,7 +391,7 @@ lzc_hold(nvlist_t *holds, int cleanup_fd, nvlist_t **errlist)
  *
  * The keys in the nvlist are snapshot names.
  * The snapshots must all be in the same pool.
- * The value is a nvlist whose keys are the holds to remove.
+ * The value is an nvlist whose keys are the holds to remove.
  *
  * Holds which failed to release because they didn't exist will have an entry
  * added to errlist, but will not cause an overall failure.
@@ -424,7 +424,7 @@ lzc_release(nvlist_t *holds, nvlist_t **errlist)
 /*
  * Retrieve list of user holds on the specified snapshot.
  *
- * On success, *holdsp will be set to a nvlist which the caller must free.
+ * On success, *holdsp will be set to an nvlist which the caller must free.
  * The keys are the names of the holds, and the value is the creation time
  * of the hold (uint64) in seconds since the epoch.
  */

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -2022,7 +2022,7 @@ typedef struct {
 /*
  * nvs operations are:
  *   - nvs_nvlist
- *     encoding / decoding of a nvlist header (nvlist_t)
+ *     encoding / decoding of an nvlist header (nvlist_t)
  *     calculates the size used for header and end detection
  *
  *   - nvs_nvpair

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -154,7 +154,7 @@ fm_printf(int depth, int c, int cols, const char *format, ...)
 }
 
 /*
- * Recursively print a nvlist in the specified column width and return the
+ * Recursively print an nvlist in the specified column width and return the
  * column we end up in.  This function is called recursively by fm_nvprint(),
  * below.  We generically format the entire nvpair using hexadecimal
  * integers and strings, and elide any integer arrays.  Arrays are basically

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -46,7 +46,7 @@
  * The history log is stored as a dmu object containing
  * <packed record length, record nvlist> tuples.
  *
- * Where "record nvlist" is a nvlist containing uint64_ts and strings, and
+ * Where "record nvlist" is an nvlist containing uint64_ts and strings, and
  * "packed record length" is the packed length of the "record nvlist" stored
  * as a little endian uint64_t.
  *


### PR DESCRIPTION
The indefinite article before nvlist should be "an", not "a".

We have 27 "an nvlist" and 7 "a nvlist" in our comment, they should stay the same as we are such a strict filesystem  : )

Signed-off-by: GeLiXin <ge.lixin@zte.com.cn>