### PR TITLE
[ABD] Add a LRU for abd

### DIFF
--- a/include/sys/Makefile.am
+++ b/include/sys/Makefile.am
@@ -56,6 +56,7 @@ COMMON_H = \
 	$(top_srcdir)/include/sys/spa.h \
 	$(top_srcdir)/include/sys/spa_impl.h \
 	$(top_srcdir)/include/sys/spa_checksum.h \
+	$(top_srcdir)/include/sys/spinlock.h \
 	$(top_srcdir)/include/sys/sysevent.h \
 	$(top_srcdir)/include/sys/trace.h \
 	$(top_srcdir)/include/sys/trace_acl.h \

--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -53,6 +53,7 @@ typedef struct abd {
 	uint_t		abd_size;	/* excludes scattered abd_offset */
 	struct abd	*abd_parent;
 	refcount_t	abd_children;
+	list_node_t	abd_lru;
 	union {
 		struct abd_scatter {
 			uint_t		abd_offset;

--- a/include/sys/spinlock.h
+++ b/include/sys/spinlock.h
@@ -1,0 +1,62 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2016 by Jinshan Xiong. All rights reserved.
+ */
+
+#ifndef _SPINLOCK_H
+#define	_SPINLOCK_H
+
+#ifdef _KERNEL
+#include <linux/spinlock.h>
+
+#else
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	pthread_spinlock_t lock;
+} spinlock_t;
+
+static inline void spin_lock(spinlock_t *lock)
+{
+	pthread_spin_lock(&lock->lock);
+}
+
+static inline void spin_unlock(spinlock_t *lock)
+{
+	pthread_spin_unlock(&lock->lock);
+}
+
+static inline void spin_lock_init(spinlock_t *lock)
+{
+	pthread_spin_init(&lock->lock, 0);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_KERNEL */
+
+#endif	/* _SPINLOCK_H */

--- a/lib/libspl/include/sys/param.h
+++ b/lib/libspl/include/sys/param.h
@@ -28,6 +28,7 @@
 #define	_LIBSPL_SYS_PARAM_H
 
 #include_next <sys/param.h>
+#include <sys/user.h>
 #include <unistd.h>
 
 /*
@@ -63,5 +64,11 @@
 
 extern size_t spl_pagesize(void);
 #define	PAGESIZE	(spl_pagesize())
+
+#ifdef PAGESHIFT
+#undef PAGESHIFT
+#endif /* PAGESHIFT */
+
+#define PAGESHIFT PAGE_SHIFT
 
 #endif

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -647,6 +647,7 @@ typedef struct arc_stats {
 	kstat_named_t arcstat_demand_hit_predictive_prefetch;
 	kstat_named_t arcstat_need_free;
 	kstat_named_t arcstat_sys_free;
+	kstat_named_t arcstat_reclaim_count;
 } arc_stats_t;
 
 static arc_stats_t arc_stats = {
@@ -741,7 +742,8 @@ static arc_stats_t arc_stats = {
 	{ "sync_wait_for_async",	KSTAT_DATA_UINT64 },
 	{ "demand_hit_predictive_prefetch", KSTAT_DATA_UINT64 },
 	{ "arc_need_free",		KSTAT_DATA_UINT64 },
-	{ "arc_sys_free",		KSTAT_DATA_UINT64 }
+	{ "arc_sys_free",		KSTAT_DATA_UINT64 },
+	{ "arc_reclaim_count",		KSTAT_DATA_UINT64 },
 };
 
 #define	ARCSTAT(stat)	(arc_stats.stat.value.ui64)
@@ -4595,6 +4597,7 @@ arc_get_data_impl(arc_buf_hdr_t *hdr, uint64_t size, void *tag)
 		if (arc_is_overflowing()) {
 			cv_signal(&arc_reclaim_thread_cv);
 			cv_wait(&arc_reclaim_waiters_cv, &arc_reclaim_lock);
+			ARCSTAT_BUMP(arcstat_reclaim_count);
 		}
 
 		mutex_exit(&arc_reclaim_lock);


### PR DESCRIPTION
Rebased version of Jinshan's LRU patch for review. Currently fails one of the asserts when debugging is enabled and running ztest. Jinshan should be looking at it and I will update when he sends me an updated patch.


Maintain a per-cpu LRU cache for abd_t.

Two ZFS parameters have added to control the LRU:
1. zfs_abd_lru_max_size: control the maximum size of per-cpu abd size;
2. zfs_abd_lru_purge_count: number of abd should be purged from each
   LRU bucket during cache shrink.

Performance comparision after this patch is applied:

Test   | Performance
------------ | -----------------------
before     | 5871834.88 KB/sec    
after      | 6470394.88 KB/sec    

The test was performed on a node with 6 NVMe SSD drives installed.

Signed-off-by: Jinshan Xiong <jinshan.xiong@intel.com>

Requires-spl: refs/pull/598/head