### PR TITLE
fix hole_birth issue #4996 and add hole_birth Test Suite

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,6 +238,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/grow_pool/Makefile
 	tests/zfs-tests/tests/functional/grow_replicas/Makefile
 	tests/zfs-tests/tests/functional/history/Makefile
+	tests/zfs-tests/tests/functional/hole_birth/Makefile
 	tests/zfs-tests/tests/functional/inheritance/Makefile
 	tests/zfs-tests/tests/functional/inuse/Makefile
 	tests/zfs-tests/tests/functional/large_files/Makefile

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -765,6 +765,7 @@ dbuf_read_impl(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 
 		if (db->db_blkptr != NULL && db->db_level > 0 &&
 		    BP_IS_HOLE(db->db_blkptr) &&
+		    BP_GET_LEVEL(db->db_blkptr) > 0 &&
 		    db->db_blkptr->blk_birth != 0) {
 			blkptr_t *bps = db->db.db_data;
 			int i;

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  */
 
@@ -1663,6 +1663,71 @@ dnode_dirty_l1(dnode_t *dn, uint64_t l1blkid, dmu_tx_t *tx)
 	}
 }
 
+/*
+ * Dirty all the in-core level-1 dbufs in the range specified by start_blkid
+ * and end_blkid.
+ */
+static void
+dnode_dirty_l1range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
+    dmu_tx_t *tx)
+{
+	dmu_buf_impl_t db_search;
+	dmu_buf_impl_t *db;
+	avl_index_t where;
+
+	mutex_enter(&dn->dn_dbufs_mtx);
+
+	db_search.db_level = 1;
+	db_search.db_blkid = start_blkid + 1;
+	db_search.db_state = DB_SEARCH;
+	for (;;) {
+		db = avl_find(&dn->dn_dbufs, &db_search, &where);
+		if (db == NULL)
+			db = avl_nearest(&dn->dn_dbufs, where, AVL_AFTER);
+
+		if (db == NULL || db->db_level != 1 ||
+		    db->db_blkid >= end_blkid) {
+			break;
+		}
+
+		/*
+		 * Setup the next blkid we want to search for.
+		 */
+		db_search.db_blkid = db->db_blkid + 1;
+		ASSERT3U(db->db_blkid, >=, start_blkid);
+
+		/*
+		 * If the dbuf transitions to DB_EVICTING while we're trying
+		 * to dirty it, then we will be unable to discover it in
+		 * the dbuf hash table. This will result in a call to
+		 * dbuf_create() which needs to acquire the dn_dbufs_mtx
+		 * lock. To avoid a deadlock, we drop the lock before
+		 * dirtying the level-1 dbuf.
+		 */
+		mutex_exit(&dn->dn_dbufs_mtx);
+		dnode_dirty_l1(dn, db->db_blkid, tx);
+		mutex_enter(&dn->dn_dbufs_mtx);
+	}
+
+#ifdef ZFS_DEBUG
+	/*
+	 * Walk all the in-core level-1 dbufs and verify they have been dirtied.
+	 */
+	db_search.db_level = 1;
+	db_search.db_blkid = start_blkid + 1;
+	db_search.db_state = DB_SEARCH;
+	db = avl_find(&dn->dn_dbufs, &db_search, &where);
+	if (db == NULL)
+		db = avl_nearest(&dn->dn_dbufs, where, AVL_AFTER);
+	for (; db != NULL; db = AVL_NEXT(&dn->dn_dbufs, db)) {
+		if (db->db_level != 1 || db->db_blkid >= end_blkid)
+			break;
+		ASSERT(db->db_dirtycnt > 0);
+	}
+#endif
+	mutex_exit(&dn->dn_dbufs_mtx);
+}
+
 void
 dnode_free_range(dnode_t *dn, uint64_t off, uint64_t len, dmu_tx_t *tx)
 {
@@ -1814,6 +1879,8 @@ dnode_free_range(dnode_t *dn, uint64_t off, uint64_t len, dmu_tx_t *tx)
 			last = (blkid + nblks - 1) >> epbs;
 		if (last != first)
 			dnode_dirty_l1(dn, last, tx);
+
+		dnode_dirty_l1range(dn, first, last, tx);
 
 		shift = dn->dn_datablkshift + dn->dn_indblkshift -
 		    SPA_BLKPTRSHIFT;

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  */
 
 /* Portions Copyright 2007 Jeremy Teo */
@@ -1614,7 +1614,8 @@ zfs_trunc(znode_t *zp, uint64_t end)
 		return (0);
 	}
 
