### PR TITLE
Sequential SPA-level rebuild for mirror and dRAID

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -5444,7 +5444,8 @@ print_scan_status(pool_scan_stat_t *ps)
 	zfs_nicenum(ps->pss_processed, processed_buf, sizeof (processed_buf));
 
 	assert(ps->pss_func == POOL_SCAN_SCRUB ||
-	    ps->pss_func == POOL_SCAN_RESILVER);
+	    ps->pss_func == POOL_SCAN_RESILVER ||
+	    ps->pss_func == POOL_SCAN_REBUILD);
 	/*
 	 * Scan is finished or canceled.
 	 */
@@ -5453,16 +5454,20 @@ print_scan_status(pool_scan_stat_t *ps)
 		char *fmt = NULL;
 
 		if (ps->pss_func == POOL_SCAN_SCRUB) {
-			fmt = gettext("scrub repaired %s in %lluh%um with "
+			fmt = gettext("scrub repaired %s in %lluh%um%us with "
 			    "%llu errors on %s");
 		} else if (ps->pss_func == POOL_SCAN_RESILVER) {
-			fmt = gettext("resilvered %s in %lluh%um with "
+			fmt = gettext("resilvered %s in %lluh%um%us with "
 			    "%llu errors on %s");
+		} else if (ps->pss_func == POOL_SCAN_REBUILD) {
+			fmt = "rebuilt %s in %lluh%um%us with "
+			    "%llu errors on %s";
 		}
 		/* LINTED */
 		(void) printf(fmt, processed_buf,
 		    (u_longlong_t)(minutes_taken / 60),
 		    (uint_t)(minutes_taken % 60),
+		    (uint_t)((end - start) % 60),
 		    (u_longlong_t)ps->pss_errors,
 		    ctime((time_t *)&end));
 		return;
@@ -5472,6 +5477,9 @@ print_scan_status(pool_scan_stat_t *ps)
 			    ctime(&end));
 		} else if (ps->pss_func == POOL_SCAN_RESILVER) {
 			(void) printf(gettext("resilver canceled on %s"),
+			    ctime(&end));
+		} else if (ps->pss_func == POOL_SCAN_REBUILD) {
+			(void) printf("rebuild canceled on %s",
 			    ctime(&end));
 		}
 		return;
@@ -5487,6 +5495,9 @@ print_scan_status(pool_scan_stat_t *ps)
 		    ctime(&start));
 	} else if (ps->pss_func == POOL_SCAN_RESILVER) {
 		(void) printf(gettext("resilver in progress since %s"),
+		    ctime(&start));
+	} else if (ps->pss_func == POOL_SCAN_REBUILD) {
+		(void) printf("rebuild in progress since %s",
 		    ctime(&start));
 	}
 
