### PR TITLE
fix: Shift exponent too large

### DIFF
--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -270,7 +270,8 @@ typedef struct dbuf_hash_table {
 	kmutex_t hash_mutexes[DBUF_MUTEXES];
 } dbuf_hash_table_t;
 
-uint64_t dbuf_whichblock(struct dnode *di, int64_t level, uint64_t offset);
+uint64_t dbuf_whichblock(const struct dnode *di, const int64_t level,
+    const uint64_t offset);
 
 void dbuf_create_bonus(struct dnode *dn);
 int dbuf_spill_set_blksz(dmu_buf_t *db, uint64_t blksz, dmu_tx_t *tx);

--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -104,9 +104,8 @@ extern "C" {
 #define	DNODES_PER_LEVEL_SHIFT	(DN_MAX_INDBLKSHIFT - SPA_BLKPTRSHIFT)
 #define	DNODES_PER_LEVEL	(1ULL << DNODES_PER_LEVEL_SHIFT)
 
-/* The +2 here is a cheesy way to round up */
-#define	DN_MAX_LEVELS	(2 + ((DN_MAX_OFFSET_SHIFT - SPA_MINBLOCKSHIFT) / \
-	(DN_MIN_INDBLKSHIFT - SPA_BLKPTRSHIFT)))
+#define	DN_MAX_LEVELS	(DIV_ROUND_UP(DN_MAX_OFFSET_SHIFT - SPA_MINBLOCKSHIFT, \
+	DN_MIN_INDBLKSHIFT - SPA_BLKPTRSHIFT) + 1)
 
 #define	DN_BONUS(dnp)	((void*)((dnp)->dn_bonus + \
 	(((dnp)->dn_nblkptr - 1) * sizeof (blkptr_t))))

--- a/lib/libspl/include/sys/sysmacros.h
+++ b/lib/libspl/include/sys/sysmacros.h
@@ -42,6 +42,9 @@
 #ifndef ARRAY_SIZE
 #define	ARRAY_SIZE(a) (sizeof (a) / sizeof (a[0]))
 #endif
+#ifndef	DIV_ROUND_UP
+#define	DIV_ROUND_UP(n, d)	(((n) + (d) - 1) / (d))
+#endif
 
 #define	makedevice(maj, min)	makedev(maj, min)
 #define	_sysconf(a)		sysconf(a)

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1612,6 +1612,8 @@ dnode_new_blkid(dnode_t *dn, uint64_t blkid, dmu_tx_t *tx, boolean_t have_read)
 	    sz <= blkid && sz >= dn->dn_nblkptr; sz <<= epbs)
 		new_nlevels++;
 
+	ASSERT3U(new_nlevels, <=, DN_MAX_LEVELS);
+
 	if (new_nlevels > dn->dn_nlevels) {
 		int old_nlevels = dn->dn_nlevels;
 		dmu_buf_impl_t *db;
@@ -2073,7 +2075,14 @@ dnode_next_offset_level(dnode_t *dn, int flags, uint64_t *offset,
 		else
 			minfill++;
 
-		*offset = *offset >> span;
+		if (span >= 8 * sizeof (*offset)) {
+			/* This only happens on the highest indirection level */
+			ASSERT3U((lvl - 1), ==, dn->dn_phys->dn_nlevels - 1);
+			*offset = 0;
+		} else {
+			*offset = *offset >> span;
+		}
+
 		for (i = BF64_GET(*offset, 0, epbs);
 		    i >= 0 && i < epb; i += inc) {
 			if (BP_GET_FILL(&bp[i]) >= minfill &&
@@ -2083,7 +2092,13 @@ dnode_next_offset_level(dnode_t *dn, int flags, uint64_t *offset,
 			if (inc > 0 || *offset > 0)
 				*offset += inc;
 		}
-		*offset = *offset << span;
+
+		if (span >= 8 * sizeof (*offset)) {
+			*offset = start;
+		} else {
+			*offset = *offset << span;
+		}
+
 		if (inc < 0) {
 			/* traversing backwards; position offset at the end */
 			ASSERT3U(*offset, <=, start);

--- a/module/zfs/sha256.c
+++ b/module/zfs/sha256.c
@@ -76,7 +76,8 @@ SHA256Transform(uint32_t *H, const uint8_t *cp)
 	uint32_t a, b, c, d, e, f, g, h, t, T1, T2, W[64];
 
 	for (t = 0; t < 16; t++, cp += 4)
-		W[t] = (cp[0] << 24) | (cp[1] << 16) | (cp[2] << 8) | cp[3];
+		W[t] = ((uint32_t)cp[0] << 24) | ((uint32_t)cp[1] << 16) |
+		    ((uint32_t)cp[2] << 8) | (uint32_t)cp[3];
 
 	for (t = 16; t < 64; t++)
 		W[t] = sigma1(W[t - 2]) + W[t - 7] +

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -600,7 +600,7 @@ spa_tx_assign_add_nsecs(spa_t *spa, uint64_t nsecs)
 	spa_stats_history_t *ssh = &spa->spa_stats.tx_assign_histogram;
 	uint64_t idx = 0;
 
-	while (((1 << idx) < nsecs) && (idx < ssh->size - 1))
+	while (((1ULL << idx) < nsecs) && (idx < ssh->size - 1))
 		idx++;
 
 	atomic_inc_64(&((kstat_named_t *)ssh->private)[idx].value.ui64);


### PR DESCRIPTION
Undefined operation is reported while running ztest (or zloop) compiled with GCC
UndefinedBehaviorSanitizer. Error only happens on top level of dnode indirection
with large enough offset values. Logically, left shift operation would work,
but, bit because bit shift semantics in C and limitation of uint64_t, result is undefined.

Issue #5059, #4883