### PR TITLE
Disable slow tests for kmemleak

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -57,6 +57,19 @@ function is_32bit
 	fi
 }
 
+# Determine if kmemleak is enabled
+#
+# Return 0 if kmemleak is enabled, 1 if otherwise
+
+function is_kmemleak
+{
+	if is_linux && [[ -e /sys/kernel/debug/kmemleak ]]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
 # Determine whether a dataset is mounted
 #
 # $1 dataset name

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_009_pos.ksh
@@ -41,6 +41,11 @@
 
 verify_runnable "both"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5479
+if is_kmemleak; then
+	log_unsupported "Test case runs slowly when kmemleak is enabled"
+fi
+
 log_assert "'zfs get -d <n>' should get expected output."
 log_onexit depth_fs_cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
@@ -45,6 +45,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5479
+if is_kmemleak; then
+	log_unsupported "Test case runs slowly when kmemleak is enabled"
+fi
+
 function cleanup
 {
         poolexists $TESTPOOL1 && \
@@ -54,7 +59,6 @@ function cleanup
 		log_must $RM -f $file
         done
 }
-
 
 log_assert "Verify 'zpool clear' can clear errors of a storage pool."
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_024_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_024_pos.ksh
@@ -39,6 +39,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5479
+if is_kmemleak; then
+	log_unsupported "Test case runs slowly when kmemleak is enabled"
+fi
+
 function cleanup
 {
 	if [[ -n "$child_pids" ]]; then

--- a/tests/zfs-tests/tests/functional/features/async_destroy/async_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/async_destroy/async_destroy_001_pos.ksh
@@ -46,6 +46,11 @@ TEST_FS=$TESTPOOL/async_destroy
 
 verify_runnable "both"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5479
+if is_kmemleak; then
+	log_unsupported "Test case runs slowly when kmemleak is enabled"
+fi
+
 function cleanup
 {
 	datasetexists $TEST_FS && log_must $ZFS destroy $TEST_FS

--- a/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
@@ -45,6 +45,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5479
+if is_kmemleak; then
+	log_unsupported "Test case runs slowly when kmemleak is enabled"
+fi
+
 log_assert "Test properties are inherited correctly"
 
 #


### PR DESCRIPTION
### Description

Disable certain slow running test cases which take even longer when kmemleak
is enabled.  This can result in timeouts which cause testing failures.

### Motivation and Context

This change is needed to add a kmemleak TEST builder to the buildbot which
completes in a reasonable amount of time and provides a good test coverage.

Issue #5479 