### PR TITLE
Fix coverity defect by cid 153991

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1613,10 +1613,7 @@ top:
 	dmu_tx_commit(tx);
 out:
 
-	if (error) {
-		if (zp)
-			iput(ZTOI(zp));
-	} else {
+	if (error != 0) {
 		zfs_inode_update(dzp);
 		zfs_inode_update(zp);
 		*ipp = ZTOI(zp);


### PR DESCRIPTION
Fix coverity defect:
detail as follow:
*** CID 153991:  Control flow issues  (DEADCODE)
/module/zfs/zfs_vnops.c: 1618 in zfs_tmpfile()
1612     		 zfs_acl_ids_free(&acl_ids);
1613     		 dmu_tx_commit(tx);
1614     out:
1615     
1616     		 if (error) {
1617     		 		 if (zp)
>>>     CID 153991:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "iput(&zp->z_inode);".
1618     		 		 		 iput(ZTOI(zp));
1619     		 } else {
1620     		 		 zfs_inode_update(dzp);
1621     		 		 zfs_inode_update(zp);
1622     		 		 *ipp = ZTOI(zp);
1623     		 }