### PR TITLE
Update zpool_import_002_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_002_pos.ksh
@@ -53,7 +53,7 @@ verify_runnable "global"
 
 set -A pools "$TESTPOOL" "$TESTPOOL1"
 set -A devs "" "-d $DEVICE_DIR"
-set -A options "" "-R $ALTER_ROOT"
+set -A options "-s" "-s -R $ALTER_ROOT"
 set -A mtpts "$TESTDIR" "$TESTDIR1"
 
 


### PR DESCRIPTION
Older versions of blkid may not promptly detect ZFS labels when
they're located on partitions.  In order to ensure this test passes
reliably always perform a scan of default search paths (-s).

Related to commit 3f10fe0.