### PR TITLE
update zfs_destroy_004.ksh script

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -99,7 +99,6 @@ tests = ['zfs_create_001_pos', 'zfs_create_002_pos',
 
 # DISABLED:
 # zfs_destroy_001_pos - busy mountpoint behavior
-# zfs_destroy_004_pos - busy mountpoint behavior
 # zfs_destroy_005_neg - busy mountpoint behavior
 # zfs_destroy_008_pos - busy mountpoint behavior
 # zfs_destroy_009_pos - busy mountpoint behavior
@@ -108,9 +107,9 @@ tests = ['zfs_create_001_pos', 'zfs_create_002_pos',
 # zfs_destroy_012_pos - busy mountpoint behavior
 # zfs_destroy_013_neg - busy mountpoint behavior
 [tests/functional/cli_root/zfs_destroy]
-tests = ['zfs_destroy_002_pos', 'zfs_destroy_003_pos', 'zfs_destroy_006_neg',
-    'zfs_destroy_007_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
-    'zfs_destroy_016_pos']
+tests = ['zfs_destroy_002_pos', 'zfs_destroy_003_pos', 'zfs_destroy_004_pos',
+    'zfs_destroy_006_neg', 'zfs_destroy_007_neg', 'zfs_destroy_014_pos', 
+    'zfs_destroy_015_pos', 'zfs_destroy_016_pos']
 
 # DISABLED:
 # zfs_get_004_pos - nested pools

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_004_pos.ksh
@@ -109,11 +109,17 @@ for arg in "$fs1 $mntp1" "$clone $mntp2"; do
 			"destroy filesystem when it is busy."
 	cd $mntp
 	log_mustnot $ZFS destroy $fs
-
-	log_must $ZFS destroy -f $fs
-	datasetexists $fs && \
-		log_fail "'zfs destroy -f' fails to destroy busy filesystem."
-
+	
+	if is_linux; then
+		log_mustnot $ZFS destroy -f $fs
+		datasetnonexists $fs && \
+			log_fail "'zfs destroy -f' fails to destroy busy filesystem."
+	else
+		log_must $ZFS destroy -f $fs
+		datasetexists $fs && \
+			log_fail "'zfs destroy -f' fails to destroy busy filesystem."
+	fi
+	
 	cd $olddir
 done
 


### PR DESCRIPTION
issues:
In linux , when execute zfs_destroy_004.ksh script , destroy $fs is error.
The key issue here is that illumos kernel treats this case differently than the Linux kernel. On illumos you can unmount and destroy a filesystem which is busy and all consumers of it get EIO. On Linux the expected behavior is to prevent the unmount and destroy.

Cause analysis:
when create $fs file system and mount file system to $mntp. cd $mntp, linux isn't allow to destroy $fs in this mount contents.
No matter what destroy with parameters.

Solution:
so  log_mustnot $ZFS destroy $fs is ok.
cd $olddir and destroy $fs.

Signed-off-by: caoxuewen cao.xuewen@zte.com.cn