### PR TITLE
Fix automatically generated release number

### DIFF
--- a/config/zfs-meta.m4
+++ b/config/zfs-meta.m4
@@ -74,6 +74,14 @@ AC_DEFUN([ZFS_AC_META], [
 			if test -n "${_release}"; then
 				ZFS_META_RELEASE=${_release}
 				_zfs_ac_meta_type="git describe"
+			else
+				_match="${ZFS_META_NAME}-${ZFS_META_VERSION}-${ZFS_META_RELEASE}"
+	                        _alias=$(git describe --match=${_match} 2>/dev/null)
+	                        _release=$(echo ${_alias}|cut -f3- -d'-'|sed 's/-/_/g')
+				if test -n "${_release}"; then
+					ZFS_META_RELEASE=${_release}
+					_zfs_ac_meta_type="git describe"
+				fi
 			fi
 		fi
 


### PR DESCRIPTION
When building from the head of a branch a release number is
automatically generated with `git describe` using the last tag
on that branch as the base.  For this to work the last tag on the
branch needs to be predictable given the current META file.

This logic was accidentally broken when an -rcX tag was added to
the branch.  Update it to search for a VERSION or VERSION-RELEASE
tag.

Reviewed-by: Chris Siebenmann <cks.git01@cs.toronto.edu>
Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Requires-spl: refs/pull/572/head
Issue #5105