### PR TITLE
Enable user_property_002_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -170,12 +170,11 @@ tests = ['zfs_send_001_pos', 'zfs_send_002_pos', 'zfs_send_003_pos',
 # DISABLED:
 # mountpoint_003_pos - needs investigation
 # ro_props_001_pos - https://github.com/zfsonlinux/zfs/issues/5201
-# user_property_002_pos - needs investigation
 [tests/functional/cli_root/zfs_set]
 tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'canmount_002_pos', 'canmount_003_pos', 'canmount_004_pos',
     'checksum_001_pos', 'compression_001_pos', 'mountpoint_001_pos',
-    'mountpoint_002_pos', 'reservation_001_neg',
+    'mountpoint_002_pos', 'reservation_001_neg', 'user_property_002_pos',
     'share_mount_001_neg', 'snapdir_001_pos', 'onoffs_001_pos',
     'user_property_001_pos', 'user_property_003_neg', 'readonly_001_pos',
     'user_property_004_pos', 'version_001_neg', 'zfs_set_001_neg',


### PR DESCRIPTION
This script run successfully in my linux( CentOS Linux release 7.0). Running result as below:
```
Test: /home/zfs-master/tests/zfs-tests/tests/functional/cli_root/zfs_set/user_property_002_pos (run as root) [00:01] [PASS]
19:04:51.16 ASSERTION: User defined property inherited from its parent.
19:04:51.19 SUCCESS: /home/zfs-master/cmd/zfs/zfs snapshot testpool.3496/testfs.3496@snap
19:04:51.22 SUCCESS: /home/zfs-master/cmd/zfs/zfs snapshot testpool.3496/testvol3496@snap
19:04:51.26 SUCCESS: /home/zfs-master/cmd/zfs/zfs clone testpool.3496/testfs.3496@snap testpool.3496/fsclone
19:04:51.31 SUCCESS: /home/zfs-master/cmd/zfs/zfs clone testpool.3496/testvol3496@snap testpool.3496/volclone
19:04:51.34 SUCCESS: eval /home/zfs-master/cmd/zfs/zfs set .6y-dk:sw:='.Wtn#0BVV!Z<RT=!' testpool.3496
19:04:51.36 SUCCESS: eval check_user_prop testpool.3496 .6y-dk:sw: '.Wtn#0BVV!Z<RT=!'
19:04:51.52 SUCCESS: inherit_check .6y-dk:sw: testpool.3496 testpool.3496/testfs.3496 testpool.3496/testvol3496 testpool.3496/fsclone testpool.3496/volclone
19:04:51.57 SUCCESS: /home/zfs-master/cmd/zfs/zfs rename testpool.3496/fsclone testpool.3496/testfs.3496/fsclone
19:04:51.61 SUCCESS: /home/zfs-master/cmd/zfs/zfs rename testpool.3496/volclone testpool.3496/testfs.3496/volclone
19:04:51.74 SUCCESS: inherit_check .6y-dk:sw: testpool.3496 testpool.3496/testfs.3496 testpool.3496/testfs.3496/fsclone testpool.3496/testfs.3496/volclone
19:04:51.74 NOTE: Set intermediate dataset will change the inherited relationship.
19:04:51.77 SUCCESS: eval /home/zfs-master/cmd/zfs/zfs set .6y-dk:sw:='tbcPgj}\/%%;TWo$' testpool.3496/testfs.3496
19:04:51.78 SUCCESS: eval check_user_prop testpool.3496/testfs.3496 .6y-dk:sw: 'tbcPgj}\/%%;TWo$'
19:04:51.87 SUCCESS: inherit_check .6y-dk:sw: testpool.3496/testfs.3496 testpool.3496/testfs.3496/fsclone testpool.3496/testfs.3496/volclone
```