### PR TITLE
Enable cachefile_001_pos, cachefile_002_pos, cachefile_003_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -43,12 +43,12 @@ tests = ['cache_002_pos', 'cache_003_pos', 'cache_004_neg',
     'cache_005_neg', 'cache_006_pos', 'cache_007_neg', 'cache_008_neg',
     'cache_009_pos', 'cache_011_pos']
 
-# DISABLED: needs investigation
-#[tests/functional/cachefile]
-#tests = ['cachefile_001_pos', 'cachefile_002_pos', 'cachefile_003_pos',
-#    'cachefile_004_pos']
-#pre =
-#post =
+# DISABLED:
+# cachefile_004_pos - nested pools
+[tests/functional/cachefile]
+tests = ['cachefile_001_pos', 'cachefile_002_pos', 'cachefile_003_pos']
+pre =
+post =
 
 # DISABLED: needs investigation
 # 'sensitive_none_lookup', 'sensitive_none_delete',

--- a/tests/zfs-tests/tests/functional/cachefile/cachefile.cfg
+++ b/tests/zfs-tests/tests/functional/cachefile/cachefile.cfg
@@ -31,3 +31,6 @@
 export CPATH="/etc/zfs/zpool.cache"
 export CPATH1=/var/tmp/cachefile.$$
 export CPATH2=$TEST_BASE_DIR/cachefile.$$
+export DISK_ARRAY_NUM=$($ECHO ${DISKS} | $NAWK '{print NF}')
+
+set_device_dir


### PR DESCRIPTION
The first three tests pass once DEV_DSKDIR is set.  As for
cachefile_004_pos it's being left disabled until it's updated
not to create a pool within a pool which can deadlock.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>