### PR TITLE
Use "is_linux" to wrap the Linux specific changes, and add zfs_destroy_001_pos.ksh too linux.run.

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -105,8 +105,8 @@ tests = ['zfs_create_001_pos', 'zfs_create_002_pos', 'zfs_create_003_pos',
 # zfs_destroy_013_neg - busy mountpoint behavior
 [tests/functional/cli_root/zfs_destroy]
 tests = ['zfs_destroy_001_pos', 'zfs_destroy_002_pos', 'zfs_destroy_003_pos',
-       'zfs_destroy_004_pos', 'zfs_destroy_006_neg', 'zfs_destroy_007_neg',
-	   'zfs_destroy_014_pos', 'zfs_destroy_015_pos', 'zfs_destroy_016_pos']
+	'zfs_destroy_004_pos', 'zfs_destroy_006_neg', 'zfs_destroy_007_neg',
+	'zfs_destroy_014_pos', 'zfs_destroy_015_pos', 'zfs_destroy_016_pos']
 
 # DISABLED:
 # zfs_get_004_pos - nested pools

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -104,9 +104,9 @@ tests = ['zfs_create_001_pos', 'zfs_create_002_pos', 'zfs_create_003_pos',
 # zfs_destroy_012_pos - busy mountpoint behavior
 # zfs_destroy_013_neg - busy mountpoint behavior
 [tests/functional/cli_root/zfs_destroy]
-tests = ['zfs_destroy_002_pos', 'zfs_destroy_003_pos', 'zfs_destroy_004_pos',
-    'zfs_destroy_006_neg', 'zfs_destroy_007_neg', 'zfs_destroy_014_pos',
-    'zfs_destroy_015_pos', 'zfs_destroy_016_pos']
+tests = ['zfs_destroy_001_pos', 'zfs_destroy_002_pos', 'zfs_destroy_003_pos',
+       'zfs_destroy_004_pos', 'zfs_destroy_006_neg', 'zfs_destroy_007_neg',
+	   'zfs_destroy_014_pos', 'zfs_destroy_015_pos', 'zfs_destroy_016_pos']
 
 # DISABLED:
 # zfs_get_004_pos - nested pools

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
@@ -144,6 +144,13 @@ function test_n_check
 		*)	log_fail "Unsupported dataset: '$dtst'."
 	esac
 
+	# Kill any lingering instances of mkbusy, and clear the list.
+	if is_linux ; then
+		[[ -z $pidlist ]] || log_must $KILL -TERM $pidlist
+		pidlist=""
+		log_mustnot $PGREP -fl $MKBUSY
+	fi
+
 	# Firstly, umount ufs filesystem which was created by zfs volume.
 	if is_global_zone; then
 		log_must $UMOUNT -f $TESTDIR1
@@ -153,9 +160,11 @@ function test_n_check
 	log_must $ZFS destroy $opt $dtst
 
 	# Kill any lingering instances of mkbusy, and clear the list.
-	[[ -z $pidlist ]] || log_must $KILL -TERM $pidlist
-	pidlist=""
-	log_mustnot $PGREP -fl $MKBUSY
+	if ! is_linux ; then
+		[[ -z $pidlist ]] || log_must $KILL -TERM $pidlist
+		pidlist=""
+		log_mustnot $PGREP -fl $MKBUSY
+	fi
 
 	case $dtst in
 		$CTR)	check_dataset datasetnonexists \


### PR DESCRIPTION
The second part of the testcase attempts to verify that the -f option will succeed even when the dataset is busy.
This behavior can't work under. Use "is_linux" to wrap the Linux specific changes, and add this testcase too linux.run.