### PR TITLE
Fix coverity defect by cid 147475

### DIFF
--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -555,11 +555,13 @@ get_snapshot_names(differ_info_t *di, const char *fromsnap,
 
 	/*
 	 * Can accept
-	 *    dataset@snap1
-	 *    dataset@snap1 dataset@snap2
-	 *    dataset@snap1 @snap2
-	 *    dataset@snap1 dataset
-	 *    @snap1 dataset@snap2
+	 *                                      fdslen fsnlen tdslen tsnlen
+	 *       dataset@snap1
+	 *    0. dataset@snap1 dataset@snap2      >0     >1     >0     >1
+	 *    1. dataset@snap1 @snap2             >0     >1    ==0     >1
+	 *    2. dataset@snap1 dataset            >0     >1     >0    ==0
+	 *    3. @snap1 dataset@snap2            ==0     >1     >0     >1
+	 *    4. @snap1 dataset                  ==0     >1     >0    ==0
 	 */
 	if (tosnap == NULL) {
 		/* only a from snapshot given, must be valid */
@@ -596,8 +598,7 @@ get_snapshot_names(differ_info_t *di, const char *fromsnap,
 	fsnlen = strlen(fromsnap) - fdslen;	/* includes @ sign */
 	tsnlen = strlen(tosnap) - tdslen;	/* includes @ sign */
 
-	if (fsnlen <= 1 || tsnlen == 1 || (fdslen == 0 && tdslen == 0) ||
-	    (fsnlen == 0 && tsnlen == 0)) {
+	if (fsnlen <= 1 || tsnlen == 1 || (fdslen == 0 && tdslen == 0)) {
 		return (zfs_error(hdl, EZFS_INVALIDNAME, di->errbuf));
 	} else if ((fdslen > 0 && tdslen > 0) &&
 	    ((tdslen != fdslen || strncmp(fromsnap, tosnap, fdslen) != 0))) {


### PR DESCRIPTION
Fix coverity defect:
detail as follow:
*** CID 147475: Logically dead code (DEADCODE)
/lib/libzfs/libzfs_diff.c：599 in get_snapshot_names()

atptrf = strchr(fromsnap, '@');
593        atptrt = strchr(tosnap, '@');
594        fdslen = atptrf ? atptrf - fromsnap : strlen(fromsnap);
595        tdslen = atptrt ? atptrt - tosnap : strlen(tosnap);
596        fsnlen = strlen(fromsnap) - fdslen;     /* includes @ sign */
597        tsnlen = strlen(tosnap) - tdslen;       /* includes @ sign */
598

`cond_at_least: Condition fsnlen <= 1, taking false branch. Now the value of fsnlen is at least 2.
   dead_error_condition: The condition fsnlen == 0 cannot be true.
   CID 147475: Logically dead code (DEADCODE)dead_error_line: Execution cannot reach the expression tsnlen == 0 inside this statement: if (fsnlen <= 1 || tsnlen =....
`

599        if (fsnlen <= 1 || tsnlen == 1 || (fdslen == 0 && tdslen == 0) ||
   at_least: At condition fsnlen == 0, the value of fsnlen must be at least 2.
600            (fsnlen == 0 && tsnlen == 0)) {
601                return (zfs_error(hdl, EZFS_INVALIDNAME, di->errbuf));
602        } else if ((fdslen > 0 && tdslen > 0) &&
603            ((tdslen != fdslen || strncmp(fromsnap, tosnap, fdslen) != 0))) {

conclusion:
from the coverity  detect we know Execution cannot reach the expression (fsnlen == 0 && tsnlen == 0) in line 599 because now the value of fsnlen is at least 2, and this expression shoud modify to (fdslen == 0 && tsnlen == 0) .