### PR TITLE
update zfs_rename script

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -149,15 +149,13 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_010_pos', 'zfs_receive_012_pos']
 
 # DISABLED:
-# zfs_rename_002_pos - needs investigation
 # zfs_rename_005_neg - nested pools
 # zfs_rename_006_pos - needs investigation
-# zfs_rename_007_pos - needs investigation
 [tests/functional/cli_root/zfs_rename]
-tests = ['zfs_rename_001_pos', 'zfs_rename_003_pos',
-    'zfs_rename_004_neg', 'zfs_rename_008_pos', 'zfs_rename_009_neg',
-    'zfs_rename_010_neg', 'zfs_rename_011_pos', 'zfs_rename_012_neg',
-    'zfs_rename_013_pos']
+tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',
+    'zfs_rename_004_neg', 'zfs_rename_007_pos', 'zfs_rename_008_pos',
+    'zfs_rename_009_neg', 'zfs_rename_010_neg', 'zfs_rename_011_pos',
+    'zfs_rename_012_neg', 'zfs_rename_013_pos']
 
 [tests/functional/cli_root/zfs_reservation]
 tests = ['zfs_reservation_001_pos', 'zfs_reservation_002_pos']

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_002_pos.ksh
@@ -71,6 +71,7 @@ while ((i < ${#dataset[*]} )); do
 	if [[ ${dataset[i]} == *@* ]]; then
 		data=$(snapshot_mountpoint ${dataset[i]})/$TESTFILE0
 	elif [[ ${dataset[i]} == "$TESTPOOL/$TESTVOL" ]] && is_global_zone; then
+		$RM -rf $VOLDATA
 		log_must eval "$DD if=$VOL_R_PATH of=$VOLDATA bs=$BS count=$CNT >/dev/null 2>&1"
 		data=$VOLDATA
 	else

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
@@ -117,6 +117,7 @@ log_must $DIFF $SRC_FILE $obj
 if is_global_zone; then
 	vol=$TESTPOOL/$TESTFS/vol.$$ ;	volclone=$TESTPOOL/$TESTFS/volclone.$$
 	log_must $ZFS create -V 100M $vol
+	block_device_wait
 
 	obj=$(target_obj $vol)
 	log_must $DD if=$SRC_FILE of=$obj bs=$BS count=$CNT
@@ -131,9 +132,11 @@ if is_global_zone; then
 
 	# Compare source file and target file
 	obj=$(target_obj ${vol}-new)
+	$RM -rf $DST_FILE
 	log_must $DD if=$obj of=$DST_FILE bs=$BS count=$CNT
 	log_must $DIFF $SRC_FILE $DST_FILE
 	obj=$(target_obj ${volclone}-new)
+	$RM -rf $DST_FILE
 	log_must $DD if=$obj of=$DST_FILE bs=$BS count=$CNT
 	log_must $DIFF $SRC_FILE $DST_FILE
 
@@ -144,6 +147,7 @@ if is_global_zone; then
 
 	# Compare source file and target file
 	obj=$(target_obj $volclone)
+	$RM -rf $DST_FILE
 	log_must $DD if=$obj of=$DST_FILE bs=$BS count=$CNT
 	log_must $DIFF $SRC_FILE $DST_FILE
 fi


### PR DESCRIPTION
issues:
scripts zfs_rename_002_pos ,  zfs_rename_007_pos fail in CentOS 6.7 x86_64. (succ in CentOS 7.1 x86_64)

solution:
fix zfs_rename_002_pos and zfs_rename_007_pos scripts on linux.run to the increase test scene.
zfs_rename_006_pos still needs investigation.
thanks.
By the way:
My Linux version is 2.6.33.20 and
gcc version 4.4.5 20110214 (Red Hat 4.4.5-6)