### PR TITLE
fix memory leak in zfs_do_destory

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1280,8 +1280,10 @@ zfs_do_destroy(int argc, char **argv)
 		*at = '\0';
 		zhp = zfs_open(g_zfs, argv[0],
 		    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);
-		if (zhp == NULL)
+		if (zhp == NULL) {
+			fnvlist_free(cb.cb_nvl);
 			return (1);
+		}
 
 		cb.cb_snapspec = at + 1;
 		if (gather_snapshots(zfs_handle_dup(zhp), &cb) != 0 ||
@@ -1370,7 +1372,7 @@ zfs_do_destroy(int argc, char **argv)
 			    "cannot destroy bookmark");
 		}
 
-		nvlist_free(cb.cb_nvl);
+		nvlist_free(nvl);
 
 		return (err);
 	} else {


### PR DESCRIPTION
hi, there are two memory leak point in zfs_do_destory:
first, in statement below
	if (at != NULL) {

		/* Build the list of snaps to destroy in cb_nvl. */
		cb.cb_nvl = fnvlist_alloc();

		*at = '\0';
		zhp = zfs_open(g_zfs, argv[0],
		    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);
		if (zhp == NULL) {
			return (1);
        }
cb_cb_nvl leaks.

second:
in statement below, release the wrong memory.
 		nvl = fnvlist_alloc();
		fnvlist_add_boolean(nvl, argv[0]);

		err = lzc_destroy_bookmarks(nvl, NULL);
		if (err != 0) {
			(void) zfs_standard_error(g_zfs, err,
			    "cannot destroy bookmark");
		}

		nvlist_free(cb.cb_nvl);


thanks.