### PR TITLE
Fix make distclean Makefile.am removal

### DIFF
--- a/tests/zfs-tests/tests/stress/Makefile.am
+++ b/tests/zfs-tests/tests/stress/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS =


### PR DESCRIPTION
The file tests/zfs-tests/tests/stress/Makefile.am gets mistakenly
removed by the distclean target because it's empty.  Adding a
`SUBDIRS =` line prevents the removal.

This directory is being preserved as the location to add assorted
stress tests.  These may include but are not limited to.

  http://kernel.ubuntu.com/~cking/stress-ng/
  https://github.com/zfsonlinux/zfsstress/

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>