### PR TITLE
Zpool iostat show ssd

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -153,8 +153,9 @@ enum iostat_type {
 	IOS_DEFAULT = 0,
 	IOS_LATENCY = 1,
 	IOS_QUEUES = 2,
-	IOS_L_HISTO = 3,
-	IOS_RQ_HISTO = 4,
+	IOS_MEDIA_TYPE = 3,
+	IOS_L_HISTO = 4,
+	IOS_RQ_HISTO = 5,
 	IOS_COUNT,	/* always last element */
 };
 
@@ -162,6 +163,7 @@ enum iostat_type {
 #define	IOS_DEFAULT_M	(1ULL << IOS_DEFAULT)
 #define	IOS_LATENCY_M	(1ULL << IOS_LATENCY)
 #define	IOS_QUEUES_M	(1ULL << IOS_QUEUES)
+#define	IOS_MEDIA_TYPE_M	(1ULL << IOS_MEDIA_TYPE)
 #define	IOS_L_HISTO_M	(1ULL << IOS_L_HISTO)
 #define	IOS_RQ_HISTO_M	(1ULL << IOS_RQ_HISTO)
 
@@ -197,6 +199,9 @@ static const char *vsx_type_to_nvlist[IOS_COUNT][11] = {
 	    ZPOOL_CONFIG_VDEV_ASYNC_R_ACTIVE_QUEUE,
 	    ZPOOL_CONFIG_VDEV_ASYNC_W_ACTIVE_QUEUE,
 	    ZPOOL_CONFIG_VDEV_SCRUB_ACTIVE_QUEUE,
+	    NULL},
+	[IOS_MEDIA_TYPE] = {
+	    ZPOOL_CONFIG_VDEV_MEDIA_TYPE,
 	    NULL},
 	[IOS_RQ_HISTO] = {
 	    ZPOOL_CONFIG_VDEV_SYNC_IND_R_HISTO,
@@ -314,7 +319,7 @@ get_usage(zpool_help_t idx)
 		    "[-R root] [-F [-n]]\n"
 		    "\t    <pool | id> [newpool]\n"));
 	case HELP_IOSTAT:
