### PR TITLE
Fix cred leak in zpl_fallocate_common

### DIFF
--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -650,8 +650,6 @@ zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 	if (mode != (FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE))
 		return (error);
 
-	crhold(cr);
-
 	if (offset < 0 || len <= 0)
 		return (-EINVAL);
 
@@ -670,6 +668,7 @@ zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 	bf.l_len = len;
 	bf.l_pid = 0;
 
+	crhold(cr);
 	cookie = spl_fstrans_mark();
 	error = -zfs_space(ip, F_FREESP, &bf, FWRITE, offset, cr);
 	spl_fstrans_unmark(cookie);


### PR DESCRIPTION
This is caught by kmemleak when running compress_004_pos

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>