### PR TITLE
Repair indent of zpool.8 man page, just before zpool labelclear details.

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1764,6 +1764,9 @@ All queue statistics are instantaneous measurements of the number of entries
 in the queues.  If you specify an interval, the measurements will be sampled
 from the end of the interval.
 .RE
+
+.RE
+
 .sp
 .ne 2
 .na


### PR DESCRIPTION
Seems to be introduced by 193a37cb2 (git bisect).