### PR TITLE
abd: adapt avx512bw raidz assembly

### DIFF
--- a/module/zfs/vdev_raidz_math.c
+++ b/module/zfs/vdev_raidz_math.c
@@ -61,7 +61,7 @@ const raidz_impl_ops_t *raidz_all_maths[] = {
 	&vdev_raidz_avx512f_impl,
 #endif
 #if defined(__x86_64) && defined(HAVE_AVX512BW)	/* only x86_64 for now */
-	// &vdev_raidz_avx512bw_impl,
+	&vdev_raidz_avx512bw_impl,
 #endif
 #if defined(__aarch64__)
 	&vdev_raidz_aarch64_neon_impl,


### PR DESCRIPTION
Adapt avx512bw raidz implementation for use with abd buffers.

### Description
Rewrite MUL2() in more compact form using the BW instr. set.
Cleanup unused macros
Parameterized abd raidz methods.

### Motivation and Context
Performance optimization for non yet available hardware.

### How Has This Been Tested?
Very lightly. Since the hardware is not publicly available, this has been only tested by running `raidz_test` in SDE emulator.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