-	error = dmu_free_long_range(zsb->z_os, zp->z_id, end,  -1);
+	error = dmu_free_long_range(zsb->z_os, zp->z_id, end,
+	    DMU_OBJECT_END);
 	if (error) {
 		zfs_range_unlock(rl);
 		return (error);

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -427,6 +427,9 @@ tests = ['history_001_pos', 'history_002_pos', 'history_003_pos',
     'history_007_pos', 'history_008_pos', 'history_009_pos',
     'history_010_pos']
 
+[tests/functional/hole_birth]
+tests = ['hole_birth_001_pos', 'hole_birth_002_pos', 'hole_birth_003_pos']
+
 [tests/functional/inheritance]
 tests = ['inherit_001_pos']
 pre =

--- a/tests/zfs-tests/tests/functional/Makefile.am
+++ b/tests/zfs-tests/tests/functional/Makefile.am
@@ -17,6 +17,7 @@ SUBDIRS = \
 	grow_pool \
 	grow_replicas \
 	history \
+	hole_birth \
 	inheritance \
 	inuse \
 	large_files \

--- a/tests/zfs-tests/tests/functional/hole_birth/Makefile.am
+++ b/tests/zfs-tests/tests/functional/hole_birth/Makefile.am
@@ -1,0 +1,9 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/hole_birth
+dist_pkgdata_SCRIPTS = \
+	hole_birth.cfg \
+	hole_birth.kshlib \
+	setup.ksh \
+	cleanup.ksh \
+	hole_birth_001_pos.ksh \
+	hole_birth_002_pos.ksh \
+	hole_birth_003_pos.ksh

--- a/tests/zfs-tests/tests/functional/hole_birth/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/cleanup.ksh
@@ -1,0 +1,42 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+verify_runnable "both"
+
+if is_global_zone ; then
+	destroy_pool $POOL
+else
+	cleanup_pool $POOL
+fi
+
+log_pass

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth.cfg
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth.cfg
@@ -1,0 +1,32 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+export DISK1=$($ECHO $DISKS | $AWK '{print $1}')
+
+export POOL=$TESTPOOL

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth.kshlib
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth.kshlib
@@ -1,0 +1,86 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.cfg
+
+#
+# Cleanup given pool content and all the sub datasets
+#
+# $1 pool name
+#
+function cleanup_pool
+{
+	typeset pool=$1
+
+	if is_global_zone ; then
+		log_must $ZFS destroy -Rf $pool
+	else
+		typeset list=$($ZFS list -H -r -t filesystem,snapshot,volume -o name $pool)
+		for ds in $list ; do
+			if [[ $ds != $pool ]] ; then
+				if datasetexists $ds ; then
+					log_must $ZFS destroy -Rf $ds
+				fi
+			fi
+		done
+	fi
+
+	typeset mntpnt=$(get_prop mountpoint $pool)
+	if ! ismounted $pool ; then
+		# Make sure mountpoint directory is empty
+		if [[ -d $mntpnt ]]; then
+			log_must $RM -rf $mntpnt/*
+		fi
+
+		log_must $ZFS mount $pool
+	fi
+	if [[ -d $mntpnt ]]; then
+		log_must $RM -rf $mntpnt/*
+	fi
+
+	return 0
+}
+
+#
+# Given two file, and compare the md5sum value
+#
+function cmp_md5sum
+{
+        file1_md5sum=$(md5sum $1 | awk '{print $1}')
+        file2_md5sum=$(md5sum $2 | awk '{print $1}')
+
+        if [ "$file1_md5sum" != "$file2_md5sum" ]; then
+                return 1
+        fi
+
+        return 0
+}
+

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth_001_pos.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	If you take a large file (tested with 300 MB file at 512 byte 
+#	recordsize), truncate it to a small size (10 MB), 
+#	and then modify something well beyond the end of the file (64 MB),
+#	check if file md5sum matched after send/receive.
+#
+
+verify_runnable "both"
+
+log_assert "Verify hole_birth bug of illumos #7176"
+log_onexit cleanup_pool $POOL
+
+sendfs=$POOL/sendfs
+recvfs=$POOL/recvfs
+
+if datasetexists $recvfs; then
+	log_must $ZFS destroy -r $recvfs
+fi
+if datasetexists $sendfs; then
+	log_must $ZFS destroy -r $sendfs
+fi
+
+log_must $ZFS create $sendfs -o recordsize=512
+
+log_must truncate --size=300M /$sendfs/file1
+create_snapshot $sendfs snap1
+
+log_must truncate --size=10M /$sendfs/file1
+log_must dd if=/dev/urandom of=/$sendfs/file1 bs=512 count=1 seek=96k conv=notrunc
+create_snapshot $sendfs snap2
+
+$ZFS send $sendfs@snap1 | $ZFS receive $recvfs
+$ZFS send -i $sendfs@snap1 $sendfs@snap2 | $ZFS receive $recvfs
+
+log_must cmp_md5sum /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL
+log_must cleanup_pool $POOL
+
+log_pass "Verify hole_birth bug of illumos #7176"

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth_002_pos.ksh
@@ -1,0 +1,73 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	Create a file(256k with recordsize=128k), rewrite this file to smaller
+#	size(128k), then rewrite with seek(384k, not exceed 128k*128),
+#	check if file md5sum matched after send/receive.
+#
+
+verify_runnable "both"
+
+log_assert "Verify hole_birth bug of Zol #4996"
+log_onexit cleanup_pool $POOL
+
+sendfs=$POOL/sendfs
+recvfs=$POOL/recvfs
+
+if datasetexists $recvfs; then
+	log_must $ZFS destroy -r $recvfs
+fi
+if datasetexists $sendfs; then
+	log_must $ZFS destroy -r $sendfs
+fi
+
+log_must $ZFS create $sendfs -o recordsize=128k
+
+log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1 seek=1
+create_snapshot $sendfs snap1
+
+log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1
+log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1 seek=3
+create_snapshot $sendfs snap2
+
+$ZFS send $sendfs@snap1 | $ZFS receive $recvfs
+$ZFS send -i $sendfs@snap1 $sendfs@snap2 | $ZFS receive $recvfs
+
+log_must cmp_md5sum /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL
+log_must cleanup_pool $POOL
+
+log_pass "Verify hole_birth bug of Zol #4996"

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth_003_pos.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	Sleep 5s while editing the file,
+#	check if file md5sum matched after send/receive.
+#
+
+verify_runnable "both"
+
+log_assert "Verify hole_birth bug of Zol #5030"
+log_onexit cleanup_pool $POOL
+
+sendfs=$POOL/sendfs
+recvfs=$POOL/recvfs
+
+if datasetexists $recvfs; then
+	log_must $ZFS destroy -r $recvfs
+fi
+if datasetexists $sendfs; then
+	log_must $ZFS destroy -r $sendfs
+fi
+
+log_must $ZFS create $sendfs -o recordsize=128k
+
+log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
+create_snapshot $sendfs snap1
+
+log_must truncate -s 4194304 /$sendfs/file1
+log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=152 seek=384 conv=notrunc
+sleep 5
+log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
+create_snapshot $sendfs snap2
+
+$ZFS send $sendfs@snap1 | $ZFS receive $recvfs
+$ZFS send -i $sendfs@snap1 $sendfs@snap2 | $ZFS receive $recvfs
+
+log_must cmp_md5sum /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL
+log_must cleanup_pool $POOL
+
+log_pass "Verify hole_birth bug of Zol #5030"

--- a/tests/zfs-tests/tests/functional/hole_birth/setup.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/setup.ksh
@@ -1,0 +1,40 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+verify_runnable "both"
+
+if is_global_zone ; then
+	log_must $ZPOOL create $POOL $DISK1
+fi
+
+log_pass


### PR DESCRIPTION
Issue #4996 is ultimately caused because of a problem in the freeing logic.
At the time when the dbufs are bzero'd, zfs doesn't yet have enough
information to properly handle writes later in the same TXG. By changing
the code to use the new dbuf_write_children_ready code path in more cases,
we address this issue. The only time free_children will bzero a dbuf now is
if we are freeing the entire dnode.

Add Test Suite for hole_birth issues: illumos #7176, Zol #4996, Zol #5030.

Change meaningless -1 into DMU_OBJECT_END