### PR TITLE
Disable zpool_upgrade_002_pos test case

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -323,10 +323,11 @@ post =
 tests = ['zpool_status_001_pos', 'zpool_status_002_pos']
 
 # DISABLED:
+# zpool_upgrade_002_pos - Issue zfsonlinux/zfs#4034
 # zpool_upgrade_004_pos - Issue zfsonlinux/zfs#4034
 # zpool_upgrade_007_pos - needs investigation
 [tests/functional/cli_root/zpool_upgrade]
-tests = ['zpool_upgrade_001_pos', 'zpool_upgrade_002_pos',
+tests = ['zpool_upgrade_001_pos',
     'zpool_upgrade_003_pos', 'zpool_upgrade_005_neg',
     'zpool_upgrade_006_neg', 'zpool_upgrade_008_pos',
     'zpool_upgrade_009_neg']


### PR DESCRIPTION
This test cause frequently triggers issue #4034.  Disable this
test case until the root cause of this issue has been addressed.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #4034