### PR TITLE
Don't count '@' for dataset namelen if not a snapshot

### DIFF
--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -705,7 +705,11 @@ dsl_dataset_namelen(dsl_dataset_t *ds)
 	int len;
 	VERIFY0(dsl_dataset_get_snapname(ds));
 	mutex_enter(&ds->ds_lock);
-	len = dsl_dir_namelen(ds->ds_dir) + 1 + strlen(ds->ds_snapname);
+	len = strlen(ds->ds_snapname);
+	/* add '@' if ds is a snap */
+	if (len > 0)
+		len++;
+	len += dsl_dir_namelen(ds->ds_dir);
 	mutex_exit(&ds->ds_lock);
 	return (len);
 }

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -95,7 +95,7 @@ tests = ['zfs_create_001_pos', 'zfs_create_002_pos', 'zfs_create_003_pos',
     'zfs_create_004_pos', 'zfs_create_005_pos', 'zfs_create_006_pos',
     'zfs_create_007_pos', 'zfs_create_008_neg', 'zfs_create_009_neg',
     'zfs_create_010_neg', 'zfs_create_011_pos', 'zfs_create_012_pos',
-    'zfs_create_013_pos']
+    'zfs_create_013_pos', 'zfs_create_014_pos']
 
 # DISABLED:
 # zfs_destroy_005_neg - busy mountpoint behavior

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/Makefile.am
@@ -17,4 +17,5 @@ dist_pkgdata_SCRIPTS = \
 	zfs_create_010_neg.ksh \
 	zfs_create_011_pos.ksh \
 	zfs_create_012_pos.ksh \
-	zfs_create_013_pos.ksh
+	zfs_create_013_pos.ksh \
+	zfs_create_014_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_014_pos.ksh
@@ -1,0 +1,59 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# check 'zfs create <filesystem>' works at the name length boundary
+#
+# STRATEGY:
+# 1. Verify creating filesystem with name length 255 would succeed
+# 2. Verify creating filesystem with name length 256 would fail
+# 3. Verify the pool can be re-imported
+
+verify_runnable "both"
+
+# namelen 255 and 256
+TESTFS1=$(for i in $(seq $((254 - ${#TESTPOOL}))); do echo z ; done | tr -d '\n')
+TESTFS2=$(for i in $(seq $((255 - ${#TESTPOOL}))); do echo z ; done | tr -d '\n')
+
+function cleanup
+{
+	datasetexists $TESTPOOL/$TESTFS1 &&
+		log_must $ZFS destroy $TESTPOOL/$TESTFS1
+}
+
+log_onexit cleanup
+
+log_assert "'zfs create <filesystem>' can create a ZFS filesystem with name length 255."
+
+log_must $ZFS create $TESTPOOL/$TESTFS1
+log_mustnot $ZFS create $TESTPOOL/$TESTFS2
+log_must $ZPOOL export $TESTPOOL
+log_must $ZPOOL import $TESTPOOL
+
+log_pass "'zfs create <filesystem>' works as expected."


### PR DESCRIPTION
This fix pool unimportable when dataset namelen is 255<br /><br />Signed-off-by: Chunwei Chen <david.chen@osnexus.com><br />Fix #5432