### PR TITLE
Amend the script readonly_001_pos in zfs_set

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -174,7 +174,6 @@ tests = ['zfs_send_001_pos', 'zfs_send_002_pos', 'zfs_send_003_pos',
 # DISABLED:
 # mountpoint_003_pos - needs investigation
 # ro_props_001_pos - https://github.com/zfsonlinux/zfs/issues/5201
-# readonly_001_pos - needs investigation
 # user_property_002_pos - needs investigation
 [tests/functional/cli_root/zfs_set]
 tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
@@ -182,7 +181,7 @@ tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'checksum_001_pos', 'compression_001_pos', 'mountpoint_001_pos',
     'mountpoint_002_pos', 'reservation_001_neg',
     'share_mount_001_neg', 'snapdir_001_pos', 'onoffs_001_pos',
-    'user_property_001_pos', 'user_property_003_neg',
+    'user_property_001_pos', 'user_property_003_neg', 'readonly_001_pos',
     'user_property_004_pos', 'version_001_neg', 'zfs_set_001_neg',
     'zfs_set_002_neg', 'zfs_set_003_neg', 'property_alias_001_pos']
 


### PR DESCRIPTION
In my linux, the script `readonly_001_pos` in `zfs_set` run failed as the `readonly` can not set successfully, the test results show as below:
```
[root@A22 home]# zfs get readonly test/test2
NAME        PROPERTY  VALUE   SOURCE
test/test2  readonly  off     default
[root@A22 home]# zfs set readonly=on test/test2
[root@A22 home]# zfs get readonly test/test2
NAME        PROPERTY  VALUE   SOURCE
test/test2  readonly  off     temporary
```
We must set the `mountpoint=legacy`, then we can set the property `readonly`, the test results show as below:
```
[root@A22 home]# zfs set mountpoint=legacy test/test2
[root@A22 home]# zfs get mountpoint test/test2
NAME        PROPERTY    VALUE       SOURCE
test/test2  mountpoint  legacy      local
[root@A22 home]# zfs set readonly=on test/test2
[root@A22 home]# zfs get readonly test/test2
NAME        PROPERTY  VALUE   SOURCE
test/test2  readonly  on      local
[root@A22 home]# zfs set readonly=off test/test2
[root@A22 home]# zfs get readonly test/test2
NAME        PROPERTY  VALUE   SOURCE
test/test2  readonly  off     local
```
If the `mountpoint= legacy`, the filesystem is not managed by  ZFS, The `readonly` is managed by superblock, the code show as below:
```
readonly_changed_cb(void *arg, uint64_t newval)
{
	zfs_sb_t *zsb = arg;
	struct super_block *sb = zsb->z_sb;

	if (sb == NULL)
		return;

	if (newval)
		sb->s_flags |= MS_RDONLY;
	else
		sb->s_flags &= ~MS_RDONLY;
}
```
So, I think we must set the `mountpoint=legacy`, then we can set `readonly`. I am not very sure this is right, or there are some other reasons?