### PR TITLE
fix zfs_receive_010_pos.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
@@ -21,7 +21,7 @@
 #
 
 #
-# Copyright (c) 2015 by Delphix. All rights reserved.
+# Copyright (c) 2015, 2016 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -138,7 +138,7 @@ $RM $mntpnt/h17
 $RM $mntpnt2/h*
 
 # Add empty objects to $fs to exercise dmu_traverse code
-for i in `seq 1 100`; do
+for i in {1..100}; do
 	log_must touch $mntpnt/uf$i
 done
 


### PR DESCRIPTION
The zfs test "zfs_receive_010.ksh" script uses the "seq" GNU utility for a simple for loop. There's no need to rely on that dependency, so it should be removed/replaced.
This changes is remove from illumos request : 7262 remove seq from zfs_receive_010.ksh.
link is:
illumos/illumos-gate@b868f5d