### PR TITLE
module/Makefile.in: use relative cp

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -21,9 +21,9 @@ modules:
 	@# installed devel headers, or they may be in the module
 	@# subdirectory when building against the spl source tree.
 	@if [ -f @SPL_OBJ@/@SPL_SYMBOLS@ ]; then \
-		/bin/cp @SPL_OBJ@/@SPL_SYMBOLS@ .; \
+		cp @SPL_OBJ@/@SPL_SYMBOLS@ .; \
 	elif [ -f @SPL_OBJ@/module/@SPL_SYMBOLS@ ]; then \
-		/bin/cp @SPL_OBJ@/module/@SPL_SYMBOLS@ .; \
+		cp @SPL_OBJ@/module/@SPL_SYMBOLS@ .; \
 	else \
 		echo -e "\n" \
 		"*** Missing spl symbols ensure you have built the spl:\n" \
@@ -71,7 +71,7 @@ modules_uninstall:
 distdir:
 	list='$(subdir-m)'; for subdir in $$list; do \
 		(cd @top_srcdir@/module && find $$subdir -name '*.c' -o -name '*.h' -o -name '*.S' |\
-		xargs /bin/cp --parents -t $$distdir); \
+		xargs cp --parents -t $$distdir); \
 	done
 
 distclean maintainer-clean: clean


### PR DESCRIPTION
### Description
causes problems on systems where cp is not in /bin such as NixOS

### Motivation and Context

NixOS update.

### How Has This Been Tested?
yes, trivial change.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

