### PR TITLE
Compile zio.h and zio_impl.h mutual include

### DIFF
--- a/include/sys/zio_impl.h
+++ b/include/sys/zio_impl.h
@@ -30,9 +30,6 @@
 #ifndef _ZIO_IMPL_H
 #define	_ZIO_IMPL_H
 
-#include <sys/zfs_context.h>
-#include <sys/zio.h>
-
 #ifdef	__cplusplus
 extern "C" {
 #endif

--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -41,7 +41,7 @@
  */
 
 #include <sys/arc.h>
-#include <sys/zio_impl.h>
+#include <sys/zio.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/vdev_impl.h>
 #include <sys/dmu_objset.h>


### PR DESCRIPTION
issues:
zio.h include zio_impl.h but zio_impl.h also include zio.h, so cause
header files to contain each other

Solution:
Get rid of zio_imlp.h include zio.h.
update zio_inject.c include zio.h, but not include zio_impl.h

Signed-off-by: cao.xuewen cao.xuewen@zte.com.cn