### PR TITLE
delete unuse function zfsctl_snapdir_inactive.

### DIFF
--- a/include/sys/zfs_ctldir.h
+++ b/include/sys/zfs_ctldir.h
@@ -74,7 +74,6 @@ extern int zfsctl_snapdir_remove(struct inode *dip, char *name, cred_t *cr,
     int flags);
 extern int zfsctl_snapdir_mkdir(struct inode *dip, char *dirname, vattr_t *vap,
     struct inode **ipp, cred_t *cr, int flags);
-extern void zfsctl_snapdir_inactive(struct inode *ip);
 extern int zfsctl_snapshot_mount(struct path *path, int flags);
 extern int zfsctl_snapshot_unmount(char *snapname, int flags);
 extern int zfsctl_snapshot_unmount_delay(spa_t *spa, uint64_t objsetid,

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -97,7 +97,6 @@ static list_t zevent_list;
 static kcondvar_t zevent_cv;
 #endif /* _KERNEL */
 
-extern void fastreboot_disable_highpil(void);
 
 /*
  * Common fault management kstats to record event generation failures


### PR DESCRIPTION
zfsctl_snapdir_inactive is define zfs-0.6.3 , 
In zfs-0.6.5.7, this is declaration , but isn't define.

Signed-off-by: caoxuewen cao.xuewen@zte.com.cn