### PR TITLE
Disable zio_dva_throttle_enabled by default

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1861,7 +1861,7 @@ Default value: \fB30,000\fR.
 Throttle block allocations in the ZIO pipeline. This allows for
 dynamic allocation distribution when devices are imbalanced.
 .sp
-Default value: \fB1\fR.
+Default value: \fB0\fR.
 .RE
 
 .sp

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -56,7 +56,7 @@ const char *zio_type_name[ZIO_TYPES] = {
 	"z_null", "z_rd", "z_wr", "z_fr", "z_cl", "z_ioctl"
 };
 
-int zio_dva_throttle_enabled = B_TRUE;
+int zio_dva_throttle_enabled = B_FALSE;
 
 /*
  * ==========================================================================


### PR DESCRIPTION
Until it can be determined definitively that a performance
regression wasn't introduced accidentally by 3dfb57a this
functionality is being disabled by default.  It can be re-
enabled by setting zio_dva_throttle_enabled=1.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #5289