### PR TITLE
Correct minor typoes in zfs dbuf module params

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -3895,7 +3895,7 @@ MODULE_PARM_DESC(dbuf_cache_hiwater_pct,
 
 module_param(dbuf_cache_lowater_pct, uint, 0644);
 MODULE_PARM_DESC(dbuf_cache_lowater_pct,
-		"Percentage below dbuf_cache_max_bytes when the evict thread stop evicting dbufs.");
+		"Percentage below dbuf_cache_max_bytes when the evict thread stops evicting dbufs.");
 
 module_param(dbuf_cache_max_shift, int, 0644);
 MODULE_PARM_DESC(dbuf_cache_max_shift,

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -3891,13 +3891,11 @@ MODULE_PARM_DESC(dbuf_cache_max_bytes,
 
 module_param(dbuf_cache_hiwater_pct, uint, 0644);
 MODULE_PARM_DESC(dbuf_cache_hiwater_pct,
-		"Percentage over dbuf_cache_max_bytes when dbufs \
-		 much be evicted directly.");
+		"Percentage over dbuf_cache_max_bytes when dbufs must be evicted directly.");
 
 module_param(dbuf_cache_lowater_pct, uint, 0644);
 MODULE_PARM_DESC(dbuf_cache_lowater_pct,
-		"Percentage below dbuf_cache_max_bytes \
-		when the evict thread stop evicting dbufs.");
+		"Percentage below dbuf_cache_max_bytes when the evict thread stop evicting dbufs.");
 
 module_param(dbuf_cache_max_shift, int, 0644);
 MODULE_PARM_DESC(dbuf_cache_max_shift,


### PR DESCRIPTION
Correct minor typoes in zfs dbuf module params

### Description
Remove huge gap in "modinfo zfs" output and correcting two typoes

### Motivation and Context
It makes my eyes not bleed

### How Has This Been Tested?
No code changes, purely visual, no testing needed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.

Remove huge gap in "modinfo zfs" output and correcting two typoes