### PR TITLE
Enable zfs_rollback_001_pos, zfs_rollback_002_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -156,11 +156,9 @@ tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',
 [tests/functional/cli_root/zfs_reservation]
 tests = ['zfs_reservation_001_pos', 'zfs_reservation_002_pos']
 
-# DISABLED:
-# zfs_rollback_001_pos - busy mountpoint behavior
-# zfs_rollback_002_pos - busy mountpoint behavior
 [tests/functional/cli_root/zfs_rollback]
-tests = ['zfs_rollback_003_neg', 'zfs_rollback_004_neg']
+tests = ['zfs_rollback_001_pos', 'zfs_rollback_002_pos',
+    'zfs_rollback_003_neg', 'zfs_rollback_004_neg']
 
 [tests/functional/cli_root/zfs_send]
 tests = ['zfs_send_001_pos', 'zfs_send_002_pos', 'zfs_send_003_pos',
@@ -575,6 +573,7 @@ tests = ['rollback_001_pos', 'rollback_002_pos',
     'snapshot_009_pos', 'snapshot_010_pos', 'snapshot_011_pos',
     'snapshot_012_pos', 'snapshot_013_pos', 'snapshot_014_pos',
     'snapshot_015_pos', 'snapshot_017_pos']
+
 [tests/functional/snapused]
 tests = ['snapused_001_pos', 'snapused_002_pos', 'snapused_003_pos',
     'snapused_004_pos', 'snapused_005_pos']

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_001_pos.ksh
@@ -70,8 +70,9 @@ function test_n_check #opt num_snap_clone num_rollback
 	# Clean up the test environment
 	datasetexists $FS && log_must $ZFS destroy -Rf $FS
 	if datasetexists $VOL; then
-		$DF -lhF ufs "$ZVOL_DEVDIR/$VOL" > /dev/null 2>&1
-		(( $? == 0 )) && log_must $UMOUNT -f $TESTDIR1
+		if ismounted $TESTDIR1 $NEWFS_DEFAULT_FS; then
+			log_must $UMOUNT -f $TESTDIR1
+		fi
 
 		log_must $ZFS destroy -Rf $VOL
 	fi
@@ -115,6 +116,7 @@ function test_n_check #opt num_snap_clone num_rollback
 		if [[ $dtst == $VOL ]]; then
 			log_must $UMOUNT -f $TESTDIR1
 			log_must $ZFS rollback $opt $dtst@$snap_point
+			block_device_wait
 			log_must $MOUNT \
 				$ZVOL_DEVDIR/$TESTPOOL/$TESTVOL $TESTDIR1
 		else
@@ -137,6 +139,7 @@ function test_n_check #opt num_snap_clone num_rollback
 		done
 
 		check_files $dtst@$snap_point
+		$PKILL ${DD##*/}
 	done
 }
 


### PR DESCRIPTION
Tests zfs_rollback_002_pos required no modifications to pass.  As for
zfs_rollback_001_pos it needs to be updated to use NEWFS_DEFAULT_FS
(ext2), wait for async volume creation, and kill the outstanding dd
commands before destroying the dataset so it isn't busy.

