### PR TITLE
According to the  Converity-Scan analysis to modify the defects about" strcpy ,strcat ,strncpy"

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6767,7 +6767,7 @@ zfs_do_bookmark(int argc, char **argv)
 		 * Snapshot name begins with @.
 		 * Default to same fs as bookmark.
 		 */
-		(void) strncpy(snapname, argv[1], sizeof (snapname));
+		(void) strlcpy(snapname, argv[1], sizeof (snapname));
 		*strchr(snapname, '#') = '\0';
 		(void) strlcat(snapname, argv[0], sizeof (snapname));
 	} else {

--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -548,7 +548,7 @@ register_handler(const char *pool, int flags, zinject_record_t *record,
 {
 	zfs_cmd_t zc = {"\0"};
 
-	(void) strcpy(zc.zc_name, pool);
+	(void) strlcpy(zc.zc_name, pool, sizeof (zc.zc_name));
 	zc.zc_inject_record = *record;
 	zc.zc_guid = flags;
 

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -304,7 +304,8 @@ changelist_rename(prop_changelist_t *clp, const char *src, const char *dst)
 		remove_mountpoint(cn->cn_handle);
 
 		(void) strlcpy(newname, dst, sizeof (newname));
-		(void) strcat(newname, cn->cn_handle->zfs_name + strlen(src));
+		(void) strlcat(newname, cn->cn_handle->zfs_name + strlen(src),
+		    sizeof (newname));
 
 		(void) strlcpy(cn->cn_handle->zfs_name, newname,
 		    sizeof (cn->cn_handle->zfs_name));

--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -425,7 +425,7 @@ differ(void *arg)
 
 	if ((ofp = fdopen(di->outputfd, "w")) == NULL) {
 		di->zerr = errno;
-		strncpy(di->errbuf, strerror(errno), sizeof (di->errbuf));
+		strlcpy(di->errbuf, strerror(errno), sizeof (di->errbuf));
 		(void) close(di->datafd);
 		return ((void *)-1);
 	}

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1107,8 +1107,8 @@ zfs_strcmp_pathname(char *name, char *cmp, int wholedisk)
 	dup = strdup(cmp);
 	dir = strtok(dup, "/");
 	while (dir) {
-		strcat(cmp_name, "/");
-		strcat(cmp_name, dir);
+		strlcat(cmp_name, "/", sizeof (cmp_name));
+		strlcat(cmp_name, dir, sizeof (cmp_name));
 		dir = strtok(NULL, "/");
 	}
 	free(dup);


### PR DESCRIPTION
the defects  is mainly related to the type about “copy into fixed size buffer”(STRING_OVERFLOW) and " buffer not null terminated"(BUFFER SIZE WARNING), replace non-safety "strcpy strncpy strcat" by security function about strlcpy,strlcat. the CID is 147656, 147655, 147653, 147443, 147441, 49339, if add the defects which @heary-cao cao.xuewen <cao.xuewen@zte.com.cn> has been modifyed, the type about "copy into fixed size buffer" has been finished.