### PR TITLE
Fix: ZFS_AC_KERNEL_SET_CACHED_ACL_USABLE check

### DIFF
--- a/config/kernel-acl.m4
+++ b/config/kernel-acl.m4
@@ -58,8 +58,8 @@ AC_DEFUN([ZFS_AC_KERNEL_SET_CACHED_ACL_USABLE], [
 	],[
 		struct inode *ip = NULL;
 		struct posix_acl *acl = posix_acl_alloc(1, 0);
-		set_cached_acl(ip, 0, acl);
-		forget_cached_acl(ip, 0);
+		set_cached_acl(ip, ACL_TYPE_ACCESS, acl);
+		forget_cached_acl(ip, ACL_TYPE_ACCESS);
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_SET_CACHED_ACL_USABLE, 1,


### PR DESCRIPTION
Pass `ACL_TYPE_ACCESS` for type parameter of `get_cached_acl()` to avoid
removing dead code after BUG() in compile time. Tested on 3.2.0 kernel.

Introduced in 3779913