### PR TITLE
libzfs unmount memory leak in zfs_unmount function

### DIFF
--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -564,8 +564,10 @@ zfs_unmount(zfs_handle_t *zhp, const char *mountpoint, int flags)
 		/*
 		 * Unshare and unmount the filesystem
 		 */
-		if (zfs_unshare_proto(zhp, mntpt, share_all_proto) != 0)
+		if (zfs_unshare_proto(zhp, mntpt, share_all_proto) != 0) {
+			free(mntpt);
 			return (-1);
+		}
 
 		if (unmount_one(hdl, mntpt, flags) != 0) {
 			free(mntpt);
@@ -904,7 +906,7 @@ zfs_unshare_proto(zfs_handle_t *zhp, const char *mountpoint,
 
 	/* check to see if need to unmount the filesystem */
 	if (mountpoint != NULL)
-		mountpoint = mntpt = zfs_strdup(hdl, mountpoint);
+		mntpt = zfs_strdup(hdl, mountpoint);
 
 	if (mountpoint != NULL || ((zfs_get_type(zhp) == ZFS_TYPE_FILESYSTEM) &&
 	    libzfs_mnttab_find(hdl, zfs_get_name(zhp), &entry) == 0)) {


### PR DESCRIPTION
issues:
libzfs  unmount the given filesystem and zfs_unshare_proto is fail, mntopt memory leak in zfs_unmount function.
and zfs_unshare_proto function, mountpoint parameter is no need for again assignment new memory, and mountpoint parameter is const type.

Cause analysis:
see code updata

Solution:
when zfs_unshare_proto is fail. will free mntopt memory. and get rid of mountpoint parameter again assignment new memory in zfs_unshare_proto function.

Signed-off-by: cao.xuewen <cao.xuewen@zte.com.cn>