### PR TITLE
Add zfs_vdev_parallel_open_enabled module parameter

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1052,6 +1052,26 @@ Default value: \fB1\fR.
 .sp
 .ne 2
 .na
+\fBzfs_vdev_parallel_open_enabled\fR (bool)
+.ad
+.RS 12n
+Accelerates vdev open from pool import or reopen from reload from cache by
+allow child vdevs to be opened in parallel.
+.sp
+This almost always deadlocks in unsupported stacked ZFS configurations where a
+zvol from one pool is the vdev for another pool. Some logic exists in the
+kernel module to disable this in the direct case when there is nothing
+in-between, but it is impossible to detect the indirect case where another
+block device exists inbetween. Disabling this will often make stacked ZFS
+configurations work, but they continue to be an unsupported configuration in
+the indirect case.
+.sp
+Use \fB1\fR for yes (default) and \fB0\fR for no.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_vdev_sync_read_max_active\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -52,6 +52,11 @@
 int metaslabs_per_vdev = 200;
 
 /*
+ * Allow system administrator to disable parallel open optimization so that
+ * unsupported ZFS on something else on zvol is semi-safe.
+ */
+int zfs_vdev_parallel_open_enabled = 1;
+/*
  * Virtual device management.
  */
 
@@ -1136,7 +1141,7 @@ vdev_uses_zvols(vdev_t *vd)
 	int c;
 
 #ifdef _KERNEL
-	if (zvol_is_zvol(vd->vdev_path))
+	if (zfs_vdev_parallel_open_enabled == 0 || zvol_is_zvol(vd->vdev_path))
 		return (B_TRUE);
 #endif
 
@@ -3641,6 +3646,10 @@ EXPORT_SYMBOL(vdev_degrade);
 EXPORT_SYMBOL(vdev_online);
 EXPORT_SYMBOL(vdev_offline);
 EXPORT_SYMBOL(vdev_clear);
