### PR TITLE
Add configure option to enable ksym's for rpms

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -159,6 +159,15 @@ AC_DEFUN([ZFS_AC_RPM], [
 	AC_MSG_CHECKING([whether spec files are available])
 	AC_MSG_RESULT([yes ($RPM_SPEC_DIR/*.spec.in)])
 
+	AC_MSG_CHECKING([whether rpms will use ksyms])
+	AC_ARG_ENABLE([rpm-ksym],
+		[AC_HELP_STRING([--enable-rpm-ksym],
+		[Build RPMs with ksym() in Provides])],[
+		       AC_MSG_RESULT([yes])
+		       RPM_DEFINE_KMOD=$RPM_DEFINE_KMOD' --define "_use_internal_dependency_generator 0"'
+		],
+		[AC_MSG_RESULT([no])])
+
 	AC_SUBST(HAVE_RPM)
 	AC_SUBST(RPM)
 	AC_SUBST(RPM_VERSION)


### PR DESCRIPTION
Add ability to build with ksym's in rpm. This is needed for weak-modules.
This is also needed for master builds of Lustre.  Lustre added weak-module
support which needs ksym() definitions in Provides.

Signed-off-by: Nathaniel Clark <Nathaniel.Clark@misrule.us>

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
I have tested this buy compiling with and without the new flag.  Without yields no changes; with yields kmod rpms that include ksym() support.
I tested on el7.2.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
