### PR TITLE
Fix: incorrect pool state after import

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1423,7 +1423,7 @@ vdev_validate(vdev_t *vd, boolean_t strict)
 		    spa_last_synced_txg(spa) : -1ULL;
 
 		if ((label = vdev_label_read_config(vd, txg)) == NULL) {
-			vdev_set_state(vd, B_TRUE, VDEV_STATE_CANT_OPEN,
+			vdev_set_state(vd, B_FALSE, VDEV_STATE_CANT_OPEN,
 			    VDEV_AUX_BAD_LABEL);
 			return (0);
 		}


### PR DESCRIPTION
**The issue:**
Import a raidz pool which have a vdev of bad label, zpool status shows a right state of vdev, but wrong state of pool. The pool state should be DEGRADED, not ONLINE.

  pool: gpool
 state: ONLINE
status: One or more devices could not be used because the label is missing or
        invalid.  Sufficient replicas exist for the pool to continue
        functioning in a degraded state.
action: Replace the device using 'zpool replace'.
   see: http://zfsonlinux.org/msg/ZFS-8000-4J
  scan: none requested
config:

        NAME                     STATE     READ WRITE CKSUM
        gpool                    ONLINE       0     0     0
          raidz1-0               ONLINE       0     0     0
            /home/glx/disk1      ONLINE       0     0     0
            6507082734343245157  UNAVAIL      0     0     0  was /home/glx/disk2
            /home/glx/disk3      ONLINE       0     0     0
            /home/glx/disk4      ONLINE       0     0     0

errors: No known data errors

**The way to reproduce:**
1、for i in {1..4};do dd if=/dev/zero of=/home/glx/disk$i bs=1M count=100;done
2、zpool create gpool raidz1 /home/glx/disk1 /home/glx/disk2 /home/glx/disk3 /home/glx/disk4 -f
3、zpool export gpool
4、dd if=/dev/zero of=/home/glx/disk2 bs=1M count=100
5、zpool import -d /home/glx gpool
6、zpool status gpool

**Analysis:**
We examine the label in vdev_validate while spa_load_impl, bad label can be detacted but didn't propagate it's state to parent.
There are other chance to propagate state in the following vdev_load if we failed to load DTL, but our pool is raidz1 which can tolerate a fault disk , so we lost the last chance to correct the pool state.

**Solution:**
Propagate the leaf vdev's state to parent if it's label was corrupted.
The other way is use different propagate strategy between caller of spa_load_impl and vdev_reopen, which is logically more reasonable but seems not enough necessity?