### PR TITLE
Skip test suites on 32-bit TEST builders

### DIFF
--- a/TEST
+++ b/TEST
@@ -93,3 +93,14 @@ Ubuntu*)
 *)
     ;;
 esac
+
+###
+#
+# Disable the following test suites on 32-bit systems.
+#
+if [ $(getconf LONG_BIT) = "32" ]; then
+    TEST_ZTEST_SKIP="yes"
+    TEST_FILEBENCH_SKIP="yes"
+    TEST_XFSTESTS_SKIP="yes"
+    TEST_ZFSSTRESS_SKIP="yes"
+fi


### PR DESCRIPTION
The ztest, filebench, zfstests, and zfsstress test suites should
be skipped when testing on 32-bit platforms until they pass
reliably.
