### PR TITLE
Dereferencing null pointer in kcf_remove_mech_provider

### DIFF
--- a/module/icp/core/kcf_mech_tabs.c
+++ b/module/icp/core/kcf_mech_tabs.c
@@ -659,7 +659,9 @@ kcf_remove_mech_provider(char *mech_name, kcf_provider_desc_t *prov_desc)
 		mech_entry->me_sw_prov = NULL;
 		break;
 	default:
-		break;
+		/* unexpected crypto_provider_type_t */
+		mutex_exit(&mech_entry->me_mutex);
+		return;
 	}
 
 	mutex_exit(&mech_entry->me_mutex);


### PR DESCRIPTION
If switch case default, the prov_mech is NULL, then "mil = prov_mech->pm_mi_list" will dereferencing null pointer.