### PR TITLE
Fix userquota_compare() function

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1355,12 +1355,15 @@ userquota_compare(const void *l, const void *r)
 {
 	const userquota_node_t *luqn = l;
 	const userquota_node_t *ruqn = r;
+	int rv;
 
 	/*
 	 * NB: can only access uqn_id because userquota_update_cache() doesn't
 	 * pass in an entire userquota_node_t.
 	 */
-	return (strcmp(luqn->uqn_id, ruqn->uqn_id));
+	rv = strcmp(luqn->uqn_id, ruqn->uqn_id);
+
+	return (AVL_ISIGN(rv));
 }
 
 static void


### PR DESCRIPTION
The AVL tree compare function requires that either -1, 0, or 1 be
returned.  However the strcmp() function only guarantees that a
negative, zero, or positive value is returned.  Therefore, the
return value of strcmp() needs to be sanitized with AVL_ISIGN.

This was initially overlooked because the x86_64 implementation
of strcmp() happens to only returns the allowed values.  This
was observed on an aarch64 platform which behaves correctly but
differently as described above.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>