### PR TITLE
Use "is_linux" to wrap the Linux specific changes, and add zfs_destroy_001_pos.ksh too linux.run.

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -108,7 +108,7 @@ tests = ['zfs_create_001_pos', 'zfs_create_002_pos',
 # zfs_destroy_012_pos - busy mountpoint behavior
 # zfs_destroy_013_neg - busy mountpoint behavior
 [tests/functional/cli_root/zfs_destroy]
-tests = ['zfs_destroy_002_pos', 'zfs_destroy_003_pos', 'zfs_destroy_006_neg',
+tests = ['zfs_destroy_001_pos', 'zfs_destroy_002_pos', 'zfs_destroy_003_pos', 'zfs_destroy_006_neg',
     'zfs_destroy_007_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
     'zfs_destroy_016_pos']
 


### PR DESCRIPTION
The second part of the testcase attempts to verify that the -f option will succeed even when the dataset is busy. 
This behavior can't work under. Use "is_linux" to wrap the Linux specific changes, and add this testcase too linux.run.