### PR TITLE
Skip xfstests on Ubuntu 16.04 and CentOS 7

### DIFF
--- a/TEST
+++ b/TEST
@@ -76,7 +76,13 @@ TEST_ZCONFIG_OPTIONS="-c -s10"
 case "$BB_NAME" in
 Amazon*)
     ;;
-CentOS*)
+CentOS-7*)
+    # ZFS enabled xfstests fails to build
+    TEST_XFSTESTS_SKIP="yes"
+    # Sporadic VERIFY(!zilog_is_dirty(zilog)) failed
+    TEST_ZILTEST_SKIP="yes"
+    ;;
+CentOS-6*)
     # Sporadic VERIFY(!zilog_is_dirty(zilog)) failed
     TEST_ZILTEST_SKIP="yes"
     ;;
@@ -87,6 +93,11 @@ Fedora*)
 RHEL*)
     ;;
 SUSE*)
+    ;;
+Ubuntu-16.04*)
+    # ZFS enabled xfstests fails to build
+    TEST_XFSTESTS_SKIP="yes"
+    TEST_FILEBENCH_SKIP="yes"
     ;;
 Ubuntu*)
     ;;


### PR DESCRIPTION
The ZFS enabled versions of xfstests fails to build cleanly on
Ubuntu 16.04 and CentOS 7.  This issue should be resolved by
rebasing the ZFS patches against the latest xfstests and pushing
those patches upstream.  This would allow us to use an unmodified
xfstests.

Issue #5481