### PR TITLE
Fix do_link portion of ctime test

### DIFF
--- a/tests/zfs-tests/tests/functional/ctime/ctime_001_pos.c
+++ b/tests/zfs-tests/tests/functional/ctime/ctime_001_pos.c
@@ -145,17 +145,19 @@ do_link(const char *pfile)
 {
 	int ret = 0;
 	char link_file[BUFSIZ] = { 0 };
+	char pfile_copy[BUFSIZ] = { 0 };
 	char *dname;
 
 	if (pfile == NULL) {
 		return (-1);
 	}
 
+	strcpy(pfile_copy, pfile);
 	/*
 	 * Figure out source file directory name, and create
 	 * the link file in the same directory.
 	 */
-	dname = dirname((char *)pfile);
+	dname = dirname((char *)pfile_copy);
 	(void) snprintf(link_file, BUFSIZ, "%s/%s", dname, "link_file");
 
 	if (link(pfile, link_file) == -1) {


### PR DESCRIPTION
From the man page of dirname: " Both dirname() and basename()
may modify the contents of path, so it may be desirable to pass
a copy when calling one of these functions." And in fact on linux
using dirname actually changes the contents of the passed parameter as
evident from the following failure when running the ctime test:

link(/root/zfs-mount, /root/zfs-mount/link_file)

Fix this by creating a copy of the input parameter and passing that
to dirname, thus not compromising the original parameter, allowing
the creation of hard link to succeed.