### PR TITLE
Fix all coverity defects of type 'Out-of-bounds read'

### DIFF
--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -270,6 +270,13 @@ _zed_event_add_var(uint64_t eid, zed_strings_t *zsp,
 	*dstp++ = '=';
 	buflen--;
 
+	if (buflen <= 0) {
+		errno = EMSGSIZE;
+		zed_log_msg(LOG_WARNING, "Failed to add %s for eid=%llu: %s",
+		    keybuf, eid, "Exceeded buffer size");
+		return (-1);
+	}
+
 	va_start(vargs, fmt);
 	n = vsnprintf(dstp, buflen, fmt, vargs);
 	va_end(vargs);


### PR DESCRIPTION
coverity scan CID: 147587, type: Out-of-bounds read
---- May overrunning array of 4096 bytes at byte offset 4096 by dereferencing pointer dstp.
---- In other words, may call `vsnprintf` with `buflen` which may be zero.

All the other defects of this type seems tobe false positive: 

```
CID: 147586
CID: 147583
CID: 147582
CID: 147581
CID: 147580
```

Signed-off-by: GeLiXin ge.lixin@zte.com.cn
