### PR TITLE
lzjb: Check for input buffer overrun

### DIFF
--- a/module/zfs/lzjb.c
+++ b/module/zfs/lzjb.c
@@ -105,12 +105,13 @@ lzjb_decompress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 {
 	uchar_t *src = s_start;
 	uchar_t *dst = d_start;
+	uchar_t *s_end = (uchar_t *)s_start + s_len;
 	uchar_t *d_end = (uchar_t *)d_start + d_len;
 	uchar_t *cpy;
 	uchar_t copymap = 0;
 	int copymask = 1 << (NBBY - 1);
 
-	while (dst < d_end) {
+	while ((dst < d_end) && (src < s_end)) {
 		if ((copymask <<= 1) == (1 << NBBY)) {
 			copymask = 1;
 			copymap = *src++;


### PR DESCRIPTION
This is a PR based on the comment from @rewolff here:
https://github.com/zfsonlinux/zfs/issues/3831#issuecomment-172832495

I take no position on whether this change is good or bad. I haven't even compiled it. I'm just "transferring" it to be a pull request, so it can get built by the buildbots, reviewed, etc.

@rewolff, if you want to resubmit this as your on PR, that'd be even better.
