### PR TITLE
Allow ZVOL bookmarks to be listed recursively

### DIFF
--- a/cmd/zfs/zfs_iter.c
+++ b/cmd/zfs/zfs_iter.c
@@ -444,13 +444,13 @@ zfs_for_each(int argc, char **argv, int flags, zfs_type_t types,
 
 		/*
 		 * If we're recursive, then we always allow filesystems as
-		 * arguments.  If we also are interested in snapshots, then we
-		 * can take volumes as well.
+		 * arguments.  If we also are interested in snapshots or
+		 * bookmarks, then we can take volumes as well.
 		 */
 		argtype = types;
 		if (flags & ZFS_ITER_RECURSE) {
 			argtype |= ZFS_TYPE_FILESYSTEM;
-			if (types & ZFS_TYPE_SNAPSHOT)
+			if (types & (ZFS_TYPE_SNAPSHOT | ZFS_TYPE_BOOKMARK))
 				argtype |= ZFS_TYPE_VOLUME;
 		}
 


### PR DESCRIPTION
When trying to list bookmarks recursively, if the parent dataset (`-r tank/path`) is a ZVOL the command fails:

```
# zfs list -H -o name -t bookmark -r tank/path
cannot open 'tank/path': operation not applicable to datasets of this type
```

Fix issue #4503

EDIT: fixed checkstyle warning