### PR TITLE
dbuf_read_impl() returns (SET_ERROR(err)) when err can be 0

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1080,7 +1080,7 @@ dbuf_read_impl(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 	    (flags & DB_RF_CANFAIL) ? ZIO_FLAG_CANFAIL : ZIO_FLAG_MUSTSUCCEED,
 	    &aflags, &zb);
 
-	return (SET_ERROR(err));
+	return (err);
 }
 
 /*


### PR DESCRIPTION
dbuf_read_impl() returns (SET_ERROR(err)) when err can be 0, which adds
lots of noise in tracing.

Closes #4430
Signed-off-by: Isaac Huang <he.huang@intel.com>