### PR TITLE
Add paxcheck make lint target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,11 +55,16 @@ shellcheck:
 		 done; \
 	 fi
 
-lint: cppcheck
+lint: cppcheck paxcheck
 
 cppcheck:
 	@if type cppcheck > /dev/null 2>&1; then \
 		cppcheck --quiet --force --error-exitcode=2 ${top_srcdir}; \
+	fi
+
+paxcheck:
+	@if type scanelf > /dev/null 2>&1; then \
+		scripts/paxcheck.sh ${top_srcdir}; \
 	fi
 
 flake8:

--- a/scripts/paxcheck.sh
+++ b/scripts/paxcheck.sh
@@ -2,7 +2,7 @@
 
 if ! type scanelf > /dev/null 2>&1; then
     echo "scanelf (from pax-utils) is required for these checks." >&2
-    exit 1
+    exit 3
 fi
 
 RET=0
@@ -27,7 +27,7 @@ fi
 OUT="$(scanelf -qyRAF '%T %p' $1)"
 
 if [ x"${OUT}" != x ]; then
-    RET=3
+    RET=2
     echo "The following files contain runtime text relocations"
     echo " Text relocations force the dynamic linker to perform extra"
     echo " work at startup, waste system resources, and may pose a security"

--- a/scripts/paxcheck.sh
+++ b/scripts/paxcheck.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+if ! type scanelf > /dev/null 2>&1; then
+    echo "scanelf (from pax-utils) is required for these checks." >&2
+    exit 1
+fi
+
+RET=0
+
+# check for exec stacks
+OUT="$(scanelf -qyRAF '%e %p' $1)"
+
+if [ x"${OUT}" != x ]; then
+    RET=2
+    echo "The following files contain writable and executable sections"
+    echo " Files with such sections will not work properly (or at all!) on some"
+    echo " architectures/operating systems."
+    echo " For more information, see:"
+    echo "   https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart"
+    echo
+    echo "${OUT}"
+    echo
+fi
+
+
+# check for TEXTRELS
+OUT="$(scanelf -qyRAF '%T %p' $1)"
+
+if [ x"${OUT}" != x ]; then
+    RET=3
+    echo "The following files contain runtime text relocations"
+    echo " Text relocations force the dynamic linker to perform extra"
+    echo " work at startup, waste system resources, and may pose a security"
+    echo " risk.  On some architectures, the code may not even function"
+    echo " properly, if at all."
+    echo " For more information, see:"
+    echo "   https://wiki.gentoo.org/wiki/Hardened/HOWTO_locate_and_fix_textrels"
+    echo
+    echo "${OUT}"
+    echo
+fi
+
+exit $RET


### PR DESCRIPTION
Requested here: https://github.com/zfsonlinux/zfs/pull/5332#issuecomment-256107000

This uses scanelf (from pax-utils) to check for any issues with the
binaries. It currently checks for executable stacks and textrels.
The checks are in a script so can be extended easily in the future for
more checks and exits cleanly if scanelf does not exist. (should it print a warning instead?)
Executable stacks and textrels are frequently caused by issues in asm
files and lead to security and perf problems.

This target needs the object files built in order to check them. It looks like the STYLE builder does not currently do a full build. Also it only checks the built ones so perhaps this target is better off added to the BUILD bots so we get all the arches?

