### PR TITLE
Update migration tests

### DIFF
--- a/tests/zfs-tests/tests/functional/migration/setup.ksh
+++ b/tests/zfs-tests/tests/functional/migration/setup.ksh
@@ -34,10 +34,6 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $ZFS_DISK) ; then
-	log_unsupported "Only partitionable physical disks can be used"
-fi
-
 case $DISK_COUNT in
 0)
 	log_untested "Need at least 1 disk device for test"
@@ -50,10 +46,7 @@ case $DISK_COUNT in
 	;;
 esac
 
-set_partition ${ZFSSIDE_DISK##*s} "" $FS_SIZE $ZFS_DISK
-set_partition ${NONZFSSIDE_DISK##*s} "" $FS_SIZE $NONZFS_DISK
-
-create_pool $TESTPOOL "$ZFSSIDE_DISK"
+create_pool $TESTPOOL "$ZFS_DISK"
 
 $RM -rf $TESTDIR  || log_unresolved Could not remove $TESTDIR
 $MKDIR -p $TESTDIR || log_unresolved Could not create $TESTDIR
@@ -64,10 +57,10 @@ log_must $ZFS set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 $RM -rf $NONZFS_TESTDIR  || log_unresolved Could not remove $NONZFS_TESTDIR
 $MKDIR -p $NONZFS_TESTDIR || log_unresolved Could not create $NONZFS_TESTDIR
 
-$ECHO "y" | $NEWFS -v ${DEV_DSKDIR}/$NONZFSSIDE_DISK
+$ECHO "y" | $NEWFS -v ${DEV_DSKDIR}/$NONZFS_DISK
 (( $? != 0 )) &&
 	log_untested "Unable to setup a UFS file system"
 
-log_must $MOUNT ${DEV_DSKDIR}/$NONZFSSIDE_DISK $NONZFS_TESTDIR
+log_must $MOUNT ${DEV_DSKDIR}/$NONZFS_DISK $NONZFS_TESTDIR
 
 log_pass


### PR DESCRIPTION
**Due to the instability of the migration tests, the test will skip.**

Test: /usr/share/zfs/zfs-tests/tests/functional/migration/setup (run as root) [00:00] [SKIP]
03:08:56.97 lsblk: /dev/mapper/loop0: not a block device
03:08:56.97 lsblk: /dev/mapper/loop0: not a block device
03:08:56.97 lsblk: /dev/mapper/loop0: not a block device
03:08:56.98 lsblk: /dev/mapper/loop1: not a block device
03:08:56.98 lsblk: /dev/mapper/loop1: not a block device
03:08:56.99 Only partitionable physical disks can be used
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_001_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_002_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_003_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_004_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_005_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_006_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_007_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_008_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_009_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_010_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_011_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/migration_012_pos (run as root) [00:00] [SKIP]
Test: /usr/share/zfs/zfs-tests/tests/functional/migration/cleanup (run as root) [00:00] [PASS]
03:08:57.02 lsblk: /dev/mapper/loop0: not a block device
03:08:57.02 lsblk: /dev/mapper/loop0: not a block device
03:08:57.03 lsblk: /dev/mapper/loop0: not a block device
03:08:57.03 lsblk: /dev/mapper/loop1: not a block device
03:08:57.03 lsblk: /dev/mapper/loop1: not a block device
03:08:57.05 NOTE: Pool does not exist. (testpool.26868)
03:08:57.05 lsblk: /dev/mapper/loop0: not a block device
03:08:57.13 SUCCESS: /sbin/zpool create -f foopool3915 loop0 loop1
03:08:57.16 SUCCESS: cleanup_devices loop0 loop1

**The migration tests focus on migrating test file from fs to ZFS fs.
We can use linux native fs instead of UFS fs, so that reducing complexity 
of setup.**
