### PR TITLE
Fix sizeof_mismatch detect with cid 154591

### DIFF
--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -447,7 +447,7 @@ vdev_cmd_data_list_t *
 all_pools_for_each_vdev_run(int argc, char **argv, char *cmd)
 {
 	vdev_cmd_data_list_t *vcdl;
-	vcdl = safe_malloc(sizeof (vcdl));
+	vcdl = safe_malloc(sizeof (vdev_cmd_data_list_t));
 	vcdl->cmd = cmd;
 
 	/* Gather our list of all vdevs in all pools */


### PR DESCRIPTION
Fix sizeof_mismatch problem in function all_pools_for_each_vdev_run().
*** CID 154591:  Incorrect expression  (SIZEOF_MISMATCH)

thanks.