-		return (gettext("\tiostat [-c CMD] [-T d | u] [-ghHLpPvy] "
+		return (gettext("\tiostat [-c CMD] [-T d | u] [-ghHLMpPvy] "
 		    "[[-lq]|[-r|-w]]\n"
 		    "\t    [[pool ...]|[pool vdev ...]|[vdev ...]] "
 		    "[interval [count]]\n"));
@@ -337,7 +342,7 @@ get_usage(zpool_help_t idx)
 	case HELP_SCRUB:
 		return (gettext("\tscrub [-s] <pool> ...\n"));
 	case HELP_STATUS:
-		return (gettext("\tstatus [-c CMD] [-gLPvxD] [-T d|u] [pool]"
+		return (gettext("\tstatus [-c CMD] [-gLMPvxD] [-T d|u] [pool]"
 		    " ... [interval [count]]\n"));
 	case HELP_UPGRADE:
 		return (gettext("\tupgrade\n"
@@ -1457,6 +1462,30 @@ max_width(zpool_handle_t *zhp, nvlist_t *nv, int depth, int max,
 	return (max);
 }
 
+static const char *
+media_type_mark(nvlist_t *nv)
+{
+	nvlist_t *nvx;
+	uint64_t type = VDEV_MEDIA_TYPE_UNKNOWN;
+
+	if (nvlist_lookup_nvlist(nv, ZPOOL_CONFIG_VDEV_STATS_EX, &nvx) == 0)
+		nvlist_lookup_uint64(nvx, ZPOOL_CONFIG_VDEV_MEDIA_TYPE,
+		    &type);
+
+	switch (type) {
+	case VDEV_MEDIA_TYPE_SSD:
+		return ("ssd");
+	case VDEV_MEDIA_TYPE_FILE:
+		return ("file");
+	case VDEV_MEDIA_TYPE_MIXED:
+		return ("mix");
+	case VDEV_MEDIA_TYPE_HDD:
+		return ("hdd");
+	default:
+		return ("-");
+	}
+}
+
 typedef struct spare_cbdata {
 	uint64_t	cb_guid;
 	zpool_handle_t	*cb_zhp;
@@ -1511,6 +1540,7 @@ typedef struct status_cbdata {
 	boolean_t	cb_explain;
 	boolean_t	cb_first;
 	boolean_t	cb_dedup_stats;
+	boolean_t	cb_media_type;
 	boolean_t	cb_print_status;
 	vdev_cmd_data_list_t	*vcdl;
 } status_cbdata_t;
@@ -1574,7 +1604,12 @@ print_status_config(zpool_handle_t *zhp, status_cbdata_t *cb, const char *name,
 		zfs_nicenum(vs->vs_write_errors, wbuf, sizeof (wbuf));
 		zfs_nicenum(vs->vs_checksum_errors, cbuf, sizeof (cbuf));
 		(void) printf(" %5s %5s %5s", rbuf, wbuf, cbuf);
+	} else {
+		(void) printf("                  ");
 	}
+
+	if (cb->cb_media_type)
+		(void) printf(" %5s", media_type_mark(nv));
 
 	if (nvlist_lookup_uint64(nv, ZPOOL_CONFIG_NOT_PRESENT,
 	    &notpresent) == 0) {
@@ -2630,6 +2665,7 @@ static const name_and_columns_t iostat_top_labels[][IOSTAT_MAX_LABELS] =
 	[IOS_QUEUES] = {{"syncq_read", 2}, {"syncq_write", 2},
 	    {"asyncq_read", 2}, {"asyncq_write", 2}, {"scrubq_read", 2},
 	    {NULL}},
+	[IOS_MEDIA_TYPE] = {{"", 1}, {NULL}},
 	[IOS_L_HISTO] = {{"total_wait", 2}, {"disk_wait", 2},
 	    {"sync_queue", 2}, {"async_queue", 2}, {NULL}},
 	[IOS_RQ_HISTO] = {{"sync_read", 2}, {"sync_write", 2},
@@ -2646,6 +2682,7 @@ static const name_and_columns_t iostat_bottom_labels[][IOSTAT_MAX_LABELS] =
 	    {"write"}, {"read"}, {"write"}, {"wait"}, {NULL}},
 	[IOS_QUEUES] = {{"pend"}, {"activ"}, {"pend"}, {"activ"}, {"pend"},
 	    {"activ"}, {"pend"}, {"activ"}, {"pend"}, {"activ"}, {NULL}},
+	[IOS_MEDIA_TYPE] = {{"media"}, {NULL}},
 	[IOS_L_HISTO] = {{"read"}, {"write"}, {"read"}, {"write"}, {"read"},
 	    {"write"}, {"read"}, {"write"}, {"scrub"}, {NULL}},
 	[IOS_RQ_HISTO] = {{"ind"}, {"agg"}, {"ind"}, {"agg"}, {"ind"}, {"agg"},
@@ -2708,9 +2745,10 @@ default_column_width(iostat_cbdata_t *cb, enum iostat_type type)
 		[IOS_DEFAULT] = 15, /* 1PB capacity */
 		[IOS_LATENCY] = 10, /* 1B ns = 10sec */
 		[IOS_QUEUES] = 6,   /* 1M queue entries */
+		[IOS_MEDIA_TYPE] = 5, /* type/file/ssd/hdd/mix */
 	};
 
-	if (cb->cb_literal)
+	if (cb->cb_literal || type == IOS_MEDIA_TYPE)
 		column_width = widths[type];
 
 	return (column_width);
@@ -3415,6 +3453,9 @@ print_vdev_stats(zpool_handle_t *zhp, const char *name, nvlist_t *oldnv,
 		print_iostat_latency(cb, oldnv, newnv, scale);
 	if (cb->cb_flags & IOS_QUEUES_M)
 		print_iostat_queues(cb, oldnv, newnv, scale);
+	if (cb->cb_flags & IOS_MEDIA_TYPE_M)
+		printf("%s%5s", cb->cb_scripted ? "\t" : "  ",
+		    media_type_mark(newnv));
 	if (cb->cb_flags & IOS_ANYHISTO_M) {
 		printf("\n");
 		print_iostat_histos(cb, oldnv, newnv, scale, name);
@@ -3965,7 +4006,7 @@ fsleep(float sec)
 
 
 /*
- * zpool iostat [-c CMD] [-ghHLpPvy] [[-lq]|[-r|-w]] [-n name] [-T d|u]
+ * zpool iostat [-c CMD] [-ghHLMpPvy] [[-lq]|[-r|-w]] [-n name] [-T d|u]
  *		[[ pool ...]|[pool vdev ...]|[vdev ...]]
  *		[interval [count]]
  *
@@ -3979,6 +4020,7 @@ fsleep(float sec)
  *	-H	Scripted mode.  Don't display headers, and separate properties
  *		by a single tab.
  *	-l	Display average latency
+ *	-M      Display media type of device, e.g. solid-state or mixed.
  *	-q	Display queue depths
  *	-w	Display latency histograms
  *	-r	Display request size histogram
@@ -4006,6 +4048,7 @@ zpool_do_iostat(int argc, char **argv)
 	boolean_t guid = B_FALSE;
 	boolean_t follow_links = B_FALSE;
 	boolean_t full_name = B_FALSE;
+	boolean_t media_type = B_FALSE;
 	iostat_cbdata_t cb = { 0 };
 	char *cmd = NULL;
 
@@ -4016,7 +4059,7 @@ zpool_do_iostat(int argc, char **argv)
 	uint64_t unsupported_flags;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "c:gLPT:vyhplqrwH")) != -1) {
+	while ((c = getopt(argc, argv, "c:gLPT:vyhplMqrwH")) != -1) {
 		switch (c) {
 		case 'c':
 			cmd = optarg;
@@ -4026,6 +4069,9 @@ zpool_do_iostat(int argc, char **argv)
 			break;
 		case 'L':
 			follow_links = B_TRUE;
+			break;
+		case 'M':
+			media_type = B_TRUE;
 			break;
 		case 'P':
 			full_name = B_TRUE;
@@ -4194,6 +4240,8 @@ zpool_do_iostat(int argc, char **argv)
 			cb.cb_flags |= IOS_LATENCY_M;
 		if (queues)
 			cb.cb_flags |= IOS_QUEUES_M;
+		if (media_type)
+			cb.cb_flags |= IOS_MEDIA_TYPE_M;
 	}
 
 	/*
@@ -6012,9 +6060,9 @@ status_callback(zpool_handle_t *zhp, void *data)
 			cbp->cb_namewidth = 10;
 
 		(void) printf(gettext("config:\n\n"));
-		(void) printf(gettext("\t%-*s  %-8s %5s %5s %5s\n"),
+		(void) printf(gettext("\t%-*s  %-8s %5s %5s %5s%s\n"),
 		    cbp->cb_namewidth, "NAME", "STATE", "READ", "WRITE",
-		    "CKSUM");
+		    "CKSUM", cbp->cb_media_type ? " MEDIA" : "");
 		print_status_config(zhp, cbp, zpool_get_name(zhp), nvroot, 0,
 		    B_FALSE);
 
@@ -6074,11 +6122,12 @@ status_callback(zpool_handle_t *zhp, void *data)
 }
 
 /*
- * zpool status [-c CMD] [-gLPvx] [-T d|u] [pool] ... [interval [count]]
+ * zpool status [-c CMD] [-gLMPvx] [-T d|u] [pool] ... [interval [count]]
  *
  *	-c CMD	For each vdev, run command CMD
  *	-g	Display guid for individual vdev name.
  *	-L	Follow links when resolving vdev path name.
+ *	-M      Display media type of device, e.g. solid-state or mixed.
  *	-P	Display full path for vdev name.
  *	-v	Display complete error logs
  *	-x	Display only pools with potential problems
@@ -6098,7 +6147,7 @@ zpool_do_status(int argc, char **argv)
 	char *cmd = NULL;
 
 	/* check options */
-	while ((c = getopt(argc, argv, "c:gLPvxDT:")) != -1) {
+	while ((c = getopt(argc, argv, "c:gLMPvxDT:")) != -1) {
 		switch (c) {
 		case 'c':
 			cmd = optarg;
@@ -6108,6 +6157,9 @@ zpool_do_status(int argc, char **argv)
 			break;
 		case 'L':
 			cb.cb_name_flags |= VDEV_NAME_FOLLOW_LINKS;
+			break;
+		case 'M':
+			cb.cb_media_type = B_TRUE;
 			break;
 		case 'P':
 			cb.cb_name_flags |= VDEV_NAME_PATH;

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -600,6 +600,9 @@ typedef struct zpool_rewind_policy {
 /* vdev enclosure sysfs path */
 #define	ZPOOL_CONFIG_VDEV_ENC_SYSFS_PATH	"vdev_enc_sysfs_path"
 
+/* Type (ssd, file, mix, hdd) (part of vdev_stat_ex_t) */
+#define	ZPOOL_CONFIG_VDEV_MEDIA_TYPE	"media_type"
+
 #define	ZPOOL_CONFIG_WHOLE_DISK		"whole_disk"
 #define	ZPOOL_CONFIG_ERRCOUNT		"error_count"
 #define	ZPOOL_CONFIG_NOT_PRESENT	"not_present"
@@ -734,6 +737,14 @@ typedef enum vdev_aux {
 	VDEV_AUX_EXTERNAL,	/* external diagnosis			*/
 	VDEV_AUX_SPLIT_POOL	/* vdev was split off into another pool	*/
 } vdev_aux_t;
+
+typedef enum vdev_media_type_info {
+	VDEV_MEDIA_TYPE_UNKNOWN = 0,	/* not set yet			*/
+	VDEV_MEDIA_TYPE_SSD,		/* device is solid state	*/
+	VDEV_MEDIA_TYPE_FILE,		/* device is file backed	*/
+	VDEV_MEDIA_TYPE_MIXED,		/* device has both types	*/
+	VDEV_MEDIA_TYPE_HDD		/* device is not solid state	*/
+} vdev_media_type_info_t;
 
 /*
  * pool state.  The following states are written to disk as part of the normal
@@ -892,6 +903,11 @@ typedef struct vdev_stat_ex {
 	uint64_t vsx_agg_histo[ZIO_PRIORITY_NUM_QUEUEABLE]
 	    [VDEV_RQ_HISTO_BUCKETS];
 
+	/*
+	 * Rotational type of vdev (ssd, file, mixed, hdd).
+	 * Exported as one value.
+	 */
+	uint64_t vsx_media_type;
 } vdev_stat_ex_t;
 
 /*

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -159,6 +159,7 @@ struct vdev {
 	boolean_t	vdev_expanding;	/* expand the vdev?		*/
 	boolean_t	vdev_reopening;	/* reopen in progress?		*/
 	boolean_t	vdev_nonrot;	/* true if solid state		*/
+	boolean_t	vdev_nonrot_mix; /* true if partial solid state	*/
 	int		vdev_open_error; /* error on last open		*/
 	kthread_t	*vdev_open_thread; /* thread opening children	*/
 	uint64_t	vdev_crtxg;	/* txg when top-level was added */

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -96,7 +96,7 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
-\fB\fBzpool iostat\fR [\fB-c\fR \fBCMD\fR] [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-ghHLpPvy\fR] [\fB-lq\fR]|[\fB-r\fR|-\fBw\fR]]
+\fB\fBzpool iostat\fR [\fB-c\fR \fBCMD\fR] [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-ghHLMpPvy\fR] [\fB-lq\fR]|[\fB-r\fR|-\fBw\fR]]
      [[\fIpool\fR ...]|[\fIpool vdev\fR ...]|[\fIvdev\fR ...]] [\fIinterval\fR[\fIcount\fR]]\fR
 
 .fi
@@ -159,7 +159,7 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
-\fBzpool status\fR [\fB-c\fR \fBCMD\fR] [\fB-gLPvxD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
+\fBzpool status\fR [\fB-c\fR \fBCMD\fR] [\fB-gLMPvxD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
 .fi
 
 .LP
@@ -1523,7 +1523,7 @@ Scan using the default search path, the libblkid cache will not be consulted.  A
 .sp
 .ne 2
 .na
-\fB\fBzpool iostat\fR [\fB-c\fR \fBCMD\fR] [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-ghHLpPvy\fR] [[\fB-lq\fR]|[\fB-r\fR|\fB-w\fR]] [[\fIpool\fR ...]|[\fIpool vdev\fR ...]|[\fIvdev\fR ...]] [\fIinterval\fR[\fIcount\fR]]\fR
+\fB\fBzpool iostat\fR [\fB-c\fR \fBCMD\fR] [\fB-T\fR \fBd\fR | \fBu\fR] [\fB-ghHLMpPvy\fR] [[\fB-lq\fR]|[\fB-r\fR|\fB-w\fR]] [[\fIpool\fR ...]|[\fIpool vdev\fR ...]|[\fIvdev\fR ...]] [\fIinterval\fR[\fIcount\fR]]\fR
 
 .ad
 .sp .6
@@ -1592,6 +1592,15 @@ Scripted mode. Do not display headers, and separate fields by a single tab inste
 .ad
 .RS 12n
 Display real paths for vdevs resolving all symbolic links. This can be used to look up the current block device name regardless of the /dev/disk/ path used to open it.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-M\fR\fR
+.ad
+.RS 12n
+Display the media type of device a pool or vdev is based on: ssd, hdd or file.  Mixed mirror vdevs that have both ssd (or file) and hdd members are marked "mix".  A pool is considered ssd or mixed if all members are at least ssd or mixed, i.e. it has no lower-grade top-level vdevs.  These definitions may change in the future and should not be considered a stable API.
 .RE
 
 .sp
@@ -2099,7 +2108,7 @@ Sets the specified property for \fInewpool\fR. See the “Properties” section 
 .sp
 .ne 2
 .na
-\fBzpool status\fR [\fB-c\fR \fBCMD\fR] [\fB-gLPvxD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
+\fBzpool status\fR [\fB-c\fR \fBCMD\fR] [\fB-gLMPvxD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
 .ad
 .sp .6
 .RS 4n
@@ -2140,6 +2149,15 @@ Display vdev GUIDs instead of the normal device names. These GUIDs can be used i
 .ad
 .RS 12n
 Display real paths for vdevs resolving all symbolic links. This can be used to look up the current block device name regardless of the /dev/disk/ path used to open it.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-M\fR\fR
+.ad
+.RS 12n
+Display the media type of device a pool or vdev is based on: ssd, hdd or file.  Mixed mirror vdevs that have both ssd (or file) and hdd members are marked "mix".  A pool is considered ssd or mixed if all members are at least ssd or mixed, i.e. it has no lower-grade top-level vdevs.  These definitions may change in the future and should not be considered a stable API.
 .RE
 
 .sp

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1173,6 +1173,7 @@ vdev_open_children(vdev_t *vd)
 	taskq_t *tq;
 	int children = vd->vdev_children;
 	int c;
+	boolean_t nonrot_some;
 
 	/*
 	 * in order to handle pools on top of zvols, do the opens
@@ -1198,9 +1199,19 @@ retry_sync:
 	}
 
 	vd->vdev_nonrot = B_TRUE;
+	vd->vdev_nonrot_mix = B_TRUE;
+	nonrot_some = B_FALSE;
 
-	for (c = 0; c < children; c++)
+	for (c = 0; c < children; c++) {
 		vd->vdev_nonrot &= vd->vdev_child[c]->vdev_nonrot;
+		vd->vdev_nonrot_mix &= vd->vdev_child[c]->vdev_nonrot_mix |
+		    vd->vdev_child[c]->vdev_nonrot;
+		nonrot_some |= vd->vdev_child[c]->vdev_nonrot;
+	}
+	if (vd->vdev_ops == &vdev_mirror_ops)
+		vd->vdev_nonrot_mix |= nonrot_some;
+	if (vd->vdev_nonrot)
+		vd->vdev_nonrot_mix = B_FALSE;
 }
 
 /*
@@ -2894,6 +2905,17 @@ vdev_get_stats_ex_impl(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 			vsx->vsx_pend_queue[t] = avl_numnodes(
 			    &vd->vdev_queue.vq_class[t].vqc_queued_tree);
 		}
+	}
+	if (vsx) {
+		if (vd->vdev_nonrot) {
+			if (vd->vdev_ops == &vdev_file_ops)
+				vsx->vsx_media_type = VDEV_MEDIA_TYPE_FILE;
+			else
+				vsx->vsx_media_type = VDEV_MEDIA_TYPE_SSD;
+		} else if (vd->vdev_nonrot_mix)
+			vsx->vsx_media_type = VDEV_MEDIA_TYPE_MIXED;
+		else
+			vsx->vsx_media_type = VDEV_MEDIA_TYPE_HDD;
 	}
 }
 

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -321,6 +321,7 @@ skip_open:
 
 	/* Inform the ZIO pipeline that we are non-rotational */
 	v->vdev_nonrot = blk_queue_nonrot(bdev_get_queue(vd->vd_bdev));
+	v->vdev_nonrot_mix = B_FALSE;
 
 	/* Physical volume size in bytes */
 	*psize = bdev_capacity(vd->vd_bdev);

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -62,6 +62,7 @@ vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 
 	/* Rotational optimizations only make sense on block devices */
 	vd->vdev_nonrot = B_TRUE;
+	vd->vdev_nonrot_mix = B_FALSE;
 
 	/*
 	 * We must have a pathname, and it must be absolute.

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -344,6 +344,9 @@ vdev_config_generate_stats(vdev_t *vd, nvlist_t *nv)
 	    vsx->vsx_agg_histo[ZIO_PRIORITY_SCRUB],
 	    ARRAY_SIZE(vsx->vsx_agg_histo[ZIO_PRIORITY_SCRUB]));
 
+	fnvlist_add_uint64(nvx, ZPOOL_CONFIG_VDEV_MEDIA_TYPE,
+	    vsx->vsx_media_type);
+
 	/* Add extended stats nvlist to main nvlist */
 	fnvlist_add_nvlist(nv, ZPOOL_CONFIG_VDEV_STATS_EX, nvx);
 


### PR DESCRIPTION
Some questions:
- Currently the output is narrow, only using one character and the header overlaps the column separating spaces:
  ![zpool_iostat_ssd](https://cloud.githubusercontent.com/assets/4685122/18581265/1e265cdc-7c00-11e6-88fd-b3ed4e2a2c08.png)
  Should more space be used, and the info spelled out (yes, no and mix)?
- Since it adds a field and thus may break scripts, should it depend on a command-line option to zpool?
- The question in the second commit for module/zfs/vdev.c
