### PR TITLE
Fix: Build warnings with different gcc optimization levels in debug mode

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1572,7 +1572,7 @@ zfs_prop_set_list(zfs_handle_t *zhp, nvlist_t *props)
 	char errbuf[1024];
 	libzfs_handle_t *hdl = zhp->zfs_hdl;
 	nvlist_t *nvl;
-	int nvl_len;
+	int nvl_len = 0;
 	int added_resv = 0;
 	zfs_prop_t prop = 0;
 	nvpair_t *elem;
@@ -1602,7 +1602,6 @@ zfs_prop_set_list(zfs_handle_t *zhp, nvlist_t *props)
 	 * Check how many properties we're setting and allocate an array to
 	 * store changelist pointers for postfix().
 	 */
-	nvl_len = 0;
 	for (elem = nvlist_next_nvpair(nvl, NULL);
 	    elem != NULL;
 	    elem = nvlist_next_nvpair(nvl, elem))

--- a/module/icp/core/kcf_sched.c
+++ b/module/icp/core/kcf_sched.c
@@ -496,7 +496,7 @@ kcf_resubmit_request(kcf_areq_node_t *areq)
 	kcf_provider_desc_t *new_pd;
 	crypto_mechanism_t *mech1 = NULL, *mech2 = NULL;
 	crypto_mech_type_t prov_mt1, prov_mt2;
-	crypto_func_group_t fg;
+	crypto_func_group_t fg = 0;
 
 	if (!can_resubmit(areq, &mech1, &mech2, &fg))
 		return (error);


### PR DESCRIPTION
Inspired by @ironMann, I build my ZFS with different gcc optimization levels in debug mode, 
this fix resolves warnings reported during compiling.

Test tools:
```
gcc version 4.4.7 20120313 (Red Hat 4.4.7-16) (GCC)
Linux version: 2.6.32-573.18.1.el6.x86_64, Red Hat Enterprise Linux Server release 6.1 (Santiago)
```

List of warnings:
CFLAGS=-O1 ./configure --enable-debug ;make
```
../../module/icp/core/kcf_sched.c: In function ‘kcf_aop_done’:
../../module/icp/core/kcf_sched.c:499: error: ‘fg’ may be used uninitialized in this function
../../module/icp/core/kcf_sched.c:499: note: ‘fg’ was declared here
```

CFLAGS=-O3 ./configure --enable-debug ; make
```
../../module/zfs/ddt.c: In function ‘ddt_entry_compare’:
../../module/zfs/ddt.c:824: error: array subscript is above array bounds
```

CFLAGS=-Os ./configure --enable-debug ; make
```
libzfs_dataset.c: In function ‘zfs_prop_set_list’:
libzfs_dataset.c:1575: error: ‘nvl_len’ may be used uninitialized in this function
```