### PR TITLE
Fix coverity defects: CID 147654 153352 147690

### DIFF
--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -397,8 +397,8 @@ change_one(zfs_handle_t *zhp, void *data)
 	char property[ZFS_MAXPROPLEN];
 	char where[64];
 	prop_changenode_t *cn;
-	zprop_source_t sourcetype;
-	zprop_source_t share_sourcetype;
+	zprop_source_t sourcetype = ZPROP_SRC_NONE;
+	zprop_source_t share_sourcetype = ZPROP_SRC_NONE;
 
 	/*
 	 * We only want to unmount/unshare those filesystems that may inherit

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3212,7 +3212,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 	/*
 	 * Determine name of destination snapshot.
 	 */
-	(void) strcpy(destsnap, tosnap);
+	(void) strlcpy(destsnap, tosnap, sizeof (destsnap));
 	(void) strlcat(destsnap, chopprefix, sizeof (destsnap));
 	free(cp);
 	if (!zfs_name_valid(destsnap, ZFS_TYPE_SNAPSHOT)) {


### PR DESCRIPTION
coverity scan CID:147654, type: Copy into fixed size buffer
---- string operation may write past the end of the fixed-size destination buffer

~~coverity scan CID:153352, type: Uninitialized scalar variable~~
~~----  parameter `sha_digest_len` may used uninitialized.~~

coverity scan CID:147690, type: Uninitialized scalar variable
---- call zfs_prop_get before other judging condition in case we use `sourcetype ` 
        and  `share_sourcetype `without initialization

@tcaputi @tonyhutter Could you please help to review the code in sha2_mod.c? Thanks!

Signed-off-by: GeLiXin <ge.lixin@zte.com.cn>