### PR TITLE
Fix script path in zfs_commands.cfg

### DIFF
--- a/tests/zfs-tests/include/Makefile.am
+++ b/tests/zfs-tests/include/Makefile.am
@@ -5,6 +5,3 @@ dist_pkgdata_SCRIPTS = \
 	libtest.shlib \
 	math.shlib \
 	properties.shlib
-
-EXTRA_DIST = \
-	zfs_commands.cfg

--- a/tests/zfs-tests/include/default.cfg.in
+++ b/tests/zfs-tests/include/default.cfg.in
@@ -47,8 +47,8 @@ export RAIDZ_TEST=${RAIDZ_TEST:-${bindir}/raidz_test}
 . $STF_SUITE/include/libtest.shlib
 
 # Optionally override the installed ZFS commands to run in-tree
-if [[ -f "$STF_SUITE/include/zfs_commands.cfg" ]]; then
-	. $STF_SUITE/include/zfs_commands.cfg
+if [[ -f "$SRCDIR/zfs-script-config.sh" ]]; then
+	. $SRCDIR/zfs-script-config.sh
 fi
 
 # Define run length constants

--- a/tests/zfs-tests/include/zfs_commands.cfg
+++ b/tests/zfs-tests/include/zfs_commands.cfg
@@ -1,1 +1,0 @@
-../../../zfs-script-config.sh


### PR DESCRIPTION
zfs_commands.cfg have printed "No such file or directory", When executing
script/zfs-test.sh. The script path must be "${SRCDIR}/zfs-script-config.sh"

zfs-test.sh->default.cfg->zfs_commands.cfg
The path of the parent process is under "${SRCDIR}/scripts/", not "tests/zfs-tests/include".
So it can not find the script "zfs-script-config.sh" by "../../zfs-script-config.sh"
 
Signed-off-by: legend-hua <liu.hua130@zte.com.cn>