### PR TITLE
modify nvlist memory leak of the function "zfs_ioc_objset_stats_impl"

### DIFF
--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -1127,6 +1127,10 @@ dsl_prop_get_all_ds(dsl_dataset_t *ds, nvlist_t **nvp,
 			break;
 	}
 out:
+	if (err) {
+		nvlist_free(*nvp);
+		*nvp = NULL;
+	}
 	return (err);
 }
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -2033,8 +2033,10 @@ zfs_ioc_objset_stats_impl(zfs_cmd_t *zc, objset_t *os)
 		if (!zc->zc_objset_stats.dds_inconsistent &&
 		    dmu_objset_type(os) == DMU_OST_ZVOL) {
 			error = zvol_get_stats(os, nv);
-			if (error == EIO)
+			if (error == EIO) {
+				nvlist_free(nv);
 				return (error);
+			}
 			VERIFY0(error);
 		}
 		if (error == 0)


### PR DESCRIPTION
 in the abnormal process，if "zvol_get_stats" excute faild, there is a nvlist memory leak in the function "zfs_ioc_objset_stats_impl"
