### PR TITLE
Compatibility improvements for 32-bit systems

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -495,6 +495,8 @@ typedef struct taskq {
 #define	TQ_NOQUEUE	0x02		/* Do not enqueue if can't dispatch */
 #define	TQ_FRONT	0x08		/* Queue in front */
 
+#define	TASKQID_INVALID		((taskqid_t)0)
+
 extern taskq_t *system_taskq;
 
 extern taskq_t	*taskq_create(const char *, int, pri_t, int, int, uint_t);

--- a/include/sys/zvol.h
+++ b/include/sys/zvol.h
@@ -32,6 +32,9 @@
 #define	ZVOL_OBJ		1ULL
 #define	ZVOL_ZAP_OBJ		2ULL
 
+#define	SPEC_MAXOFFSET_T	((1LL << ((NBBY * sizeof (daddr32_t)) + \
+				DEV_BSHIFT - 1)) - 1)
+
 extern void *zvol_tag;
 
 extern void zvol_create_minors(spa_t *spa, const char *name, boolean_t async);

--- a/module/icp/core/kcf_sched.c
+++ b/module/icp/core/kcf_sched.c
@@ -561,7 +561,7 @@ kcf_resubmit_request(kcf_areq_node_t *areq)
 		taskq_t *taskq = new_pd->pd_sched_info.ks_taskq;
 
 		if (taskq_dispatch(taskq, process_req_hwp, areq, TQ_NOSLEEP) ==
-		    (taskqid_t)0) {
+		    TASKQID_INVALID) {
 			error = CRYPTO_HOST_MEMORY;
 		} else {
 			error = CRYPTO_QUEUED;
@@ -782,7 +782,7 @@ kcf_submit_request(kcf_provider_desc_t *pd, crypto_ctx_t *ctx,
 
 			if (taskq_dispatch(taskq,
 			    process_req_hwp, areq, TQ_NOSLEEP) ==
-			    (taskqid_t)0) {
+			    TASKQID_INVALID) {
 				error = CRYPTO_HOST_MEMORY;
 				if (!(crq->cr_flag & CRYPTO_SKIP_REQID))
 					kcf_reqid_delete(areq);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3479,7 +3479,7 @@ arc_prune_async(int64_t adjust)
 		refcount_add(&ap->p_refcnt, ap->p_pfunc);
 		ap->p_adjust = adjust;
 		if (taskq_dispatch(arc_prune_taskq, arc_prune_task,
-		    ap, TQ_SLEEP) == 0) {
+		    ap, TQ_SLEEP) == TASKQID_INVALID) {
 			refcount_remove(&ap->p_refcnt, ap->p_pfunc);
 			continue;
 		}

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1118,7 +1118,7 @@ dmu_objset_upgrade(objset_t *os, dmu_objset_upgrade_cb_t cb)
 		os->os_upgrade_id = taskq_dispatch(
 		    os->os_spa->spa_upgrade_taskq,
 		    dmu_objset_upgrade_task_cb, os, TQ_SLEEP);
-		if (os->os_upgrade_id == 0)
+		if (os->os_upgrade_id == TASKQID_INVALID)
 			os->os_upgrade_status = ENOMEM;
 	}
 	mutex_exit(&os->os_upgrade_lock);

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -615,8 +615,8 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 	}
 
 	if (!(flags & TRAVERSE_PREFETCH_DATA) ||
-	    0 == taskq_dispatch(system_taskq, traverse_prefetch_thread,
-	    td, TQ_NOQUEUE))
+	    taskq_dispatch(system_taskq, traverse_prefetch_thread,
+	    td, TQ_NOQUEUE) == TASKQID_INVALID)
 		pd->pd_exited = B_TRUE;
 
 	err = traverse_visitbp(td, NULL, rootbp, czb);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -1724,7 +1724,7 @@ metaslab_group_preload(metaslab_group_t *mg)
 		 */
 		mutex_exit(&mg->mg_lock);
 		VERIFY(taskq_dispatch(mg->mg_taskq, metaslab_preload,
-		    msp, TQ_SLEEP) != 0);
+		    msp, TQ_SLEEP) != TASKQID_INVALID);
 		mutex_enter(&mg->mg_lock);
 		msp = msp_next;
 	}

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1191,7 +1191,7 @@ retry_sync:
 
 		for (c = 0; c < children; c++)
 			VERIFY(taskq_dispatch(tq, vdev_open_child,
-			    vd->vdev_child[c], TQ_SLEEP) != 0);
+			    vd->vdev_child[c], TQ_SLEEP) != TASKQID_INVALID);
 
 		taskq_destroy(tq);
 	}

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -202,7 +202,8 @@ vdev_file_io_start(zio_t *zio)
 			 */
 			if (spl_fstrans_check()) {
 				VERIFY3U(taskq_dispatch(system_taskq,
-				    vdev_file_io_fsync, zio, TQ_SLEEP), !=, 0);
+				    vdev_file_io_fsync, zio, TQ_SLEEP), !=,
+				    TASKQID_INVALID);
 				return;
 			}
 
