### PR TITLE
When vdev_psize increases, the uberblock rings from labels 2 and 3 are lost

### DIFF
--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -229,6 +229,7 @@ struct vdev {
 	boolean_t	vdev_cant_write; /* vdev is failing all writes	*/
 	boolean_t	vdev_isspare;	/* was a hot spare		*/
 	boolean_t	vdev_isl2cache;	/* was a l2cache device		*/
+	boolean_t	vdev_copy_uberblocks;  /* post expand copy uberblocks */
 	vdev_queue_t	vdev_queue;	/* I/O deadline schedule queue	*/
 	vdev_cache_t	vdev_cache;	/* physical block cache		*/
 	spa_aux_vdev_t	*vdev_aux;	/* for l2cache and spares vdevs	*/

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1330,6 +1330,13 @@ vdev_open(vdev_t *vd)
 		max_asize = max_osize;
 	}
 
+	/*
+	 * If the vdev was expanded, record this so that we can re-create the
+	 * uberblock rings in labels {2,3}, during the next sync.
+	 */
+	if ((psize > vd->vdev_psize) && (vd->vdev_psize != 0))
+		vd->vdev_copy_uberblocks = B_TRUE;
+
 	vd->vdev_psize = psize;
 
 	/*

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -276,7 +276,7 @@ tests = ['zpool_detach_001_neg']
 # zpool_expand_001_pos - https://github.com/zfsonlinux/zfs/issues/2437
 # zpool_expand_003_pos - https://github.com/zfsonlinux/zfs/issues/2437
 [tests/functional/cli_root/zpool_expand]
-tests = ['zpool_expand_002_pos']
+tests = ['zpool_expand_002_pos', 'zpool_expand_004_pos']
 
 # DISABLED:
 # zpool_export_004_pos - https://github.com/zfsonlinux/zfs/issues/3484

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/Makefile.am
@@ -5,4 +5,5 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	zpool_expand_001_pos.ksh \
 	zpool_expand_002_pos.ksh \
-	zpool_expand_003_neg.ksh
+	zpool_expand_003_neg.ksh \
+	zpool_expand_004_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_004_pos.ksh
@@ -1,0 +1,102 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+# Copyright (c) 2017 Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_expand/zpool_expand.cfg
+
+#
+# DESCRIPTION:
+# After vdev expansion, all 4 labels have the same set of uberblocks.
+#
+#
+# STRATEGY:
+# 1) Create 3 files
+# 2) Create a pool backed by the files
+# 3) Expand the files' size with truncate
+# 4) Use zpool online -e to expand the vdevs
+# 5) Check that for all the devices, all 4 labels have the same uberblocks
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+        if poolexists $TESTPOOL1; then
+                log_must zpool destroy $TESTPOOL1
+        fi
+
+	for i in 1 2 3; do
+		[ -e ${TEMPFILE}.$i ] && log_must rm ${TEMPFILE}.$i
+	done
+}
+
+log_onexit cleanup
+
+log_assert "After vdev expansion, all 4 labels have the same set of uberblocks."
+
+for type in " " mirror raidz raidz2; do
+	for i in 1 2 3; do
+		log_must truncate -s $org_size ${TEMPFILE}.$i
+	done
+
+	log_must zpool create $TESTPOOL1 $type $TEMPFILE.1 \
+	    $TEMPFILE.2 $TEMPFILE.3
+
+	sync_pool $TESTPOOL1
+
+	for i in 1 2 3; do
+		log_must truncate -s $exp_size ${TEMPFILE}.$i
+	done
+
+	for i in 1 2 3; do
+		log_must zpool online -e $TESTPOOL1 ${TEMPFILE}.$i
+	done
+
+	sync_pool $TESTPOOL1
+
+
+	for i in 1 2 3; do
+		non_uniform=$(zdb -lu ${TEMPFILE}.$i	| \
+		    grep 'labels = '			| \
+		    grep -c -v 'labels = 0 1 2 3')
+
+		log_note "non-uniform label count: $non_uniform"
+
+		if [[ $non_uniform -ne 0 ]]; then
+			log_fail "After vdev expansion, all labels contents are not identical"
+		fi
+	done
+
+	log_must zpool destroy $TESTPOOL1
+done
+
+log_pass "After vdev expansion, all 4 labels have the same set of uberblocks."


### PR DESCRIPTION
When vdev_psize increases, the location of labels 2 and 3 changes
because their location is relative to the end of the device.  They are
effectively lost; they will be overwritten by objects and/or metadata
eventually, and there is no record of their previous location (at least
that I can see).

The config is re-written during the next spa_sync because the
vdev config is marked dirty.  However, the uberblock rings are
not re-written in their new location, leaving the device
vulnerable to the beginning of the device being overwritten or
damanged.

This PR copies the uberblocks from label 0 to labels 2 and 3 upon
the next sync, after the change in vdev_psize is detected.

It has been tested via zloop, and by running the test added to the zpool
expand test suite.