### PR TITLE
Enable mountpoint_003_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -167,8 +167,6 @@ tests = ['zfs_send_001_pos', 'zfs_send_002_pos', 'zfs_send_003_pos',
     'zfs_send_004_neg', 'zfs_send_005_pos', 'zfs_send_006_pos',
     'zfs_send_007_pos']
 
-# DISABLED:
-# mountpoint_003_pos - needs investigation
 [tests/functional/cli_root/zfs_set]
 tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'canmount_002_pos', 'canmount_003_pos', 'canmount_004_pos',
@@ -178,7 +176,7 @@ tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'user_property_001_pos', 'user_property_003_neg', 'readonly_001_pos',
     'user_property_004_pos', 'version_001_neg', 'zfs_set_001_neg',
     'zfs_set_002_neg', 'zfs_set_003_neg', 'property_alias_001_pos',
-    'ro_props_001_pos']
+    'ro_props_001_pos', 'mountpoint_003_pos']
 
 # DISABLED: Tests need to be updated for Linux share behavior
 # zfs_share_005_pos - needs investigation, probably unsupported NFS share format


### PR DESCRIPTION
In this script, ZFS test filesystem was mounted with specific options and make sure the filesystem was mounted with specific option. I test in my linux(Cent OS 7), these specific options were showed as label after setting, like this:
`raid0/fs9 on /raid0 type zfs (rw,nodev,relatime,xattr,noacl)`
However, the label just show negated option for some options, for example `dev`:
```
[root@localhost raid0]# /usr/bin/mount -t zfs -o **dev** raid0/fs11 /raid0
[root@localhost raid0]# mount
raid0/fs11 on /raid0 type zfs (rw,relatime,xattr,noacl)
[root@localhost raid0]# /usr/bin/mount -t zfs -o **nodev** raid0/fs12 /raid0
[root@localhost raid0]# mount
raid0/fs12 on /raid0 type zfs (rw,**nodev**,relatime,xattr,noacl)
```
So while ZFS test filesystem was mounted with specific options like `dev`, the script run successfully If the label have no `nodev`.
The test results in my linux show as below:
```
Test: /home/zfs-master/tests/zfs-tests/tests/functional/cli_root/zfs_set/mountpoint_003_pos (run as root) [00:01] [PASS]
14:56:20.73 ASSERTION: With legacy mount, FSType-specific option works well.
14:56:20.73 SUCCESS: /usr/bin/mkdir /tmpmnt.11224
14:56:20.79 SUCCESS: /home/zfs-master/cmd/zfs/zfs set mountpoint=legacy testpool.9977/testfs.9977
14:56:20.81 SUCCESS: /usr/bin/mount -t zfs -o **nodev** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:20.81 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,**nodev**,relatime,xattr,noacl)
14:56:20.82 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:20.84 SUCCESS: /usr/bin/mount -t zfs -o dev testpool.9977/testfs.9977 /tmpmnt.11224
14:56:20.84 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,relatime,xattr,noacl)
14:56:20.86 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:20.87 SUCCESS: /usr/bin/mount -t zfs -o **noexec** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:20.88 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,**noexec**,relatime,xattr,noacl)
14:56:20.89 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:20.91 SUCCESS: /usr/bin/mount -t zfs -o exec testpool.9977/testfs.9977 /tmpmnt.11224
14:56:20.91 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,relatime,xattr,noacl)
14:56:20.93 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:20.94 SUCCESS: /usr/bin/mount -t zfs -o **mand** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:20.95 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,relatime,**mand**,xattr,noacl)
14:56:20.96 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:20.97 SUCCESS: /usr/bin/mount -t zfs -o nomand testpool.9977/testfs.9977 /tmpmnt.11224
14:56:20.98 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,relatime,xattr,noacl)
14:56:20.99 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:21.01 SUCCESS: /usr/bin/mount -t zfs -o **ro** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:21.01 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (**ro**,relatime,xattr,noacl)
14:56:21.03 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:21.04 SUCCESS: /usr/bin/mount -t zfs -o **rw** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:21.04 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (**rw**,relatime,xattr,noacl)
14:56:21.06 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:21.07 SUCCESS: /usr/bin/mount -t zfs -o **nosuid** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:21.08 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,**nosuid**,relatime,xattr,noacl)
14:56:21.09 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:21.10 SUCCESS: /usr/bin/mount -t zfs -o suid testpool.9977/testfs.9977 /tmpmnt.11224
14:56:21.11 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,relatime,xattr,noacl)
14:56:21.12 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:21.14 SUCCESS: /usr/bin/mount -t zfs -o **xattr** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:21.14 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,relatime,**xattr**,noacl)
14:56:21.18 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:21.20 SUCCESS: /usr/bin/mount -t zfs -o **noxattr** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:21.20 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,relatime,**noxattr**,noacl)
14:56:21.21 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:21.23 SUCCESS: /usr/bin/mount -t zfs -o **atime** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:21.23 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,**relatime**,xattr,noacl)
14:56:21.29 SUCCESS: /usr/bin/umount /tmpmnt.11224
14:56:21.75 SUCCESS: /usr/bin/mount -t zfs -o **noatime** testpool.9977/testfs.9977 /tmpmnt.11224
14:56:21.76 testpool.9977/testfs.9977 on /tmpmnt.11224 type zfs (rw,**noatime**,xattr,noacl)
14:56:21.77 SUCCESS: /usr/bin/umount /tmpmnt.11224
```