### PR TITLE
There was a error when building zfs

### DIFF
--- a/tests/zfs-tests/cmd/randfree_file/randfree_file.c
+++ b/tests/zfs-tests/cmd/randfree_file/randfree_file.c
@@ -98,11 +98,18 @@ main(int argc, char *argv[])
 
 	free(buf);
 
+#if defined(FALLOC_FL_PUNCH_HOLE) && defined(FALLOC_FL_KEEP_SIZE)
 	if (fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
 	    start_off, off_len) < 0) {
 		perror("fallocate");
 		return (1);
 	}
+#else /* !(defined(FALLOC_FL_PUNCH_HOLE) && defined(FALLOC_FL_KEEP_SIZE)) */
+	{
+		perror("FALLOC_FL_PUNCH_HOLE unsupported");
+		return (1);
+	}
+#endif /* defined(FALLOC_FL_PUNCH_HOLE) && defined(FALLOC_FL_KEEP_SIZE) */
 
 	return (0);
 }


### PR DESCRIPTION
issues:
zfs build
#./configure --with-spl=/home/liuhua/OpenZFS/spl-master913/spl-master/
#make -s -j$(nproc)

randfree_file.c: In function ‘main’:
randfree_file.c:101: error: ‘FALLOC_FL_PUNCH_HOLE’ undeclared (first use in this function)
randfree_file.c:101: error: (Each undeclared identifier is reported only once
randfree_file.c:101: error: for each function it appears in.)
make[5]: *** [randfree_file.o] Error 1
make[4]: *** [all-recursive] Error 1
make[3]: *** [all-recursive] Error 1
make[2]: *** [all-recursive] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2

The FALLOC_FL_PUNCH_HOLE flag was introduced in the 2.6.38 kernel. So we need add the "#if...#endif" when linux kernel is 2.6.33.20.