### PR TITLE
delete unuse DMU_OS_IS_L2COMPRESSIBLE and fix coverity defects with CID 147623, 147622

### DIFF
--- a/cmd/zinject/translate.c
+++ b/cmd/zinject/translate.c
@@ -474,6 +474,7 @@ translate_device(const char *pool, const char *device, err_type_t label_type,
 		if (tgt == NULL) {
 			(void) fprintf(stderr, "cannot find device '%s' in "
 			    "pool '%s'\n", device, pool);
+			zpool_close(zhp);
 			return (-1);
 		}
 
@@ -515,5 +516,6 @@ translate_device(const char *pool, const char *device, err_type_t label_type,
 		record->zi_end = record->zi_start + VDEV_PAD_SIZE - 1;
 		break;
 	}
+	zpool_close(zhp);
 	return (0);
 }

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -758,7 +758,7 @@ zpool_do_remove(int argc, char **argv)
 {
 	char *poolname;
 	int i, ret = 0;
-	zpool_handle_t *zhp;
+	zpool_handle_t *zhp = NULL;
 
 	argc--;
 	argv++;
@@ -782,6 +782,7 @@ zpool_do_remove(int argc, char **argv)
 		if (zpool_vdev_remove(zhp, argv[i]) != 0)
 			ret = 1;
 	}
+	zpool_close(zhp);
 
 	return (ret);
 }

--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -138,8 +138,6 @@ struct objset {
 	((os)->os_secondary_cache == ZFS_CACHE_ALL ||		\
 	(os)->os_secondary_cache == ZFS_CACHE_METADATA)
 
-#define	DMU_OS_IS_L2COMPRESSIBLE(os)	(zfs_mdcomp_disable == B_FALSE)
-
 /* called from zpl */
 int dmu_objset_hold(const char *name, void *tag, objset_t **osp);
 int dmu_objset_own(const char *name, dmu_objset_type_t type,

--- a/tests/zfs-tests/tests/functional/ctime/ctime_001_pos.c
+++ b/tests/zfs-tests/tests/functional/ctime/ctime_001_pos.c
@@ -110,6 +110,7 @@ do_read(const char *pfile)
 	if (read(fd, buf, sizeof (buf)) == -1) {
 		(void) fprintf(stderr, "read(%d, buf, %zd) failed with errno "
 		    "%d\n", fd, sizeof (buf), errno);
+		(void) close(fd);
 		return (1);
 	}
 	(void) close(fd);
@@ -133,6 +134,7 @@ do_write(const char *pfile)
 	if (write(fd, buf, strlen(buf)) == -1) {
 		(void) fprintf(stderr, "write(%d, buf, %d) failed with errno "
 		    "%d\n", fd, (int)strlen(buf), errno);
+		(void) close(fd);
 		return (1);
 	}
 	(void) close(fd);


### PR DESCRIPTION
issues:
fix coverity defects 
coverity scan CID:147623, Type: Resource leak. 
coverity scan CID:147622, Type: Resource leak. 
reason: zpool_open zhp, but not zpool_close zhp. so resource leak.

delete unuse definition DMU_OS_IS_L2COMPRESSIBLE.
