### PR TITLE
Properly use the Dracut cleanup hook to order pool shutdown.

### DIFF
--- a/contrib/dracut/90zfs/Makefile.am
+++ b/contrib/dracut/90zfs/Makefile.am
@@ -5,6 +5,7 @@ pkgdracut_SCRIPTS = \
 	mount-zfs.sh \
 	parse-zfs.sh \
 	zfs-generator.sh \
+	zfs-needshutdown.sh \
 	zfs-lib.sh
 
 EXTRA_DIST = \
@@ -13,6 +14,7 @@ EXTRA_DIST = \
 	$(top_srcdir)/contrib/dracut/90zfs/mount-zfs.sh.in \
 	$(top_srcdir)/contrib/dracut/90zfs/parse-zfs.sh.in \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-generator.sh.in \
+	$(top_srcdir)/contrib/dracut/90zfs/zfs-needshutdown.sh.in \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-lib.sh.in
 
 $(pkgdracut_SCRIPTS):%:%.in

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -58,6 +58,7 @@ install() {
 		inst_script "${moddir}/zfs-generator.sh" "$systemdutildir"/system-generators/dracut-zfs-generator
 	fi
 	inst_hook mount 98 "${moddir}/mount-zfs.sh"
+	inst_hook cleanup 99 "${moddir}/zfs-needshutdown.sh"
 	inst_hook shutdown 20 "${moddir}/export-zfs.sh"
 
 	inst_simple "${moddir}/zfs-lib.sh" "/lib/dracut-zfs-lib.sh"

--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -22,7 +22,6 @@ if [ -e "$GENERATOR_FILE" -a -e "$GENERATOR_EXTENSION" ] ; then
 	# Let us tell the initrd to run on shutdown.
 	# We have a shutdown hook to run
 	# because we imported the pool.
-	need_shutdown
 	# We now prevent Dracut from running this thing again.
 	for zfsmounthook in "$hookdir"/mount/*zfs* ; do
 		if [ -f "$zfsmounthook" ] ; then
@@ -60,7 +59,6 @@ if import_pool "${ZFS_POOL}" ; then
 	# Let us tell the initrd to run on shutdown.
 	# We have a shutdown hook to run
 	# because we imported the pool.
-	need_shutdown
 	info "ZFS: Mounting dataset ${ZFS_DATASET}..."
 	if mount_dataset "${ZFS_DATASET}" ; then
 		ROOTFS_MOUNTED=yes

--- a/contrib/dracut/90zfs/zfs-needshutdown.sh.in
+++ b/contrib/dracut/90zfs/zfs-needshutdown.sh.in
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if zpool list 2>&1 | grep -q 'no pools available' ; then
+    info "ZFS: No active pools, no need to export anything."
+else
+    info "ZFS: There is an active pool, will export it."
+    need_shutdown
+fi


### PR DESCRIPTION
When Dracut starts up, it needs to determine whether a pool will remain
"hanging open" before the system shuts off.  In such a case, then the
code to clean up the pool (using the previous `export -F` work) must
be invoked.  Since Dracut has had a recent change that makes
`mount-zfs.sh` simply not run when the root dataset is already mounted,
we must use the cleanup hook to order Dracut to do shutdown cleanup.