### PR TITLE
fix the mistake in zfs_create_010_neg.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_009_neg.ksh
@@ -76,7 +76,7 @@ function cleanup
 		#
 		# new fs created during the test, cleanup it
 		#
-		if [[ $found == "false" ]]; then
+		if [[ $found == "true" ]]; then
 			log_must $ZFS destroy -f $dset
 		fi
 	done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_010_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_010_neg.ksh
@@ -77,7 +77,7 @@ function cleanup
 		#
 		# new fs created during the test, cleanup it
 		#
-		if [[ $found == "false" ]]; then
+		if [[ $found == "true" ]]; then
 			log_must $ZFS destroy -f $dset
 		fi
 	done


### PR DESCRIPTION
Just cleanup the new fs created during the test, so the "$found" should be "true".