### PR TITLE
FIX: Invalied negative argument of CID: 147536 147537 147538

### DIFF
--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -106,10 +106,11 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 		return;
 	} else if (pid == 0) {
 		(void) umask(022);
-		fd = open("/dev/null", O_RDWR);
-		(void) dup2(fd, STDIN_FILENO);
-		(void) dup2(fd, STDOUT_FILENO);
-		(void) dup2(fd, STDERR_FILENO);
+		if ((fd = open("/dev/null", O_RDWR)) != -1) {
+			(void) dup2(fd, STDIN_FILENO);
+			(void) dup2(fd, STDOUT_FILENO);
+			(void) dup2(fd, STDERR_FILENO);
+		}
 		(void) dup2(zfd, ZEVENT_FILENO);
 		zed_file_close_from(ZEVENT_FILENO + 1);
 		execle(path, prog, NULL, env);

--- a/tests/zfs-tests/cmd/dir_rd_update/dir_rd_update.c
+++ b/tests/zfs-tests/cmd/dir_rd_update/dir_rd_update.c
@@ -94,6 +94,12 @@ main(int argc, char **argv)
 		int rdret;
 		int j = 0;
 
+		if (fd < 0) {
+			(void) printf("%s: open <%s> again failed:"
+			    " errno = %d\n", argv[0], dirpath, errno);
+			exit(-1);
+		}
+
 		while (j < op_num) {
 			(void) sleep(1);
 			rdret = read(fd, buf, 16);
@@ -106,6 +112,12 @@ main(int argc, char **argv)
 		int fd = open(dirpath, O_RDONLY);
 		int chownret;
 		int k = 0;
+
+		if (fd < 0) {
+			(void) printf("%s: open(<%s>, O_RDONLY) again failed:"
+			    " errno (decimal)=%d\n", argv[0], dirpath, errno);
+			exit(-1);
+		}
 
 		while (k < op_num) {
 			(void) sleep(1);

--- a/tests/zfs-tests/cmd/rm_lnkcnt_zero_file/rm_lnkcnt_zero_file.c
+++ b/tests/zfs-tests/cmd/rm_lnkcnt_zero_file/rm_lnkcnt_zero_file.c
@@ -103,10 +103,15 @@ writer(void *a)
 	int ret;
 
 	while (TRUE) {
-		(void) close (*fd);
+		if (*fd != -1)
+			(void) close (*fd);
+
 		*fd = open(filebase, O_APPEND | O_RDWR | O_CREAT, 0644);
-		if (*fd < 0)
-			perror("refreshing file");
+		if (*fd == -1) {
+			perror("fail to open test file, refreshing it");
+			continue;
+		}
+
 		ret = write(*fd, "test\n", 5);
 		if (ret != 5)
 			perror("writing file");


### PR DESCRIPTION
Fix coverity defects: CID 147536 147537 147538

	coverity scan CID:147536, type: Argument cannot be negative
		---- may write or close fd which is negative
	coverity scan CID:147537, type: Argument cannot be negative
		---- may call dup2 with a negative fd
	coverity scan CID:147538, type: Argument cannot be negative
		---- may read or fchown with a negative fd

Signed-off-by: GeLiXin <ge.lixin@zte.com.cn>