### PR TITLE
Process all systemd services through the systemd scriptlets

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -39,6 +39,7 @@
 # Generic enable switch for systemd
 %if %{with systemd}
 %define _systemd 1
+%define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target
 %endif
 
 # RHEL >= 7 comes with systemd
@@ -239,7 +240,7 @@ find %{?buildroot}%{_libdir} -name '*.la' -exec rm -f {} \;
 
 %post
 %if 0%{?_systemd}
-%systemd_post zfs.target
+%systemd_post %{systemd_svcs}
 %else
 if [ -x /sbin/chkconfig ]; then
     /sbin/chkconfig --add zfs-import
@@ -252,7 +253,7 @@ exit 0
 
 %preun
 %if 0%{?_systemd}
-%systemd_preun zfs.target
+%systemd_preun %{systemd_svcs}
 %else
 if [ $1 -eq 0 ] && [ -x /sbin/chkconfig ]; then
     /sbin/chkconfig --del zfs-import
@@ -265,7 +266,7 @@ exit 0
 
 %postun
 %if 0%{?_systemd}
-%systemd_postun zfs.target
+%systemd_postun %{systemd_svcs}
 %endif
 
 %files


### PR DESCRIPTION
This patch ensures that all systemd services are processed through the systemd scriptlets, so that services are properly configured per the preset file installed by the package.

Without this, `zfs.target` is set, but none of the services are enabled per the preset file, meaning automounting filesystems and such won't work out of the box.