### PR TITLE
Fix coverity defects by cid  147659, 150952 and 147645 

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -7440,7 +7440,7 @@ main(int argc, char **argv)
 		 */
 		char buf[16384];
 		int fd = open(ZFS_DEV, O_RDWR);
-		(void) strcpy((void *)buf, argv[2]);
+		(void) strlcpy((void *)buf, argv[2], sizeof (buf));
 		return (!!ioctl(fd, ZFS_IOC_POOL_FREEZE, buf));
 	} else {
 		(void) fprintf(stderr, gettext("unrecognized "

--- a/module/icp/io/sha2_mod.c
+++ b/module/icp/io/sha2_mod.c
@@ -681,7 +681,7 @@ sha2_mac_init_ctx(sha2_hmac_ctx_t *ctx, void *keyval, uint_t length_in_bytes)
 {
 	uint64_t ipad[SHA256_HMAC_BLOCK_SIZE / sizeof (uint64_t)];
 	uint64_t opad[SHA256_HMAC_BLOCK_SIZE / sizeof (uint64_t)];
-	int i, block_size, blocks_per_int64 = 0;
+	int i, block_size = 0, blocks_per_int64 = 0;
 
 	/* Determine the block size */
 	if (ctx->hc_mech_type <= SHA256_HMAC_GEN_MECH_INFO_TYPE) {

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4303,7 +4303,7 @@ zfs_ioc_recv(zfs_cmd_t *zc)
 	    strchr(zc->zc_value, '%'))
 		return (SET_ERROR(EINVAL));
 
-	(void) strcpy(tofs, zc->zc_value);
+	(void) strlcpy(tofs, zc->zc_value, sizeof (tofs));
 	tosnap = strchr(tofs, '@');
 	*tosnap++ = '\0';
 


### PR DESCRIPTION
According to the coverity scan defects reports:

1.cid 147659 : 
In main(int argc, char **argv) [cmd/zpool/zpool_main.c] 
if the size of argv[2] is larger than the size of buf, it will corrupts. (Although the possibility is very small )

2.cid 150952
In static void
sha2_mac_init_ctx(sha2_hmac_ctx_t *ctx, void *keyval, uint_t length_in_bytes) [module/icp/io/sha2_mod.c]
Using uninitialized value block_size when calling memset Under the condition of ctx->hc_mech_type larger than SHA256_HMAC_GEN_MECH_INFO_TYPE

 3.cid 147645 
In zfs_ioc_recv(zfs_cmd_t *zc) [module/zfs/zfs_ioctl.c]
string_overflow: might overrun the 256-character destination string tofs by writing 8192 characters from zc->zc_value

thanks!
