### PR TITLE
Fix regression that broke dracut initramfs generation

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -38,11 +38,17 @@ install() {
 	dracut_install grep
 	dracut_install @sbindir@/zfs
 	dracut_install @sbindir@/zpool
-	# Include libgcc_s.so.1 to workaround zfsonlinux/zfs#4749
-	if type gcc-config 2>&1 1>/dev/null; then
+	# Workaround for zfsonlinux/zfs#4749 by ensuring libgcc_s.so(.1) is included
+	if [[ -n "$(ldd @sbindir@/zpool | grep -F 'libgcc_s.so')" ]]; then
+		# Dracut will have already tracked and included it
+		:;
+	elif command -v gcc-config 2>&1 1>/dev/null; then
+		# On systems with gcc-config (Gentoo, Funtoo, etc.):
+		# Use the current profile to resolve the appropriate path
 		dracut_install "/usr/lib/gcc/$(s=$(gcc-config -c); echo ${s%-*}/${s##*-})/libgcc_s.so.1"
 	else
-		dracut_install /usr/lib/gcc/*/*/libgcc_s.so.1
+		# Fallback: Guess the path and include all matches
+		dracut_install /usr/lib/gcc/*/*/libgcc_s.so*
 	fi
 	dracut_install @sbindir@/mount.zfs
 	dracut_install @udevdir@/vdev_id


### PR DESCRIPTION
Based upon @ryao's initial fix for 1c73494394fc9de9283b3fd4f00bcdf4bd300a7
( 5e9843405f63fdabe76e87b92b81a127d488abc7 ) this one also uses
`command -v` instead of `type`, but additionally only applies the
fix to close zfsonlinux/zfs#4749 when `libgcc_s.so.1` has not been included
by dracut automatically (verified by whether `zpool` links directly to
`libgcc_s.so`), as well as change the fallback option to match `libgcc_s.so*`.

Fixes zfsonlinux/zfs#5089