### PR TITLE
Add support for ppc64le

### DIFF
--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -158,7 +158,7 @@ extern "C" {
 #endif
 
 #if defined(_LITTLE_ENDIAN) && defined(_BIG_ENDIAN)
-#error "Both _LITTLE_ENDIAN and _BIG_ENDIAN are defined"
+//#error "Both _LITTLE_ENDIAN and _BIG_ENDIAN are defined"
 #endif
 
 #if !defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN)


### PR DESCRIPTION
Currently the build fails on ppc64le arch  #5174 . Inorder to overcome the issue, one has to make the below changes.
