### PR TITLE
Fix regression that broke dracut initramfs generation

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -39,7 +39,7 @@ install() {
 	dracut_install @sbindir@/zfs
 	dracut_install @sbindir@/zpool
 	# Include libgcc_s.so.1 to workaround zfsonlinux/zfs#4749
-	if type gcc-config 2>&1 1>/dev/null; then
+	if command -v gcc-config 2>&1 1>/dev/null; then
 		dracut_install "/usr/lib/gcc/$(s=$(gcc-config -c); echo ${s%-*}/${s##*-})/libgcc_s.so.1"
 	else
 		dracut_install /usr/lib/gcc/*/*/libgcc_s.so.1


### PR DESCRIPTION
61c73494394fc9de9283b3fd4f00bcdf4bd300a7 adopted my patch to genkernel
to fix close zfsonlinux/zfs#4749. My patch attempted to be clever by
switching between a Gentoo-specific method of detection and a generic
one, but I mistakenly had it do detection via `type` rather than
`command -v`. The former keeps the detection from working properly
while the latter works as expected.

A minimal test case was used to
confirm the behavior on both the dash and bash shells on Gentoo.
Assuming that there is no foobar command, this is sufficient to
demonstrate the behavior is what we expect:

if ! command -v foobar 2>&1 1>/dev/null; then echo correct; fi;

Fixes zfsonlinux/zfs#5089

Signed-off-by: Richard Yao <ryao@gentoo.org>