### PR TITLE
Rename hole_birth tunable to match OpenZFS

### DIFF
--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -732,6 +732,6 @@ MODULE_PARM_DESC(zfs_pd_bytes_max, "Max number of bytes to prefetch");
 module_param_named(ignore_hole_birth, send_holes_without_birth_time, bool, 0644);
 MODULE_PARM_DESC(ignore_hole_birth, "Alias for send_holes_without_birth_time");
 
-module_param_named(send_holes_without_birth_time,send_holes_without_birth_time, bool, 0644);
-MODULE_PARM_DESC(ignore_hole_birth, "Ignore hole_birth txg for send");
+module_param_named(send_holes_without_birth_time, send_holes_without_birth_time, bool, 0644);
+MODULE_PARM_DESC(send_holes_without_birth_time, "Ignore hole_birth txg for send");
 #endif

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -39,7 +39,7 @@
 #include <sys/zfeature.h>
 
 int32_t zfs_pd_bytes_max = 50 * 1024 * 1024;	/* 50MB */
-int32_t ignore_hole_birth = 1;
+boolean_t send_holes_without_birth_time = 1;
 
 typedef struct prefetch_data {
 	kmutex_t pd_mtx;
@@ -729,6 +729,9 @@ EXPORT_SYMBOL(traverse_pool);
 module_param(zfs_pd_bytes_max, int, 0644);
 MODULE_PARM_DESC(zfs_pd_bytes_max, "Max number of bytes to prefetch");
 
-module_param(ignore_hole_birth, int, 0644);
+module_param_named(ignore_hole_birth, send_holes_without_birth_time, bool, 0644);
+MODULE_PARM_DESC(ignore_hole_birth, "Alias for send_holes_without_birth_time");
+
+module_param_named(send_holes_without_birth_time,send_holes_without_birth_time, bool, 0644);
 MODULE_PARM_DESC(ignore_hole_birth, "Ignore hole_birth txg for send");
 #endif

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -39,7 +39,7 @@
 #include <sys/zfeature.h>
 
 int32_t zfs_pd_bytes_max = 50 * 1024 * 1024;	/* 50MB */
-boolean_t send_holes_without_birth_time = 1;
+int32_t send_holes_without_birth_time = 1;
 
 typedef struct prefetch_data {
 	kmutex_t pd_mtx;
@@ -729,9 +729,9 @@ EXPORT_SYMBOL(traverse_pool);
 module_param(zfs_pd_bytes_max, int, 0644);
 MODULE_PARM_DESC(zfs_pd_bytes_max, "Max number of bytes to prefetch");
 
-module_param_named(ignore_hole_birth, send_holes_without_birth_time, bool, 0644);
+module_param_named(ignore_hole_birth, send_holes_without_birth_time, int, 0644);
 MODULE_PARM_DESC(ignore_hole_birth, "Alias for send_holes_without_birth_time");
 
-module_param_named(send_holes_without_birth_time, send_holes_without_birth_time, bool, 0644);
+module_param_named(send_holes_without_birth_time, send_holes_without_birth_time, int, 0644);
 MODULE_PARM_DESC(send_holes_without_birth_time, "Ignore hole_birth txg for send");
 #endif

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -252,7 +252,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		 *
 		 * Note that the meta-dnode cannot be reallocated.
 		 */
-		if (!ignore_hole_birth && (!td->td_realloc_possible ||
+		if (!send_holes_without_birth_time && (!td->td_realloc_possible ||
 			zb->zb_object == DMU_META_DNODE_OBJECT) &&
 			td->td_hole_birth_enabled_txg <= td->td_min_txg)
 			return (0);


### PR DESCRIPTION
Since OpenZFS decided that ignore_hole_birth was too imprecise and incorrect a name (and went with send_holes_without_birth_time), it's probably a good idea to rename it in ZoL too, while keeping the name "ignore_hole_birth" pointing to the same variable.

I also changed it to boolean_t to match OpenZFS.