### PR TITLE
Fixes for zfs dracut module

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -38,6 +38,12 @@ install() {
 	dracut_install grep
 	dracut_install @sbindir@/zfs
 	dracut_install @sbindir@/zpool
+	# Include libgcc_s.so.1 to workaround zfsonlinux/zfs#4749
+	if type gcc-config 2>&1 1>/dev/null; then
+		dracut_install "/usr/lib/gcc/$(s=$(gcc-config -c); echo ${s%-*}/${s##*-})/libgcc_s.so.1"
+	else
+		dracut_install /usr/lib/gcc/*/*/libgcc_s.so.1
+	fi
 	dracut_install @sbindir@/mount.zfs
 	dracut_install @udevdir@/vdev_id
 	dracut_install @udevdir@/zvol_id

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -10,14 +10,16 @@ case "${root}" in
 	*) return ;;
 esac
 
-# If sysroot.mount exists, the initial RAM disk configured
-# it to mount ZFS on root.  In that case, we bail early.
-loadstate="$(systemctl --system --show -p LoadState sysroot.mount || true)"
-if [ "${loadstate}" = "LoadState=not-found" -o "${loadstate}" = "" ] ; then
-	info "ZFS: sysroot.mount absent, mounting root with mount-zfs.sh"
-else
-	info "ZFS: sysroot.mount present, delegating root mount to it"
-	return
+if command -v systemctl >/dev/null; then
+	# If sysroot.mount exists, the initial RAM disk configured
+	# it to mount ZFS on root.  In that case, we bail early.
+	loadstate="$(systemctl --system --show -p LoadState sysroot.mount || true)"
+	if [ "${loadstate}" = "LoadState=not-found" -o "${loadstate}" = "" ] ; then
+		info "ZFS: sysroot.mount absent, mounting root with mount-zfs.sh"
+	else
+		info "ZFS: sysroot.mount present, delegating root mount to it"
+		return
+	fi
 fi
 
 # Delay until all required block devices are present.


### PR DESCRIPTION
1. Adapt existing genkernel fix regarding missing `/usr/lib/libgcc_s.so.1`.
2. Check for presence of `systemctl` before trying to use it (not everyone uses sytemd).