@@ -5525,6 +5536,9 @@ print_scan_status(pool_scan_stat_t *ps)
 		    processed_buf, 100 * fraction_done);
 	} else if (ps->pss_func == POOL_SCAN_SCRUB) {
 		(void) printf(gettext("\t%s repaired, %.2f%% done\n"),
+		    processed_buf, 100 * fraction_done);
+	} else if (ps->pss_func == POOL_SCAN_REBUILD) {
+		(void) printf("    %s rebuilt, %.2f%% done\n",
 		    processed_buf, 100 * fraction_done);
 	}
 }

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -113,6 +113,8 @@ typedef struct dsl_scan {
 	uint64_t scn_sync_start_time;
 	zio_t *scn_zio_root;
 
+	boolean_t scn_is_sequential;
+
 	/* for freeing blocks */
 	boolean_t scn_is_bptree;
 	boolean_t scn_async_destroying;

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -747,6 +747,7 @@ typedef enum pool_scan_func {
 	POOL_SCAN_NONE,
 	POOL_SCAN_SCRUB,
 	POOL_SCAN_RESILVER,
+	POOL_SCAN_REBUILD, /* sequential SPA scan */
 	POOL_SCAN_FUNCS
 } pool_scan_func_t;
 

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -174,6 +174,7 @@ struct metaslab {
 	boolean_t	ms_condense_wanted;
 	boolean_t	ms_loaded;
 	boolean_t	ms_loading;
+	boolean_t	ms_rebuilding;
 
 	int64_t		ms_deferspace;	/* sum of ms_defermap[] space	*/
 	uint64_t	ms_weight;	/* weight vs. others in group	*/

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -4513,6 +4513,214 @@ spa_vdev_add(spa_t *spa, nvlist_t *nvroot)
 	return (0);
 }
 
+typedef struct {
+	vdev_t  *ssa_newvd;
+	vdev_t  *ssa_draid;
+	uint64_t ssa_dtl_max;
+} sequential_scan_arg_t;
+
+int vdev_draid_max_rebuild = 128;
+
+static void
+vdev_draid_scan_done(zio_t *zio)
+{
+	spa_t *spa = zio->io_spa;
+	dsl_scan_t *scn = spa->spa_dsl_pool->dp_scan;
+
+	ASSERT(zio->io_bp != NULL);
+
+	zio_data_buf_free(zio->io_data, zio->io_size);
+	kmem_free(zio->io_private, sizeof(blkptr_t));
+
+	scn->scn_phys.scn_examined += DVA_GET_ASIZE(&zio->io_bp->blk_dva[0]);
+	spa->spa_scan_pass_exam += DVA_GET_ASIZE(&zio->io_bp->blk_dva[0]);
+
+	mutex_enter(&spa->spa_scrub_lock);
+
+	spa->spa_scrub_inflight--;
+	cv_broadcast(&spa->spa_scrub_io_cv);
+
+	if (zio->io_error && (zio->io_error != ECKSUM ||
+	    !(zio->io_flags & ZIO_FLAG_SPECULATIVE))) {
+		spa->spa_dsl_pool->dp_scan->scn_phys.scn_errors++;
+	}
+
+	mutex_exit(&spa->spa_scrub_lock);
+}
+
+static void
+vdev_draid_rebuild_block(zio_t *pio, vdev_t *vd, uint64_t offset, uint64_t asize)
+{
+	/* HH: maybe bp can be on the stack */
+	blkptr_t *bp = kmem_alloc(sizeof(*bp), KM_SLEEP);
+	dva_t *dva = bp->blk_dva;
+	uint64_t psize;
+	spa_t *spa = vd->vdev_spa;
+
+	ASSERT3P(vd->vdev_ops, ==, &vdev_mirror_ops);
+
+	psize = asize;
+	ASSERT3U(asize, ==, vdev_psize_to_asize(vd, psize));
+
+	mutex_enter(&spa->spa_scrub_lock);
+	while (spa->spa_scrub_inflight > vdev_draid_max_rebuild)
+		cv_wait(&spa->spa_scrub_io_cv, &spa->spa_scrub_lock);
+	spa->spa_scrub_inflight++;
+	mutex_exit(&spa->spa_scrub_lock);
+
+	BP_ZERO(bp);
+
+	DVA_SET_VDEV(&dva[0], vd->vdev_id);
+	DVA_SET_OFFSET(&dva[0], offset);
+	DVA_SET_GANG(&dva[0], !!0);
+	DVA_SET_ASIZE(&dva[0], asize);
+
+	BP_SET_BIRTH(bp, TXG_INITIAL, TXG_INITIAL);
+	BP_SET_LSIZE(bp, psize);
+	BP_SET_PSIZE(bp, psize);
+	BP_SET_COMPRESS(bp, ZIO_COMPRESS_OFF);
+	BP_SET_CHECKSUM(bp, ZIO_CHECKSUM_OFF);
+	BP_SET_TYPE(bp, DMU_OT_NONE);
+	BP_SET_LEVEL(bp, 0);
+	BP_SET_DEDUP(bp, 0);
+	BP_SET_BYTEORDER(bp, ZFS_HOST_BYTEORDER);
+
+	zio_nowait(zio_read(pio, spa, bp,
+		   zio_data_buf_alloc(psize), psize,
+		   vdev_draid_scan_done, bp, ZIO_PRIORITY_SCRUB,
+		   ZIO_FLAG_SCAN_THREAD | ZIO_FLAG_RAW | ZIO_FLAG_CANFAIL | ZIO_FLAG_RESILVER, NULL));
+}
+
+static void
+vdev_draid_rebuild(zio_t *pio, vdev_t *vd, uint64_t offset, uint64_t length)
+{
+	while (length > 0) {
+		uint64_t chunksz = MIN(length, vdev_psize_to_asize(vd, SPA_MAXBLOCKSIZE));
+
+		vdev_draid_rebuild_block(pio, vd, offset, chunksz);
+		length -= chunksz;
+		offset += chunksz;
+	}
+}
+
+void
+vdev_draid_scan_thread(void *arg)
+{
+	sequential_scan_arg_t *sscan = arg;
+	vdev_t *vd = sscan->ssa_draid;
+	spa_t *spa = vd->vdev_spa;
+	zio_t *pio = zio_root(spa, NULL, NULL, 0);
+	range_tree_t *allocd_segs;
+	kmutex_t lock;
+	uint64_t msi;
+	int err;
+
+	/* HH: allows zpool to return from syscall quickly */
+	txg_wait_synced(spa->spa_dsl_pool, sscan->ssa_dtl_max);
+
+	mutex_init(&lock, NULL, MUTEX_DEFAULT, NULL);
+	allocd_segs = range_tree_create(NULL, NULL, &lock);
+
+	for (msi = 0; msi < vd->vdev_ms_count; msi++) {
+		metaslab_t *msp = vd->vdev_ms[msi];
+
+		ASSERT0(range_tree_space(allocd_segs));
+
+		mutex_enter(&msp->ms_lock);
+
+		VERIFY(!msp->ms_condensing); /* HH: need to handle this */
+		VERIFY(!msp->ms_rebuilding);
+		msp->ms_rebuilding = B_TRUE;
+
+		/*
+		 * If the metaslab has ever been allocated from (ms_sm!=NULL),
+		 * read the allocated segments from the space map object
+		 * into svr_allocd_segs. Since we do this while holding
+		 * svr_lock and ms_sync_lock, concurrent frees (which
+		 * would have modified the space map) will wait for us
+		 * to finish loading the spacemap, and then take the
+		 * appropriate action (see free_from_removing_vdev()).
+		 */
+		if (msp->ms_sm != NULL) {
+			space_map_t *sm = NULL;
+
+			/*
+			 * We have to open a new space map here, because
+			 * ms_sm's sm_length and sm_alloc may not reflect
+			 * what's in the object contents, if we are in between
+			 * metaslab_sync() and metaslab_sync_done().
+			 *
+			 * Note: space_map_open() drops and reacquires the
+			 * caller-provided lock.  Therefore we can not provide
+			 * any lock that we are using (e.g. ms_lock, svr_lock).
+			 */
+			VERIFY0(space_map_open(&sm,
+			    spa->spa_dsl_pool->dp_meta_objset,
+			    msp->ms_sm->sm_object, msp->ms_sm->sm_start,
+			    msp->ms_sm->sm_size, msp->ms_sm->sm_shift, &lock));
+			mutex_enter(&lock);
+			space_map_update(sm);
+			VERIFY0(space_map_load(sm, allocd_segs, SM_ALLOC));
+			mutex_exit(&lock);
+			space_map_close(sm);
+
+			/*
+			 * When we are resuming from a paused removal (i.e.
+			 * when importing a pool with a removal in progress),
+			 * discard any state that we have already processed.
+			range_tree_clear(svr->svr_allocd_segs, 0, start_offset);
+			 */
+		}
+		mutex_exit(&msp->ms_lock);
+
+		zfs_dbgmsg("Scanning %llu segments for metaslab %llu",
+		    avl_numnodes(&allocd_segs->rt_root), msp->ms_id);
+
+		mutex_enter(&lock);
+		while (range_tree_space(allocd_segs) != 0) {
+			range_seg_t *rs = avl_first(&allocd_segs->rt_root);
+			uint64_t offset, length;
+
+			if (rs == NULL)
+				continue;
+
+			offset = rs->rs_start;
+			length = rs->rs_end - rs->rs_start;
+
+			range_tree_remove(allocd_segs, offset, length);
+			mutex_exit(&lock);
+
+#ifdef _KERNEL
+			/* GPL only {facepalm}
+			trace_printk("MS (%llu at %lluK) segment: %lluK + %lluK\n", msp->ms_id, msp->ms_start >> 10, (offset - msp->ms_start) >> 10, length >> 10);
+			*/
+#endif
+
+			vdev_draid_rebuild(pio, vd, offset, length);
+
+			mutex_enter(&lock);
+		}
+		mutex_exit(&lock);
+
+		mutex_enter(&msp->ms_lock);
+
+		/* HH: wait for rebuild IOs to complete for this metaslab? */
+		msp->ms_rebuilding = B_FALSE;
+
+		mutex_exit(&msp->ms_lock);
+	}
+
+	range_tree_destroy(allocd_segs);
+	mutex_destroy(&lock);
+
+	err = zio_wait(pio);
+	if (err != 0) /* HH: handle error */
+		err = SET_ERROR(err);
+	kmem_free(sscan, sizeof(*sscan));
+	/* HH: we don't use scn_visited_this_txg anyway */
+	spa->spa_dsl_pool->dp_scan->scn_visited_this_txg = 19890604;
+}
+
 /*
  * Attach a device to a mirror.  The arguments are the path to any device
  * in the mirror, and the nvroot for the new device.  If the path specifies
@@ -4535,6 +4743,9 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing)
 	char *oldvdpath, *newvdpath;
 	int newvd_isspare;
 	int error;
+	sequential_scan_arg_t *sscan_arg;
+	boolean_t rebuild = B_FALSE;
+
 	ASSERTV(vdev_t *rvd = spa->spa_root_vdev);
 
 	ASSERT(spa_writeable(spa));
@@ -4550,6 +4761,8 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing)
 		return (spa_vdev_exit(spa, NULL, txg, ENOTSUP));
 
 	pvd = oldvd->vdev_parent;
+	if (pvd->vdev_ops == &vdev_mirror_ops && vdev_draid_max_rebuild > 0)
+		rebuild = B_TRUE; /* HH: let zpool cmd choose */
 
 	if ((error = spa_config_parse(spa, &newrootvd, nvroot, NULL, 0,
 	    VDEV_ALLOC_ATTACH)) != 0)
@@ -4700,7 +4913,19 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing)
 	 * ensure that dmu_sync-ed blocks have been stitched into the
 	 * respective datasets.
 	 */
