### PR TITLE
Skip zpool_scrub_004_pos on 32-bit systems

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
@@ -48,6 +48,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5444
+if is_32bit; then
+	log_unsupported "Test case fails on 32-bit systems"
+fi
+
 log_assert "Resilver prevent scrub from starting until the resilver completes"
 
 log_must $ZPOOL detach $TESTPOOL $DISK2


### PR DESCRIPTION
The zpool_scrub_004_pos test case currently fails when testing on
a 32-bit system.  Conditionally skip this test case on 32-bit
systems until the root cause is identified and resolved.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #5444