### PR TITLE
spelling fixes

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -3249,7 +3249,7 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
 	(void) printf("\n%s\n%6s   %s  0123456789abcdef\n", label, "", hdr);
 
 #ifdef _LITTLE_ENDIAN
-	/* correct the endianess */
+	/* correct the endianness */
 	do_bswap = !do_bswap;
 #endif
 	for (i = 0; i < nwords; i += 2) {
@@ -3271,7 +3271,7 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
  *	child[.child]*    - For example: 0.1.1
  *
  * The second form can be used to specify arbitrary vdevs anywhere
- * in the heirarchy.  For example, in a pool with a mirror of
+ * in the hierarchy.  For example, in a pool with a mirror of
  * RAID-Zs, you can specify either RAID-Z vdev with 0.0 or 0.1 .
  */
 static vdev_t *

--- a/cmd/zed/agents/zfs_agents.c
+++ b/cmd/zed/agents/zfs_agents.c
@@ -217,7 +217,7 @@ zfs_agent_dispatch(const char *class, const char *subclass, nvlist_t *nvl)
 	 * On illumos these subscriptions reside in:
 	 * 	/usr/lib/fm/fmd/plugins/zfs-retire.conf
 	 *
-	 * NOTE: faults events come directy from our diagnosis engine
+	 * NOTE: faults events come directly from our diagnosis engine
 	 * and will not pass through the zfs kernel module.
 	 */
 	if (strcmp(class, FM_LIST_SUSPECT_CLASS) == 0 ||

--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -477,7 +477,7 @@ zfs_iter_vdev(zpool_handle_t *zhp, nvlist_t *nvl, void *data)
 	} else if (dp->dd_compare != NULL) {
 		/*
 		 * NOTE: On Linux there is an event for partition, so unlike
-		 * illumos, substring matching is not required to accomodate
+		 * illumos, substring matching is not required to accommodate
 		 * the partition suffix. An exact match will be present in
 		 * the dp->dd_compare value.
 		 */

--- a/cmd/zed/zed_disk_event.c
+++ b/cmd/zed/zed_disk_event.c
@@ -185,7 +185,7 @@ zed_udev_monitor(void *arg)
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 
 		/*
-		 * Strongly typed device is the prefered filter
+		 * Strongly typed device is the preferred filter
 		 */
 		type = udev_device_get_property_value(dev, "ID_FS_TYPE");
 		if (type != NULL && type[0] != '\0') {

--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -71,7 +71,7 @@ _zed_exec_create_env(zed_strings_t *zsp)
 
 /*
  * Fork a child process to handle event [eid].  The program [prog]
- * in directory [dir] is executed with the envionment [env].
+ * in directory [dir] is executed with the environment [env].
  *
  * The file descriptor [zfd] is the zevent_fd used to track the
  * current cursor location within the zevent nvlist.

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -2174,7 +2174,7 @@ zfs_do_upgrade(int argc, char **argv)
 		if (cb.cb_numfailed != 0)
 			ret = 1;
 	} else {
-		/* List old-version filesytems */
+		/* List old-version filesystems */
 		boolean_t found;
 		(void) printf(gettext("This system is currently running "
 		    "ZFS filesystem version %llu.\n\n"), ZPL_VERSION);
@@ -3376,7 +3376,7 @@ zfs_do_promote(int argc, char **argv)
  *
  *	-r	Delete any intervening snapshots before doing rollback
  *	-R	Delete any snapshots and their clones
- *	-f	ignored for backwards compatability
+ *	-f	ignored for backwards compatibility
  *
  * Given a filesystem, rollback to a specific snapshot, discarding any changes
  * since then and making it the active dataset.  If more recent snapshots exist,

--- a/cmd/zinject/translate.c
+++ b/cmd/zinject/translate.c
@@ -436,7 +436,7 @@ translate_raw(const char *str, zinject_record_t *record)
 {
 	/*
 	 * A raw bookmark of the form objset:object:level:blkid, where each
-	 * number is a hexidecimal value.
+	 * number is a hexadecimal value.
 	 */
 	if (sscanf(str, "%llx:%llx:%x:%llx", (u_longlong_t *)&record->zi_objset,
 	    (u_longlong_t *)&record->zi_object, &record->zi_level,

--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -282,7 +282,7 @@ usage(void)
 	    "\n"
 	    "\t\tInject an error into pool 'pool' with the numeric bookmark\n"
 	    "\t\tspecified by the remaining tuple.  Each number is in\n"
-	    "\t\thexidecimal, and only one block can be specified.\n"
+	    "\t\thexadecimal, and only one block can be specified.\n"
 	    "\n"
 	    "\tzinject [-q] <-t type> [-e errno] [-l level] [-r range]\n"
 	    "\t    [-a] [-m] [-u] [-f freq] <object>\n"

--- a/cmd/zpios/zpios.h
+++ b/cmd/zpios/zpios.h
@@ -1,7 +1,7 @@
 /*
  *  ZPIOS is a heavily modified version of the original PIOS test code.
  *  It is designed to have the test code running in the Linux kernel
- *  against ZFS while still being flexibly controled from user space.
+ *  against ZFS while still being flexibly controlled from user space.
  *
  *  Copyright (C) 2008-2010 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).

--- a/cmd/zpios/zpios_util.c
+++ b/cmd/zpios/zpios_util.c
@@ -1,7 +1,7 @@
 /*
  *  ZPIOS is a heavily modified version of the original PIOS test code.
  *  It is designed to have the test code running in the Linux kernel
- *  against ZFS while still being flexibly controled from user space.
+ *  against ZFS while still being flexibly controlled from user space.
  *
  *  Copyright (C) 2008-2010 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1909,7 +1909,7 @@ show_import(nvlist_t *config)
 
 	case ZPOOL_STATUS_UNSUP_FEAT_READ:
 		(void) printf(gettext("status: The pool uses the following "
-		    "feature(s) not supported on this sytem:\n"));
+		    "feature(s) not supported on this system:\n"));
 		zpool_print_unsup_feat(config);
 		break;
 
@@ -7251,7 +7251,7 @@ get_callback(zpool_handle_t *zhp, void *data)
  *		by a single tab.
  *	-o	List of columns to display.  Defaults to
  *		"name,property,value,source".
- * 	-p	Diplay values in parsable (exact) format.
+ * 	-p	Display values in parsable (exact) format.
  *
  * Get properties of pools in the system. Output space statistics
  * for each one as well as other attributes.

--- a/config/kernel-mkdir-umode-t.m4
+++ b/config/kernel-mkdir-umode-t.m4
@@ -4,7 +4,7 @@ dnl # The VFS .create, .mkdir and .mknod callbacks were updated to take a
 dnl # umode_t type rather than an int.  The expectation is that any backport
 dnl # would also change all three prototypes.  However, if it turns out that
 dnl # some distribution doesn't backport the whole thing this could be
-dnl # broken apart in to three seperate checks.
+dnl # broken apart in to three separate checks.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_MKDIR_UMODE_T], [
 	AC_MSG_CHECKING([whether iops->create()/mkdir()/mknod() take umode_t])

--- a/config/kernel-xattr-handler.m4
+++ b/config/kernel-xattr-handler.m4
@@ -296,7 +296,7 @@ dnl #
 AC_DEFUN([ZFS_AC_KERNEL_XATTR_HANDLER_LIST], [
 	dnl # 4.5 API change,
 	dnl # The xattr_handler->list() callback was changed to take only a
-	dnl # dentry and it only needs to return if it's accessable.
+	dnl # dentry and it only needs to return if it's accessible.
 	AC_MSG_CHECKING([whether xattr_handler->list() wants simple])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/xattr.h>

--- a/config/user-commands.m4
+++ b/config/user-commands.m4
@@ -95,7 +95,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_COMMANDS_COMMON], [
 ])
 
 dnl #
-dnl # Linux commands, used withing 'is_linux' blocks of test scripts.
+dnl # Linux commands, used within 'is_linux' blocks of test scripts.
 dnl # These commands may take different command line arguments.
 dnl #
 AC_DEFUN([ZFS_AC_CONFIG_USER_COMMANDS_LINUX], [

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -130,7 +130,7 @@ get_pools()
 		if [ -n "$npools" ]
 		then
 			# Because we have found extra pool(s) here, which wasn't
-			# found 'normaly', we need to force USE_DISK_BY_ID to
+			# found 'normally', we need to force USE_DISK_BY_ID to
 			# make sure we're able to actually import it/them later.
 			USE_DISK_BY_ID='yes'
 
@@ -195,7 +195,7 @@ import_pool()
 	# Make as sure as we can to not require '-f' to import.
 	"${ZPOOL}" status "$pool" > /dev/null 2>&1 && return 0
 
-	# For backwards compability, make sure that ZPOOL_IMPORT_PATH is set
+	# For backwards compatibility, make sure that ZPOOL_IMPORT_PATH is set
 	# to something we can use later with the real import(s). We want to
 	# make sure we find all by* dirs, BUT by-vdev should be first (if it
 	# exists).
@@ -485,7 +485,7 @@ destroy_fs()
 
 # Clone snapshot $1 to destination filesystem $2
 # Set 'canmount=noauto' and 'mountpoint=none' so that we get to keep
-# manual controll over it's mounting (i.e., make sure it's not automatically
+# manual control over it's mounting (i.e., make sure it's not automatically
 # mounted with a 'zfs mount -a' in the init/systemd scripts).
 clone_snap()
 {
@@ -497,7 +497,7 @@ clone_snap()
 
 	# Clone the snapshot into a dataset we can boot from
 	# + We don't want this filesystem to be automatically mounted, we
-	#   want controll over this here and nowhere else.
+	#   want control over this here and nowhere else.
 	# + We don't need any mountpoint set for the same reason.
 	# We use the 'org.zol:mountpoint' property to remember the mountpoint.
 	ZFS_CMD="${ZFS} clone -o canmount=noauto -o mountpoint=none"
@@ -585,7 +585,7 @@ EOT
 	echo -n "  Snap nr [0-$((i-1))]? " > /dev/stderr
 	read snapnr
 
-	# Reenable debugging.
+	# Re-enable debugging.
 	if [ -n "${debug}" ]; then
 		ZFS_DEBUG=1
 		set -x
@@ -795,7 +795,7 @@ mountroot()
 	#       supported by ZoL (whatever it's for).
 	if [ -z "$ZFS_RPOOL" ]
 	then
-		# The ${zfs-bootfs} variable is set at the kernel commmand
+		# The ${zfs-bootfs} variable is set at the kernel command
 		# line, usually by GRUB, but it cannot be referenced here
 		# directly because bourne variable names cannot contain a
 		# hyphen.

--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -98,7 +98,7 @@ do_import_all_visible()
 		if [ -n "$npools" ]
 		then
 			# Because we have found extra pool(s) here, which wasn't
-			# found 'normaly', we need to force USE_DISK_BY_ID to
+			# found 'normally', we need to force USE_DISK_BY_ID to
 			# make sure we're able to actually import it/them later.
 			USE_DISK_BY_ID='yes'
 
@@ -148,7 +148,7 @@ do_import_all_visible()
 		available_pools="$apools"
 	fi
 
-	# For backwards compability, make sure that ZPOOL_IMPORT_PATH is set
+	# For backwards compatibility, make sure that ZPOOL_IMPORT_PATH is set
 	# to something we can use later with the real import(s). We want to
 	# make sure we find all by* dirs, BUT by-vdev should be first (if it
 	# exists).
@@ -157,7 +157,7 @@ do_import_all_visible()
 		local dirs
 		dirs="$(for dir in $(echo /dev/disk/by-*)
 		do
-			# Ignore by-vdev here - we wan't it first!
+			# Ignore by-vdev here - we want it first!
 			echo "$dir" | grep -q /by-vdev && continue
 			[ ! -d "$dir" ] && continue
 
@@ -217,7 +217,7 @@ do_import_all_visible()
 
 		# Import by using ZPOOL_IMPORT_PATH (either set above or in
 		# the config file) _or_ with the 'built in' default search
-		# paths. This is the prefered way.
+		# paths. This is the preferred way.
 		"$ZPOOL" import -N ${ZPOOL_IMPORT_OPTS} "$pool" 2> /dev/null
 		r="$?" ; RET=$((RET + r))
 		if [ "$r" -eq 0 ]

--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -73,7 +73,7 @@ do_mount()
 	zfs_action "Mounting ZFS filesystem(s)" \
 	    "$ZFS" mount -a$verbose$overlay "$MOUNT_EXTRA_OPTIONS"
 
-	# Require each volume/filesytem to have 'noauto' and no fsck
+	# Require each volume/filesystem to have 'noauto' and no fsck
 	# option. This shouldn't really be necessary, as long as one
 	# can get zfs-import to run sufficiently early on in the boot
 	# process - before local mounts. This is just here in case/if

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -54,7 +54,7 @@ extern "C" {
  * a DVA.  These are buffers that hold dirty block copies
  * before they are written to stable storage.  By definition,
  * they are "ref'd" and are considered part of arc_mru
- * that cannot be freed.  Generally, they will aquire a DVA
+ * that cannot be freed.  Generally, they will acquire a DVA
  * as they are written and migrate onto the arc_mru list.
  *
  * The ARC_l2c_only state is for buffers that are in the second

--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -266,7 +266,7 @@ struct dnode {
 	 * duplicate entries, we order the dbufs by an arbitrary value -
 	 * their address in memory. This means that dn_dbufs cannot be used to
 	 * directly look up a dbuf. Instead, callers must use avl_walk, have
-	 * a reference to the dbuf, or look up a non-existant node with
+	 * a reference to the dbuf, or look up a non-existent node with
 	 * db_state = DB_SEARCH (see dbuf_free_range for an example).
 	 */
 	avl_tree_t dn_dbufs;

--- a/include/sys/efi_partition.h
+++ b/include/sys/efi_partition.h
@@ -272,7 +272,7 @@ typedef struct efi_gpe_Attrs {
 #define	EFI_FREEDESKTOP_BOOT	{ 0xbc13c2ff, 0x59e6, 0x4262, 0xa3, 0x52, \
 				    { 0xb2, 0x75, 0xfd, 0x6f, 0x71, 0x72 } }
 
-/* minimum # of bytes for partition table entires, per EFI spec */
+/* minimum # of bytes for partition table entries, per EFI spec */
 #define	EFI_MIN_ARRAY_SIZE	(16 * 1024)
 
 #define	EFI_PART_NAME_LEN	36

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -894,7 +894,7 @@ typedef struct vdev_stat_ex {
  * is passed between kernel and userland as an nvlist uint64 array.
  */
 typedef struct ddt_object {
-	uint64_t	ddo_count;	/* number of elments in ddt 	*/
+	uint64_t	ddo_count;	/* number of elements in ddt 	*/
 	uint64_t	ddo_dspace;	/* size of ddt on disk		*/
 	uint64_t	ddo_mspace;	/* size of ddt in-core		*/
 } ddt_object_t;

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -104,7 +104,7 @@ struct metaslab_class {
 
 /*
  * Metaslab groups encapsulate all the allocatable regions (i.e. metaslabs)
- * of a top-level vdev. They are linked togther to form a circular linked
+ * of a top-level vdev. They are linked together to form a circular linked
  * list and can belong to only one metaslab class. Metaslab groups may become
  * ineligible for allocations for a number of reasons such as limited free
  * space, fragmentation, or going offline. When this happens the allocator will

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -270,7 +270,7 @@ struct spa {
 	uint64_t	spa_errata;		/* errata issues detected */
 	spa_stats_t	spa_stats;		/* assorted spa statistics */
 	hrtime_t	spa_ccw_fail_time;	/* Conf cache write fail time */
-	taskq_t		*spa_zvol_taskq;	/* Taskq for minor managment */
+	taskq_t		*spa_zvol_taskq;	/* Taskq for minor management */
 
 	/*
 	 * spa_refcount & spa_config_lock must be the last elements

--- a/include/sys/txg_impl.h
+++ b/include/sys/txg_impl.h
@@ -65,7 +65,7 @@ extern "C" {
  * grab all tc_open_locks, increment the tx_open_txg, and drop the locks.
  * The tc_open_lock is held until the transaction is assigned into the
  * transaction group. Typically, this is a short operation but if throttling
- * is occuring it may be held for longer periods of time.
+ * is occurring it may be held for longer periods of time.
  */
 struct tx_cpu {
 	kmutex_t	tc_open_lock;	/* protects tx_open_txg */

--- a/include/sys/xvattr.h
+++ b/include/sys/xvattr.h
@@ -73,7 +73,7 @@ typedef struct xoptattr {
  * - a 32 bit quantity (xva_mapsize) that specifies the size of the
  *   attribute bitmaps in 32 bit words.
  * - A pointer to the returned attribute bitmap (needed because the
- *   previous element, the requested attribute bitmap) is variable lenth.
+ *   previous element, the requested attribute bitmap) is variable length.
  * - The requested attribute bitmap, which is an array of 32 bit words.
  *   Callers use the XVA_SET_REQ() macro to set the bits corresponding to
  *   the attributes that are being requested.
@@ -97,7 +97,7 @@ typedef struct xoptattr {
  * attributes to be requested/returned.  File systems may or may not support
  * optional attributes.  They do so at their own discretion but if they do
  * support optional attributes, they must register the VFSFT_XVATTR feature
- * so that the optional attributes can be set/retrived.
+ * so that the optional attributes can be set/retrieved.
  *
  * The fields of the xvattr structure are:
  *

--- a/include/zpios-ctl.h
+++ b/include/zpios-ctl.h
@@ -1,7 +1,7 @@
 /*
  *  ZPIOS is a heavily modified version of the original PIOS test code.
  *  It is designed to have the test code running in the Linux kernel
- *  against ZFS while still being flexibly controled from user space.
+ *  against ZFS while still being flexibly controlled from user space.
  *
  *  Copyright (C) 2008-2010 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).

--- a/include/zpios-internal.h
+++ b/include/zpios-internal.h
@@ -1,7 +1,7 @@
 /*
  *  ZPIOS is a heavily modified version of the original PIOS test code.
  *  It is designed to have the test code running in the Linux kernel
- *  against ZFS while still being flexibly controled from user space.
+ *  against ZFS while still being flexibly controlled from user space.
  *
  *  Copyright (C) 2008-2010 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).

--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -723,7 +723,7 @@ nfs_check_exportfs(void)
 }
 
 /*
- * Provides a convenient wrapper for determing nfs availability
+ * Provides a convenient wrapper for determining nfs availability
  */
 static boolean_t
 nfs_available(void)

--- a/lib/libspl/include/atomic.h
+++ b/lib/libspl/include/atomic.h
@@ -247,7 +247,7 @@ extern uint64_t atomic_swap_64(volatile uint64_t *, uint64_t);
 
 /*
  * Perform an exclusive atomic bit set/clear on a target.
- * Returns 0 if bit was sucessfully set/cleared, or -1
+ * Returns 0 if bit was successfully set/cleared, or -1
  * if the bit was already set/cleared.
  */
 extern int atomic_set_long_excl(volatile ulong_t *, uint_t);

--- a/lib/libspl/include/sys/dkio.h
+++ b/lib/libspl/include/sys/dkio.h
@@ -158,7 +158,7 @@ struct dk_geom {
 
 /*
  * The following ioctls are generic in nature and need to be
- * suported as appropriate by all disk drivers
+ * supported as appropriate by all disk drivers
  */
 #define	DKIOCGGEOM	(DKIOC|1)		/* Get geometry */
 #define	DKIOCINFO	(DKIOC|3)		/* Get info */

--- a/lib/libspl/include/sys/dklabel.h
+++ b/lib/libspl/include/sys/dklabel.h
@@ -107,7 +107,7 @@ struct dk_map2 {
 
 struct dkl_partition    {
 	uint16_t	p_tag;		/* ID tag of partition */
-	uint16_t	p_flag;		/* permision flags */
+	uint16_t	p_flag;		/* permission flags */
 	daddr32_t	p_start;	/* start sector no of partition */
 	int32_t		p_size;		/* # of blocks in partition */
 };

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -902,7 +902,7 @@ zpool_prop_get_feature(zpool_handle_t *zhp, const char *propname, char *buf,
 
 	/*
 	 * Convert from feature name to feature guid. This conversion is
-	 * unecessary for unsupported@... properties because they already
+	 * unnecessary for unsupported@... properties because they already
 	 * use guids.
 	 */
 	if (supported) {

--- a/man/man8/zinject.8
+++ b/man/man8/zinject.8
@@ -100,7 +100,7 @@ Flush the ARC before injection.
 .TP
 .BI "\-b" " objset:object:level:start:end"
 Force an error into the pool at this bookmark tuple. Each number is
-in hexidecimal, and only one block can be specified.
+in hexadecimal, and only one block can be specified.
 .TP
 .BI "\-d" " vdev"
 A vdev specified by path or GUID.

--- a/module/icp/asm-x86_64/sha2/sha256_impl.S
+++ b/module/icp/asm-x86_64/sha2/sha256_impl.S
@@ -33,7 +33,7 @@
  * level parallelism, on a given CPU implementation in this case.
  *
  * Special note on Intel EM64T. While Opteron CPU exhibits perfect
- * perfromance ratio of 1.5 between 64- and 32-bit flavors [see above],
+ * performance ratio of 1.5 between 64- and 32-bit flavors [see above],
  * [currently available] EM64T CPUs apparently are far from it. On the
  * contrary, 64-bit version, sha512_block, is ~30% *slower* than 32-bit
  * sha256_block:-( This is presumably because 64-bit shifts/rotates

--- a/module/icp/asm-x86_64/sha2/sha512_impl.S
+++ b/module/icp/asm-x86_64/sha2/sha512_impl.S
@@ -33,7 +33,7 @@
  * level parallelism, on a given CPU implementation in this case.
  *
  * Special note on Intel EM64T. While Opteron CPU exhibits perfect
- * perfromance ratio of 1.5 between 64- and 32-bit flavors [see above],
+ * performance ratio of 1.5 between 64- and 32-bit flavors [see above],
  * [currently available] EM64T CPUs apparently are far from it. On the
  * contrary, 64-bit version, sha512_block, is ~30% *slower* than 32-bit
  * sha256_block:-( This is presumably because 64-bit shifts/rotates

--- a/module/icp/core/kcf_callprov.c
+++ b/module/icp/core/kcf_callprov.c
@@ -282,7 +282,7 @@ kcf_get_mech_provider(crypto_mech_type_t mech_type, kcf_mech_entry_t **mepp,
 	prov_chain = me->me_hw_prov_chain;
 
 	/*
-	 * We check for the threshhold for using a hardware provider for
+	 * We check for the threshold for using a hardware provider for
 	 * this amount of data. If there is no software provider available
 	 * for the mechanism, then the threshold is ignored.
 	 */

--- a/module/icp/core/kcf_mech_tabs.c
+++ b/module/icp/core/kcf_mech_tabs.c
@@ -100,7 +100,7 @@ kcf_mech_entry_tab_t kcf_mech_tabs_tab[KCF_LAST_OPSCLASS + 1] = {
 };
 
 /*
- * Per-algorithm internal threasholds for the minimum input size of before
+ * Per-algorithm internal thresholds for the minimum input size of before
  * offloading to hardware provider.
  * Dispatching a crypto operation  to a hardware provider entails paying the
  * cost of an additional context switch.  Measurments with Sun Accelerator 4000

--- a/module/icp/include/sha1/sha1.h
+++ b/module/icp/include/sha1/sha1.h
@@ -35,7 +35,7 @@ extern "C" {
 /*
  * NOTE: n2rng (Niagara2 RNG driver) accesses the state field of
  * SHA1_CTX directly.  NEVER change this structure without verifying
- * compatiblity with n2rng.  The important thing is that the state
+ * compatibility with n2rng.  The important thing is that the state
  * must be in a field declared as uint32_t state[5].
  */
 /* SHA-1 context. */

--- a/module/nvpair/nvpair_alloc_fixed.c
+++ b/module/nvpair/nvpair_alloc_fixed.c
@@ -42,7 +42,7 @@
  *  - it uses a pre-allocated buffer for memory allocations.
  *  - it does _not_ free memory in the pre-allocated buffer.
  *
- * The reason for the selected implemention is simplicity.
+ * The reason for the selected implementation is simplicity.
  * This allocator is designed for the usage in interrupt context when
  * the caller may not wait for free memory.
  */

--- a/module/unicode/u8_textprep.c
+++ b/module/unicode/u8_textprep.c
@@ -842,7 +842,7 @@ do_decomp(size_t uv, uchar_t *u8s, uchar_t *s, int sz,
 	}
 
 	/*
-	 * At this point, this rountine does not know what it would get.
+	 * At this point, this routine does not know what it would get.
 	 * The caller should sort it out if the state isn't a Hangul one.
 	 */
 	*state = U8_STATE_START;

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -143,7 +143,7 @@ zfs_prop_init(void)
 		{ "noallow",	ZFS_ACL_NOALLOW },
 		{ "restricted",	ZFS_ACL_RESTRICTED },
 		{ "passthrough", ZFS_ACL_PASSTHROUGH },
-		{ "secure",	ZFS_ACL_RESTRICTED }, /* bkwrd compatability */
+		{ "secure",	ZFS_ACL_RESTRICTED }, /* bkwrd compatibility */
 		{ "passthrough-x", ZFS_ACL_PASSTHROUGH_X },
 		{ NULL }
 	};

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4438,7 +4438,7 @@ SPL_SHRINKER_DECLARE(arc_shrinker, arc_shrinker_func, DEFAULT_SEEKS);
 
 /*
  * Adapt arc info given the number of bytes we are trying to add and
- * the state that we are comming from.  This function is only called
+ * the state that we are coming from.  This function is only called
  * when we are adding new content to the cache.
  */
 static void

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -150,7 +150,7 @@ int dbuf_cache_max_shift = 5;
  * cache size). Once the eviction thread is woken up and eviction is required,
  * it will continue evicting buffers until it's able to reduce the cache size
  * to the low water mark. If the cache size continues to grow and hits the high
- * water mark, then callers adding elments to the cache will begin to evict
+ * water mark, then callers adding elements to the cache will begin to evict
  * directly from the cache until the cache is no longer above the high water
  * mark.
  */
@@ -320,7 +320,7 @@ dbuf_hash_remove(dmu_buf_impl_t *db)
 	idx = hv & h->hash_table_mask;
 
 	/*
-	 * We musn't hold db_mtx to maintain lock ordering:
+	 * We mustn't hold db_mtx to maintain lock ordering:
 	 * DBUF_HASH_MUTEX > db_mtx.
 	 */
 	ASSERT(refcount_is_zero(&db->db_holds));

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -63,7 +63,7 @@
 krwlock_t os_lock;
 
 /*
- * Tunable to overwrite the maximum number of threads for the parallization
+ * Tunable to overwrite the maximum number of threads for the parallelization
  * of dmu_objset_find_dp, needed to speed up the import of pools with many
  * datasets.
  * Default is 4 times the number of leaf vdevs.

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -539,7 +539,7 @@ dnode_sync_free(dnode_t *dn, dmu_tx_t *tx)
 	dnode_rele(dn, (void *)(uintptr_t)tx->tx_txg);
 	/*
 	 * Now that we've released our hold, the dnode may
-	 * be evicted, so we musn't access it.
+	 * be evicted, so we mustn't access it.
 	 */
 }
 

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -83,7 +83,7 @@ extern inline dsl_dataset_phys_t *dsl_dataset_phys(dsl_dataset_t *ds);
 extern int spa_asize_inflation;
 
 /*
- * Figure out how much of this delta should be propogated to the dsl_dir
+ * Figure out how much of this delta should be propagated to the dsl_dir
  * layer.  If there's a refreservation, that space has already been
  * partially accounted for in our ancestors.
  */

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -834,7 +834,7 @@ dsl_scan_visitbp(blkptr_t *bp, const zbookmark_phys_t *zb,
 		goto out;
 
 	/*
-	 * If dsl_scan_ddt() has aready visited this block, it will have
+	 * If dsl_scan_ddt() has already visited this block, it will have
 	 * already done any translations or scrubbing, so don't call the
 	 * callback again.
 	 */

--- a/module/zfs/lz4.c
+++ b/module/zfs/lz4.c
@@ -63,7 +63,7 @@ lz4_compress_zfs(void *s_start, void *d_start, size_t s_len,
 		return (s_len);
 
 	/*
-	 * Encode the compresed buffer size at the start. We'll need this in
+	 * Encode the compressed buffer size at the start. We'll need this in
 	 * decompression to counter the effects of padding which might be
 	 * added to the compressed buffer and which, if unhandled, would
 	 * confuse the hell out of our decompression function.
@@ -205,7 +205,7 @@ lz4_decompress_zfs(void *s_start, void *d_start, size_t s_len,
 
 /*
  * Little Endian or Big Endian?
- * Note: overwrite the below #define if you know your architecture endianess.
+ * Note: overwrite the below #define if you know your architecture endianness.
  */
 #if defined(_BIG_ENDIAN)
 #define	LZ4_BIG_ENDIAN 1

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -1989,7 +1989,7 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	} else {
 		/*
 		 * Since the space map is not loaded we simply update the
-		 * exisiting histogram with what was freed in this txg. This
+		 * existing histogram with what was freed in this txg. This
 		 * means that the on-disk histogram may not have an accurate
 		 * view of the free space but it's close enough to allow
 		 * us to make allocation decisions.

--- a/module/zfs/policy.c
+++ b/module/zfs/policy.c
@@ -36,7 +36,7 @@
 
 /*
  * The passed credentials cannot be directly verified because Linux only
- * provides and interface to check the *current* proces credentials.  In
+ * provides and interface to check the *current* process credentials.  In
  * order to handle this the capable() test is only run when the passed
  * credentials match the current process credentials or the kcred.  In
  * all other cases this function must fail and return the passed err.

--- a/module/zfs/rrwlock.c
+++ b/module/zfs/rrwlock.c
@@ -313,7 +313,7 @@ rrw_tsd_destroy(void *arg)
  * The idea is to split single busy lock into array of locks, so that
  * each reader can lock only one of them for read, depending on result
  * of simple hash function.  That proportionally reduces lock congestion.
- * Writer same time has to sequentially acquire write on all the locks.
+ * Writer at the same time has to sequentially acquire write on all the locks.
  * That makes write acquisition proportionally slower, but in places where
  * it is used (filesystem unmount) performance is not critical.
  *

--- a/module/zfs/rrwlock.c
+++ b/module/zfs/rrwlock.c
@@ -313,8 +313,8 @@ rrw_tsd_destroy(void *arg)
  * The idea is to split single busy lock into array of locks, so that
  * each reader can lock only one of them for read, depending on result
  * of simple hash function.  That proportionally reduces lock congestion.
- * Writer same time has to sequentially aquire write on all the locks.
- * That makes write aquisition proportionally slower, but in places where
+ * Writer same time has to sequentially acquire write on all the locks.
+ * That makes write acquisition proportionally slower, but in places where
  * it is used (filesystem unmount) performance is not critical.
  *
  * All the functions below are direct wrappers around functions above.

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -1245,7 +1245,7 @@ sa_byteswap(sa_handle_t *hdl, sa_buf_type_t buftype)
 	sa_hdr_phys->sa_layout_info = BSWAP_16(sa_hdr_phys->sa_layout_info);
 
 	/*
-	 * Determine number of variable lenghts in header
+	 * Determine number of variable lengths in header
 	 * The standard 8 byte header has one for free and a
 	 * 16 byte header would have 4 + 1;
 	 */

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3677,7 +3677,7 @@ spa_set_aux_vdevs(spa_aux_vdev_t *sav, nvlist_t **devs, int ndevs,
 		nvlist_t **newdevs;
 
 		/*
-		 * Generate new dev list by concatentating with the
+		 * Generate new dev list by concatenating with the
 		 * current dev list.
 		 */
 		VERIFY(nvlist_lookup_nvlist_array(sav->sav_config, config,
@@ -6274,7 +6274,7 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 		case ZPOOL_PROP_VERSION:
 			intval = fnvpair_value_uint64(elem);
 			/*
-			 * The version is synced seperatly before other
+			 * The version is synced separately before other
 			 * properties and should be correct by now.
 			 */
 			ASSERT3U(spa_version(spa), >=, intval);
@@ -6304,7 +6304,7 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			 * We need to dirty the configuration on all the vdevs
 			 * so that their labels get updated.  It's unnecessary
 			 * to do this for pool creation since the vdev's
-			 * configuratoin has already been dirtied.
+			 * configuration has already been dirtied.
 			 */
 			if (tx->tx_txg != TXG_INITIAL)
 				vdev_config_dirty(spa->spa_root_vdev);

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -222,7 +222,7 @@ spa_config_write(spa_config_dirent_t *dp, nvlist_t *nvl)
  * the configuration has been synced to the MOS. This exposes a window where
  * the MOS config will have been updated but the cache file has not. If
  * the system were to crash at that instant then the cached config may not
- * contain the correct information to open the pool and an explicitly import
+ * contain the correct information to open the pool and an explicit import
  * would be required.
  */
 void

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -222,7 +222,7 @@ spa_config_write(spa_config_dirent_t *dp, nvlist_t *nvl)
  * the configuration has been synced to the MOS. This exposes a window where
  * the MOS config will have been updated but the cache file has not. If
  * the system were to crash at that instant then the cached config may not
- * contain the correct information to open the pool and an explicity import
+ * contain the correct information to open the pool and an explicitly import
  * would be required.
  */
 void

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -106,7 +106,7 @@ spa_read_history_addr(kstat_t *ksp, loff_t n)
 }
 
 /*
- * When the kstat is written discard all spa_read_history_t entires.  The
+ * When the kstat is written discard all spa_read_history_t entries.  The
  * ssh->lock will be held until ksp->ks_ndata entries are processed.
  */
 static int
@@ -327,7 +327,7 @@ spa_txg_history_addr(kstat_t *ksp, loff_t n)
 }
 
 /*
- * When the kstat is written discard all spa_txg_history_t entires.  The
+ * When the kstat is written discard all spa_txg_history_t entries.  The
  * ssh->lock will be held until ksp->ks_ndata entries are processed.
  */
 static int

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -2706,7 +2706,7 @@ vdev_clear(spa_t *spa, vdev_t *vd)
 	    !vdev_readable(vd) || !vdev_writeable(vd)) {
 
 		/*
-		 * When reopening in reponse to a clear event, it may be due to
+		 * When reopening in response to a clear event, it may be due to
 		 * a fmadm repair request.  In this case, if the device is
 		 * still broken, we want to still post the ereport again.
 		 */

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -153,7 +153,7 @@ vdev_mirror_load(mirror_map_t *mm, vdev_t *vd, uint64_t zio_offset)
 
 	/*
 	 * Apply half the seek increment to I/O's within seek offset
-	 * of the last I/O queued to this vdev as they should incure less
+	 * of the last I/O queued to this vdev as they should incur less
 	 * of a seek increment.
 	 */
 	if (ABS(lastoffset - zio_offset) <

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -124,7 +124,7 @@ zap_hash(zap_name_t *zn)
 	 * Don't use all 64 bits, since we need some in the cookie for
 	 * the collision differentiator.  We MUST use the high bits,
 	 * since those are the ones that we first pay attention to when
-	 * chosing the bucket.
+	 * choosing the bucket.
 	 */
 	h &= ~((1ULL << (64 - zap_hashbits(zap))) - 1);
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4307,7 +4307,7 @@ zfs_ioc_recv_impl(char *tofs, char *tosnap, char *origin,
 		/*
 		 * dsl_props_set() will not convert RECEIVED to LOCAL on or
 		 * after SPA_VERSION_RECVD_PROPS, so we need to specify LOCAL
-		 * explictly if we're restoring local properties cleared in the
+		 * explicitly if we're restoring local properties cleared in the
 		 * first new-style receive.
 		 */
 		if (origprops != NULL &&

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -870,7 +870,7 @@ zfs_replay_acl_v0(zfs_sb_t *zsb, lr_acl_v0_t *lr, boolean_t byteswap)
  * The FUID table index may no longer be valid and
  * during zfs_create() a new index may be assigned.
  * Because of this the log will contain the original
- * doman+rid in order to create a new FUID.
+ * domain+rid in order to create a new FUID.
  *
  * The individual ACEs may contain an ephemeral uid/gid which is no
  * longer valid and will need to be replaced with an actual FUID.

--- a/module/zfs/zfs_rlock.c
+++ b/module/zfs/zfs_rlock.c
@@ -65,7 +65,7 @@
  * Otherwise, the proxy lock is split into smaller lock ranges and
  * new proxy locks created for non overlapping ranges.
  * The reference counts are adjusted accordingly.
- * Meanwhile, the orginal lock is kept around (this is the callers handle)
+ * Meanwhile, the original lock is kept around (this is the callers handle)
  * and its offset and length are used when releasing the lock.
  *
  * Thread coordination
@@ -87,7 +87,7 @@
  *
  * Grow block handling
  * -------------------
- * ZFS supports multiple block sizes currently upto 128K. The smallest
+ * ZFS supports multiple block sizes currently up to 128K. The smallest
  * block size is used for the file which is grown as needed. During this
  * growth all other writers and readers must be excluded.
  * So if the block size needs to be grown then the whole file is

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -857,7 +857,7 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 
 		/*
 		 * Clear Set-UID/Set-GID bits on successful write if not
-		 * privileged and at least one of the excute bits is set.
+		 * privileged and at least one of the execute bits is set.
 		 *
 		 * It would be nice to to this after all writes have
 		 * been done, but that would still expose the ISUID/ISGID
@@ -2127,7 +2127,7 @@ top:
 	}
 
 	/*
-	 * Grab a lock on the directory to make sure that noone is
+	 * Grab a lock on the directory to make sure that no one is
 	 * trying to add (or lookup) entries while we are removing it.
 	 */
 	rw_enter(&zp->z_name_lock, RW_WRITER);

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -544,7 +544,7 @@ zil_create(zilog_t *zilog)
 	/*
 	 * Allocate an initial log block if:
 	 *    - there isn't one already
-	 *    - the existing block is the wrong endianess
+	 *    - the existing block is the wrong endianness
 	 */
 	if (BP_IS_HOLE(&blk) || BP_SHOULD_BYTESWAP(&blk)) {
 		tx = dmu_tx_create(zilog->zl_os);

--- a/module/zfs/zpl_xattr.c
+++ b/module/zfs/zpl_xattr.c
@@ -50,7 +50,7 @@
  * are the security.selinux xattrs which are less than 100 bytes and
  * exist for every file when xattr labeling is enabled.
  *
- * The Linux xattr implemenation has been written to take advantage of
+ * The Linux xattr implementation has been written to take advantage of
  * this typical usage.  When the dataset property 'xattr=sa' is set,
  * then xattrs will be preferentially stored as System Attributes (SA).
  * This allows tiny xattrs (~100 bytes) to be stored with the dnode and

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1627,7 +1627,7 @@ zvol_create_minors_cb(const char *dsname, void *arg)
  * - for each zvol, create a minor node, then check if the zvol's snapshots
  *   are 'visible', and only then iterate over the snapshots if needed
  *
- * If the name represents a snapshot, a check is perfromed if the snapshot is
+ * If the name represents a snapshot, a check is performed if the snapshot is
  * 'visible' (which also verifies that the parent is a zvol), and if so,
  * a minor node for that snapshot is created.
  */

--- a/module/zpios/pios.c
+++ b/module/zpios/pios.c
@@ -1,7 +1,7 @@
 /*
  *  ZPIOS is a heavily modified version of the original PIOS test code.
  *  It is designed to have the test code running in the Linux kernel
- *  against ZFS while still being flexibly controled from user space.
+ *  against ZFS while still being flexibly controlled from user space.
  *
  *  Copyright (C) 2008-2010 Lawrence Livermore National Security, LLC.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).

--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -567,8 +567,8 @@ udev_trigger() {
 udev_setup() {
 	local SRC_PATH=$1
 
-	# When running in tree manually contruct symlinks in tree to
-	# the proper devices.  Symlinks are installed for all entires
+	# When running in tree manually construct symlinks in tree to
+	# the proper devices.  Symlinks are installed for all entries
 	# in the config file regardless of if that device actually
 	# exists.  When installed as a package udev can be relied on for
 	# this and it will only create links for devices which exist.

--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -64,7 +64,7 @@ my $usage =
 	-C	don't check anything in header block comments
 	-P	check for use of non-POSIX types
 	-o constructs
-		allow a comma-seperated list of optional constructs:
+		allow a comma-separated list of optional constructs:
 		    doxygen	allow doxygen-style block comments (/** /*!)
 		    splint	allow splint-style lint comments (/*@ ... @*/)
 ";

--- a/scripts/zfs-helpers.sh
+++ b/scripts/zfs-helpers.sh
@@ -42,7 +42,7 @@ DESCRIPTION:
 OPTIONS:
 	-d      Dry run
 	-h      Show this message
-	-i      Install the helper utilties
+	-i      Install the helper utilities
 	-r      Remove the helper utilities
 	-v      Verbose
 

--- a/scripts/zimport.sh
+++ b/scripts/zimport.sh
@@ -273,7 +273,7 @@ if [ ! -d $IMAGES_DIR ]; then
 fi
 
 # Given the available images in the zfs-images directory substitute the
-# list of available images for the reserved keywork 'all'.
+# list of available images for the reserved keyword 'all'.
 for TAG in $POOL_TAGS; do
 
 	if  [ "$TAG" = "all" ]; then

--- a/scripts/zpios-profile/zpios-profile.sh
+++ b/scripts/zpios-profile/zpios-profile.sh
@@ -91,7 +91,7 @@ check_pid() {
 }
 
 # NOTE: This whole process is crazy slow but it will do for now
-aquire_pids() {
+acquire_pids() {
 	echo "--- Aquiring ZFS pids ---"
 
 	for PID in `ls /proc/ | grep [0-9] | sort -n -u`; do
@@ -218,7 +218,7 @@ log_pids() {
 	done
 }
 
-aquire_pids
+acquire_pids
 log_pids
 
 # rm ${PROFILE_PID}

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -621,7 +621,7 @@ tests = ['vdev_zaps_001_pos', 'vdev_zaps_002_pos', 'vdev_zaps_003_pos',
 [tests/functional/write_dirs]
 tests = ['write_dirs_001_pos']
 
-# DISABLED: No 'runat' command, replace the Linux equivilant and add xattrtest
+# DISABLED: No 'runat' command, replace the Linux equivalent and add xattrtest
 #[tests/functional/xattr]
 #tests = ['xattr_001_pos', 'xattr_002_neg', 'xattr_003_neg', 'xattr_004_pos',
 #    'xattr_005_pos', 'xattr_006_pos', 'xattr_007_neg', 'xattr_008_pos',

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -914,7 +914,7 @@ function partition_disk	#<slice_size> <whole_disk_name>	<total_slices>
 #	filenum:    the maximum number of files per subdirectory
 #	bytes:	    number of bytes to write
 #	num_writes: numer of types to write out bytes
-#	data:	    the data that will be writen
+#	data:	    the data that will be written
 #
 #	E.g.
 #	file_fs /testdir 20 25 1024 256 0
@@ -1836,7 +1836,7 @@ function is_pool_scrub_stopped #pool
 }
 
 #
-# Use create_pool()/destroy_pool() to clean up the infomation in
+# Use create_pool()/destroy_pool() to clean up the information in
 # in the given disk to avoid slice overlapping.
 #
 function cleanup_devices #vdevs

--- a/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
+++ b/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
@@ -237,7 +237,7 @@ function usr_exec #<commands> [...]
 }
 
 #
-# Count how many ACEs for the speficied file or directory.
+# Count how many ACEs for the specified file or directory.
 #
 # $1 file or directroy name
 #

--- a/tests/zfs-tests/tests/functional/bootfs/bootfs_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/bootfs/bootfs_008_neg.ksh
@@ -34,7 +34,7 @@
 #
 # STRATEGY:
 # 1. create pools based on a valid vdev
-# 2. create a filesytem on this pool and set the compression property to gzip1-9
+# 2. create a filesystem on this pool and set the compression property to gzip1-9
 # 3. set the pool's bootfs property to filesystem we just configured which
 #    should fail
 #

--- a/tests/zfs-tests/tests/functional/casenorm/case_all_values.ksh
+++ b/tests/zfs-tests/tests/functional/casenorm/case_all_values.ksh
@@ -21,7 +21,7 @@
 # Check that we can create FS with any supported casesensitivity value.
 #
 # STRATEGY:
-# For all suported casesensitivity values:
+# For all supported casesensitivity values:
 # 1. Create FS with given casesensitivity value.
 
 verify_runnable "global"

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_001_neg.ksh
@@ -37,7 +37,7 @@
 # return an error.
 #
 # STRATEGY:
-# 1. Create an array containg bad zdb parameters.
+# 1. Create an array containing bad zdb parameters.
 # 2. For each element, execute the sub-command.
 # 3. Verify it returns an error.
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_001_neg.ksh
@@ -35,7 +35,7 @@
 # DESCRIPTION:
 #	'zfs clone' should fail with inapplicable scenarios, including:
 #		* Null arguments
-#		* non-existant snapshots.
+#		* non-existent snapshots.
 #		* invalid characters in ZFS namesapec
 #		* Leading slash in the target clone name
 #		* The argument contains an empty component.

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_010_pos.ksh
@@ -146,7 +146,7 @@ typeset -i i
 i=1
 log_must setup_ds
 
-log_note "Verify zfs clone propery for multiple clones"
+log_note "Verify zfs clone property for multiple clones"
 names=$($ZFS list -rt all -o name $TESTPOOL)
 log_must verify_clones 3 0
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_003_pos.ksh
@@ -129,25 +129,25 @@ for clone in $child_fs1_snap_clone $child_fs1_snap_clone1; do
 done
 
 log_note "Verify that 'zfs destroy -r' fails to destroy dataset " \
-	"with clone dependant outside it."
+	"with clone dependent outside it."
 
 for obj in $child_fs $child_fs1 $ctr $ctr1; do
 	log_mustnot $ZFS destroy -r $obj
 	datasetexists $obj || \
 		log_fail "'zfs destroy -r' fails to keep clone " \
-			"dependant outside the hirearchy."
+			"dependent outside the hirearchy."
 done
 
 
 log_note "Verify that 'zfs destroy -R' succeeds to destroy dataset " \
-	"with clone dependant outside it."
+	"with clone dependent outside it."
 
 log_must $ZFS destroy -R $ctr1
 datasetexists $ctr1 && \
 	log_fail "'zfs destroy -R' fails to destroy dataset with clone outside it."
 
 log_note "Verify that 'zfs destroy -r' succeeds to destroy dataset " \
-	"without clone dependant outside it."
+	"without clone dependent outside it."
 
 log_must $ZFS destroy -r $ctr
 datasetexists $ctr && \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_003_pos.ksh
@@ -129,25 +129,25 @@ for clone in $child_fs1_snap_clone $child_fs1_snap_clone1; do
 done
 
 log_note "Verify that 'zfs destroy -r' fails to destroy dataset " \
-	"with clone dependent outside it."
+	"with dependent clone outside it."
 
 for obj in $child_fs $child_fs1 $ctr $ctr1; do
 	log_mustnot $ZFS destroy -r $obj
 	datasetexists $obj || \
-		log_fail "'zfs destroy -r' fails to keep clone " \
-			"dependent outside the hirearchy."
+		log_fail "'zfs destroy -r' fails to keep dependent " \
+			"clone outside the hirearchy."
 done
 
 
 log_note "Verify that 'zfs destroy -R' succeeds to destroy dataset " \
-	"with clone dependent outside it."
+	"with dependent clone outside it."
 
 log_must $ZFS destroy -R $ctr1
 datasetexists $ctr1 && \
 	log_fail "'zfs destroy -R' fails to destroy dataset with clone outside it."
 
 log_note "Verify that 'zfs destroy -r' succeeds to destroy dataset " \
-	"without clone dependent outside it."
+	"without dependent clone outside it."
 
 log_must $ZFS destroy -r $ctr
 datasetexists $ctr && \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_005_neg.ksh
@@ -35,7 +35,7 @@
 
 #
 # DESCRIPTION:
-#	Seperately verify 'zfs destroy -f|-r|-rf|-R|-rR <dataset>' will fail in
+#	Separately verify 'zfs destroy -f|-r|-rf|-R|-rR <dataset>' will fail in
 #       different conditions.
 #
 # STRATEGY:
@@ -50,7 +50,7 @@
 
 verify_runnable "both"
 
-log_assert "Seperately verify 'zfs destroy -f|-r|-rf|-R|-rR <dataset>' will " \
+log_assert "Separately verify 'zfs destroy -f|-r|-rf|-R|-rR <dataset>' will " \
 	"fail in different conditions."
 log_onexit cleanup_testenv
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_010_pos.ksh
@@ -30,7 +30,7 @@
 
 ################################################################################
 #
-# When using 'zfs destroy -R' on a file system heirarchy that inclues a
+# When using 'zfs destroy -R' on a file system hierarchy that includes a
 # snapshot and a clone of that snapshot, and the snapshot has been
 # defer-destroyed, make sure that the 'zfs destroy -R' works as expected.
 # In particular make sure that libzfs is not confused by the fact that the

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_016_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_016_pos.ksh
@@ -90,7 +90,7 @@ for args in $valid_args; do
 	verify_snapshots
 done
 
-log_note "Verify invalid arguements"
+log_note "Verify invalid arguments"
 setup_snapshots
 for args in $invalid_args; do
 	log_mustnot $ZFS destroy $TESTPOOL/$TESTFS1$args
@@ -98,7 +98,7 @@ for args in $invalid_args; do
 	log_must verify_snapshots 1
 done
 
-log_note "Destroy the begining range"
+log_note "Destroy the beginning range"
 
 log_must $ZFS destroy $TESTPOOL/$TESTFS1@%snap3
 log_must $ZFS destroy $TESTPOOL/$TESTVOL@%snap3

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
@@ -113,7 +113,7 @@ function cleanup_testenv
 
 #
 # Delete volume and related datasets from list, if the test cases was
-# runing in local zone. Then check them are existed or non-exists.
+# running in local zone. Then check them are existed or non-exists.
 #
 # $1   function name
 # $2-n datasets name

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_009_pos.ksh
@@ -36,7 +36,7 @@
 #	1. Create a multiple depth filesystem.
 #	2. 'zfs get -d <n>' to get the output.
 #	3. 'zfs get -r|egrep' to get the expected output.
-#	4. Compare the two outputs, they shoud be same.
+#	4. Compare the two outputs, they should be same.
 #
 
 verify_runnable "both"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_008_pos.ksh
@@ -85,7 +85,7 @@ log_must $ZFS set mountpoint=$mntpnt1 $fs1
 log_must $ZFS mount $fs1
 log_must $LS $testfile1 $mntpnt1/$TESTFILE2
 
-# Verify $TESTFILE2 was not created in $fs, and $fs is accessable again.
+# Verify $TESTFILE2 was not created in $fs, and $fs is accessible again.
 log_mustnot $LS $mntpnt/$TESTFILE2
 log_must $LS $testfile
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_003_pos.ksh
@@ -40,7 +40,7 @@
 #	1. Create multiple snapshots and a clone to a middle point snapshot
 #	2. Promote the clone filesystem
 #	3. Verify the origin filesystem and promoted filesystem include
-#	   correct datasets seperated by the clone point.
+#	   correct datasets separated by the clone point.
 #
 
 verify_runnable "both"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_003_neg.ksh
@@ -30,7 +30,7 @@
 
 #
 # DESCRIPTION:
-#	Seperately verify 'zfs rollback ''|-f|-r|-rf|-R|-rR will fail in
+#	Separately verify 'zfs rollback ''|-f|-r|-rf|-R|-rR will fail in
 #	different conditions.
 #
 # STRATEGY:
@@ -53,7 +53,7 @@ function cleanup
 	done
 }
 
-log_assert "Seperately verify 'zfs rollback ''|-f|-r|-rf will fail in " \
+log_assert "Separately verify 'zfs rollback ''|-f|-r|-rf will fail in " \
 	"different conditions."
 log_onexit cleanup
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
@@ -124,7 +124,7 @@ function cleanup_user_prop
 }
 
 #
-# Random select charactor from the specified charactor set and combine into a
+# Random select character from the specified character set and combine into a
 # random string
 #
 # $1 character set name

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_008_neg.ksh
@@ -32,7 +32,7 @@
 #	are not in the same pool.
 #
 # STRATEGY:
-#	1. Create 2 separate zpools, zpool name lenghts must be the same.
+#	1. Create 2 separate zpools, zpool name lengths must be the same.
 #	2. Attempt to simultaneously create a snapshot of each pool.
 #	3. Veriy the snapshot creation failed.
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_009_pos.ksh
@@ -20,7 +20,7 @@
 #
 # STRATEGY
 # 1. Create multiple datasets
-# 2. Create mutiple snapshots with a list of valid and invalid
+# 2. Create multiple snapshots with a list of valid and invalid
 #    snapshot names
 # 3. Verify the valid snpashot creation
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unshare/zfs_unshare_003_pos.ksh
@@ -29,7 +29,7 @@
 
 #
 # DESCRIPTION:
-# Verify that a file system and its dependant are unshared when turn off sharenfs
+# Verify that a file system and its dependent are unshared when turn off sharenfs
 # property.
 #
 # STRATEGY:
@@ -81,10 +81,10 @@ function test_snap_unshare # <mntp> <filesystem>
 	    log_fail "Snapshot $mntpt@snapshot is shared (set sharenfs)."
 }
 
-log_assert "Verify that a file system and its dependant are unshared."
+log_assert "Verify that a file system and its dependent are unshared."
 log_onexit cleanup
 
 log_must $ZFS snapshot $TESTPOOL/$TESTFS@snapshot
 test_snap_unshare $TESTDIR $TESTPOOL/$TESTFS
 
-log_pass "A file system and its dependant are both unshared as expected."
+log_pass "A file system and its dependent are both unshared as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool/zpool_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool/zpool_003_pos.ksh
@@ -37,7 +37,7 @@
 #	should run successfully.
 #
 # STRATEGY:
-# 1. Create an array containg each zpool options.
+# 1. Create an array containing each zpool options.
 # 2. For each element, execute the zpool command.
 # 3. Verify it run successfully.
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/setup.ksh
@@ -45,7 +45,7 @@ fi
 
 if [[ -n $DISK ]]; then
 	#
-        # Use 'zpool create' to clean up the infomation in
+        # Use 'zpool create' to clean up the information in
         # in the given disk to avoid slice overlapping.
         #
 	cleanup_devices $DISK

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/setup.ksh
@@ -47,7 +47,7 @@ fi
 
 if [[ -n $DISK ]]; then
 	#
-        # Use 'zpool create' to clean up the infomation in
+        # Use 'zpool create' to clean up the information in
         # in the given disk to avoid slice overlapping.
         #
 	cleanup_devices $DISK

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_012_pos.ksh
@@ -100,7 +100,7 @@ log_assert "Verify all mount & share status of sub-filesystems within a pool \
 	can be restored after import [-Df]."
 
 setup_filesystem "$DEVICE_FILES" $TESTPOOL1 $TESTFS $TESTDIR1
-# create a heirarchy of filesystem
+# create a hierarchy of filesystem
 for pool in ${pools[@]} ; do
 	log_must $ZFS create $pool/$TESTFS/$TESTCTR
 	log_must $ZFS create $pool/$TESTFS/$TESTCTR/$TESTCTR1

--- a/tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list_007_pos.ksh
@@ -38,7 +38,7 @@
 # STRATEGY:
 #	1. 'zfs list -d <n>' to get the output.
 #	2. 'zfs list -r|egrep' to get the expected output.
-#	3. Compare the two outputs, they shoud be same.
+#	3. Compare the two outputs, they should be same.
 #
 
 verify_runnable "both"

--- a/tests/zfs-tests/tests/functional/compression/compress_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/compression/compress_003_pos.ksh
@@ -50,7 +50,7 @@ function cleanup
 	$RM -f $TESTDIR/*
 }
 
-log_assert "Changing blocksize doesn't casue system panic with compression settings"
+log_assert "Changing blocksize doesn't cause system panic with compression settings"
 log_onexit cleanup
 
 fs=$TESTPOOL/$TESTFS

--- a/tests/zfs-tests/tests/functional/delegate/zfs_allow_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/delegate/zfs_allow_010_pos.ksh
@@ -60,8 +60,8 @@ if is_linux; then
 # - rename      - mount(8) does not permit non-superuser mounts
 # - zoned	- zones are not supported
 # - destroy     - umount(8) does not permit non-superuser umounts
-# - sharenfs	- sharing requires superuser priviliges
-# - share	- sharing requires superuser priviliges
+# - sharenfs	- sharing requires superuser privileges
+# - share	- sharing requires superuser privileges
 # - readonly	- mount(8) does not permit non-superuser remounts
 #
 set -A perms	create		true		false	\

--- a/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
+++ b/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
@@ -32,7 +32,7 @@
 . $STF_SUITE/include/libtest.shlib
 
 #
-# Create block file or charactor file according to parameter.
+# Create block file or character file according to parameter.
 #
 # $1 device file type
 # $2 file name

--- a/tests/zfs-tests/tests/functional/inheritance/README.config
+++ b/tests/zfs-tests/tests/functional/inheritance/README.config
@@ -29,7 +29,7 @@
 # or set locally.
 #
 # Format for this file is as follows:
-#	<dataset name>	<dataset type> 	<inital property setting>
+#	<dataset name>	<dataset type> 	<initial property setting>
 #
 # <dataset name> - must be the full dataset name
 #

--- a/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
@@ -157,10 +157,10 @@ function update_recordsize { #dataset init_code
 # The mountpoint property is slightly different from other properties and
 # so is handled here. For all other properties if they are set to a specific
 # value at a higher level in the data hierarchy (i.e. checksum=on) then that
-# value propogates down the hierarchy unchanged, with the source field being
+# value propagates down the hierarchy unchanged, with the source field being
 # set to 'inherited from <higher dataset>'.
 #
-# The mountpoint property is different in that while the value propogates
+# The mountpoint property is different in that while the value propagates
 # down the hierarchy, the value at each level is determined by a combination
 # of the top-level value and the current level in the hierarchy.
 #
@@ -327,7 +327,7 @@ function scan_state { #state-file
 				# set up correctly as specified in the
 				# configX.cfg file (which includes 'set'ting
 				# properties at a higher level and checking
-				# that they propogate down to the lower levels.
+				# that they propagate down to the lower levels.
 				#
 				# Note in a few places here, we use
 				# check_failure, rather than log_must - this

--- a/tests/zfs-tests/tests/functional/inheritance/state001.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state001.cfg
@@ -33,7 +33,7 @@
 # No command is actually run (hence '-:-') but rather this state file is
 # used to verify that the property that was set on the top level pool
 # via the 'local' keyword (in the config1.cfg file) has correctly
-# propogated down the hierarchy.
+# propagated down the hierarchy.
 #
 # *** ASSERTION DESCRIPTION ***
 #

--- a/tests/zfs-tests/tests/functional/inheritance/state002.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state002.cfg
@@ -33,7 +33,7 @@
 # No command is actually run (hence '-:-') but rather this state file is
 # used to verify that the property that was set on the middle level
 # dataset via the 'local' keyword (in the configX.cfg file) has
-# correctly propogated down the hierarchy to the filesystem underneath,
+# correctly propagated down the hierarchy to the filesystem underneath,
 # while leaving the top level pools properties unchanged.
 #
 # *** ASSERTION DESCRIPTION ***

--- a/tests/zfs-tests/tests/functional/inheritance/state012.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state012.cfg
@@ -32,12 +32,12 @@
 #
 # Verify that running 'zfs inherit -r' at each level of the data hierarchy
 # when the bottom filesystem level properties have been set locally results
-# in the top level property values being propogated down the data
+# in the top level property values being propagated down the data
 # hierarchy.
 #
 # Executing inherit -r at the middle level and bottom levels after
 # running it at the top level is somewhat redundant as the top level value
-# should propogate down the entire data hierarchy. Done for completeness
+# should propagate down the entire data hierarchy. Done for completeness
 # sake.
 #
 # *** ASSERTION DESCRIPTION ***

--- a/tests/zfs-tests/tests/functional/inheritance/state014.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state014.cfg
@@ -32,12 +32,12 @@
 #
 # Verify that running 'zfs inherit -r' at each level of the data hierarchy
 # when the bottom and middle level properties have been set locally results
-# in the top level property values being propogated down the data
+# in the top level property values being propagated down the data
 # hierarchy.
 #
 # Note : executing inherit -r at the middle level and bottom levels after
 # running it at the top level is somewhat redundant as the top level value
-# should propogate down the entire data hierarchy. Done for completeness
+# should propagate down the entire data hierarchy. Done for completeness
 # sake.
 #
 # *** ASSERTION DESCRIPTION ***

--- a/tests/zfs-tests/tests/functional/inheritance/state015.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state015.cfg
@@ -40,7 +40,7 @@
 # the bottom level.
 #
 # Executing 'zfs inherit' at the bottom level is somewhat redundant but
-# is done for completness sake.
+# is done for completeness sake.
 #
 # *** ASSERTION DESCRIPTION ***
 #

--- a/tests/zfs-tests/tests/functional/inheritance/state016.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state016.cfg
@@ -37,7 +37,7 @@
 # to the top level (default) values.
 #
 # Executing 'zfs inherit -r' at the bottom and middle levels after executing
-# at the top level is somewhat redundant but ss done for completness sake.
+# at the top level is somewhat redundant but ss done for completeness sake.
 #
 # *** ASSERTION DESCRIPTION ***
 #

--- a/tests/zfs-tests/tests/functional/inheritance/state017.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state017.cfg
@@ -41,7 +41,7 @@
 # the values down to the bottom level.
 #
 # Executing 'zfs inherit' at the bottom level is somewhat redundant but
-# is done for completness sake.
+# is done for completeness sake.
 #
 # *** ASSERTION DESCRIPTION ***
 #

--- a/tests/zfs-tests/tests/functional/inheritance/state018.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state018.cfg
@@ -34,11 +34,11 @@
 # when the top level and middle level datasets properties are set locally,
 # and the bottom level has inherited its properties from the middle
 # level, results in the top level properties reverting back to their
-# default values and being propogated down to the other datasets in the
+# default values and being propagated down to the other datasets in the
 # hierarchy.
 #
 # Executing 'zfs inherit -r' at the middle and bottom levels after executing
-# it at the top level is somewhat redundant but is done for completness sake.
+# it at the top level is somewhat redundant but is done for completeness sake.
 #
 # *** ASSERTION DESCRIPTION ***
 #

--- a/tests/zfs-tests/tests/functional/inheritance/state019.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state019.cfg
@@ -37,7 +37,7 @@
 # levels inheriting the changed values.
 #
 # Executing 'zfs inherit' at the middle and bottom levels is somewhat
-# redundant but is done for completness sake.
+# redundant but is done for completeness sake.
 #
 # *** ASSERTION DESCRIPTION ***
 #

--- a/tests/zfs-tests/tests/functional/inheritance/state020.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state020.cfg
@@ -37,7 +37,7 @@
 # levels inheriting the changed values.
 #
 # Executing 'zfs inherit -r' at the middle and bottom levels is somewhat
-# redundant but is done for completness sake.
+# redundant but is done for completeness sake.
 #
 # *** ASSERTION DESCRIPTION ***
 #

--- a/tests/zfs-tests/tests/functional/inheritance/state022.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state022.cfg
@@ -37,7 +37,7 @@
 # levels inheriting the changed values.
 #
 # Executing 'zfs inherit -r' at the middle and bottom levels is somewhat
-# redundant but is done for completness sake.
+# redundant but is done for completeness sake.
 #
 # *** ASSERTION DESCRIPTION ***
 #

--- a/tests/zfs-tests/tests/functional/inheritance/state024.cfg
+++ b/tests/zfs-tests/tests/functional/inheritance/state024.cfg
@@ -33,7 +33,7 @@
 # Verify that executing 'zfs inherit -r' at the top level in the hierarchy
 # when each levels properties are set locally, results in the top level
 # properties reverting back to their default values, and the changed
-# values being propogated down the hierarchy.
+# values being propagated down the hierarchy.
 #
 # Executing 'zfs inherit -r' at the middle and bottom levels after doing so
 # at the top level is somewhat redundant but is done for completeness.

--- a/tests/zfs-tests/tests/functional/inuse/inuse_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_004_pos.ksh
@@ -48,7 +48,7 @@ verify_runnable "global"
 function cleanup
 {
 	#
-	# Essentailly this is the default_cleanup rountine but I cannot get it
+	# Essentailly this is the default_cleanup routine but I cannot get it
 	# to work correctly.  So its reproduced below.  Still need to full
 	# understand why default_cleanup does not work correctly from here.
 	#

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_volume.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_volume.ksh
@@ -46,7 +46,7 @@ log_assert "nopwrite works on volumes"
 log_must $ZFS set compress=on $origin
 log_must $ZFS set checksum=sha256 $origin
 $DD if=/dev/urandom of=$vol bs=8192 count=4096 conv=notrunc >/dev/null \
-    2>&1 || log_fail "dd into $orgin failed."
+    2>&1 || log_fail "dd into $origin failed."
 $ZFS snapshot $origin@a || log_fail "zfs snap failed"
 log_must $ZFS clone $origin@a $clone
 log_must $ZFS set compress=on $clone

--- a/tests/zfs-tests/tests/functional/refquota/refquota_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/refquota/refquota_005_pos.ksh
@@ -37,7 +37,7 @@
 #
 # STRATEGY:
 #	1. Setting refquota < quota for parent
-#	2. Create file in sub-filesytem, take snapshot and remove the file
+#	2. Create file in sub-filesystem, take snapshot and remove the file
 #	3. Verify sub-filesystem snapshot will not consume refquota
 #
 

--- a/tests/zfs-tests/tests/functional/refreserv/refreserv_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/refreserv/refreserv_005_pos.ksh
@@ -37,7 +37,7 @@
 #
 # STRATEGY:
 #	1. Create volume on filesystem
-#	2. Setting quota for parenet filesytem
+#	2. Setting quota for parenet filesystem
 #	3. Verify volume refreservation is only limited by volsize
 #	4. Verify volume refreservation can be changed when volsize changed
 #

--- a/tests/zfs-tests/tests/functional/refreserv/refreserv_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/refreserv/refreserv_005_pos.ksh
@@ -37,7 +37,7 @@
 #
 # STRATEGY:
 #	1. Create volume on filesystem
-#	2. Setting quota for parenet filesystem
+#	2. Setting quota for parent filesystem
 #	3. Verify volume refreservation is only limited by volsize
 #	4. Verify volume refreservation can be changed when volsize changed
 #

--- a/tests/zfs-tests/tests/functional/rename_dirs/rename_dirs_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rename_dirs/rename_dirs_001_pos.ksh
@@ -33,7 +33,7 @@
 
 #
 # DESCRIPTION:
-# Create two directory trees in ZFS filesystem, and concurently rename
+# Create two directory trees in ZFS filesystem, and concurrently rename
 # directory across the two trees. ZFS should be able to handle the race
 # situation.
 #

--- a/tests/zfs-tests/tests/functional/reservation/reservation_007_pos.sh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_007_pos.sh
@@ -75,7 +75,7 @@ resv_size_set=`expr $space_avail / 3`
 # for.
 #
 # Any special arguments for create are passed in via the args
-# paramater.
+# parameter.
 #
 function create_resv_destroy { # args1 dataset1 args2 dataset2
 

--- a/tests/zfs-tests/tests/functional/reservation/reservation_013_pos.sh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_013_pos.sh
@@ -82,7 +82,7 @@ sparse_vol_set_size=$(floor_volsize $sparse_vol_set_size)
 
 # When initially created, a regular volume's reservation property is set
 # equal to its size (unlike a sparse volume), so we don't need to set it
-# explictly later on
+# explicitly later on
 log_must $ZFS create -V $resv_set $TESTPOOL/$TESTVOL
 log_must $ZFS create -s -V $sparse_vol_set_size $TESTPOOL/$TESTVOL2
 

--- a/tests/zfs-tests/tests/functional/rootpool/rootpool_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/rootpool/rootpool_003_neg.ksh
@@ -47,7 +47,7 @@
 #
 
 verify_runnable "global"
-log_assert "system related filesytems can not be renamed or destroyed"
+log_assert "system related filesystems can not be renamed or destroyed"
 
 typeset rootpool=$(get_rootpool)
 typeset rootfs=$(get_rootfs)

--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -172,7 +172,7 @@ function cmp_ds_subs
 }
 
 #
-# Compare all the directores and files in two filesystems
+# Compare all the directories and files in two filesystems
 #
 # $1 source filesystem
 # $2 destination filesystem

--- a/tests/zfs-tests/tests/functional/rsend/rsend_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_008_pos.ksh
@@ -36,7 +36,7 @@
 #	Changes made by 'zfs promote' can be properly received.
 #
 # STRATEGY:
-#	1. Seperatly promote pool clone, filesystem clone and volume clone.
+#	1. Separately promote pool clone, filesystem clone and volume clone.
 #	2. Recursively backup all the POOL and restore in POOL2
 #	3. Verify all the datesets and property be properly received.
 #

--- a/tests/zfs-tests/tests/functional/rsend/rsend_019_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_019_pos.ksh
@@ -28,7 +28,7 @@
 # 2. Mess up the contents of the stream state file on disk
 # 3. Try ZFS receive, which should fail with a checksum mismatch error
 # 4. ZFS send to the stream state file again using the receive_resume_token
-# 5. ZFS receieve and verify the receive completes successfully
+# 5. ZFS receive and verify the receive completes successfully
 # 6. Repeat steps on an incremental ZFS send
 #
 

--- a/tests/zfs-tests/tests/functional/rsend/rsend_020_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_020_pos.ksh
@@ -28,7 +28,7 @@
 # 2. Mess up the contents of the stream state file on disk
 # 3. Try ZFS receive, which should fail with a checksum mismatch error
 # 4. ZFS send to the stream state file again using the receive_resume_token
-# 5. ZFS receieve and verify the receive completes successfully
+# 5. ZFS receive and verify the receive completes successfully
 #
 
 verify_runnable "both"

--- a/tests/zfs-tests/tests/functional/rsend/rsend_021_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_021_pos.ksh
@@ -29,7 +29,7 @@
 # 2. Mess up the contents of the stream state file on disk
 # 3. Try ZFS receive, which should fail with a checksum mismatch error
 # 4. ZFS send to the stream state file again using the receive_resume_token
-# 5. ZFS receieve and verify the receive completes successfully
+# 5. ZFS receive and verify the receive completes successfully
 # 6. Repeat steps on an incremental ZFS send
 #
 

--- a/tests/zfs-tests/tests/functional/rsend/rsend_022_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_022_pos.ksh
@@ -33,7 +33,7 @@
 # 6. Mess up the contents of the stream state file on disk
 # 7. Try ZFS receive, which should fail with a checksum mismatch error
 # 8. ZFS send to the stream state file again using the receive_resume_token
-# 9. ZFS receieve and verify the receive completes successfully
+# 9. ZFS receive and verify the receive completes successfully
 #
 
 verify_runnable "both"

--- a/tests/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
@@ -30,7 +30,7 @@
 # 4. Mess up the contents of the stream state file on disk
 # 5. Try ZFS receive, which should fail with a checksum mismatch error
 # 6. ZFS send to the stream state file again using the receive_resume_token
-# 7. ZFS receieve and verify the receive completes successfully
+# 7. ZFS receive and verify the receive completes successfully
 #
 
 verify_runnable "both"

--- a/tests/zfs-tests/tests/functional/slog/slog_012_neg.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_012_neg.ksh
@@ -55,7 +55,7 @@ do
 
 		mntpnt=$(get_prop mountpoint $TESTPOOL)
 		#
-		# Create file in pool to trigger writting in slog devices
+		# Create file in pool to trigger writing in slog devices
 		#
 		log_must $DD if=/dev/urandom of=$mntpnt/testfile.$$ count=100
 

--- a/tests/zfs-tests/tests/functional/threadsappend/threadsappend_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/threadsappend/threadsappend_001_pos.ksh
@@ -74,7 +74,7 @@ log_must $THREADSAPPEND ${TESTDIR}/${TESTFILE}
 #
 SIZE=`$LS -l ${TESTDIR}/${TESTFILE} | $AWK '{print $5}'`
 if [[ $SIZE -ne $FILE_SIZE ]]; then
-	log_fail "'The length of ${TESTDIR}/${TESTFILE}' doesnt equal 1310720."
+	log_fail "'The length of ${TESTDIR}/${TESTFILE}' doesn't equal 1310720."
 fi
 
 log_pass "Multiple thread appends succeeded. File size as expected"

--- a/udev/rules.d/60-zvol.rules.in
+++ b/udev/rules.d/60-zvol.rules.in
@@ -1,6 +1,6 @@
 # Persistent links for zvol
 #
 # persistent disk links: /dev/zvol/dataset_name
-# also creates compatibilty symlink of /dev/dataset_name
+# also creates compatibility symlink of /dev/dataset_name
 
 KERNEL=="zd*" SUBSYSTEM=="block" ACTION=="add|change" PROGRAM="@udevdir@/zvol_id $tempnode" SYMLINK+="zvol/%c %c"


### PR DESCRIPTION
patch contains some spelling fixes ( most in /comments/, some in debug/error-msg in tests ) as found by a bot ( https://github.com/ka7/misspell_fixer )

### Description
<!--- Describe your changes in detail -->
* spelling fixes
* one script-fix in tests/zfs-tests/tests/functional/nopwrite/nopwrite_volume.ksh (typo in varialbe name)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
