### PR TITLE
Open ZFS 7230 add assertions to dmu_send_impl() to verify that stream…

### DIFF
--- a/include/sys/dmu_impl.h
+++ b/include/sys/dmu_impl.h
@@ -273,6 +273,8 @@ typedef struct dmu_sendarg {
 	uint64_t dsa_last_data_offset;
 	uint64_t dsa_resume_object;
 	uint64_t dsa_resume_offset;
+	boolean_t dsa_sent_begin;
+	boolean_t dsa_sent_end;
 } dmu_sendarg_t;
 
 void dmu_object_zapify(objset_t *, uint64_t, dmu_object_type_t, dmu_tx_t *);


### PR DESCRIPTION
… includes BEGIN and END records

Authored by: Matt Krantz <matt.krantz@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Igor Kozhukhov <ikozhukhov@gmail.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: kernelOfTruth kerneloftruth@gmail.com
OpenZFS-issue: https://www.illumos.org/issues/7230
OpenZFS-commit: https://github.com/illumos/illumos-gate/commit/12b90ee2d3b10689fc45f4930d2392f5fe1d9cfa