### PR TITLE
open zfs_copies_002_pos.ksh to verify the space used by multiple copies is charged correctly

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -81,11 +81,11 @@ tests = ['zfs_clone_001_neg', 'zfs_clone_002_pos', 'zfs_clone_003_pos',
     'zfs_clone_007_pos', 'zfs_clone_008_neg', 'zfs_clone_009_neg']
 
 # DISABLED:
-# zfs_copies_002_pos - needs investigation
 # zfs_copies_003_pos - zpool on zvol
 # zfs_copies_005_neg - nested pools
 [tests/functional/cli_root/zfs_copies]
-tests = ['zfs_copies_001_pos', 'zfs_copies_004_neg', 'zfs_copies_006_pos']
+tests = ['zfs_copies_001_pos', 'zfs_copies_002_pos', 'zfs_copies_004_neg',
+    'zfs_copies_006_pos']
 
 [tests/functional/cli_root/zfs_create]
 tests = ['zfs_create_001_pos', 'zfs_create_002_pos', 'zfs_create_003_pos',

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_002_pos.ksh
@@ -77,9 +77,14 @@ for val in 1 2 3; do
 done
 
 log_note "Verify 'ls -s' can correctly list the space charged."
+if is_linux; then
+	blksize=1024
+else
+	blksize=512
+fi
 for val in 1 2 3; do
 	blks=`$LS -ls /$TESTPOOL/fs_$val/$FILE | $AWK '{print $1}'`
-	(( used = blks * 512 / (1024 * 1024) ))
+	(( used = blks * $blksize / (1024 * 1024) ))
 	check_used $used $val
 done
 


### PR DESCRIPTION
information：

open zfs_copies_002_pos.ksh in zfs_copies Test group,and because the default blocksize in linux is 1024, 
so use a variable to distinguish blocksize between linux with illumos, after fix this script test passed,
thanks!