### PR TITLE
Fix multilist_create() memory leak

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6265,6 +6265,8 @@ arc_state_fini(void)
 	multilist_destroy(&arc_mru_ghost->arcs_list[ARC_BUFC_DATA]);
 	multilist_destroy(&arc_mfu->arcs_list[ARC_BUFC_DATA]);
 	multilist_destroy(&arc_mfu_ghost->arcs_list[ARC_BUFC_DATA]);
+	multilist_destroy(&arc_l2c_only->arcs_list[ARC_BUFC_METADATA]);
+	multilist_destroy(&arc_l2c_only->arcs_list[ARC_BUFC_DATA]);
 }
 
 uint64_t


### PR DESCRIPTION
In arc_state_fini() the `arc_l2c_only->arcs_list[*]` multilists
must be destroyed.  This accidentally regressed in d3c2ae1c.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #5151