### PR TITLE
explicit null dereferenced with CID 147490-88

### DIFF
--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1585,6 +1585,7 @@ zprop_parse_value(libzfs_handle_t *hdl, nvpair_t *elem, int prop,
 	const char *propname;
 	char *value;
 	boolean_t isnone = B_FALSE;
+	int err = 0;
 
 	if (type == ZFS_TYPE_POOL) {
 		proptype = zpool_prop_get_type(prop);
@@ -1607,7 +1608,12 @@ zprop_parse_value(libzfs_handle_t *hdl, nvpair_t *elem, int prop,
 			    "'%s' must be a string"), nvpair_name(elem));
 			goto error;
 		}
-		(void) nvpair_value_string(elem, svalp);
+		err = nvpair_value_string(elem, svalp);
+		if (err != 0) {
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "'%s' in invalid"), nvpair_name(elem));
+			goto error;
+		}
 		if (strlen(*svalp) >= ZFS_MAXPROPLEN) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 			    "'%s' is too long"), nvpair_name(elem));

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -1611,7 +1611,7 @@ zprop_parse_value(libzfs_handle_t *hdl, nvpair_t *elem, int prop,
 		err = nvpair_value_string(elem, svalp);
 		if (err != 0) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "'%s' in invalid"), nvpair_name(elem));
+			    "'%s' is invalid"), nvpair_name(elem));
 			goto error;
 		}
 		if (strlen(*svalp) >= ZFS_MAXPROPLEN) {

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -4945,7 +4945,7 @@ spa_vdev_detach(spa_t *spa, uint64_t guid, uint64_t pguid, int replace_done)
 	 * But first make sure we're not on any *other* txg's DTL list, to
 	 * prevent vd from being accessed after it's freed.
 	 */
-	vdpath = spa_strdup(vd->vdev_path);
+	vdpath = spa_strdup(vd->vdev_path ? vd->vdev_path : "none");
 	for (t = 0; t < TXG_SIZE; t++)
 		(void) txg_list_remove_this(&tvd->vdev_dtl_list, vd, t);
 	vd->vdev_detached = B_TRUE;


### PR DESCRIPTION
issues:
fix coverity defects 
coverity scan CID:147490, Type:dereference null return value
coverity scan CID:147488, Type:explicit null dereferenced

Signed-off-by: cao.xuewen <cao.xuewen@zte.com.cn>