### PR TITLE
FIX: Invalied negative argument of CID: 147531 147532 147533 147535

### DIFF
--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -519,6 +519,7 @@ nfs_validate_shareopts(const char *shareopts)
 static boolean_t
 nfs_is_share_active(sa_share_impl_t impl_share)
 {
+	int fd;
 	char line[512];
 	char *tab, *cur;
 	FILE *nfs_exportfs_temp_fp;
@@ -526,7 +527,10 @@ nfs_is_share_active(sa_share_impl_t impl_share)
 	if (!nfs_available())
 		return (B_FALSE);
 
-	nfs_exportfs_temp_fp = fdopen(dup(nfs_exportfs_temp_fd), "r");
+	if ((fd = dup(nfs_exportfs_temp_fd)) == -1)
+		return (B_FALSE);
+
+	nfs_exportfs_temp_fp = fdopen(fd, "r");
 
 	if (nfs_exportfs_temp_fp == NULL ||
 	    fseek(nfs_exportfs_temp_fp, 0, SEEK_SET) < 0) {

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -668,7 +668,11 @@ vn_open(char *path, int x1, int flags, int mode, vnode_t **vpp, int x2, int x3)
 	 * FREAD and FWRITE to the corresponding O_RDONLY, O_WRONLY, and O_RDWR.
 	 */
 	fd = open64(realpath, flags - FREAD, mode);
-	err = errno;
+	if (fd == -1) {
+		err = errno;
+		free(realpath);
+		return (err);
+	}
 
 	if (flags & FCREAT)
 		(void) umask(old_umask);
@@ -690,9 +694,6 @@ vn_open(char *path, int x1, int flags, int mode, vnode_t **vpp, int x2, int x3)
 	}
 
 	free(realpath);
-
-	if (fd == -1)
-		return (err);
 
 	if (fstat64_blk(fd, &st) == -1) {
 		err = errno;
@@ -740,7 +741,7 @@ vn_rdwr(int uio, vnode_t *vp, void *addr, ssize_t len, offset_t offset,
 
 	if (uio == UIO_READ) {
 		rc = pread64(vp->v_fd, addr, len, offset);
-		if (vp->v_dump_fd != -1) {
+		if (vp->v_dump_fd != -1 && rc != -1) {
 			int status;
 			status = pwrite64(vp->v_dump_fd, addr, rc, offset);
 			ASSERT(status != -1);

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -1260,6 +1260,8 @@ nvpair_type_is_array(nvpair_t *nvp)
 static int
 nvpair_value_common(nvpair_t *nvp, data_type_t type, uint_t *nelem, void *data)
 {
+	int value_sz;
+
 	if (nvp == NULL || nvpair_type(nvp) != type)
 		return (EINVAL);
 
@@ -1289,8 +1291,9 @@ nvpair_value_common(nvpair_t *nvp, data_type_t type, uint_t *nelem, void *data)
 #endif
 		if (data == NULL)
 			return (EINVAL);
-		bcopy(NVP_VALUE(nvp), data,
-		    (size_t)i_get_value_size(type, NULL, 1));
+		if ((value_sz = i_get_value_size(type, NULL, 1)) < 0)
+			return (EINVAL);
+		bcopy(NVP_VALUE(nvp), data, (size_t)value_sz);
 		if (nelem != NULL)
 			*nelem = 1;
 		break;


### PR DESCRIPTION
Fix coverity defects: CID 147531 147532 147533 147535

    coverity scan CID:147531,type: Argument cannot be negative
		---- may copy data with negative size
    coverity scan CID:147532,type: Argument cannot be negative
		---- may close a fd which is negative
    coverity scan CID:147533,type: Argument cannot be negative
		---- may call pwrite64 with a negative size
    coverity scan CID:147535,type: Argument cannot be negative
		---- may call fdopen with a negative fd

Signed-off-by: GeLiXin <ge.lixin@zte.com.cn>