### PR TITLE
Allow zfs to send replication streams when missing snapshots in the hierarchy

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -830,15 +830,7 @@ send_iterate_fs(zfs_handle_t *zhp, void *arg)
 				    "skipping dataset %s: snapshot %s does "
 				    "not exist\n"), zhp->zfs_name, sd->tosnap);
 			}
-		} else {
-			(void) fprintf(stderr, dgettext(TEXT_DOMAIN,
-			    "cannot send %s@%s%s: snapshot %s@%s does not "
-			    "exist\n"), sd->fsname, sd->tosnap, sd->recursive ?
-			    dgettext(TEXT_DOMAIN, " recursively") : "",
-			    zhp->zfs_name, sd->tosnap);
-			rv = -1;
 		}
-		goto out;
 	}
 
 	VERIFY(0 == nvlist_alloc(&nvfs, NV_UNIQUE_NAME, 0));

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -165,7 +165,7 @@ tests = ['zfs_rollback_003_neg', 'zfs_rollback_004_neg']
 [tests/functional/cli_root/zfs_send]
 tests = ['zfs_send_001_pos', 'zfs_send_002_pos', 'zfs_send_003_pos',
     'zfs_send_004_neg', 'zfs_send_005_pos', 'zfs_send_006_pos',
-    'zfs_send_007_pos']
+    'zfs_send_007_pos', 'zfs_send_008_pos']
 
 # DISABLED:
 # mountpoint_003_pos - needs investigation

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/Makefile.am
@@ -9,4 +9,5 @@ dist_pkgdata_SCRIPTS = \
 	zfs_send_004_neg.ksh \
 	zfs_send_005_pos.ksh \
 	zfs_send_006_pos.ksh \
-	zfs_send_007_pos.ksh
+	zfs_send_007_pos.ksh \
+	zfs_send_008_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_008_pos.ksh
@@ -1,0 +1,101 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2016, loli10K. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/cli_root/cli_common.kshlib
+. $STF_SUITE/tests/functional/cli_root/zfs_send/zfs_send.cfg
+
+#
+# DESCRIPTION:
+#	Verify 'zfs send' can create valid replication send streams even when
+#	we're missing snapshots in the dataset hierarchy.
+#
+# STRATEGY:
+#	1. Create a child fs first and then only snapshot the parent
+#	2. Create a full replication send stream and verify it can be received
+#	3. Create a snapshot first and then a child fs
+#	4. Create another replication send stream and verify it can be received
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	for snap in $snap1 $snap2 $dsnap1 $dsnap2; do
+		snapexists $snap && \
+			log_must $ZFS destroy -f $snap
+	done
+
+	for ds in $src1 $src2 $dst1 $dst2; do
+		datasetexists $ds && \
+			log_must $ZFS destroy -Rf $ds
+	done
+
+	for file in $bkup1 $bkup2; do
+		[[ -e $file ]] && log_must $RM -f $file
+	done
+}
+
+log_assert "Verify 'zfs send' can create replication send streams."
+log_onexit cleanup
+
+src1=$TESTPOOL/$TESTFS/src1
+src1child=$src1/src1child
+src2=$TESTPOOL/$TESTFS/src2
+src2child=$src2/src2child
+snap1=$src1@snap1
+snap2=$src2@snap2
+bkup1=/var/tmp/bkup1.$$
+bkup2=/var/tmp/bkup2.$$
+dst1=$TESTPOOL/$TESTFS/dst1
+dst1child=$dst1/dst1child
+dst2=$TESTPOOL/$TESTFS/dst2
+dst2child=$dst2/dst2child
+dsnap1=$dst1@snap1
+dsnap2=$dst2@snap2
+
+log_note "Verify 'zfs send' warns about missing snapshots for datasets"\
+	"created before but still create a valid send stream"
+
+log_must $ZFS create $src1
+log_must $ZFS set mountpoint=none $src1
+log_must $ZFS create $src1child
+log_must $ZFS snapshot $snap1
+log_mustnot eval "$ZFS send -R $snap1 > $bkup1"
+log_must eval "$ZFS receive $dst1 < $bkup1"
+receive_check $dsnap1
+
+log_note "Verify 'zfs send' warns about missing snapshots for datasets"\
+	"created after but still create a valid send stream"
+
+log_must $ZFS create $src2
+log_must $ZFS set mountpoint=none $src2
+log_must $ZFS snapshot $snap2
+log_must $ZFS create $src2child
+log_mustnot eval "$ZFS send -R $snap2 > $bkup2"
+log_must eval "$ZFS receive $dst2 < $bkup2"
+receive_check $dsnap2
+
+log_pass "Verify 'zfs send' can create replication send streams."


### PR DESCRIPTION
Since the integration of OpenZFS 6111 (https://github.com/zfsonlinux/zfs/commit/6635624020506a76cb79c65c7ff5a580c4685a0b) we lost the ability to create replication send streams when we're missing even a single snapshot in the whole hierarchy.

```
# fallocate -l 256m /var/tmp/zfs-vdev1
# zpool create tank /var/tmp/zfs-vdev1
# zfs create tank/important-data1
# zfs create tank/important-data2
# zfs create tank/important-data3
# zfs create tank/not-so-much
# zfs snapshot -r tank@sendme
# zfs destroy tank/not-so-much@sendme
# zfs send -Rv tank@sendme > /dev/null
cannot send tank@sendme recursively: snapshot tank/not-so-much@sendme does not exist
# echo $?
1
# 
```

I don't know if OpenZFS 6111 intentionally removed this functionality but this could seriously break user scripts used for backups/replication (as demonstrated by the open issue) and slightly violates the principle of least astonishment.

Also add a new script to the ZFS test suite.

This should fix #5196
