### PR TITLE
Fix cppcheck warning in buf_init()

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1249,7 +1249,7 @@ hdr_recl(void *unused)
 static void
 buf_init(void)
 {
-	uint64_t *ct;
+	uint64_t *ct = NULL;
 	uint64_t hsize = 1ULL << 12;
 	int i, j;
 


### PR DESCRIPTION
Cppcheck 1.63 erroneously complains about an uninitialized value
in buf_init().  Newer versions of cppcheck (1.72) handle this
correctly but we'll initialize the value anyway to silence the
warning.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>