### PR TITLE
Enable zfs_receive_011_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -139,12 +139,12 @@ tests = []
 
 # DISABLED:
 # zfs_receive_004_neg - Fails for OpenZFS on illumos
-# zfs_receive_011_pos - Requires port of OpenZFS 6562
 [tests/functional/cli_root/zfs_receive]
 tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_005_neg', 'zfs_receive_006_pos',
     'zfs_receive_007_neg', 'zfs_receive_008_pos', 'zfs_receive_009_neg',
-    'zfs_receive_010_pos', 'zfs_receive_012_pos', 'zfs_receive_013_pos']
+    'zfs_receive_010_pos', 'zfs_receive_011_pos', 'zfs_receive_012_pos',
+    'zfs_receive_013_pos']
 
 # DISABLED:
 # zfs_rename_002_pos - needs investigation


### PR DESCRIPTION
The zfs_receive_011_pos test can be enabled now that OpenZFS 6562
has been merged.