### PR TITLE
update zfs_destroy_004.ksh script

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3095,6 +3095,8 @@ spa_load_best(spa_t *spa, spa_load_state_t state, int mosconfig,
 
 	if (config && (rewind_error || state != SPA_LOAD_RECOVER))
 		spa_config_set(spa, config);
+	else
+		nvlist_free(config);
 
 	if (state == SPA_LOAD_RECOVER) {
 		ASSERT3P(loadinfo, ==, NULL);

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -108,9 +108,9 @@ tests = ['zfs_create_001_pos', 'zfs_create_002_pos',
 # zfs_destroy_012_pos - busy mountpoint behavior
 # zfs_destroy_013_neg - busy mountpoint behavior
 [tests/functional/cli_root/zfs_destroy]
-tests = ['zfs_destroy_002_pos', 'zfs_destroy_003_pos', 'zfs_destroy_006_neg',
-    'zfs_destroy_007_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
-    'zfs_destroy_016_pos']
+tests = ['zfs_destroy_002_pos', 'zfs_destroy_003_pos', zfs_destroy_004_pos,
+    'zfs_destroy_006_neg', 'zfs_destroy_007_neg', 'zfs_destroy_014_pos',
+    'zfs_destroy_015_pos','zfs_destroy_016_pos']
 
 # DISABLED:
 # zfs_get_004_pos - nested pools

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_004_pos.ksh
@@ -110,11 +110,11 @@ for arg in "$fs1 $mntp1" "$clone $mntp2"; do
 	cd $mntp
 	log_mustnot $ZFS destroy $fs
 
+	cd $olddir
 	log_must $ZFS destroy -f $fs
 	datasetexists $fs && \
 		log_fail "'zfs destroy -f' fails to destroy busy filesystem."
 
-	cd $olddir
 done
 
 log_pass "'zfs destroy -f' succeeds as root."


### PR DESCRIPTION
issues:
when execute zfs_destroy_004.ksh script , destroy $fs is error.

Cause analysis:
when create $fs file system and mount file system to $mntp. cd $mntp, linux isn't allow to destroy $fs in this mount contents.
No matter what destroy with parameters.

Solution:
so  log_mustnot $ZFS destroy $fs is ok.
cd $olddir and destroy $fs.

Signed-off-by: caoxuewen cao.xuewen@zte.com.cn