@@ -220,7 +221,7 @@ vdev_file_io_start(zio_t *zio)
 	zio->io_target_timestamp = zio_handle_io_delay(zio);
 
 	VERIFY3U(taskq_dispatch(system_taskq, vdev_file_io_strategy, zio,
-	    TQ_SLEEP), !=, 0);
+	    TQ_SLEEP), !=, TASKQID_INVALID);
 }
 
 /* ARGSUSED */

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -147,7 +147,7 @@ zfsctl_snapshot_alloc(char *full_name, char *full_path, spa_t *spa,
 	se->se_spa = spa;
 	se->se_objsetid = objsetid;
 	se->se_root_dentry = root_dentry;
-	se->se_taskqid = -1;
+	se->se_taskqid = TASKQID_INVALID;
 
 	refcount_create(&se->se_refcount);
 
@@ -339,7 +339,7 @@ snapentry_expire(void *data)
 		return;
 	}
 
-	se->se_taskqid = -1;
+	se->se_taskqid = TASKQID_INVALID;
 	(void) zfsctl_snapshot_unmount(se->se_name, MNT_EXPIRE);
 	zfsctl_snapshot_rele(se);
 
@@ -366,7 +366,7 @@ zfsctl_snapshot_unmount_cancel(zfs_snapentry_t *se)
 	ASSERT(RW_LOCK_HELD(&zfs_snapshot_lock));
 
 	if (taskq_cancel_id(zfs_expire_taskq, se->se_taskqid) == 0) {
-		se->se_taskqid = -1;
+		se->se_taskqid = TASKQID_INVALID;
 		zfsctl_snapshot_rele(se);
 	}
 }
