### PR TITLE
open zfs_clone_010_pos.ksh to verify zfs clones property displays right

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -74,11 +74,11 @@ tests = ['zfs_001_neg', 'zfs_002_pos', 'zfs_003_neg']
 
 # DISABLED:
 # zfs_clone_005_pos - busy unmount
-# zfs_clone_010_pos - needs investigation
 [tests/functional/cli_root/zfs_clone]
 tests = ['zfs_clone_001_neg', 'zfs_clone_002_pos', 'zfs_clone_003_pos',
     'zfs_clone_004_pos', 'zfs_clone_006_pos',
-    'zfs_clone_007_pos', 'zfs_clone_008_neg', 'zfs_clone_009_neg']
+    'zfs_clone_007_pos', 'zfs_clone_008_neg', 'zfs_clone_009_neg',
+    'zfs_clone_010_pos']
 
 # DISABLED:
 # zfs_copies_002_pos - needs investigation


### PR DESCRIPTION
information：

open zfs_clone_010_pos.ksh in zfs_clone Test group,and because the macro ZFS_MAXPROPLEN used
in function print_dataset which size is 4096, so modify the clone number and truncated length for clone list,
after modify this script test passed, thanks!