### PR TITLE
Enable cachefile test case group

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -43,12 +43,11 @@ tests = ['cache_002_pos', 'cache_003_pos', 'cache_004_neg',
     'cache_005_neg', 'cache_006_pos', 'cache_007_neg', 'cache_008_neg',
     'cache_009_pos', 'cache_011_pos']
 
-# DISABLED: needs investigation
-#[tests/functional/cachefile]
-#tests = ['cachefile_001_pos', 'cachefile_002_pos', 'cachefile_003_pos',
-#    'cachefile_004_pos']
-#pre =
-#post =
+[tests/functional/cachefile]
+tests = ['cachefile_001_pos', 'cachefile_002_pos', 'cachefile_003_pos',
+    'cachefile_004_pos']
+pre =
+post =
 
 # DISABLED: needs investigation
 # 'sensitive_none_lookup', 'sensitive_none_delete',

--- a/tests/zfs-tests/tests/functional/cachefile/cachefile.cfg
+++ b/tests/zfs-tests/tests/functional/cachefile/cachefile.cfg
@@ -29,5 +29,5 @@
 #
 
 export CPATH="/etc/zfs/zpool.cache"
-export CPATH1=/var/tmp/cachefile.$$
-export CPATH2=$TEST_BASE_DIR/cachefile.$$
+export CPATH1=/var/tmp/cachefile1.$$
+export CPATH2=$TEST_BASE_DIR/cachefile2.$$


### PR DESCRIPTION
The cachefile_001_pos and cachefile_002_pos and cachefile_003_pos test case can passing without modification, but cachefile_004_pos test faild because cachefile1's path is the same with cachefile2, 
so modify cachefile name to distinguish, and at last all test script can test passed.thanks!