### PR TITLE
Don't hardcode perl path but use /usr/bin/env instead.

### DIFF
--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # CDDL HEADER START
 #
@@ -51,6 +51,7 @@
 #
 
 require 5.0;
+use warnings;
 use IO::File;
 use Getopt::Std;
 use strict;


### PR DESCRIPTION
### Description
Don't hardcode perl path but use /usr/bin/env instead.

Also replace the deprecated "-w" argument with "use warnings;", as
otherwise env would invoke a command called "perl -w".

### Motivation and Context
NixOS doesn't use the FHS, and perl lives in a non-standard location. /usr/bin/env is the usual entry point to locate perl via $PATH. 

### How Has This Been Tested?
Run cstyle manually against a bunch of files on NixOS.
Run "make cstyle" on my Debian test VM.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