@@ -377,7 +377,7 @@ zfsctl_snapshot_unmount_cancel(zfs_snapentry_t *se)
 static void
 zfsctl_snapshot_unmount_delay_impl(zfs_snapentry_t *se, int delay)
 {
-	ASSERT3S(se->se_taskqid, ==, -1);
+	ASSERT3S(se->se_taskqid, ==, TASKQID_INVALID);
 
 	if (delay <= 0)
 		return;

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -548,7 +548,6 @@ zfsctl_inode_lookup(zfs_sb_t *zsb, uint64_t id,
 int
 zfsctl_create(zfs_sb_t *zsb)
 {
-#if defined(CONFIG_64BIT)
 	ASSERT(zsb->z_ctldir == NULL);
 
 	zsb->z_ctldir = zfsctl_inode_alloc(zsb, ZFSCTL_INO_ROOT,
@@ -557,9 +556,6 @@ zfsctl_create(zfs_sb_t *zsb)
 		return (SET_ERROR(ENOENT));
 
 	return (0);
-#else
-	return (SET_ERROR(EOPNOTSUPP));
-#endif /* CONFIG_64BIT */
 }
 
 /*

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -952,7 +952,7 @@ zfs_iput_async(struct inode *ip)
 
 	if (atomic_read(&ip->i_count) == 1)
 		VERIFY(taskq_dispatch(dsl_pool_iput_taskq(dmu_objset_pool(os)),
-		    (task_func_t *)iput, ip, TQ_SLEEP) != 0);
+		    (task_func_t *)iput, ip, TQ_SLEEP) != TASKQID_INVALID);
 	else
 		iput(ip);
 }

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1557,7 +1557,7 @@ zio_delay_interrupt(zio_t *zio)
 				tid = taskq_dispatch_delay(system_taskq,
 				    (task_func_t *) zio_interrupt,
 				    zio, TQ_NOSLEEP, expire_at_tick);
-				if (!tid) {
+				if (tid == TASKQID_INVALID) {
 					/*
 					 * Couldn't allocate a task.  Just
 					 * finish the zio without a delay.

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1895,7 +1895,7 @@ zvol_create_minors(spa_t *spa, const char *name, boolean_t async)
 		return;
 
 	id = taskq_dispatch(spa->spa_zvol_taskq, zvol_task_cb, task, TQ_SLEEP);
-	if ((async == B_FALSE) && (id != 0))
+	if ((async == B_FALSE) && (id != TASKQID_INVALID))
 		taskq_wait_id(spa->spa_zvol_taskq, id);
 }
 
@@ -1910,7 +1910,7 @@ zvol_remove_minors(spa_t *spa, const char *name, boolean_t async)
 		return;
 
 	id = taskq_dispatch(spa->spa_zvol_taskq, zvol_task_cb, task, TQ_SLEEP);
-	if ((async == B_FALSE) && (id != 0))
+	if ((async == B_FALSE) && (id != TASKQID_INVALID))
 		taskq_wait_id(spa->spa_zvol_taskq, id);
 }
 
@@ -1926,7 +1926,7 @@ zvol_rename_minors(spa_t *spa, const char *name1, const char *name2,
 		return;
 
 	id = taskq_dispatch(spa->spa_zvol_taskq, zvol_task_cb, task, TQ_SLEEP);
-	if ((async == B_FALSE) && (id != 0))
+	if ((async == B_FALSE) && (id != TASKQID_INVALID))
 		taskq_wait_id(spa->spa_zvol_taskq, id);
 }
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -281,7 +281,7 @@ zvol_check_volsize(uint64_t volsize, uint64_t blocksize)
 		return (SET_ERROR(EINVAL));
 
 #ifdef _ILP32
-	if (volsize - 1 > MAXOFFSET_T)
+	if (volsize - 1 > SPEC_MAXOFFSET_T)
 		return (SET_ERROR(EOVERFLOW));
 #endif
 	return (0);

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -44,6 +44,19 @@ function is_linux
 	fi
 }
 
+# Determine if this is a 32-bit system
+#
+# Return 0 if platform is 32-bit, 1 if otherwise
+
+function is_32bit
+{
+	if [[ $(getconf LONG_BIT) == "32" ]]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
 # Determine whether a dataset is mounted
 #
 # $1 dataset name

--- a/tests/zfs-tests/tests/functional/features/async_destroy/setup.ksh
+++ b/tests/zfs-tests/tests/functional/features/async_destroy/setup.ksh
@@ -31,6 +31,10 @@
 
 . $STF_SUITE/include/libtest.shlib
 
+if is_32bit; then
+	log_unsupported "Test case fails on 32-bit systems"
+fi
+
 DISK=${DISKS%% *}
 
 default_setup $DISK


### PR DESCRIPTION
Intended to improve 32-bit support to the point where we can start regularly running the ZFS Test Suite on an 32-bit system.  It still may be necessary to increase the default `vmalloc=<size>`.  However, it's hoped that at some point with the changes in #5135 that will no longer be required.

Requires zfsonlinux/spl#583
