### PR TITLE
Fixing ICP memleak introduced in #4760

### DIFF
--- a/module/icp/io/skein_mod.c
+++ b/module/icp/io/skein_mod.c
@@ -231,6 +231,19 @@ skein_mod_init(void)
 
 int
 skein_mod_fini(void) {
+	int ret;
+
+	if (skein_prov_handle != 0) {
+		if ((ret = crypto_unregister_provider(skein_prov_handle)) !=
+		    CRYPTO_SUCCESS) {
+			cmn_err(CE_WARN,
+			    "skein _fini: crypto_unregister_provider() "
+			    "failed (0x%x)", ret);
+			return (EBUSY);
+		}
+		skein_prov_handle = 0;
+	}
+
 	return (mod_remove(&modlinkage));
 }
 


### PR DESCRIPTION
The ICP requires destructors to for each crypto module that is added.
These do not necessarily exist in Illumos because they assume that
these modules can never be unloaded from the kernel. Some of this
cleanup code was missed when #4760 was merged, resulting in leaks.
This patch simply fixes that.