### PR TITLE
kmem_zalloc with KM_SLEEP will never return null

### DIFF
--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -426,8 +426,6 @@ zfs_zevent_alloc(void)
 	zevent_t *ev;
 
 	ev = kmem_zalloc(sizeof (zevent_t), KM_SLEEP);
-	if (ev == NULL)
-		return (NULL);
 
 	list_create(&ev->ev_ze_list, sizeof (zfs_zevent_t),
 		    offsetof(zfs_zevent_t, ze_node));


### PR DESCRIPTION

start a new pr to pull the origin changes in " Fix incorrect use of KM_SLEEP in memory alloc #5037"

kmem_zalloc with flag KM_SLEEP will never return null, in order to prevent further confusion, it is better to delete the failure judement.
thanks.

refs: https://github.com/zfsonlinux/zfs/pull/5037

