### PR TITLE
Skip spurious resilver IO on raidz vdev

### DIFF
--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -65,6 +65,7 @@ extern void vdev_dtl_dirty(vdev_t *vd, vdev_dtl_type_t d,
 extern boolean_t vdev_dtl_contains(vdev_t *vd, vdev_dtl_type_t d,
     uint64_t txg, uint64_t size);
 extern boolean_t vdev_dtl_empty(vdev_t *vd, vdev_dtl_type_t d);
+extern boolean_t vdev_dtl_need_resilver(vdev_t *vd, uint64_t off, size_t size);
 extern void vdev_dtl_reassess(vdev_t *vd, uint64_t txg, uint64_t scrub_txg,
     int scrub_done);
 extern boolean_t vdev_dtl_required(vdev_t *vd);

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -68,6 +68,7 @@ typedef uint64_t vdev_asize_func_t(vdev_t *vd, uint64_t psize);
 typedef void	vdev_io_start_func_t(zio_t *zio);
 typedef void	vdev_io_done_func_t(zio_t *zio);
 typedef void	vdev_state_change_func_t(vdev_t *vd, int, int);
+typedef boolean_t vdev_need_resilver_func_t(vdev_t *vd, uint64_t, size_t);
 typedef void	vdev_hold_func_t(vdev_t *vd);
 typedef void	vdev_rele_func_t(vdev_t *vd);
 
@@ -78,6 +79,7 @@ typedef const struct vdev_ops {
 	vdev_io_start_func_t		*vdev_op_io_start;
 	vdev_io_done_func_t		*vdev_op_io_done;
 	vdev_state_change_func_t	*vdev_op_state_change;
+	vdev_need_resilver_func_t	*vdev_op_need_resilver;
 	vdev_hold_func_t		*vdev_op_hold;
 	vdev_rele_func_t		*vdev_op_rele;
 	char				vdev_op_type[16];

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1820,6 +1820,21 @@ vdev_dtl_empty(vdev_t *vd, vdev_dtl_type_t t)
 }
 
 /*
+ * Returns B_TRUE if vdev determines offset needs to be resilvered.
+ */
+boolean_t
+vdev_dtl_need_resilver(vdev_t *vd, uint64_t offset, size_t psize)
+{
+	ASSERT(vd != vd->vdev_spa->spa_root_vdev);
+
+	if (vd->vdev_ops->vdev_op_need_resilver == NULL ||
+	    vd->vdev_ops->vdev_op_leaf)
+		return (B_TRUE);
+
+	return (vd->vdev_ops->vdev_op_need_resilver(vd, offset, psize));
+}
+
+/*
  * Returns the lowest txg in the DTL range.
  */
 static uint64_t

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -796,6 +796,7 @@ vdev_ops_t vdev_disk_ops = {
 	vdev_disk_io_start,
 	vdev_disk_io_done,
 	NULL,
+	NULL,
 	vdev_disk_hold,
 	vdev_disk_rele,
 	VDEV_TYPE_DISK,		/* name of this vdev type */

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -250,6 +250,7 @@ vdev_ops_t vdev_file_ops = {
 	vdev_file_io_start,
 	vdev_file_io_done,
 	NULL,
+	NULL,
 	vdev_file_hold,
 	vdev_file_rele,
 	VDEV_TYPE_FILE,		/* name of this vdev type */
@@ -282,6 +283,7 @@ vdev_ops_t vdev_disk_ops = {
 	vdev_default_asize,
 	vdev_file_io_start,
 	vdev_file_io_done,
+	NULL,
 	NULL,
 	vdev_file_hold,
 	vdev_file_rele,

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -615,6 +615,7 @@ vdev_ops_t vdev_mirror_ops = {
 	vdev_mirror_state_change,
 	NULL,
 	NULL,
+	NULL,
 	VDEV_TYPE_MIRROR,	/* name of this vdev type */
 	B_FALSE			/* not a leaf vdev */
 };
@@ -628,6 +629,7 @@ vdev_ops_t vdev_replacing_ops = {
 	vdev_mirror_state_change,
 	NULL,
 	NULL,
+	NULL,
 	VDEV_TYPE_REPLACING,	/* name of this vdev type */
 	B_FALSE			/* not a leaf vdev */
 };
@@ -639,6 +641,7 @@ vdev_ops_t vdev_spare_ops = {
 	vdev_mirror_io_start,
 	vdev_mirror_io_done,
 	vdev_mirror_state_change,
+	NULL,
 	NULL,
 	NULL,
 	VDEV_TYPE_SPARE,	/* name of this vdev type */

--- a/module/zfs/vdev_missing.c
+++ b/module/zfs/vdev_missing.c
@@ -88,6 +88,7 @@ vdev_ops_t vdev_missing_ops = {
 	NULL,
 	NULL,
 	NULL,
+	NULL,
 	VDEV_TYPE_MISSING,	/* name of this vdev type */
 	B_TRUE			/* leaf vdev */
 };
@@ -98,6 +99,7 @@ vdev_ops_t vdev_hole_ops = {
 	vdev_default_asize,
 	vdev_missing_io_start,
 	vdev_missing_io_done,
+	NULL,
 	NULL,
 	NULL,
 	NULL,

--- a/module/zfs/vdev_root.c
+++ b/module/zfs/vdev_root.c
@@ -120,6 +120,7 @@ vdev_ops_t vdev_root_ops = {
 	vdev_root_state_change,
 	NULL,
 	NULL,
+	NULL,
 	VDEV_TYPE_ROOT,		/* name of this vdev type */
 	B_FALSE			/* not a leaf vdev */
 };


### PR DESCRIPTION
On a raidz vdev, a block that does not span all child vdev's, excluding its skip sectors if any, may not be affected by a child vdev outage or failure. In such cases, the block does not need to be resilvered. However, current resilver algorithm simply resilvers all blocks on a degraded raidz vdev. Such spurious IO not only is wasteful, but also adds the risk of overwriting good data.

For example, in the graph below, if disk C fails, the two blocks that start at 3D and 8E will not need to be resilvered:
![e28fc7ba04b0ce92b1e99d34f82531fb](https://cloud.githubusercontent.com/assets/6722662/19586889/0002fd8c-9717-11e6-8b7b-ac62e9be91d0.jpg)
This patch eliminates such spurious IOs.

I've tested the patch on a 8+1 raidz1 vdev, by offline/online/replace a drive to trigger resilver, then scrub to make sure every block is correctly resilvered. All worked fine. The pool was populated with about 3G data, mostly small files (e.g. zfs/spl source tree), which is ideal to test this patch. The following histogram shows ZIOs skipped with this patch:
![io sizes](https://cloud.githubusercontent.com/assets/6722662/19587090/b8495048-9718-11e6-9f6c-77b45a1877c5.png)

The ashift was 12 on the 9-drive raidz1, so the largest possible block to skip is 28KB (psize excluding parity). Not surprisingly, most skipped blocks were no more than 4KB.

Actually most of the blocks were skipped, the resilver was about 30% faster than a same resilver without skipping spurious ZIOs.

Signed-off-by: Isaac Huang he.huang@intel.com