-	dsl_resilver_restart(spa->spa_dsl_pool, dtl_max_txg);
+	if (rebuild) {
+		spa->spa_dsl_pool->dp_scan->scn_restart_txg = dtl_max_txg;
+		spa->spa_dsl_pool->dp_scan->scn_is_sequential = B_TRUE;
+
+		sscan_arg = kmem_alloc(sizeof(*sscan_arg), KM_SLEEP);
+		sscan_arg->ssa_draid = tvd;
+		sscan_arg->ssa_newvd = newvd;
+		sscan_arg->ssa_dtl_max = dtl_max_txg;
+		(void) thread_create(NULL, 0, vdev_draid_scan_thread, sscan_arg, 0, NULL,
+				TS_RUN, defclsyspri);
+	} else {
+		dsl_resilver_restart(spa->spa_dsl_pool, dtl_max_txg);
+	}
 
 	if (spa->spa_bootfs)
 		spa_event_notify(spa, newvd, ESC_ZFS_BOOTFS_VDEV_ATTACH);
@@ -6910,5 +7135,8 @@ MODULE_PARM_DESC(spa_load_verify_data,
 module_param(zio_taskq_batch_pct, uint, 0444);
 MODULE_PARM_DESC(zio_taskq_batch_pct,
 	"Percentage of CPUs to run an IO worker thread");
+
+module_param(vdev_draid_max_rebuild, int, 0644);
+MODULE_PARM_DESC(vdev_draid_max_rebuild, "Max dRAID rebuild I/Os");
 
 #endif

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3053,7 +3053,7 @@ vdev_stat_update(zio_t *zio, uint64_t psize)
 
 	if (type == ZIO_TYPE_WRITE && txg != 0 &&
 	    (!(flags & ZIO_FLAG_IO_REPAIR) ||
-	    (flags & ZIO_FLAG_SCAN_THREAD) ||
+	    ((flags & ZIO_FLAG_SCAN_THREAD) && !spa->spa_dsl_pool->dp_scan->scn_is_sequential) ||
 	    spa->spa_claiming)) {
 		/*
 		 * This is either a normal write (not a repair), or it's


### PR DESCRIPTION
This patch implements SPA-level rebuild for mirror and the upcoming dRAID (#3497) vdev's. It works by scanning the metaslabs and rebuilding each used segment of DVA. The redundancy layout (i.e. where the copies, data/parity blocks are) must be determined by the DVA only. That's why it does not work with raidz. Since the scan happens at SPA/metaslab level, it doesn't traverse the block pointer tree. The downside is that block checksum cannot be verified during the scan. The upside is that the IO is perfectly sequential and IO size is often larger than block size. Note that this is different from #3625, which is still resilver.

The following tests compared rebuild and resilver on the same hardware populated with exactly the same data:

```
# modprobe zfs zfs_vdev_scrub_min_active=8 zfs_vdev_scrub_max_active=10 zfs_vdev_async_write_min_active=10
# zpool create -f tank mirror sdc sde
# for i in `seq 1 20`; do cat ubuntu-14.04.4-desktop-amd64.iso > /tank/$i.iso; done
# tar xf linux-4.7.3.tar.xz -C /tank/
# tar xf linux-4.5.tar.xz -C /tank/
# df -h /tank/
Filesystem      Size  Used Avail Use% Mounted on
tank            1.8T   22G  1.8T   2% /tank
# zpool attach -f tank sdc sdg
# zpool status
  pool: tank
 state: ONLINE
  scan: rebuilt 21.5G in 0h1m46s with 0 errors on Thu Sep 22 19:57:46 2016
config: 

        NAME        STATE     READ WRITE CKSUM
        tank        ONLINE       0     0     0
          mirror-0  ONLINE       0     0     0
            sdc     ONLINE       0     0     0
            sde     ONLINE       0     0     0
            sdg     ONLINE       0     0     0

errors: No known data errors
# zpool export tank
# zpool create -f tank mirror sdc sde
# for i in `seq 1 20`; do cat ubuntu-14.04.4-desktop-amd64.iso > /tank/$i.iso; done
# tar xf linux-4.7.3.tar.xz -C /tank/
# tar xf linux-4.5.tar.xz -C /tank/
# df -h /tank/
Filesystem      Size  Used Avail Use% Mounted on
tank            1.8T   22G  1.8T   2% /tank
# echo 0 > /sys/module/zfs/parameters/vdev_draid_max_rebuild # Disable Rebuild
# zpool attach -f tank sdc sdg
# zpool status
  pool: tank
 state: ONLINE
  scan: resilvered 21.5G in 0h3m0s with 0 errors on Thu Sep 22 20:05:18 2016
config: 

        NAME        STATE     READ WRITE CKSUM
        tank        ONLINE       0     0     0
          mirror-0  ONLINE       0     0     0
            sdc     ONLINE       0     0     0
            sde     ONLINE       0     0     0
            sdg     ONLINE       0     0     0

errors: No known data errors
```

The rebuild took 106 seconds while the resilver took 180 seconds:
- scan: **rebuilt** 21.5G in 0h1m46s with 0 errors on Thu Sep 22 19:57:46 2016
- scan: **resilvered** 21.5G in 0h3m0s with 0 errors on Thu Sep 22 20:05:18 2016

The resilver took about 70% more time to complete. Note that this is a very ideal workload for resilver: new and nearly empty pool, mostly large files. But rebuild is sequential by design and is not that allergic to aging, fragmentation, or file sizes. So this test actually favors resilver.

The following two pictures shows graphics of IO data during the rebuild and the resilver:
![rebuild](https://cloud.githubusercontent.com/assets/6722662/18766970/f4482f10-80d9-11e6-96c2-2af0c404dc9f.png)
![resilver](https://cloud.githubusercontent.com/assets/6722662/18766969/f4446768-80d9-11e6-8d04-2df9e1ecc2b1.png)
In each picture, there are 4 graphs:
- X axis shows wall clock time. Each graph shows 120 seconds of IO data
- The 1st graph shows read bw in MB/s for the individual drives
- The 2nd graph shows write bw in MB/s for the individual drives
- The 3rd and 4th graphs show average read/write request sizes in KB, respectively.

The most interesting part is the 3rd and 4th graphs showing average IO request sizes. For rebuild, the r/w request sizes averaged at about 1M, but for resilver the sizes were at around 128K, which is the _recordsize_. This is because rebuild scans metaslabs, and fixes used segments each of which may contain many blocks.

Comments and suggestions are very welcome. The code at this point is rough and hacky. It may panic and/or destroy your data. That said, I was able to test rebuilds successfully, and scrub found no errors.

How to use:
1. Apply this patch.
2. Then all attach and replace operations of a mirror vdev will use the sequential rebuild mechanism. To use resilver instead: `echo 0 > /sys/module/zfs/parameters/vdev_draid_max_rebuild`
