### PR TITLE
Stop upgrade thread at the end of 'zfs recv'

### DIFF
--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -190,6 +190,7 @@ boolean_t dmu_objset_userobjspace_present(objset_t *os);
 static inline boolean_t dmu_objset_userobjspace_upgradable(objset_t *os)
 {
 	return (dmu_objset_type(os) == DMU_OST_ZFS &&
+	    !dmu_objset_is_snapshot(os) &&
 	    dmu_objset_userobjused_enabled(os) &&
 	    !dmu_objset_userobjspace_present(os));
 }


### PR DESCRIPTION
'zfs recv' could disown a living objset without calling<br />dmu_objset_disown(). This will cause the problem that the objset<br />would be released while upgrading thread is still running.<br /><br />This patch calls dmu_objset_upgrade_stop() in dmu_recv_end().<br /><br />ZoL-bug-id: https://github.com/zfsonlinux/zfs/issues/5295<br /><br />Signed-off-by: Jinshan Xiong <jinshan.xiong@intel.com>