### PR TITLE
Give taskq_now a definite initial value

### DIFF
--- a/lib/libzpool/taskq.c
+++ b/lib/libzpool/taskq.c
@@ -30,7 +30,7 @@
 
 #include <sys/zfs_context.h>
 
-int taskq_now;
+int taskq_now = 0;
 taskq_t *system_taskq;
 
 #define	TASKQ_ACTIVE	0x00010000


### PR DESCRIPTION
taskq_now has no definite initial value, may be it is better to give it a definite initial value.
thanks.