### PR TITLE
implement per-cpu cache for SA layouts and index tables.

### DIFF
--- a/include/sys/sa_impl.h
+++ b/include/sys/sa_impl.h
@@ -114,6 +114,29 @@ typedef struct sa_idx_tab {
 	uint32_t	*sa_idx_tab;	/* array of offsets */
 } sa_idx_tab_t;
 
+#define	SA_IDX_ENTRIES		5
+
+typedef struct sa_idx_cache {
+	kmutex_t 	sac_lock;
+	int		sac_head;
+	struct sa_idx_cache_entry {
+		sa_idx_tab_t	*sac_idx;
+		sa_lot_t	*sac_lot;
+#ifdef _KERNEL
+	} sac_entries[SA_IDX_ENTRIES] ____cacheline_aligned_in_smp;
+#else
+	} sac_entries[SA_IDX_ENTRIES];
+#endif
+} sa_idx_cache_t;
+
+#define	SA_LAYOUT_ENTRIES	7	/* to fit cacheline */
+
+typedef struct sa_layout_cache {
+	kmutex_t 	slc_lock;
+	int		slc_head;
+	sa_lot_t	*slc_lot[SA_LAYOUT_ENTRIES];
+} sa_layout_cache_t;
+
 /*
  * Since the offset/index information into the actual data
  * will usually be identical we can share that information with
@@ -147,6 +170,8 @@ struct sa_os {
 	avl_tree_t	sa_layout_hash_tree; /* keyed by layout hash value */
 	int		sa_user_table_sz;
 	sa_attr_type_t	*sa_user_table; /* user name->attr mapping table */
+	sa_idx_cache_t	*sa_idx_cache;
+	sa_layout_cache_t *sa_layout_cache;
 };
 
 /*


### PR DESCRIPTION
e.g. 1000 file creations shows 5262 hits and 19 misses.
this significantly improves multicore creation rate.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
