### PR TITLE
Enable ignore_hole_birth module option by default

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -34,7 +34,7 @@ When set, the hole_birth optimization will not be used, and all holes will
 always be sent on zfs send. Useful if you suspect your datasets are affected
 by a bug in hole_birth.
 .sp
-Use \fB1\fR for on and \fB0\fR (default) for off.
+Use \fB1\fR for on (default) and \fB0\fR for off.
 .RE
 
 .sp

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -39,7 +39,7 @@
 #include <sys/zfeature.h>
 
 int32_t zfs_pd_bytes_max = 50 * 1024 * 1024;	/* 50MB */
-int32_t ignore_hole_birth = 0;
+int32_t ignore_hole_birth = 1;
 
 typedef struct prefetch_data {
 	kmutex_t pd_mtx;


### PR DESCRIPTION
Enable ignore_hole_birth by default until all known hole birth bugs
have been resolved and relevant test cases added.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #4809