### PR TITLE
zdb: do not reset ashift in dump_label() after label 0

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2266,7 +2266,8 @@ dump_label(const char *dev)
 
 		if (nvlist_unpack(buf, buflen, &config, 0) != 0) {
 			(void) printf("failed to unpack label %d\n", l);
-			ashift = SPA_MINBLOCKSHIFT;
+			if (l == 0)
+				ashift = SPA_MINBLOCKSHIFT;
 		} else {
 			nvlist_t *vdev_tree = NULL;
 


### PR DESCRIPTION
dump_label() iterates over the labels from 0 to 4 in order, attempting
each time to unpack the nvlist containing the config, and then using the
ashift value found there when interpreting the Uberblock ring.  If
unpacking fails, it falls back on setting ashift to SPA_MINBLOCKSHIFT.
For a leaf vdev whose first label has a valid config, but whose later
labels config is corrupt, the first label is the only one whose
Uberlocks are correctly displayed.

This patch changes that behavior, so that it falls back on
SPA_MINBLOCKSHIFT only for label 0.

For a later label, if the config cannot be unpacked, it uses the ashift
value determined earlier.  This way once a valid ashift value is
determined, it is used when later Uberblock rings are dumped.
