### PR TITLE
Use -F to export pools so as not to dirty up device labels.

### DIFF
--- a/contrib/dracut/90zfs/export-zfs.sh.in
+++ b/contrib/dracut/90zfs/export-zfs.sh.in
@@ -4,18 +4,19 @@
 
 _do_zpool_export() {
 	local ret=0
+	local errs=""
 	local final="${1}"
-	local opts=""
 
-	if [ "x${final}" != "x" ]; then
-		opts="-f"
+	info "ZFS: Exporting ZFS storage pools..."
+	errs=$(export_all -F 2>&1)
+	ret=$?
+	[ -z "${errs}" ] || echo "${errs}" | vwarn
+	if [ "x${ret}" != "x0" ]; then
+		info "ZFS: There was a problem exporting pools."
 	fi
 
-	info "Exporting ZFS storage pools."
-	export_all ${opts} || ret=$?
-
 	if [ "x${final}" != "x" ]; then
-		info "zpool list"
+		info "ZFS: pool list"
 		zpool list 2>&1 | vinfo
 	fi
 

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -58,7 +58,7 @@ install() {
 		inst_script "${moddir}/zfs-generator.sh" "$systemdutildir"/system-generators/dracut-zfs-generator
 	fi
 	inst_hook mount 98 "${moddir}/mount-zfs.sh"
-	inst_hook shutdown 30 "${moddir}/export-zfs.sh"
+	inst_hook shutdown 20 "${moddir}/export-zfs.sh"
 
 	inst_simple "${moddir}/zfs-lib.sh" "/lib/dracut-zfs-lib.sh"
 	if [ -e @sysconfdir@/zfs/zpool.cache ]; then

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -44,7 +44,7 @@ if [ "${root}" = "zfs:AUTO" ] ; then
 		ZFS_DATASET="$(find_bootfs)"
 		if [ $? -ne 0 ] ; then
 			warn "ZFS: No bootfs attribute found in importable pools."
-			export_all || export_all "-f"
+			export_all -F
 
 			rootok=0
 			return 1

--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -90,7 +90,7 @@ mount_dataset() {
 # export_all OPTS
 #   exports all imported zfs pools.
 export_all() {
-	local opts="${1}"
+	local opts="${@}"
 	local ret=0
 
 	IFS="${NEWLINE}"


### PR DESCRIPTION
We are also initiating the shutdown hook a bit earlier during the process, to let ZFS release block devices like LUKS and DM, such that they can finish.  It's mostly a performance change which avoids a temporary failure during poweroff, since dracut will try 40 times to run all the hooks in order.  Previously, under a regime where LUKS encryption underlies a pool (analogous to ZFS on top of DM):

```
n=0
/hooks/shutdown/30-crypt.sh -> 1
/hooks/shutdown/30-zfs.sh -> 0
(some stuff)
n=1
/hooks/shutdown/30-crypt.sh -> 0
```

Now:

```
n=0
/hooks/shutdown/20-zfs.sh -> 0
/hooks/shutdown/30-crypt.sh -> 0
(some stuff)
```

This also closes https://github.com/zfsonlinux/zfs/issues/5228 .