### PR TITLE
Linux 4.7: fix deadlock during lookup on case-insensitive

### DIFF
--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -101,9 +101,13 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 		struct dentry *new_dentry;
 		struct qstr ci_name;
 
-		ci_name.name = pn.pn_buf;
-		ci_name.len = strlen(pn.pn_buf);
-		new_dentry = d_add_ci(dentry, ip, &ci_name);
+		if (strcmp(dname(dentry), pn.pn_buf) == 0) {
+			new_dentry = d_splice_alias(ip,  dentry);
+		} else {
+			ci_name.name = pn.pn_buf;
+			ci_name.len = strlen(pn.pn_buf);
+			new_dentry = d_add_ci(dentry, ip, &ci_name);
+		}
 		pn_free(ppn);
 		return (new_dentry);
 	} else {


### PR DESCRIPTION
We must not use d_add_ci if the dentry already has the real name. Otherwise,
d_add_ci()->d_alloc_parallel() will find itself on the lookup hash and wait
on itself causing deadlock.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>