### PR TITLE
Fix typoes and whitespace in dbuf.c

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -3887,20 +3887,20 @@ EXPORT_SYMBOL(dmu_buf_get_blkptr);
 
 module_param(dbuf_cache_max_bytes, ulong, 0644);
 MODULE_PARM_DESC(dbuf_cache_max_bytes,
-		"Maximum size in bytes of the dbuf cache.");
+	"Maximum size in bytes of the dbuf cache.");
 
 module_param(dbuf_cache_hiwater_pct, uint, 0644);
 MODULE_PARM_DESC(dbuf_cache_hiwater_pct,
-		"Percentage over dbuf_cache_max_bytes when dbufs \
-		 much be evicted directly.");
+	"Percentage over dbuf_cache_max_bytes when dbufs must be evicted "
+	"directly.");
 
 module_param(dbuf_cache_lowater_pct, uint, 0644);
 MODULE_PARM_DESC(dbuf_cache_lowater_pct,
-		"Percentage below dbuf_cache_max_bytes \
-		when the evict thread stop evicting dbufs.");
+	"Percentage below dbuf_cache_max_bytes when the evict thread stops "
+	"evicting dbufs.");
 
 module_param(dbuf_cache_max_shift, int, 0644);
 MODULE_PARM_DESC(dbuf_cache_max_shift,
-		"Cap the size of the dbuf cache to log2 fraction of arc size.");
+	"Cap the size of the dbuf cache to log2 fraction of arc size.");
 
 #endif


### PR DESCRIPTION
### Description
This removes two large whitespaces in "modinfo zfs" as well as correcting a couple typoes.  Should be cstyle compliant this time.

### Motivation and Context
It makes my eyes not bleed, still.

### How Has This Been Tested?
Visual changes only, no code changes, testing should not be needed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.

This removes two large whitespaces in "modinfo zfs" as well as correcting a couple typoes.