### PR TITLE
Performance Regression Test Suite Fixes

### DIFF
--- a/tests/zfs-tests/tests/perf/regression/random_reads.ksh
+++ b/tests/zfs-tests/tests/perf/regression/random_reads.ksh
@@ -31,8 +31,14 @@
 
 function cleanup
 {
-	log_must $ZFS destroy $TESTFS
+	# kill fio and iostat
+	$PKILL ${FIO##*/}
+	$PKILL ${IOSTAT##*/}
+	log_must_busy $ZFS destroy $TESTFS
+	log_must_busy $ZPOOL destroy $PERFPOOL
 }
+
+trap "log_fail \"Measure IO stats during random read load\"" SIGTERM
 
 log_assert "Measure IO stats during random read load"
 log_onexit cleanup

--- a/tests/zfs-tests/tests/perf/regression/random_readwrite.ksh
+++ b/tests/zfs-tests/tests/perf/regression/random_readwrite.ksh
@@ -31,8 +31,14 @@
 
 function cleanup
 {
-	log_must $ZFS destroy $TESTFS
+	# kill fio and iostat
+	$PKILL ${FIO##*/}
+	$PKILL ${IOSTAT##*/}
+	log_must_busy $ZFS destroy $TESTFS
+	log_must_busy $ZPOOL destroy $PERFPOOL
 }
+
+trap "log_fail \"Measure IO stats during random read load\"" SIGTERM
 
 log_assert "Measure IO stats during random read-write load"
 log_onexit cleanup

--- a/tests/zfs-tests/tests/perf/regression/random_writes.ksh
+++ b/tests/zfs-tests/tests/perf/regression/random_writes.ksh
@@ -30,8 +30,14 @@
 
 function cleanup
 {
-	log_must $ZFS destroy $TESTFS
+	# kill fio and iostat
+	$PKILL ${FIO##*/}
+	$PKILL ${IOSTAT##*/}
+	log_must_busy $ZFS destroy $TESTFS
+	log_must_busy $ZPOOL destroy $PERFPOOL
 }
+
+trap "log_fail \"Measure IO stats during random read load\"" SIGTERM
 
 log_assert "Measure IO stats during random write load"
 log_onexit cleanup

--- a/tests/zfs-tests/tests/perf/regression/sequential_reads.ksh
+++ b/tests/zfs-tests/tests/perf/regression/sequential_reads.ksh
@@ -31,8 +31,14 @@
 
 function cleanup
 {
-	log_must $ZFS destroy $TESTFS
+	# kill fio and iostat
+	$PKILL ${FIO##*/}
+	$PKILL ${IOSTAT##*/}
+	log_must_busy $ZFS destroy $TESTFS
+	log_must_busy $ZPOOL destroy $PERFPOOL
 }
+
+trap "log_fail \"Measure IO stats during random read load\"" SIGTERM
 
 log_assert "Measure IO stats during sequential read load"
 log_onexit cleanup

--- a/tests/zfs-tests/tests/perf/regression/sequential_reads_cached.ksh
+++ b/tests/zfs-tests/tests/perf/regression/sequential_reads_cached.ksh
@@ -30,8 +30,14 @@
 
 function cleanup
 {
-	log_must $ZFS destroy $TESTFS
+	# kill fio and iostat
+	$PKILL ${FIO##*/}
+	$PKILL ${IOSTAT##*/}
+	log_must_busy $ZFS destroy $TESTFS
+	log_must_busy $ZPOOL destroy $PERFPOOL
 }
+
+trap "log_fail \"Measure IO stats during random read load\"" SIGTERM
 
 log_assert "Measure IO stats during sequential read load"
 log_onexit cleanup

--- a/tests/zfs-tests/tests/perf/regression/sequential_reads_cached_clone.ksh
+++ b/tests/zfs-tests/tests/perf/regression/sequential_reads_cached_clone.ksh
@@ -36,8 +36,14 @@
 
 function cleanup
 {
-	log_must $ZFS destroy $TESTFS
+	# kill fio and iostat
+	$PKILL ${FIO##*/}
+	$PKILL ${IOSTAT##*/}
+	log_must_busy $ZFS destroy $TESTFS
+	log_must_busy $ZPOOL destroy $PERFPOOL
 }
+
+trap "log_fail \"Measure IO stats during random read load\"" SIGTERM
 
 log_assert "Measure IO stats during sequential read load"
 log_onexit cleanup

--- a/tests/zfs-tests/tests/perf/regression/sequential_writes.ksh
+++ b/tests/zfs-tests/tests/perf/regression/sequential_writes.ksh
@@ -33,8 +33,14 @@ log_onexit cleanup
 
 function cleanup
 {
-	log_must $ZFS destroy $TESTFS
+	# kill fio and iostat
+	$PKILL ${FIO##*/}
+	$PKILL ${IOSTAT##*/}
+	log_must_busy $ZFS destroy $TESTFS
+	log_must_busy $ZPOOL destroy $PERFPOOL
 }
+
+trap "log_fail \"Measure IO stats during random read load\"" SIGTERM
 
 export TESTFS=$PERFPOOL/testfs
 recreate_perfpool


### PR DESCRIPTION
The performance regression test suite doesn't properly clean up after each test. This is apparent from the hang during the PERF builder's zfstests build step. Each test attempts to setup a pool and dataset, but there are cases where partial cleanup occurs. So, this pull request introduces killing of fio and iostat during cleanup, perf pool cleanup, and trapping SIGTERM so cleanup occurs if a test is killed.