### PR TITLE
Fix zfs receive on large_dnode-enabled datasets

### DIFF
--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1184,6 +1184,7 @@ dnode_is_free(dmu_buf_impl_t *db, int idx, int slots)
  * errors:
  * EINVAL - invalid object number.
  * ENOSPC - hole too small to fulfill "slots" request
+ * ENOENT - the requested dnode is not allocated
  * EIO - i/o error.
  * succeeds even for free dnodes.
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description and Context
Since OpenZFS 6393 `zfs receive` is broken when `SPA_FEATURE_LARGE_DNODE` is active on the receiving dataset. This manifests as a race condition where send streams can be received without problems only if we can push all `DRR_FREERECORDS` before large dnodes get enabled on the dataset (which itself seems like a bug, shouldn't we enable features before we start receiving any kind data?)

The problem is that since https://github.com/zfsonlinux/zfs/commit/50c957f702ea6d08a634e42f73e8a49931dd8055 (_Implement large_dnode pool feature_) `dmu_object_next()` returns `ENOENT` when receiving freeobjects and with https://github.com/zfsonlinux/zfs/commit/e6d3a843d6ced970cbc74a3f809d744c30a7ec7c (_OpenZFS 6393 - zfs receive a full send as a clone_) we treat that `ENOENT` as an error (we expect `ESRCH` as a return code from `dmu_object_next()`). More info in https://github.com/zfsonlinux/zfs/issues/5027 comments.

I thought about these possible solutions but i'd appreciate external input. The fix can be placed:
- [1] in `receive_freeobjects()`, consider `ENOENT` as the expected return value from `dmu_object_next()` (instead of `ESRCH`)
- [2] in `dmu_object_next()`, when 'feature@large_dnode' is enabled we "convert" and return the `ENOENT` from `dmu_object_info()` to `ESRCH`
- [3] in `dnode_hold_impl()`, sed 's/ENOENT/ESRCH/g'

Given that:
[1] https://github.com/zfsonlinux/zfs/commit/e6d3a843d6ced970cbc74a3f809d744c30a7ec7c is already in Illumos and is working ok without large dnodes.
[3] could probably work but `ENOENT` would remain in commit https://github.com/zfsonlinux/zfs/commit/50c957f702ea6d08a634e42f73e8a49931dd8055 message as the "expected" return value from `dnode_hold_impl()` ... could be confusing for someone reading that.

...  i opted for [2].

Also, how do we add a test case for this? We probably need to generate big send streams (this is the reason the current test in `large_dnode_005_pos.ksh` doesn't catch this) or induce latency on the receive side.

Minimal reproducer:

```
#
# issue-5027
#
POOLNAME='testpool'
TMPDIR='/var/tmp'
mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
zpool destroy $POOLNAME
fallocate -l 65m $TMPDIR/zpool.dat
zpool create $POOLNAME $TMPDIR/zpool.dat
zfs create $POOLNAME/send
zfs set dnodesize=1k $POOLNAME/send
touch /$POOLNAME/send/.dnonesize
# ensure large_dnodes is active
sleep `cat /sys/module/zfs/parameters/zfs_txg_timeout`
zpool get feature@large_dnode $POOLNAME
zfs snap $POOLNAME/send@snap1
zfs send -v $POOLNAME/send@snap1 > $TMPDIR/snap_full.dat
# use mbuffer to receive slowly so txg_sync has enough time to enable 'feature@large_dnode' before we start receiving DRR_FREERECORDS
mbuffer -r 1k < $TMPDIR/snap_full.dat | zfs receive -Fvu $POOLNAME/recv
```

### Motivation
Fix issue https://github.com/zfsonlinux/zfs/issues/5027

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
