### PR TITLE
Fix lookup_bdev() on Ubuntu

### DIFF
--- a/config/kernel-lookup-bdev.m4
+++ b/config/kernel-lookup-bdev.m4
@@ -1,17 +1,29 @@
 dnl #
-dnl # 2.6.27 API change
-dnl # lookup_bdev() was exported.
+dnl # 2.6.27, lookup_bdev() was exported.
+dnl # 4.4.0-6.21 - x.y on Ubuntu, lookup_bdev() takes 2 arguments.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_LOOKUP_BDEV],
-	[AC_MSG_CHECKING([whether lookup_bdev() is available])
+	[AC_MSG_CHECKING([whether lookup_bdev() wants 1 arg])
 	ZFS_LINUX_TRY_COMPILE_SYMBOL([
 		#include <linux/fs.h>
 	], [
 		lookup_bdev(NULL);
 	], [lookup_bdev], [fs/block_dev.c], [
 		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_LOOKUP_BDEV, 1, [lookup_bdev() is available])
+		AC_DEFINE(HAVE_1ARG_LOOKUP_BDEV, 1, [lookup_bdev() wants 1 arg])
 	], [
 		AC_MSG_RESULT(no)
+		AC_MSG_CHECKING([whether lookup_bdev() wants 2 args])
+		ZFS_LINUX_TRY_COMPILE_SYMBOL([
+			#include <linux/fs.h>
+		], [
+			lookup_bdev(NULL, FMODE_READ);
+		], [lookup_bdev], [fs/block_dev.c], [
+			AC_MSG_RESULT(yes)
+			AC_DEFINE(HAVE_2ARGS_LOOKUP_BDEV, 1,
+			    [lookup_bdev() wants 2 args])
+		], [
+			AC_MSG_RESULT(no)
+		])
 	])
 ])

--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -263,12 +263,21 @@ bio_set_flags_failfast(struct block_device *bdev, int *flags)
 
 /*
  * 2.6.27 API change
- * The function was exported for use, prior to this it existed by the
+ * The function was exported for use, prior to this it existed but the
  * symbol was not exported.
+ *
+ * 4.4.0-6.21 API change for Ubuntu
+ * lookup_bdev() gained a second argument, FMODE_*, to check inode permissions.
  */
-#ifndef HAVE_LOOKUP_BDEV
-#define	lookup_bdev(path)		ERR_PTR(-ENOTSUP)
-#endif
+#ifdef HAVE_1ARG_LOOKUP_BDEV
+#define	vdev_lookup_bdev(path)	lookup_bdev(path)
+#else
+#ifdef HAVE_2ARGS_LOOKUP_BDEV
+#define	vdev_lookup_bdev(path)	lookup_bdev(path, 0)
+#else
+#define	vdev_lookup_bdev(path)	ERR_PTR(-ENOTSUP)
+#endif /* HAVE_2ARGS_LOOKUP_BDEV */
+#endif /* HAVE_1ARG_LOOKUP_BDEV */
 
 /*
  * 2.6.30 API change

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -174,7 +174,7 @@ zvol_is_zvol(const char *device)
 	struct block_device *bdev;
 	unsigned int major;
 
-	bdev = lookup_bdev(device);
+	bdev = vdev_lookup_bdev(device);
 	if (IS_ERR(bdev))
 		return (B_FALSE);
 


### PR DESCRIPTION
Ubuntu added support for checking inode permissions to lookup_bdev() in kernel
commit 193fb6a2c94fab8eb8ce70a5da4d21c7d4023bee (merged in 4.4.0-6.21).
Upstream bug: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1636517

This patch adds a test for Ubuntu's variant of lookup_bdev() to configure and
calls the function in the correct way.