### PR TITLE
zstreamdump needs to initialize fletcher 4 support

### DIFF
--- a/cmd/zstreamdump/zstreamdump.c
+++ b/cmd/zstreamdump/zstreamdump.c
@@ -265,6 +265,7 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
+	fletcher_4_init();
 	send_stream = stdin;
 	while (read_hdr(drr, &zc)) {
 
@@ -618,6 +619,7 @@ main(int argc, char *argv[])
 		pcksum = zc;
 	}
 	free(buf);
+	fletcher_4_fini();
 
 	/* Print final summary */
 


### PR DESCRIPTION
Without it, the checksum function pointers aren't initialized and can't
be used.