### PR TITLE
SPA stats histogram showing only 32 buckets

### DIFF
--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -600,7 +600,7 @@ spa_tx_assign_add_nsecs(spa_t *spa, uint64_t nsecs)
 	spa_stats_history_t *ssh = &spa->spa_stats.tx_assign_histogram;
 	uint64_t idx = 0;
 
-	while (((1 << idx) < nsecs) && (idx < ssh->size - 1))
+	while ((((u_longlong_t)1 << idx) < nsecs) && (idx < ssh->size - 1))
 		idx++;
 
 	atomic_inc_64(&((kstat_named_t *)ssh->private)[idx].value.ui64);


### PR DESCRIPTION
The histogram is supposed to have 64 buckets but the logic to select the bucket is not right as it ends up only selecting the first 32 buckets only. 