### PR TITLE
Fix coverity defects: CID 147643 152204 49339

### DIFF
--- a/cmd/zpios/zpios_main.c
+++ b/cmd/zpios/zpios_main.c
@@ -550,7 +550,8 @@ run_one(cmd_args_t *args, uint32_t id, uint32_t T, uint32_t N,
 	print_stats(args, cmd);
 
 	if (args->verbose) {
-		rc2 = read(zpiosctl_fd, zpios_buffer, zpios_buffer_size - 1);
+		rc2 = read(zpiosctl_fd, zpios_buffer, zpios_buffer_size);
+		zpios_buffer[zpios_buffer_size - 1] = '\0';
 		if (rc2 < 0) {
 			fprintf(stdout, "Error reading results: %d\n", rc2);
 		} else if ((rc2 > 0) && (strlen(zpios_buffer) > 0)) {

--- a/tests/zfs-tests/cmd/xattrtest/xattrtest.c
+++ b/tests/zfs-tests/cmd/xattrtest/xattrtest.c
@@ -177,6 +177,7 @@ parse_args(int argc, char **argv)
 			break;
 		case 't':
 			strncpy(script, optarg, PATH_MAX);
+			script[PATH_MAX - 1] = '\0';
 			break;
 		case 'e':
 			seed = strtol(optarg, NULL, 0);

--- a/tests/zfs-tests/tests/functional/ctime/ctime_001_pos.c
+++ b/tests/zfs-tests/tests/functional/ctime/ctime_001_pos.c
@@ -154,7 +154,8 @@ do_link(const char *pfile)
 		return (-1);
 	}
 
-	strcpy(pfile_copy, pfile);
+	strncpy(pfile_copy, pfile, sizeof (pfile_copy));
+	pfile_copy[sizeof (pfile_copy) - 1] = '\0';
 	/*
 	 * Figure out source file directory name, and create
 	 * the link file in the same directory.


### PR DESCRIPTION
coverity scan CID:147643, type: String not null terminated
- make sure that the string is null terminated before strlen and fprintf.

coverity scan CID:152204, type: Copy into fixed size buffer
- since `strlcpy` isn't availabe here, use strncpy and terminate the string manually.

coverity scan CID:49339, type: Buffer not null terminated
- since `strlcpy ` isn't availabe here, terminate the string manually before fprintf.


BTW,  CID 153393, 147634, 147635, 147636 is false positives, @behlendorf could you 
classification these to "False Positive" in Coverity as I do not have the authority to do so.

Signed-off-by: GeLiXin <ge.lixin@zte.com.cn>