### PR TITLE
Fix a wrong comment

### DIFF
--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -361,7 +361,7 @@ typedef struct {
  *	- the write occupies only one block
  * WR_COPIED:
  *    If we know we'll immediately be committing the
- *    transaction (FSYNC or FDSYNC), the we allocate a larger
+ *    transaction (FSYNC or FDSYNC), then we allocate a larger
  *    log record here for the data and copy the data in.
  * WR_NEED_COPY:
  *    Otherwise we don't allocate a buffer, and *if* we need to


### PR DESCRIPTION
the following comment in zil.h

 * WR_COPIED:
 *    If we know we'll immediately be committing the
 *    transaction (FSYNC or FDSYNC), then we allocate a larger
 *    log record here for the data and copy the data in.

The word "the" should be "then".
The zfs is such a strict filesystem, so that we can not be too rigorous.
Thanks.