### PR TITLE
Enable quota_002_pos and quota_004_pos and quota_005_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -500,12 +500,9 @@ tests = ['poolversion_001_pos', 'poolversion_002_pos']
 #[tests/functional/privilege]
 #tests = ['privilege_001_pos', 'privilege_002_pos']
 
-# DISABLED:
-# quota_002_pos - size is less than current used or reserved space
-# quota_004_pos - size is less than current used or reserved space
-# quota_005_pos - size is less than current used or reserved space
 [tests/functional/quota]
-tests = ['quota_001_pos', 'quota_003_pos', 'quota_006_neg']
+tests = ['quota_001_pos', 'quota_002_pos', 'quota_003_pos',
+         'quota_004_pos', 'quota_005_pos', 'quota_006_neg']
 
 [tests/functional/raidz]
 tests = ['raidz_001_neg', 'raidz_002_pos']

--- a/tests/zfs-tests/tests/functional/quota/quota.kshlib
+++ b/tests/zfs-tests/tests/functional/quota/quota.kshlib
@@ -60,9 +60,9 @@ function fill_quota
         [[ $zret -ne $EDQUOT ]] && \
             log_fail "Returned error code: $zret. Expected: $EDQUOT."
 
-	typeset -i file_size=`$LS -ls $MNTPT/$TESTFILE1 | $AWK '{ print $1 }'`
+	typeset -i file_size=`$LS -lsk $MNTPT/$TESTFILE1 | $AWK '{ print $1 }'`
 	typeset -i limit=0
-	(( file_size = file_size * 512 ))
+	(( file_size = file_size * 1024 ))
 	(( limit = QUOTA_VALUE + TOLERANCE ))
 	(( file_size > limit )) && \
 	    log_fail "File was created larger than the quota value, aborting!!!"

--- a/tests/zfs-tests/tests/functional/quota/quota_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_002_pos.ksh
@@ -42,7 +42,7 @@
 # 1) Apply quota to the ZFS file system
 # 2) Exceed the quota
 # 3) Attempt to write another file
-# 4) Verify the attempt fails with error code 49 (EDQUOTA)
+# 4) Verify the attempt fails with error code EDQUOTA (linux 122, others 49)
 #
 #
 

--- a/tests/zfs-tests/tests/functional/quota/quota_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/quota/quota_004_pos.ksh
@@ -42,7 +42,7 @@
 # 1) Apply quota to the ZFS file system dataset
 # 2) Exceed the quota
 # 3) Attempt to write another file
-# 4) Verify the attempt fails with error code 49 (EDQUOTA)
+# 4) Verify the attempt fails with error code EDQUOTA (linux 122, others 49)
 #
 #
 


### PR DESCRIPTION
Analysis:
In this test case which used ls -ls command to print testfile size in blocks,
because the testfile write used blocksize is 8192, so that ls -ls command 
print the testfile size in blocks based write blocksize(8192), but when calculate 
the file_size uesd 512, so in this test case we get testfile size inaccurate. 

The ls command list testfile detail information as following describe, 
and from it we can find that ls command list size in blocks equal to the good_writes, 
so this ls -ls command print testfile size in blocks based write blocksize(8192).

```
Test: /home/yuxiang/zfs-master/tests/zfs-tests/tests/functional/quota/quota_002_pos (run as root) [00:05] [PASS]
13:59:59.55 ASSERTION: Verify that a file write cannot exceed the file system quota
13:59:59.57 NOTE: poolsize:2063925760
13:59:59.60 SUCCESS: /home/yuxiang/zfs-master/cmd/zfs/zfs set quota=10000000 testpool.19626/testfs.19626
14:00:04.93 /var/tmp/testdir19626/file1: block_size = 8192, write_count = 20000000, offset = 0, data = 0->120
14:00:04.93 write failed (-1), good_writes = 1217, error: Disk quota exceeded[122] close fd
14:00:04.94 NOTE: file_size:1233, 1233 -rw-r--r-- 1 root root 1217 Oct 12 14:00 /var/tmp/testdir19626/file1
14:00:04.94 SUCCESS: fill_quota testpool.19626/testfs.19626 /var/tmp/testdir19626
14:00:04.94 NOTE: Creating a file in a FS that has already exceeded its quota
14:00:04.95 open /var/tmp/testdir19626/file2: failed [Disk quota exceeded]122. Aborting!
14:00:04.95 SUCCESS: exceed_quota testpool.19626/testfs.19626 /var/tmp/testdir19626
14:00:04.95 NOTE: Performing local cleanup via log_onexit (cleanup)
14:00:04.95 SUCCESS: rm -f /var/tmp/testdir19626/file1
14:00:04.95 Could not write file. Quota limit enforced as expected
```

modify:
1.enable these test case script in quota test group.
2.modify the file_size calculate by use tesefile write blocksize(this test case is 8192).

At last the quota test group test passd.thanks!