### PR TITLE
Illumos 6940 Cannot unlink directories when over quota

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2003,6 +2003,7 @@ top:
 	dmu_tx_hold_zap(tx, zsb->z_unlinkedobj, FALSE, NULL);
 	zfs_sa_upgrade_txholds(tx, zp);
 	zfs_sa_upgrade_txholds(tx, dzp);
+	dmu_tx_mark_netfree(tx);
 	error = dmu_tx_assign(tx, waited ? TXG_WAITED : TXG_NOWAIT);
 	if (error) {
 		rw_exit(&zp->z_parent_lock);


### PR DESCRIPTION
From user perspective, I would expect that ZFS is always able to remove files and directories even when the quota is exceeded.

Authored by: Simon Klinkert <simon.klinkert@gmail.com>
Reviewed by: Dan McDonald <danmcd@omniti.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: kernelOfTruth kerneloftruth@gmail.com
OpenZFS-issue: https://www.illumos.org/issues/6940
OpenZFS-commit: https://github.com/illumos/illumos-gate/commit/99189164df06057fb968ca7be701bb1a0d5da8c9

References:
https://github.com/zfsonlinux/zfs/commit/1a04bab34808694f3bf1cef3dc208c9499d103aa llumos 6334 - Cannot unlink files when over quota
https://www.illumos.org/issues/6334