### PR TITLE
defects dereference null return value with CID 147565-147567

### DIFF
--- a/lib/libzpool/util.c
+++ b/lib/libzpool/util.c
@@ -123,13 +123,15 @@ show_vdev_stats(const char *desc, const char *ctype, nvlist_t *nv, int indent)
 
 	for (c = 0; c < children; c++) {
 		nvlist_t *cnv = child[c];
-		char *cname, *tname;
+		char *cname = NULL, *tname;
 		uint64_t np;
+		int len;
 		if (nvlist_lookup_string(cnv, ZPOOL_CONFIG_PATH, &cname) &&
 		    nvlist_lookup_string(cnv, ZPOOL_CONFIG_TYPE, &cname))
 			cname = "<unknown>";
-		tname = calloc(1, strlen(cname) + 2);
-		(void) strcpy(tname, cname);
+		len = strlen(cname) + 2;
+		tname = umem_zalloc(len, UMEM_NOFAIL);
+		(void) strlcpy(tname, cname, len);
 		if (nvlist_lookup_uint64(cnv, ZPOOL_CONFIG_NPARITY, &np) == 0)
 			tname[strlen(tname)] = '0' + np;
 		show_vdev_stats(tname, ctype, cnv, indent + 2);

--- a/module/zfs/bqueue.c
+++ b/module/zfs/bqueue.c
@@ -87,13 +87,14 @@ bqueue_enqueue(bqueue_t *q, void *data, uint64_t item_size)
 void *
 bqueue_dequeue(bqueue_t *q)
 {
-	void *ret;
+	void *ret = NULL;
 	uint64_t item_size;
 	mutex_enter(&q->bq_lock);
 	while (q->bq_size == 0) {
 		cv_wait(&q->bq_pop_cv, &q->bq_lock);
 	}
 	ret = list_remove_head(&q->bq_list);
+	ASSERT3P(ret, !=, NULL);
 	item_size = obj2node(q, ret)->bqn_size;
 	q->bq_size -= item_size;
 	mutex_exit(&q->bq_lock);

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -270,6 +270,7 @@ spa_config_sync(spa_t *target, boolean_t removing, boolean_t postsysevent)
 			mutex_enter(&spa->spa_props_lock);
 			tdp = list_head(&spa->spa_config_list);
 			if (spa->spa_config == NULL ||
+			    tdp == NULL ||
 			    tdp->scd_path == NULL ||
 			    strcmp(tdp->scd_path, dp->scd_path) != 0) {
 				mutex_exit(&spa->spa_props_lock);


### PR DESCRIPTION
issues:
fix coverity defects 
coverity scan CID:147567, Type:dereference null return value
coverity scan CID:147566, Type:dereference null return value
coverity scan CID:147565, Type:dereference null return value

Signed-off-by: cao.xuewen <cao.xuewen@zte.com.cn>