### PR TITLE
Fix: Array bounds read in zprop_print_one_property()

### DIFF
--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1433,7 +1433,8 @@ zprop_print_one_property(const char *name, zprop_get_cbdata_t *cbp,
 			continue;
 		}
 
-		if (cbp->cb_columns[i + 1] == GET_COL_NONE)
+		if (i == (ZFS_GET_NCOLS - 1) ||
+		    cbp->cb_columns[i + 1] == GET_COL_NONE)
 			(void) printf("%s", str);
 		else if (cbp->cb_scripted)
 			(void) printf("%s\t", str);


### PR DESCRIPTION
If the loop index `i` comes to `(ZFS_GET_NCOLS - 1)`, the `cbp->cb_columns[i + 1] `actually
read the data of `cbp->cb_colwidths[0]`, which means the array subscript is above array bounds.

Luckily the `cbp->cb_colwidths[0] `is always 0 `(GET_COL_NONE)` now, and it seems we haven't looped enough times to exceed the array bounds so far, but it's really a secluded risk someday.