### PR TITLE
Enable remaining rename test cases

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -146,11 +146,9 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_010_pos', 'zfs_receive_011_pos', 'zfs_receive_012_pos',
     'zfs_receive_013_pos']
 
-# DISABLED:
-# zfs_rename_006_pos - needs investigation
 [tests/functional/cli_root/zfs_rename]
 tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',
-    'zfs_rename_004_neg', 'zfs_rename_005_neg',
+    'zfs_rename_004_neg', 'zfs_rename_005_neg', 'zfs_rename_006_pos',
     'zfs_rename_007_pos', 'zfs_rename_008_pos', 'zfs_rename_009_neg',
     'zfs_rename_010_neg', 'zfs_rename_011_pos', 'zfs_rename_012_neg',
     'zfs_rename_013_pos']

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -147,13 +147,11 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_013_pos']
 
 # DISABLED:
-# zfs_rename_002_pos - needs investigation
-# zfs_rename_005_neg - nested pools
 # zfs_rename_006_pos - needs investigation
-# zfs_rename_007_pos - needs investigation
 [tests/functional/cli_root/zfs_rename]
-tests = ['zfs_rename_001_pos', 'zfs_rename_003_pos',
-    'zfs_rename_004_neg', 'zfs_rename_008_pos', 'zfs_rename_009_neg',
+tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',
+    'zfs_rename_004_neg', 'zfs_rename_005_neg',
+    'zfs_rename_007_pos', 'zfs_rename_008_pos', 'zfs_rename_009_neg',
     'zfs_rename_010_neg', 'zfs_rename_011_pos', 'zfs_rename_012_neg',
     'zfs_rename_013_pos']
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename.kshlib
@@ -71,6 +71,7 @@ function rename_dataset # src dest
 	typeset dest=$2
 
 	log_must $ZFS rename $src $dest
+	block_device_wait
 
 	#
 	# Verify src name no longer in use

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_006_pos.ksh
@@ -24,6 +24,10 @@
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+
+#
+# Copyright (c) 2015 by Delphix. All rights reserved.
+#
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zfs_rename/zfs_rename.kshlib
 
@@ -35,6 +39,7 @@
 #       1. Create a snapshot of volume.
 #       2. Rename volume snapshot to a new one.
 #	3. Rename volume to a new one.
+#       4. Create a clone of the snapshot.
 #       5. Verify that the rename operations are successful and zfs list can
 #	   list them.
 #
@@ -62,14 +67,18 @@ rename_dataset $vol ${vol}-new
 rename_dataset ${vol}-new@${snap}-new ${vol}-new@$snap
 rename_dataset ${vol}-new $vol
 
+clone=$TESTPOOL/${snap}_clone
+create_clone $vol@$snap $clone
+
 #verify data integrity
-for input in $VOL_R_PATH ${VOL_R_PATH}@$snap; do
+for input in $VOL_R_PATH $ZVOL_RDEVDIR/$clone; do
 	log_must eval "$DD if=$input of=$VOLDATA bs=$BS count=$CNT >/dev/null 2>&1"
 	if ! cmp_data $VOLDATA $DATA ; then
 		log_fail "$input gets corrupted after rename operation."
 	fi
 done
 
+destroy_clone $clone
 log_must $ZFS destroy $vol@$snap
 
 log_pass "'zfs rename' can rename volume snapshot as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_007_pos.ksh
@@ -117,6 +117,7 @@ log_must $DIFF $SRC_FILE $obj
 if is_global_zone; then
 	vol=$TESTPOOL/$TESTFS/vol.$$ ;	volclone=$TESTPOOL/$TESTFS/volclone.$$
 	log_must $ZFS create -V 100M $vol
+	block_device_wait
 
 	obj=$(target_obj $vol)
 	log_must $DD if=$SRC_FILE of=$obj bs=$BS count=$CNT
@@ -124,10 +125,12 @@ if is_global_zone; then
 	snap=${vol}@snap.$$
 	log_must $ZFS snapshot $snap
 	log_must $ZFS clone $snap $volclone
+	block_device_wait
 
 	# Rename dataset & clone
 	log_must $ZFS rename $vol ${vol}-new
 	log_must $ZFS rename $volclone ${volclone}-new
+	block_device_wait
 
 	# Compare source file and target file
 	obj=$(target_obj ${vol}-new)
@@ -141,6 +144,7 @@ if is_global_zone; then
 	log_must $ZFS rename ${vol}-new $vol
 	log_must $ZFS rename $snap ${snap}-new
 	log_must $ZFS clone ${snap}-new $volclone
+	block_device_wait
 
 	# Compare source file and target file
 	obj=$(target_obj $volclone)


### PR DESCRIPTION
- OpenZFS 6877 - zfs_rename_006_pos fails due to missing zvol snapshot dev
- Enable zfs_rename_002_pos, zfs_rename_005_neg, zfs_rename_007_pos

Supersedes  #5076.  @luozhengzheng please review.