### PR TITLE
OpenZFS 7104 - Increase indirect block size

### DIFF
--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -64,7 +64,7 @@ extern "C" {
  * 4 levels of indirect blocks would not be able to guarantee addressing an
  * entire object, so 5 levels will be used, but 5 * (20 - 7) = 65.
  */
-#define	DN_MAX_INDBLKSHIFT	14	/* 16k */
+#define	DN_MAX_INDBLKSHIFT	17	/* 128k */
 #define	DNODE_BLOCK_SHIFT	14	/* 16k */
 #define	DNODE_CORE_SIZE		64	/* 64 bytes for dnode sans blkptrs */
 #define	DN_MAX_OBJECT_SHIFT	48	/* 256 trillion (zfs_fid_t limit) */
@@ -101,6 +101,11 @@ extern "C" {
 
 #define	DNODES_PER_BLOCK_SHIFT	(DNODE_BLOCK_SHIFT - DNODE_SHIFT)
 #define	DNODES_PER_BLOCK	(1ULL << DNODES_PER_BLOCK_SHIFT)
+
+/*
+ * This is inaccurate if the indblkshift of the particular object is not the
+ * max.  But it's only used by userland to calculate the zvol reservation.
+ */
 #define	DNODES_PER_LEVEL_SHIFT	(DN_MAX_INDBLKSHIFT - SPA_BLKPTRSHIFT)
 #define	DNODES_PER_LEVEL	(1ULL << DNODES_PER_LEVEL_SHIFT)
 

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -667,6 +667,8 @@ typedef struct zpool_rewind_policy {
 
 /*
  * This is needed in userland to report the minimum necessary device size.
+ *
+ * Note that the zfs test suite uses 64MB vdevs.
  */
 #define	SPA_MINDEVSIZE		(64ULL << 20)
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -334,9 +334,14 @@ int spa_asize_inflation = 24;
  * it is possible to run the pool completely out of space, causing it to
  * be permanently read-only.
  *
+ * Note that on very small pools, the slop space will be larger than
+ * 3.2%, in an effort to have it be at least spa_min_slop (128MB),
+ * but we never allow it to be more than half the pool size.
+ *
  * See also the comments in zfs_space_check_t.
  */
 int spa_slop_shift = 5;
+uint64_t spa_min_slop = 128 * 1024 * 1024;
 
 /*
  * ==========================================================================
@@ -1598,14 +1603,16 @@ spa_get_asize(spa_t *spa, uint64_t lsize)
 
 /*
  * Return the amount of slop space in bytes.  It is 1/32 of the pool (3.2%),
- * or at least 32MB.
+ * or at least 128MB, unless that would cause it to be more than half the
+ * pool size.
  *
  * See the comment above spa_slop_shift for details.
  */
 uint64_t
-spa_get_slop_space(spa_t *spa) {
+spa_get_slop_space(spa_t *spa)
+{
 	uint64_t space = spa_get_dspace(spa);
-	return (MAX(space >> spa_slop_shift, SPA_MINDEVSIZE >> 1));
+	return (MAX(space >> spa_slop_shift, MIN(space >> 1, spa_min_slop)));
 }
 
 uint64_t

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -522,7 +522,8 @@ tests = ['quota_001_pos', 'quota_003_pos', 'quota_006_neg']
 tests = ['raidz_001_neg', 'raidz_002_pos']
 
 [tests/functional/redundancy]
-tests = ['redundancy_001_pos', 'redundancy_002_pos', 'redundancy_003_pos']
+tests = ['redundancy_001_pos', 'redundancy_002_pos', 'redundancy_003_pos',
+    'redundancy_004_neg']
 
 # DISABLED:
 # refquota_002_pos - size is less than current used or reserved space

--- a/tests/zfs-tests/include/default.cfg.in
+++ b/tests/zfs-tests/include/default.cfg.in
@@ -153,6 +153,12 @@ export BIGVOLSIZE=1eb
 # Default to limit disks to be checked
 export MAX_FINDDISKSNUM=6
 
+# Default minimum size for file based vdevs in the test suite
+export MINVDEVSIZE=$((256 * 1024 * 1024))
+
+# Minimum vdev size possible as defined in the OS
+export SPA_MINDEVSIZE=$((64 * 1024 * 1024))
+
 # For iscsi target support
 export ISCSITGTFILE=/tmp/iscsitgt_file
 export ISCSITGT_FMRI=svc:/system/iscsitgt:default

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1277,7 +1277,7 @@ function zfs_zones_setup #zone_name zone_root zone_ip
 	#
 	if verify_slog_support ; then
 		typeset sdevs="/var/tmp/sdev1 /var/tmp/sdev2"
-		log_must $MKFILE 100M $sdevs
+		log_must $MKFILE $MINVDEVSIZE $sdevs
 		log_must $ZPOOL add $pool_name log mirror $sdevs
 	fi
 
@@ -2235,7 +2235,7 @@ function verify_slog_support
 	typeset sdev=$dir/b
 
 	$MKDIR -p $dir
-	$MKFILE 64M $vdev $sdev
+	$MKFILE $MINVDEVSIZE $vdev $sdev
 
 	typeset -i ret=0
 	if ! $ZPOOL create -n $pool $vdev log $sdev > /dev/null 2>&1; then

--- a/tests/zfs-tests/tests/functional/bootfs/bootfs_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/bootfs/bootfs_001_pos.ksh
@@ -27,6 +27,10 @@
 # Copyright 2015 Nexenta Systems, Inc.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -62,7 +66,7 @@ log_onexit cleanup
 
 typeset VDEV=$TESTDIR/bootfs_001_pos_a.$$.dat
 
-log_must $MKFILE 400m $VDEV
+log_must $MKFILE $MINVDEVSIZE $VDEV
 create_pool "$TESTPOOL" "$VDEV"
 log_must $ZFS create $TESTPOOL/$TESTFS
 

--- a/tests/zfs-tests/tests/functional/bootfs/bootfs_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/bootfs/bootfs_002_neg.ksh
@@ -27,6 +27,10 @@
 # Copyright 2015 Nexenta Systems, Inc.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #

--- a/tests/zfs-tests/tests/functional/bootfs/bootfs_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/bootfs/bootfs_003_pos.ksh
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -59,7 +63,7 @@ fi
 log_onexit cleanup
 
 log_assert "Valid pool names are accepted by zpool set bootfs"
-$MKFILE 64m $TESTDIR/bootfs_003.$$.dat
+$MKFILE $MINVDEVSIZE $TESTDIR/bootfs_003.$$.dat
 
 typeset -i i=0;
 

--- a/tests/zfs-tests/tests/functional/bootfs/bootfs_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/bootfs/bootfs_004_neg.ksh
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -74,7 +78,7 @@ pools[${#pools[@]}]="$bigname"
 
 
 
-$MKFILE 64m $TESTDIR/bootfs_004.$$.dat
+$MKFILE $MINVDEVSIZE $TESTDIR/bootfs_004.$$.dat
 
 typeset -i i=0;
 

--- a/tests/zfs-tests/tests/functional/bootfs/bootfs_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/bootfs/bootfs_005_neg.ksh
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 

--- a/tests/zfs-tests/tests/functional/bootfs/bootfs_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/bootfs/bootfs_006_pos.ksh
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -92,7 +96,7 @@ log_assert "Pools of correct vdev types accept boot property"
 
 
 log_onexit cleanup
-log_must $MKFILE 64m $VDEV1 $VDEV2 $VDEV3 $VDEV4
+log_must $MKFILE $MINVDEVSIZE $VDEV1 $VDEV2 $VDEV3 $VDEV4
 
 
 ## the following configurations are supported bootable pools

--- a/tests/zfs-tests/tests/functional/bootfs/bootfs_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/bootfs/bootfs_008_neg.ksh
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -60,7 +64,7 @@ typeset COMP_FS=$TESTPOOL/COMP_FS
 log_onexit cleanup
 log_assert $assert_msg
 
-log_must $MKFILE 300m $VDEV
+log_must $MKFILE $MINVDEVSIZE $VDEV
 log_must $ZPOOL create $TESTPOOL $VDEV
 log_must $ZFS create $COMP_FS
 

--- a/tests/zfs-tests/tests/functional/cache/cache.cfg
+++ b/tests/zfs-tests/tests/functional/cache/cache.cfg
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -59,7 +59,7 @@ function set_disks
 
 set_disks
 
-export SIZE=64M
+export SIZE=$MINVDEVSIZE
 
 export VDIR=$TESTDIR/disk.cache
 export VDIR2=$TESTDIR/disk2.cache

--- a/tests/zfs-tests/tests/functional/cachefile/cachefile_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cachefile/cachefile_004_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -84,7 +84,7 @@ log_must $ZPOOL create $TESTPOOL $DISKS
 mntpnt=$(get_prop mountpoint $TESTPOOL)
 typeset -i i=0
 while ((i < 2)); do
-	log_must $MKFILE 64M $mntpnt/vdev$i
+	log_must $MKFILE $MINVDEVSIZE $mntpnt/vdev$i
 	eval vdev$i=$mntpnt/vdev$i
 	((i += 1))
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_015_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_015_pos.ksh
@@ -11,7 +11,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 # DESCRIPTION
@@ -139,7 +139,7 @@ log_must snapexists $TESTPOOL/$TESTFS1@snap3
 
 log_note "zfs destroy for snapshots from different pools"
 VIRTUAL_DISK=/var/tmp/disk
-log_must $DD if=/dev/urandom of=$VIRTUAL_DISK bs=1M count=64
+log_must mkfile $MINVDEVSIZE $VIRTUAL_DISK
 log_must $ZPOOL create $TESTPOOL2 $VIRTUAL_DISK
 log_must poolexists $TESTPOOL2
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_004_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -107,9 +107,9 @@ allds="$fs $clone $fssnap $volsnap"
 
 #create pool and datasets to guarantee testing under multiple pools and datasets.
 file=$TESTDIR1/poolfile
-typeset -i FILESIZE=104857600    #100M
-(( DFILESIZE = FILESIZE * 2 ))   # double of FILESIZE
-typeset -i VOLSIZE=10485760      #10M
+typeset FILESIZE=$MINVDEVSIZE
+(( DFILESIZE = $FILESIZE * 2 ))
+typeset -i VOLSIZE=10485760
 availspace=$(get_prop available $TESTPOOL)
 typeset -i i=0
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_005_neg.ksh
@@ -24,6 +24,11 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zfs_rename/zfs_rename.kshlib
 
@@ -63,8 +68,7 @@ log_assert "'zfs rename' should fail while datasets are within different pool."
 
 additional_setup
 
-typeset FILESIZE=64m
-log_must $MKFILE $FILESIZE $TESTDIR/$TESTFILE1
+log_must $MKFILE $MINVDEVSIZE $TESTDIR/$TESTFILE1
 create_pool $TESTPOOL1 $TESTDIR/$TESTFILE1
 
 for src in ${src_dataset[@]} ; do

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_008_neg.ksh
@@ -21,7 +21,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/cli_root/zfs_snapshot/zfs_snapshot.cfg
@@ -57,8 +57,8 @@ function cleanup
 log_assert "'zfs snapshot pool1@snap1 pool2@snap2' should fail since snapshots are in different pools."
 log_onexit cleanup
 
-log_must $MKFILE 64m $SNAPDEV1
-log_must $MKFILE 64m $SNAPDEV2
+log_must $MKFILE $MINVDEVSIZE $SNAPDEV1
+log_must $MKFILE $MINVDEVSIZE $SNAPDEV2
 
 log_must $ZPOOL create $SNAPPOOL1 $SNAPDEV1
 log_must $ZPOOL create $SNAPPOOL2 $SNAPDEV2

--- a/tests/zfs-tests/tests/functional/cli_root/zpool/zpool_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool/zpool_002_pos.ksh
@@ -24,6 +24,11 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -66,7 +71,7 @@ vdev1=$TESTDIR/file1
 vdev2=$TESTDIR/file2
 vdev3=$TESTDIR/file3
 for vdev in $vdev1 $vdev2 $vdev3; do
-	$MKFILE 64m $vdev
+	$MKFILE $MINVDEVSIZE $vdev
 done
 
 set -A cmds "create $pool mirror $vdev1 $vdev2" "list $pool" "iostat $pool" \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.cfg
@@ -25,17 +25,12 @@
 #
 
 #
-# Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 export DISK_ARRAY_NUM=0
 export DISK_ARRAY_LIMIT=4
 export DISKSARRAY=""
-
-#
-# Variables for zpool_add_006
-#
-export VDEVS_NUM=32
 
 function set_disks
 {
@@ -66,10 +61,7 @@ function set_disks
 
 set_disks
 
-export FILESIZE="100m"
-export FILESIZE1="150m"
-export SIZE="150m"
-export SIZE1="250m"
+export SIZE="$(((MINVDEVSIZE / (1024 * 1024)) * 2))m"
 
 if is_linux; then
 	export SLICE_PREFIX="p"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_006_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2014 by Delphix. All rights reserved.
+# Copyright (c) 2014, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -38,7 +38,7 @@
 #
 # STRATEGY:
 # 1. Create a file based pool.
-# 2. Add 32 file based vdevs to it.
+# 2. Add 16 file based vdevs to it.
 # 3. Attempt to add a file based vdev that's too small; verify failure.
 #
 
@@ -61,11 +61,11 @@ log_onexit cleanup
 
 create_pool $TESTPOOL ${DISKS%% *}
 log_must $ZFS create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS
-log_must $MKFILE 64m $TESTDIR/file.00
+log_must $MKFILE $MINVDEVSIZE $TESTDIR/file.00
 create_pool "$TESTPOOL1" "$TESTDIR/file.00"
 
-vdevs_list=$($ECHO $TESTDIR/file.{01..32})
-log_must $MKFILE 64m $vdevs_list
+vdevs_list=$($ECHO $TESTDIR/file.{01..16})
+log_must $MKFILE $MINVDEVSIZE $vdevs_list
 
 log_must $ZPOOL add -f "$TESTPOOL1" $vdevs_list
 log_must vdevs_in_pool "$TESTPOOL1" "$vdevs_list"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear.cfg
@@ -25,9 +25,9 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
-export FILESIZE=100m
+export FILESIZE=$MINVDEVSIZE
 export BLOCKSZ=$(( 1024 * 1024 ))
 export NUM_WRITES=40

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/setup.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -45,12 +45,12 @@ if [[ -n $DISK ]]; then
         #
 	cleanup_devices $DISK
 
-        partition_disk $SIZE $DISK 7
+        partition_disk $((($MINVDEVSIZE / (1024 * 1024)) * 3))m $DISK 7
 else
 	for disk in `$ECHO $DISKSARRAY`; do
 		cleanup_devices $disk
 
-		partition_disk $SIZE $disk 7
+		partition_disk $((($MINVDEVSIZE / (1024 * 1024)) * 3))m $disk 7
 	done
 fi
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.cfg
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -33,7 +33,6 @@
 export DISK_ARRAY_NUM=0
 export DISK_ARRAY_LIMIT=4
 export DISKSARRAY=""
-export VDEVS_NUM=32
 
 function set_disks
 {
@@ -57,10 +56,10 @@ function set_disks
 
 set_disks
 
-export FILESIZE="100m"
-export FILESIZE1="150m"
-export SIZE="200m"
-export SIZE1="250m"
+export FILESIZE="$MINVDEVSIZE"
+export FILESIZE1="$(($MINVDEVSIZE * 2))"
+export SIZE="$((MINVDEVSIZE / (1024 * 1024)))"m
+export SIZE1="$(($MINVDEVSIZE * 2 / (1024 * 1024)))m"
 
 if is_linux; then
 	export SLICE_PREFIX="p"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_001_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -52,11 +52,12 @@ function cleanup
 	clean_blockfile "$TESTDIR0 $TESTDIR1"
 
 	if [[ -n $DISK ]]; then
-		partition_disk $SIZE $DISK 7
+		partition_disk $((($MINVDEVSIZE / (1024 * 1024)) * 3))m $DISK 7
 	else
 		typeset disk=""
 		for disk in $DISK0 $DISK1; do
-			partition_disk $SIZE $disk 7
+			partition_disk \
+			    $((($MINVDEVSIZE / (1024 * 1024)) * 3))m $disk 7
 		done
 	fi
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_004_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/cli_root/zpool_create/zpool_create.shlib
@@ -54,15 +54,15 @@ function cleanup
 	partition_disk $SIZE $disk 6
 }
 
-log_assert "Storage pools with $VDEVS_NUM file based vdevs can be created."
+log_assert "Storage pools with 16 file based vdevs can be created."
 log_onexit cleanup
 
 disk=${DISKS%% *}
 create_pool $TESTPOOL $disk
 log_must $ZFS create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 
-vdevs_list=$($ECHO $TESTDIR/file.{01..32})
-log_must $MKFILE 64m $vdevs_list
+vdevs_list=$($ECHO $TESTDIR/file.{01..16})
+log_must $MKFILE $MINVDEVSIZE $vdevs_list
 
 create_pool "$TESTPOOL1" $vdevs_list
 log_must vdevs_in_pool "$TESTPOOL1" "$vdevs_list"
@@ -74,7 +74,7 @@ else
 fi
 
 log_must $MKFILE 32m $TESTDIR/broken_file
-vdevs_list="$vdevs_list ${TESTDIR}/broken_file"
+vdevs_list="$vdevs_list $TESTDIR/broken_file"
 log_mustnot $ZPOOL create -f $TESTPOOL1 $vdevs_list
 
 log_pass "Storage pools with many file based vdevs can be created."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_006_pos.ksh
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -33,7 +37,7 @@
 #
 # STRATEGY:
 #	1. Create base filesystem to hold virtual disk files.
-#	2. Create several files >= 64M.
+#	2. Create several files == $MINVDEVSIZE.
 #	3. Verify 'zpool create' succeed with valid keywords combination.
 #
 
@@ -54,7 +58,7 @@ mntpnt=$(get_prop mountpoint $TESTPOOL)
 
 typeset -i i=0
 while ((i < 10)); do
-	log_must $MKFILE 64M $mntpnt/vdev$i
+	log_must $MKFILE $MINVDEVSIZE $mntpnt/vdev$i
 
 	eval vdev$i=$mntpnt/vdev$i
 	((i += 1))

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_010_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_010_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -34,7 +34,7 @@
 
 #
 # DESCRIPTION:
-# 'zpool create' should return an error with VDEVsof size  <64mb
+# 'zpool create' should return an error with VDEVs of size SPA_MINDEVSIZE
 #
 # STRATEGY:
 # 1. Create an array of parameters
@@ -42,7 +42,7 @@
 # 3. Verify an error is returned.
 #
 
-log_assert "'zpool create' should return an error with VDEVs <64mb"
+log_assert "'zpool create' should return an error with VDEVs SPA_MINDEVSIZE"
 
 verify_runnable "global"
 
@@ -69,9 +69,10 @@ create_pool $TESTPOOL $disk
 log_must $ZFS create $TESTPOOL/$TESTFS
 log_must $ZFS set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 
+typeset -l devsize=$(($SPA_MINDEVSIZE - 1024 * 1024))
 for files in $TESTDIR/file1 $TESTDIR/file2
 do
-	log_must $MKFILE 63m $files
+	log_must $MKFILE $devsize $files
 done
 
 set -A args \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_002_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -103,7 +103,7 @@ for type in " " mirror raidz raidz2; do
 	    "expanded size: $expand_size"
 
 	# compare available pool size from zfs
-	if [[ $zfs_expand_size > $zfs_prev_size ]]; then
+	if [[ $zfs_expand_size -gt $zfs_prev_size ]]; then
 	# check for zpool history for the pool size expansion
 		if [[ $type == " " ]]; then
 			typeset	size_addition=$($ZPOOL history -il $TESTPOOL1 \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_004_pos.ksh
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -69,7 +73,7 @@ mntpnt=$(get_prop mountpoint $TESTPOOL)
 
 typeset -i i=0
 while ((i < 5)); do
-	log_must $MKFILE 64M $mntpnt/vdev$i
+	log_must $MKFILE $MINVDEVSIZE $mntpnt/vdev$i
 	eval vdev$i=$mntpnt/vdev$i
 	((i += 1))
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.cfg
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -75,8 +75,8 @@ esac
 export DISK_COUNT ZFS_DISK1 ZFSSIDE_DISK1 ZFS_DISK2 ZFSSIDE_DISK2
 
 export FS_SIZE=1g
-export FILE_SIZE=64m
-export SLICE_SIZE=128m
+export FILE_SIZE=$MINVDEVSIZE
+export SLICE_SIZE="$((MINVDEVSIZE / (1024 * 1024)))m"
 export MAX_NUM=5
 export GROUP_NUM=3
 export DEVICE_DIR=$TEST_BASE_DIR/dev_import-test

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_002_neg.ksh
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -99,7 +103,7 @@ arguments[${#arguments[@]}]="bootfs=$bigname"
 # Create a pool called bootfs (so-called, so as to trip any clashes between
 # property name, and pool name)
 # Also create a filesystem in this pool
-log_must $MKFILE 64m /tmp/zpool_set_002.$$.dat
+log_must $MKFILE $MINVDEVSIZE /tmp/zpool_set_002.$$.dat
 log_must $ZPOOL create bootfs /tmp/zpool_set_002.$$.dat
 log_must $ZFS create bootfs/root
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_003_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -56,7 +56,7 @@ log_onexit cleanup
 
 log_assert "zpool set cannot set a readonly property"
 
-log_must $MKFILE 64m /tmp/zpool_set_003.$$.dat
+log_must $MKFILE $MINVDEVSIZE /tmp/zpool_set_003.$$.dat
 log_must $ZPOOL create $TESTPOOL /tmp/zpool_set_003.$$.dat
 
 typeset -i i=0;

--- a/tests/zfs-tests/tests/functional/cli_user/misc/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/setup.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -116,14 +116,14 @@ then
 
 	# Now create several virtual disks to test zpool with
 
-	$MKFILE 100m /$TESTDIR/disk1.dat
-	$MKFILE 100m /$TESTDIR/disk2.dat
-	$MKFILE 100m /$TESTDIR/disk3.dat
-	$MKFILE 100m /$TESTDIR/disk-additional.dat
-	$MKFILE 100m /$TESTDIR/disk-export.dat
-	$MKFILE 100m /$TESTDIR/disk-offline.dat
-	$MKFILE 100m /$TESTDIR/disk-spare1.dat
-	$MKFILE 100m /$TESTDIR/disk-spare2.dat
+	$MKFILE $MINVDEVSIZE /$TESTDIR/disk1.dat
+	$MKFILE $MINVDEVSIZE /$TESTDIR/disk2.dat
+	$MKFILE $MINVDEVSIZE /$TESTDIR/disk3.dat
+	$MKFILE $MINVDEVSIZE /$TESTDIR/disk-additional.dat
+	$MKFILE $MINVDEVSIZE /$TESTDIR/disk-export.dat
+	$MKFILE $MINVDEVSIZE /$TESTDIR/disk-offline.dat
+	$MKFILE $MINVDEVSIZE /$TESTDIR/disk-spare1.dat
+	$MKFILE $MINVDEVSIZE /$TESTDIR/disk-spare2.dat
 
 	# and create a pool we can perform attach remove replace,
 	# etc. operations with

--- a/tests/zfs-tests/tests/functional/history/history_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_001_pos.ksh
@@ -25,7 +25,7 @@
 # Use is subject to license terms.
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/history/history_common.kshlib
@@ -63,8 +63,8 @@ mntpnt=$(get_prop mountpoint $TESTPOOL)
 VDEV1=$mntpnt/vdev1; VDEV2=$mntpnt/vdev2;
 VDEV3=$mntpnt/vdev3; VDEV4=$mntpnt/vdev4;
 
-log_must $MKFILE 64m $VDEV1 $VDEV2 $VDEV3
-log_must $MKFILE 100m $VDEV4
+log_must $MKFILE $MINVDEVSIZE $VDEV1 $VDEV2 $VDEV3
+log_must $MKFILE $(($MINVDEVSIZE * 2)) $VDEV4
 
 run_and_verify -p "$MPOOL" "$ZPOOL create $MPOOL mirror $VDEV1 $VDEV2"
 run_and_verify -p "$MPOOL" "$ZPOOL add -f $MPOOL spare $VDEV3"

--- a/tests/zfs-tests/tests/functional/online_offline/online_offline_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/online_offline/online_offline_003_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013, 2014 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -58,7 +58,7 @@ log_onexit cleanup
 
 specials_list=""
 for i in 0 1 2; do
-	$MKFILE 64m $TESTDIR/$TESTFILE1.$i
+	$MKFILE $MINVDEVSIZE $TESTDIR/$TESTFILE1.$i
 	specials_list="$specials_list $TESTDIR/$TESTFILE1.$i"
 done
 disk=($specials_list)

--- a/tests/zfs-tests/tests/functional/poolversion/setup.ksh
+++ b/tests/zfs-tests/tests/functional/poolversion/setup.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -34,12 +34,12 @@
 verify_runnable "global"
 
 # create a version 1 pool
-log_must $MKFILE 64m /tmp/zpool_version_1.dat
+log_must $MKFILE $MINVDEVSIZE /tmp/zpool_version_1.dat
 log_must $ZPOOL create -o version=1 $TESTPOOL /tmp/zpool_version_1.dat
 
 
 # create another version 1 pool
-log_must $MKFILE 64m /tmp/zpool2_version_1.dat
+log_must $MKFILE $MINVDEVSIZE /tmp/zpool2_version_1.dat
 log_must $ZPOOL create -o version=1 $TESTPOOL2 /tmp/zpool2_version_1.dat
 
 log_pass

--- a/tests/zfs-tests/tests/functional/redundancy/redundancy.cfg
+++ b/tests/zfs-tests/tests/functional/redundancy/redundancy.cfg
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 export BASEDIR=/var/tmp/basedir.$$
@@ -33,8 +33,6 @@ export TESTFILE=testfile.$$
 
 export PRE_RECORD_FILE=$BASEDIR/pre-record-file.$$
 export PST_RECORD_FILE=$BASEDIR/pst-record-file.$$
-
-export DEV_SIZE=64M
 
 export BLOCKSZ=$(( 1024 * 1024 ))
 export NUM_WRITES=40

--- a/tests/zfs-tests/tests/functional/redundancy/redundancy.kshlib
+++ b/tests/zfs-tests/tests/functional/redundancy/redundancy.kshlib
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -119,7 +119,7 @@ function setup_test_env
 		destroy_pool $pool
 	fi
 
-	log_must $MKFILE $DEV_SIZE $vdevs
+	log_must $MKFILE $MINVDEVSIZE $vdevs
 
 	log_must $ZPOOL create -m $TESTDIR $pool $keyword $vdevs
 
@@ -252,7 +252,7 @@ function replace_missing_devs
 
 	typeset vdev
 	for vdev in $@; do
-		log_must $MKFILE $DEV_SIZE $vdev
+		log_must $MKFILE $MINVDEVSIZE $vdev
 		log_must $ZPOOL replace -f $pool $vdev $vdev
 		while true; do
 			if ! is_pool_resilvered $pool ; then
@@ -278,19 +278,20 @@ function damage_devs
 	typeset -i cnt=$2
 	typeset label="$3"
 	typeset vdevs
-	typeset -i bs_count
+	typeset -i bs_count=$((64 * 1024))
 
 	vdevs=$(get_vdevs $pool $cnt)
+	typeset dev
 	if [[ -n $label ]]; then
-		typeset dev
 		for dev in $vdevs; do
-			bs_count=$($LS -l $dev | $AWK '{print $5}')
-			(( bs_count = bs_count/1024 - 512 ))
 			$DD if=/dev/zero of=$dev seek=512 bs=1024 \
-				count=$bs_count conv=notrunc >/dev/null 2>&1
+			    count=$bs_count conv=notrunc >/dev/null 2>&1
 		done
 	else
-		log_must $MKFILE $DEV_SIZE $vdevs
+		for dev in $vdevs; do
+			$DD if=/dev/zero of=$dev bs=1024 count=$bs_count \
+			    conv=notrunc >/dev/null 2>&1
+		done
 	fi
 
 	sync_pool $pool

--- a/tests/zfs-tests/tests/functional/replacement/replacement_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/replacement_001_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -125,7 +125,7 @@ function replace_test
 specials_list=""
 i=0
 while [[ $i != 2 ]]; do
-        $MKFILE 100m $TESTDIR/$TESTFILE1.$i
+        $MKFILE $MINVDEVSIZE $TESTDIR/$TESTFILE1.$i
         specials_list="$specials_list $TESTDIR/$TESTFILE1.$i"
 
         ((i = i + 1))
@@ -134,7 +134,7 @@ done
 #
 # Create a replacement disk special file.
 #
-$MKFILE 100m $TESTDIR/$REPLACEFILE
+$MKFILE $MINVDEVSIZE $TESTDIR/$REPLACEFILE
 
 for type in "" "raidz" "raidz1" "mirror"; do
 	for op in "" "-f"; do

--- a/tests/zfs-tests/tests/functional/replacement/replacement_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/replacement_002_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -125,7 +125,7 @@ function attach_test
 specials_list=""
 i=0
 while [[ $i != 2 ]]; do
-	$MKFILE 100m $TESTDIR/$TESTFILE1.$i
+	$MKFILE $MINVDEVSIZE $TESTDIR/$TESTFILE1.$i
 	specials_list="$specials_list $TESTDIR/$TESTFILE1.$i"
 
 	((i = i + 1))
@@ -134,7 +134,7 @@ done
 #
 # Create a replacement disk special file.
 #
-$MKFILE 100m $TESTDIR/$REPLACEFILE
+$MKFILE $MINVDEVSIZE $TESTDIR/$REPLACEFILE
 
 for op in "" "-f"; do
 	create_pool $TESTPOOL1 mirror $specials_list

--- a/tests/zfs-tests/tests/functional/replacement/replacement_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/replacement_003_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -122,7 +122,7 @@ function detach_test
 specials_list=""
 i=0
 while [[ $i != 2 ]]; do
-	$MKFILE 100m $TESTDIR/$TESTFILE1.$i
+	$MKFILE $MINVDEVSIZE $TESTDIR/$TESTFILE1.$i
 	specials_list="$specials_list $TESTDIR/$TESTFILE1.$i"
 
 	((i = i + 1))

--- a/tests/zfs-tests/tests/functional/rsend/rsend_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_009_pos.ksh
@@ -58,10 +58,10 @@ function cleanup
 log_assert "Verify zfs receive can handle out of space correctly."
 log_onexit cleanup
 
-log_must $MKFILE 100M $TESTDIR/bfile
-log_must $MKFILE 64M  $TESTDIR/sfile
-log_must $ZPOOL create bpool $TESTDIR/bfile
-log_must $ZPOOL create spool $TESTDIR/sfile
+log_must $MKFILE $MINVDEVSIZE $TESTDIR/bfile
+log_must $MKFILE $SPA_MINDEVSIZE  $TESTDIR/sfile
+log_must zpool create bpool $TESTDIR/bfile
+log_must zpool create spool $TESTDIR/sfile
 
 #
 # Test out of space on sub-filesystem

--- a/tests/zfs-tests/tests/functional/slog/setup.ksh
+++ b/tests/zfs-tests/tests/functional/slog/setup.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -45,6 +45,6 @@ if [[ -d $VDEV2 ]]; then
 	log_must $RM -rf $VDIR2
 fi
 log_must $MKDIR -p $VDIR $VDIR2
-log_must $MKFILE $SIZE $VDEV $SDEV $LDEV $VDEV2 $SDEV2 $LDEV2
+log_must $MKFILE $MINVDEVSIZE $VDEV $SDEV $LDEV $VDEV2 $SDEV2 $LDEV2
 
 log_pass

--- a/tests/zfs-tests/tests/functional/slog/slog.cfg
+++ b/tests/zfs-tests/tests/functional/slog/slog.cfg
@@ -25,10 +25,8 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
-
-export SIZE=64M
 
 export VDIR=/disk-slog
 export VDIR2=/disk2-slog

--- a/tests/zfs-tests/tests/functional/slog/slog_012_neg.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_012_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/slog/slog.kshlib
@@ -60,7 +60,7 @@ do
 		log_must $DD if=/dev/urandom of=$mntpnt/testfile.$$ count=100
 
 		ldev=$(random_get $LDEV)
-		log_must $MKFILE $SIZE $ldev
+		log_must $MKFILE $MINVDEVSIZE $ldev
 		log_must $ZPOOL scrub $TESTPOOL
 
 		log_must display_status $TESTPOOL

--- a/tests/zfs-tests/tests/functional/slog/slog_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_013_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/slog/slog.kshlib
@@ -81,14 +81,12 @@ log_must verify_slog_device $TESTPOOL $lofidev 'ONLINE'
 log_pass "Verify slog device can be disk, file, lofi device or any device " \
 	"that presents a block interface."
 
-# Temp disable fore bug 6569095
 # Add file which reside in the itself
 mntpnt=$(get_prop mountpoint $TESTPOOL)
-log_must $MKFILE 100M $mntpnt/vdev
+log_must $MKFILE $MINVDEVSIZE $mntpnt/vdev
 log_must $ZPOOL add $TESTPOOL $mntpnt/vdev
 
-# Temp disable fore bug 6569072
 # Add ZFS volume
 vol=$TESTPOOL/vol
-log_must $ZPOOL create -V 64M $vol
+log_must $ZPOOL create -V $MINVDEVSIZE $vol
 log_must $ZPOOL add $TESTPOOL ${ZVOL_DEVDIR}/$vol


### PR DESCRIPTION
Reviewed by: George Wilson george.wilson@delphix.com
Reviewed by: Paul Dagnelie pcd@delphix.com
Ported by: Boris Lukashev blukashev@sempervictus.com
Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov

The current default indirect block size is 16KB. We can improve
performance by increasing it to 128KB.  This is especially helpful for
any workload that needs to read most of the metadata, e.g.
scrub/resilver, file deletion, filesystem deletion, and zfs send.

We also need to fix a few space estimation errors to make the tests
pass.

OpenZFS-issue: https://www.illumos.org/issues/7104
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/5eaefb353
Upstream bug: DLPX-35881
