### PR TITLE
zhp not close in zpool_do_destory when zpool_disable_datasets failed

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1295,6 +1295,7 @@ zpool_do_destroy(int argc, char **argv)
 	if (zpool_disable_datasets(zhp, force) != 0) {
 		(void) fprintf(stderr, gettext("could not destroy '%s': "
 		    "could not unmount datasets\n"), zpool_get_name(zhp));
+		zpool_close(zhp);
 		return (1);
 	}
 


### PR DESCRIPTION
zhp not closed when zpool_disable_datasets failed.
thanks.