### PR TITLE
Unsigned compared against zero with CID 147540-42

### DIFF
--- a/include/zpios-ctl.h
+++ b/include/zpios-ctl.h
@@ -146,7 +146,7 @@ zpios_timespec_normalize(zpios_timespec_t *ts, uint32_t sec, uint32_t nsec)
 		nsec -= NSEC_PER_SEC;
 		sec++;
 	}
-	while (nsec < 0) {
+	while (((int32_t)nsec) < 0) {
 		nsec += NSEC_PER_SEC;
 		sec--;
 	}

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -555,8 +555,7 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 
 		case ZPOOL_PROP_FAILUREMODE:
 			error = nvpair_value_uint64(elem, &intval);
-			if (!error && (intval < ZIO_FAILURE_MODE_WAIT ||
-			    intval > ZIO_FAILURE_MODE_PANIC))
+			if (!error && intval > ZIO_FAILURE_MODE_PANIC)
 				error = SET_ERROR(EINVAL);
 
 			/*


### PR DESCRIPTION
issues:
coverity scan CID:147540, function: zpios_timespec_normalize
coverity scan CID:147542, function: spa_prop_validate

Signed-off-by: cao.xuewen cao.xuewen@zte.com.cn