### PR TITLE
Fix panic : free a NULL point in dmu_send_impl

### DIFF
--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -859,7 +859,10 @@ dmu_send_impl(void *tag, dsl_pool_t *dp, dsl_dataset_t *to_ds,
 	}
 
 	err = dump_record(dsp, payload, payload_len);
-	fnvlist_pack_free(payload, payload_len);
+	if (payload_len != 0) {
+		fnvlist_pack_free(payload, payload_len);
+	}
+
 	if (err != 0) {
 		err = dsp->dsa_err;
 		goto out;


### PR DESCRIPTION
Reference issue: #https://github.com/zfsonlinux/zfs/issues/4967

This issue maybe introduced by commit #https://github.com/zfsonlinux/zfs/commit/47dfff3b86c67c6ae184c2b7166eaa529590c2d2

[93344.134598]  [<ffffffff8130fa9d>] dump_stack+0x4d/0x63
[93344.134603]  [<ffffffffa0d10f13>] spl_dumpstack+0x3d/0x3f [spl]
[93344.134605]  [<ffffffffa0d110cb>] spl_panic+0xa9/0xdc [spl]
[93344.134608]  [<ffffffffa0d10593>] ? vn_rdwr+0x159/0x1b3 [spl]
[93344.134611]  [<ffffffff814d0a10>] ? mutex_unlock+0x9/0xb
[93344.134628]  [<ffffffffa0dddff9>] ? dump_bytes_cb+0x10f/0x123 [zfs]
[93344.134630]  [<ffffffffa0d0a412>] spl_kmem_free+0x44/0xbf [spl]
[93344.134633]  [<ffffffffa0d3b6ec>] fnvlist_pack_free+0x9/0xb [znvpair]
[93344.134644]  [<ffffffffa0ddf884>] dmu_send_impl+0x529/0x120a [zfs]
[93344.134645]  [<ffffffff814d0a10>] ? mutex_unlock+0x9/0xb
[93344.134657]  [<ffffffffa0de06fc>] dmu_send_obj+0x197/0x1bc [zfs]
[93344.134669]  [<ffffffffa0e5aa52>] zfs_ioc_send+0x1f7/0x236 [zfs]
[93344.134682]  [<ffffffffa0e60a63>] zfsdev_ioctl+0x40e/0x521 [zfs]
[93344.134684]  [<ffffffff81059337>] ? check_preempt_curr+0x3e/0x6c
[93344.134686]  [<ffffffff810fc891>] do_vfs_ioctl+0x3f5/0x43d
[93344.134688]  [<ffffffff8103fd2e>] ? _do_fork+0x229/0x24e
[93344.134689]  [<ffffffff810368d2>] ? __do_page_fault+0x24e/0x367
[93344.134691]  [<ffffffff810fc912>] SyS_ioctl+0x39/0x61
[93344.134692]  [<ffffffff814d2317>] entry_SYSCALL_64_fastpath+0x12/0x6a

Analysis:
If the send stream isn't resume from specified object and offset, we come to dmu_send_impl() with zero input of resumeobj and resumeoff, which means we will not initialize the buffer of payload.
In other words, the address of buffer payload will stay NULL, we shouldn't free it in this situation.

Solution:
Examine the buf len of payload before we decide to free it.