### PR TITLE
Free property names with spa_strfree() rather than strfree()

### DIFF
--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -261,7 +261,7 @@ dsl_prop_fini(dsl_dir_t *dd)
 
 	while ((pr = list_remove_head(&dd->dd_props)) != NULL) {
 		list_destroy(&pr->pr_cbs);
-		strfree((char *)pr->pr_propname);
+		spa_strfree((char *)pr->pr_propname);
 		kmem_free(pr, sizeof (dsl_prop_record_t));
 	}
 	list_destroy(&dd->dd_props);


### PR DESCRIPTION
Since they're allocated with spa_strdup(), they should be freed with
spa_strfree() so the proper length buffer is freed.

Fixes: #5082