### PR TITLE
fix memory illegal access in abd_raidz_gen_iterate with cid 154617

### DIFF
--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -1321,7 +1321,7 @@ abd_raidz_gen_iterate(abd_t **cabds, abd_t *dabd,
 	int i;
 	ssize_t len, dlen;
 	struct abd_iter caiters[3];
-	struct abd_iter daiter;
+	struct abd_iter daiter = {0};
 	void *caddrs[3];
 	unsigned long flags;
 


### PR DESCRIPTION
In abd_raidz_gen_iterate, the value "daiter.iter_mapaddr" may be null when calling func_raidz_gen(caddrs, daiter.iter_mapaddr, len, dlen);

*** CID 154617:  Memory - illegal accesses  (UNINIT)

thanks.