### PR TITLE
fix coverity defects with CID 152975

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -369,12 +369,17 @@ dmu_spill_hold_by_dnode(dnode_t *dn, uint32_t flags, void *tag, dmu_buf_t **dbp)
 	if ((flags & DB_RF_HAVESTRUCT) == 0)
 		rw_exit(&dn->dn_struct_rwlock);
 
-	ASSERT(db != NULL);
+	if (db == NULL) {
+		*dbp = NULL;
+		return (SET_ERROR(EIO));
+	}
 	err = dbuf_read(db, NULL, flags);
 	if (err == 0)
 		*dbp = &db->db;
-	else
+	else {
 		dbuf_rele(db, tag);
+		*dbp = NULL;
+	}
 	return (err);
 }
 


### PR DESCRIPTION
issues:
fix coverity defects
coverity scan CID:152975, Type:Dereference null return value

Signed-off-by: cao.xuewen cao.xuewen@zte.com.cn
