### PR TITLE
Revert "Disable zio_dva_throttle_enabled by default"

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1863,7 +1863,7 @@ Default value: \fB30,000\fR.
 Throttle block allocations in the ZIO pipeline. This allows for
 dynamic allocation distribution when devices are imbalanced.
 .sp
-Default value: \fB0\fR.
+Default value: \fB1\fR.
 .RE
 
 .sp

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -57,7 +57,7 @@ const char *zio_type_name[ZIO_TYPES] = {
 	"z_null", "z_rd", "z_wr", "z_fr", "z_cl", "z_ioctl"
 };
 
-int zio_dva_throttle_enabled = B_FALSE;
+int zio_dva_throttle_enabled = B_TRUE;
 
 /*
  * ==========================================================================


### PR DESCRIPTION
Enable zio_dva_throttle_enabled=1 by default.  Subsequent
testing has been unable to reproduce the suspected regression.

Tested-by: kernelOfTruth <kerneloftruth@gmail.com>
Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reverts #5335 
Closes #5289 