+
+module_param(zfs_vdev_parallel_open_enabled, int, 0644);
+MODULE_PARM_DESC(zfs_vdev_parallel_open_enabled,
+	"Open vdev children in parallel during import.");
 
 module_param(metaslabs_per_vdev, int, 0644);
 MODULE_PARM_DESC(metaslabs_per_vdev,

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -83,12 +83,9 @@ tests = ['zfs_clone_001_neg', 'zfs_clone_002_pos', 'zfs_clone_003_pos',
     'zfs_clone_007_pos', 'zfs_clone_008_neg', 'zfs_clone_009_neg',
     'zfs_clone_010_pos']
 
-# DISABLED:
-# zfs_copies_003_pos - zpool on zvol
-# zfs_copies_005_neg - nested pools
 [tests/functional/cli_root/zfs_copies]
-tests = ['zfs_copies_001_pos', 'zfs_copies_002_pos', 'zfs_copies_004_neg',
-    'zfs_copies_006_pos']
+tests = ['zfs_copies_001_pos', 'zfs_copies_002_pos', 'zfs_copies_003_pos',
+    'zfs_copies_004_neg', 'zfs_copies_005_neg', 'zfs_copies_006_pos']
 
 [tests/functional/cli_root/zfs_create]
 tests = ['zfs_create_001_pos', 'zfs_create_002_pos', 'zfs_create_003_pos',
@@ -107,11 +104,10 @@ tests = ['zfs_destroy_001_pos', 'zfs_destroy_002_pos', 'zfs_destroy_003_pos',
     'zfs_destroy_014_pos','zfs_destroy_015_pos', 'zfs_destroy_016_pos']
 
 # DISABLED:
-# zfs_get_004_pos - nested pools
 # zfs_get_006_neg - needs investigation
 [tests/functional/cli_root/zfs_get]
 tests = ['zfs_get_001_pos', 'zfs_get_002_pos', 'zfs_get_003_pos',
-    'zfs_get_005_neg', 'zfs_get_007_neg', 'zfs_get_008_pos',
+    'zfs_get_004_pos', 'zfs_get_005_neg', 'zfs_get_007_neg', 'zfs_get_008_pos',
     'zfs_get_009_pos', 'zfs_get_010_neg']
 
 [tests/functional/cli_root/zfs_inherit]
@@ -217,12 +213,11 @@ tests = ['zfs_upgrade_001_pos', 'zfs_upgrade_002_pos', 'zfs_upgrade_003_pos',
 tests = ['zpool_001_neg', 'zpool_002_pos', 'zpool_003_pos']
 
 # DISABLED:
-# zpool_add_004_pos - nested pools
 # zpool_add_005_pos - no 'dumpadm' command.
-# zpool_add_006_pos - nested pools
 [tests/functional/cli_root/zpool_add]
 tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
-    'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg']
+    'zpool_add_004_pos', 'zpool_add_006_pos', 'zpool_add_007_neg',
+    'zpool_add_008_neg', 'zpool_add_009_neg']
 
 [tests/functional/cli_root/zpool_attach]
 tests = ['zpool_attach_001_neg']
@@ -234,7 +229,6 @@ tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg']
 # zpool_create_001_pos - needs investigation
 # zpool_create_002_pos - needs investigation
 # zpool_create_004_pos - needs investigation
-# zpool_create_006_pos - nested pools
 # zpool_create_008_pos - uses VTOC labels (?) and 'overlapping slices'
 # zpool_create_011_neg - tries to access /etc/vfstab etc
 # zpool_create_012_neg - swap devices
@@ -244,9 +238,9 @@ tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg']
 # zpool_create_020_pos - needs investigation
 [tests/functional/cli_root/zpool_create]
 tests = [
-    'zpool_create_003_pos', 'zpool_create_005_pos', 'zpool_create_007_neg',
-    'zpool_create_009_neg', 'zpool_create_010_neg', 'zpool_create_017_neg',
-    'zpool_create_018_pos', 'zpool_create_019_pos',
+    'zpool_create_003_pos', 'zpool_create_005_pos', 'zpool_create_006_pos',
+    'zpool_create_007_neg', 'zpool_create_009_neg', 'zpool_create_010_neg',
+    'zpool_create_017_neg', 'zpool_create_018_pos', 'zpool_create_019_pos',
     'zpool_create_021_pos', 'zpool_create_022_pos', 'zpool_create_023_neg',
     'zpool_create_features_001_pos', 'zpool_create_features_002_pos',
     'zpool_create_features_003_pos', 'zpool_create_features_004_neg']
@@ -268,11 +262,9 @@ tests = ['zpool_detach_001_neg']
 #tests = ['zpool_expand_001_pos', 'zpool_expand_002_pos',
 #    'zpool_expand_003_neg']
 
-# DISABLED:
-# zpool_export_004_pos - nested pools
 [tests/functional/cli_root/zpool_export]
 tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
-    'zpool_export_003_neg']
+    'zpool_export_003_neg', 'zpool_export_004_pos']
 
 [tests/functional/cli_root/zpool_get]
 tests = ['zpool_get_001_pos', 'zpool_get_002_pos', 'zpool_get_003_pos',
@@ -516,9 +508,8 @@ tests = ['refquota_001_pos', 'refquota_002_pos', 'refquota_003_pos',
 tests = ['refreserv_001_pos', 'refreserv_002_pos', 'refreserv_003_pos',
     'refreserv_005_pos']
 
-# DISABLED: nested pool
-#[tests/functional/rename_dirs]
-#tests = ['rename_dirs_001_pos']
+[tests/functional/rename_dirs]
+tests = ['rename_dirs_001_pos']
 
 [tests/functional/replacement]
 tests = ['replacement_001_pos', 'replacement_002_pos', 'replacement_003_pos']
@@ -561,11 +552,10 @@ tests = ['slog_001_pos', 'slog_002_pos', 'slog_003_pos', 'slog_004_pos',
     'slog_009_neg', 'slog_010_neg', 'slog_011_neg']
 
 # DISABLED:
-# clone_001_pos - nested pools
 # rollback_003_pos - Hangs in unmount and spins.
 # snapshot_016_pos - Problem with automount
 [tests/functional/snapshot]
-tests = ['rollback_001_pos', 'rollback_002_pos',
+tests = ['clone_001_pos', 'rollback_001_pos', 'rollback_002_pos',
     'snapshot_001_pos', 'snapshot_002_pos',
     'snapshot_003_pos', 'snapshot_004_pos', 'snapshot_005_pos',
     'snapshot_006_pos', 'snapshot_007_pos', 'snapshot_008_pos',

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_003_pos.ksh
@@ -50,12 +50,19 @@ function cleanup
 	if datasetexists $vol; then
 		log_must $ZFS destroy $vol
 	fi
+
+	if is_linux; then
+		echo 1 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
 }
 
 log_assert "Verify that ZFS volume space used by multiple copies is charged correctly."
 log_onexit cleanup
 vol=$TESTPOOL/$TESTVOL1
 
+if is_linux; then
+	echo 0 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+fi
 
 for val in 1 2 3; do
 	do_vol_test zfs $val

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_005_neg.ksh
@@ -48,10 +48,18 @@ function cleanup
 	if [[ -f $TESTDIR/$ZPOOL_VERSION_1_FILES ]]; then
 		rm -f $TESTDIR/$ZPOOL_VERSION_1_FILES
 	fi
+
+	if is_linux; then
+		echo 1 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
 }
 
 log_assert "Verify that copies cannot be set with pool version 1"
 log_onexit cleanup
+
+if is_linux; then
+	echo 0 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+fi
 
 $CP $STF_SUITE/tests/functional/cli_root/zpool_upgrade/blockfiles/$ZPOOL_VERSION_1_FILES $TESTDIR
 $BUNZIP2 $TESTDIR/$ZPOOL_VERSION_1_FILES

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_004_pos.ksh
@@ -68,10 +68,19 @@ function cleanup
 				log_must $ZFS destroy -rf $fs
 		done
 	fi
+
+	if is_linux; then
+		echo 1 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
+
 }
 
 log_assert "Verify the functions of 'zfs get all' work."
 log_onexit cleanup
+
+if is_linux; then
+	echo 0 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+fi
 
 typeset globalzone=""
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_004_pos.ksh
@@ -57,11 +57,18 @@ function cleanup
 
 	partition_cleanup
 
+	if is_linux; then
+		echo 1 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
 }
 
 log_assert "'zpool add <pool> <vdev> ...' can add zfs volume to the pool."
 
 log_onexit cleanup
