### PR TITLE
zinject: fix trival spelling mistake, "hexidecimal" should be "hexade…

### DIFF
--- a/cmd/zinject/translate.c
+++ b/cmd/zinject/translate.c
@@ -436,7 +436,7 @@ translate_raw(const char *str, zinject_record_t *record)
 {
 	/*
 	 * A raw bookmark of the form objset:object:level:blkid, where each
-	 * number is a hexidecimal value.
+	 * number is a hexadecimal value.
 	 */
 	if (sscanf(str, "%llx:%llx:%x:%llx", (u_longlong_t *)&record->zi_objset,
 	    (u_longlong_t *)&record->zi_object, &record->zi_level,

--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -282,7 +282,7 @@ usage(void)
 	    "\n"
 	    "\t\tInject an error into pool 'pool' with the numeric bookmark\n"
 	    "\t\tspecified by the remaining tuple.  Each number is in\n"
-	    "\t\thexidecimal, and only one block can be specified.\n"
+	    "\t\thexadecimal, and only one block can be specified.\n"
 	    "\n"
 	    "\tzinject [-q] <-t type> [-e errno] [-l level] [-r range]\n"
 	    "\t    [-a] [-m] [-u] [-f freq] <object>\n"

--- a/man/man8/zinject.8
+++ b/man/man8/zinject.8
@@ -100,7 +100,7 @@ Flush the ARC before injection.
 .TP
 .BI "\-b" " objset:object:level:start:end"
 Force an error into the pool at this bookmark tuple. Each number is
-in hexidecimal, and only one block can be specified.
+in hexadecimal, and only one block can be specified.
 .TP
 .BI "\-d" " vdev"
 A vdev specified by path or GUID.


### PR DESCRIPTION
…cimal"

Trivial fix on spelling mistake of hexadecimal. No functional change.

Closes ##5546

Signed-off-by: Colin Ian King <colin.king@canonical.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
