### PR TITLE
Fix dsl_props_set_sync_impl to work with nested nvlist

### DIFF
--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -892,11 +892,15 @@ dsl_props_set_sync_impl(dsl_dataset_t *ds, zprop_source_t source,
 
 	while ((elem = nvlist_next_nvpair(props, elem)) != NULL) {
 		nvpair_t *pair = elem;
+		const char *name = nvpair_name(pair);
 
 		if (nvpair_type(pair) == DATA_TYPE_NVLIST) {
 			/*
-			 * dsl_prop_get_all_impl() returns properties in this
-			 * format.
+			 * This usually happens when we reuse the nvlist_t data
+			 * returned by the counterpart dsl_prop_get_all_impl().
+			 * For instance we do this to restore the original
+			 * received properties when an error occurs in the
+			 * zfs_ioc_recv() codepath.
 			 */
 			nvlist_t *attrs = fnvpair_value_nvlist(pair);
 			pair = fnvlist_lookup_nvpair(attrs, ZPROP_VALUE);
@@ -904,14 +908,14 @@ dsl_props_set_sync_impl(dsl_dataset_t *ds, zprop_source_t source,
 
 		if (nvpair_type(pair) == DATA_TYPE_STRING) {
 			const char *value = fnvpair_value_string(pair);
-			dsl_prop_set_sync_impl(ds, nvpair_name(pair),
+			dsl_prop_set_sync_impl(ds, name,
 			    source, 1, strlen(value) + 1, value, tx);
 		} else if (nvpair_type(pair) == DATA_TYPE_UINT64) {
 			uint64_t intval = fnvpair_value_uint64(pair);
-			dsl_prop_set_sync_impl(ds, nvpair_name(pair),
+			dsl_prop_set_sync_impl(ds, name,
 			    source, sizeof (intval), 1, &intval, tx);
 		} else if (nvpair_type(pair) == DATA_TYPE_BOOLEAN) {
-			dsl_prop_set_sync_impl(ds, nvpair_name(pair),
+			dsl_prop_set_sync_impl(ds, name,
 			    source, 0, 0, NULL, tx);
 		} else {
 			panic("invalid nvpair type");

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -144,7 +144,7 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_005_neg', 'zfs_receive_006_pos',
     'zfs_receive_007_neg', 'zfs_receive_008_pos', 'zfs_receive_009_neg',
     'zfs_receive_010_pos', 'zfs_receive_011_pos', 'zfs_receive_012_pos',
-    'zfs_receive_013_pos']
+    'zfs_receive_013_pos', 'zfs_receive_014_pos']
 
 [tests/functional/cli_root/zfs_rename]
 tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/Makefile.am
@@ -14,4 +14,5 @@ dist_pkgdata_SCRIPTS = \
 	zfs_receive_010_pos.ksh \
 	zfs_receive_011_pos.ksh \
 	zfs_receive_012_pos.ksh \
-	zfs_receive_013_pos.ksh
+	zfs_receive_013_pos.ksh \
+	zfs_receive_014_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_014_pos.ksh
@@ -1,0 +1,122 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2016, loli10K. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
+
+#
+# DESCRIPTION:
+# Verify ZFS successfully receive and restore properties.
+#
+# STRATEGY:
+# 1. Create a filesystem.
+# 2. Create a full stream with properties and receive it.
+# 3. Create also an incremental stream without some properties and a truncated
+#    stream.
+# 4. Fail to receive the truncated incremental stream and verify previously
+#    received properties are still present.
+# 5. Receive the complete incremental send stream and verify that sent
+#    properties are successfully received.
+#
+
+verify_runnable "both"
+
+orig=$TESTPOOL/$TESTFS1
+dest=$TESTPOOL/$TESTFS2
+typeset userprop=$(valid_user_property 8)
+typeset userval=$(user_property_value 8)
+typeset streamfile_full=/var/tmp/streamfile_full.$$
+typeset streamfile_incr=/var/tmp/streamfile_incr.$$
+typeset streamfile_trun=/var/tmp/streamfile_trun.$$
+
+function cleanup
+{
+	log_must $RM $streamfile_full
+	log_must $RM $streamfile_incr
+	log_must $RM $streamfile_trun
+	log_must $ZFS destroy -rf $orig
+	log_must $ZFS destroy -rf $dest
+}
+
+#
+# Verify property $2 is set from source $4 on dataset $1 and has value $3.
+#
+# $1 checked dataset
+# $2 user property
+# $3 property value
+# $4 source
+#
+function check_prop_source
+{
+	typeset dataset=$1
+	typeset prop=$2
+	typeset value=$3
+	typeset source=$4
+	typeset chk_value=$(get_prop "$prop" "$dataset")
+	typeset chk_source=$(get_source "$prop" "$dataset")
+	if [[ "$chk_value" != "$value" || \
+	    "$chk_source" != "$4" ]]
+	then
+		return 1
+	else
+		return 0
+	fi
+}
+
+log_assert "ZFS successfully receive and restore properties."
+log_onexit cleanup
+
+# 1. Create a filesystem.
+log_must eval "$ZFS create $orig"
+mntpnt=$(get_prop mountpoint $orig)
+
+# 2. Create a full stream with properties and receive it.
+log_must eval "$ZFS set compression='gzip-1' $orig"
+log_must eval "$ZFS set '$userprop'='$userval' $orig"
+log_must eval "$ZFS snapshot $orig@snap1"
+log_must eval "$ZFS send -p $orig@snap1 > $streamfile_full"
+log_must eval "$ZFS recv $dest < $streamfile_full"
+log_must eval "check_prop_source $dest compression 'gzip-1' received"
+log_must eval "check_prop_source $dest '$userprop' '$userval' received"
+
+# 3. Create also an incremental stream without some properties and a truncated
+#    stream.
+log_must eval "$ZFS set compression='gzip-2' $orig"
+log_must eval "$ZFS inherit '$userprop' $orig"
+log_must eval "$DD if=/dev/urandom of=$mntpnt/file bs=1024k count=10"
+log_must eval "$ZFS snapshot $orig@snap2"
+log_must eval "$ZFS send -p -i $orig@snap1 $orig@snap2 > $streamfile_incr"
+log_must eval "$DD if=$streamfile_incr of=$streamfile_trun bs=1024k count=9"
+log_must eval "$ZFS snapshot $orig@snap3"
+log_must eval "$ZFS send -p -i $orig@snap1 $orig@snap3 > $streamfile_incr"
+
+# 4. Fail to receive the truncated incremental stream and verify previously
+#    received properties are still present.
+log_mustnot eval "$ZFS recv -F $dest < $streamfile_trun"
+log_must eval "check_prop_source $dest compression 'gzip-1' received"
+log_must eval "check_prop_source $dest '$userprop' '$userval' received"
+
+# 5. Receive the complete incremental send stream and verify that sent
+#    properties are successfully received.
+log_must eval "$ZFS recv -F $dest < $streamfile_incr"
+log_must eval "check_prop_source $dest compression 'gzip-2' received"
+log_must eval "check_prop_source $dest '$userprop' '-' '-'"
+
+log_pass "ZFS properties are successfully received and restored."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
When we iterate over the input (nested) nvlist `props` in `dsl_props_set_sync_impl()` we don't preserve the nvpair name before looking up `ZPROP_VALUE`, so when we later go to process it `nvpair_name()` is always "value" and not the actual property name.

### Motivation and Context
This issue was discovered while trying to implement zfs receive override (-o|-x) properties, it manifests when we fail to receive a send stream causing previously received properties to be wiped clean (instead of being restored). Other codepaths may be affected.
Also, i previously assumed Illumos was not affected because i had no way to manually inject an error in `zfs_ioc_recv()` via `zfs_ioc_recv_inject_err` (i used systemtap for ZoL) but now i found a way to reproduce the same behaviour on a semi-new release of smartos (20160527T033529Z) ... so it seems Illumos is affected too.

I was going to push this change with the feature PR but given that it's taking more time than expected and this is a small change might as well push it for review as a separate PR.

EDIT: test case added.

### How Has This Been Tested?
Shell script here: https://gist.github.com/loli10K/3828245287eb6405bfc661c17a458166 (requires systemtap and a DEBUG-compiled ZFS)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
