### PR TITLE
fix coverity defects with CID 49339-153393

### DIFF
--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -553,7 +553,7 @@ zfs_userspace_one(zfs_sb_t *zsb, zfs_userquota_prop_t type,
 		return (0);
 
 	if (type == ZFS_PROP_USEROBJUSED || type == ZFS_PROP_GROUPOBJUSED) {
-		strncpy(buf, DMU_OBJACCT_PREFIX, DMU_OBJACCT_PREFIX_LEN);
+		strlcpy(buf, DMU_OBJACCT_PREFIX, DMU_OBJACCT_PREFIX_LEN);
 		offset = DMU_OBJACCT_PREFIX_LEN;
 	}
 

--- a/tests/zfs-tests/cmd/xattrtest/xattrtest.c
+++ b/tests/zfs-tests/cmd/xattrtest/xattrtest.c
@@ -168,6 +168,7 @@ parse_args(int argc, char **argv)
 			break;
 		case 'p':
 			strncpy(path, optarg, PATH_MAX);
+			path[PATH_MAX - 1] = '\0';
 			break;
 		case 'c':
 			synccaches = 1;
@@ -177,6 +178,7 @@ parse_args(int argc, char **argv)
 			break;
 		case 't':
 			strncpy(script, optarg, PATH_MAX);
+			script[PATH_MAX - 1] = '\0';
 			break;
 		case 'e':
 			seed = strtol(optarg, NULL, 0);


### PR DESCRIPTION
issues:
fix coverity defects
coverity scan CID:49339, Type:Buffer not null terminated
coverity scan CID:153393, Type:Buffer not null terminated

Signed-off-by: cao.xuewen cao.xuewen@zte.com.cn