### PR TITLE
Allow partition aliases in vdev_id.conf

### DIFF
--- a/udev/rules.d/69-vdev.rules.in
+++ b/udev/rules.d/69-vdev.rules.in
@@ -3,6 +3,7 @@
 #
 
 ENV{DEVTYPE}=="disk", IMPORT{program}="@udevdir@/vdev_id -d %k"
+ENV{DEVTYPE}=="partition", IMPORT{program}="@udevdir@/vdev_id -d %k"
 
 KERNEL=="*[!0-9]", ENV{SUBSYSTEM}=="block", ENV{ID_VDEV}=="?*", SYMLINK+="$env{ID_VDEV_PATH}"
 KERNEL=="*[0-9]", ENV{SUBSYSTEM}=="block", ENV{DEVTYPE}=="partition", ENV{ID_VDEV}=="?*", SYMLINK+="$env{ID_VDEV_PATH}-part%n"


### PR DESCRIPTION
When pools are assembled from partitions, vdev_id.conf aliases
do not work.  The directory /dev/disk/by-vdev is not created because
the associated udev rule for parsing vdev_id.conf is never called.
Extend to logic to match "disk" and "partition".

Patch-proposed-by: @sparksh
Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #3859