### PR TITLE
fix Integer overflowed argument with CID 157521-150937

### DIFF
--- a/lib/libzfs/libzfs_config.c
+++ b/lib/libzfs/libzfs_config.c
@@ -341,7 +341,7 @@ check_restricted(const char *poolname)
 	static char *restricted = NULL;
 
 	const char *cur, *end;
-	int len, namelen;
+	uint32_t len, namelen;
 
 	if (!initialized) {
 		initialized = B_TRUE;

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -193,7 +193,7 @@ ddt_update(libzfs_handle_t *hdl, dedup_table_t *ddt, zio_cksum_t *cs,
 }
 
 static int
-dump_record(dmu_replay_record_t *drr, void *payload, int payload_len,
+dump_record(dmu_replay_record_t *drr, void *payload, size_t payload_len,
     zio_cksum_t *zc, int outfd)
 {
 	ASSERT3U(offsetof(dmu_replay_record_t, drr_u.drr_checksum.drr_checksum),
@@ -277,7 +277,7 @@ cksummer(void *arg)
 		{
 			struct drr_begin *drrb = &drr->drr_u.drr_begin;
 			int fflags;
-			int sz = 0;
+			size_t sz = 0;
 			ZIO_SET_CHECKSUM(&stream_cksum, 0, 0, 0, 0);
 
 			ASSERT3U(drrb->drr_magic, ==, DMU_BACKUP_MAGIC);


### PR DESCRIPTION
issues:
fix coverity defects
coverity scan CID:157521, Type:Integer overflowed argument
coverity scan CID:150937, Type:Integer overflowed argument

Signed-off-by: cao.xuewen cao.xuewen@zte.com.cn
