### PR TITLE
open the scripts in zfs_set

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -170,16 +170,14 @@ tests = ['zfs_send_001_pos', 'zfs_send_002_pos', 'zfs_send_003_pos',
 
 # DISABLED:
 # mountpoint_003_pos - needs investigation
-# ro_props_001_pos - needs investigation
-# onoffs_001_pos - needs investigation
 # readonly_001_pos - needs investigation
 # user_property_002_pos - needs investigation
 [tests/functional/cli_root/zfs_set]
 tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'canmount_002_pos', 'canmount_003_pos', 'canmount_004_pos',
     'checksum_001_pos', 'compression_001_pos', 'mountpoint_001_pos',
-    'mountpoint_002_pos', 'reservation_001_neg',
-    'share_mount_001_neg', 'snapdir_001_pos',
+    'mountpoint_002_pos', 'reservation_001_neg', 'ro_props_001_pos',
+    'share_mount_001_neg', 'snapdir_001_pos', 'onoffs_001_pos',
     'user_property_001_pos', 'user_property_003_neg',
     'user_property_004_pos', 'version_001_neg', 'zfs_set_001_neg',
     'zfs_set_002_neg', 'zfs_set_003_neg', 'property_alias_001_pos']


### PR DESCRIPTION
As the scripts(`ro_props_001_pos`, `onoffs_001_pos`) in `zfs_set` can run successfully on my linux, open these two scripts to see if they pass the buildbot.