+
+if is_linux; then
+	echo 0 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+fi
 
 create_pool "$TESTPOOL" "${disk}${SLICE_PREFIX}${SLICE0}"
 log_must poolexists "$TESTPOOL"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_006_pos.ksh
@@ -54,10 +54,18 @@ function cleanup
 
 	[[ -d $TESTDIR ]] && log_must $RM -rf $TESTDIR
 	partition_cleanup
+
+	if is_linux; then
+		echo 1 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
 }
 
 log_assert "Adding a large number of file based vdevs to a zpool works."
 log_onexit cleanup
+
+if is_linux; then
+	echo 0 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+fi
 
 create_pool $TESTPOOL ${DISKS%% *}
 log_must $ZFS create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_006_pos.ksh
@@ -44,11 +44,18 @@ function cleanup
 {
 	datasetexists $TESTPOOL1 && destroy_pool $TESTPOOL1
 	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	if is_linux; then
+		echo 1 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
 }
 
 
 log_assert "Verify 'zpool create' succeed with keywords combination."
 log_onexit cleanup
+
+if is_linux; then
+	echo 0 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+fi
 
 create_pool $TESTPOOL $DISKS
 mntpnt=$(get_prop mountpoint $TESTPOOL)

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_004_pos.ksh
@@ -59,11 +59,19 @@ function cleanup
 		fi
 		((i += 1))
 	done
+
+	if is_linux; then
+		echo 1 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
 }
 
 
 log_assert "Verify zpool export succeed or fail with spare."
 log_onexit cleanup
+
+if is_linux; then
+	echo 0 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+fi
 
 mntpnt=$(get_prop mountpoint $TESTPOOL)
 

--- a/tests/zfs-tests/tests/functional/rename_dirs/rename_dirs_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rename_dirs/rename_dirs_001_pos.ksh
@@ -49,11 +49,19 @@ verify_runnable "both"
 function cleanup
 {
 	log_must $RM -rf $TESTDIR/*
+
+	if is_linux; then
+		echo 1 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
 }
 
 log_assert "ZFS can handle race directory rename operation."
 
 log_onexit cleanup
+
+if is_linux; then
+	echo 0 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+fi
 
 $CD $TESTDIR
 $MKDIR -p 1/2/3/4/5 a/b/c/d/e

--- a/tests/zfs-tests/tests/functional/snapshot/clone_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/clone_001_pos.ksh
@@ -65,6 +65,10 @@ function setup_all
 	log_must $ZFS create $TESTPOOL1/$TESTFS
 	log_must $ZFS set mountpoint=$TESTDIR2 $TESTPOOL1/$TESTFS
 
+	if is_linux; then
+		echo 0 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
+
 	return 0
 }
 
@@ -93,6 +97,10 @@ function cleanup_all
 
 	[[ -d $TESTDIR2 ]] && \
 		log_must $RM -rf $TESTDIR2
+
+	if is_linux; then
+		echo 1 > /sys/module/zfs/parameters/zfs_vdev_parallel_open_enabled
+	fi
 
 	return 0
 }


### PR DESCRIPTION
Parallel vdev open causes the driver to deadlock when running ZFS on top
of a zvol with something in between, including, but not limited to the
loop device. Such configurations are unsupported because we do not have
regression test coverage for them, but enough people have requested the
capability over the years that we ought to give them a knob to make the
configuration work in most instances.

Signed-off-by: Richard Yao ryao@gentoo.org
