### PR TITLE
Don't run 'zpool iostat -c CMD' command on all vdevs, if vdevs specified

### DIFF
--- a/cmd/zpool/zpool_util.h
+++ b/cmd/zpool/zpool_util.h
@@ -86,11 +86,21 @@ typedef struct vdev_cmd_data_list
 {
 	char *cmd;		/* Command to run */
 	unsigned int count;	/* Number of vdev_cmd_data items (vdevs) */
+
+	/* vars to whitelist only certain vdevs, if requested */
+	libzfs_handle_t *g_zfs;
+	char **vdev_names;
+	int vdev_names_count;
+	int cb_name_flags;
+
 	vdev_cmd_data_t *data;	/* Array of vdevs */
+
 } vdev_cmd_data_list_t;
 
 vdev_cmd_data_list_t *all_pools_for_each_vdev_run(int argc, char **argv,
-    char *cmd);
+    char *cmd, libzfs_handle_t *g_zfs, char **vdev_names, int vdev_names_count,
+    int cb_name_flags);
+
 void free_vdev_cmd_data_list(vdev_cmd_data_list_t *vcdl);
 
 #ifdef	__cplusplus

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -362,7 +362,8 @@ user =
 
 [tests/functional/cli_user/zpool_iostat]
 tests = ['zpool_iostat_001_neg', 'zpool_iostat_002_pos',
-    'zpool_iostat_003_neg', 'zpool_iostat_004_pos']
+    'zpool_iostat_003_neg', 'zpool_iostat_004_pos',
+    'zpool_iostat_005_pos']
 user =
 
 [tests/functional/cli_user/zpool_list]


### PR DESCRIPTION
zpool iostat allows you to specify only certain vdevs to display.
Currently, if you run 'zpool iostat -c CMD vdev1 vdev2 ...'
on specific vdevs, it will actually run the command on *all* vdevs,
and just display the results for the vdevs you specify.  This patch
corrects the behavior to only run the command on the specified vdevs.