### PR TITLE
Fix zfs-share systemd unit file

### DIFF
--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -9,7 +9,7 @@ PartOf=smb.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=-@bindir@/rm -f /etc/dfs/sharetab
+ExecStartPre=-/bin/rm -f /etc/dfs/sharetab
 ExecStart=@sbindir@/zfs share -a
 
 [Install]


### PR DESCRIPTION
### Description, Motivation and Context
Today i had to rebuild a Fedora24 laptop, installed ZoL from source but forgot to specify a custom bindir from the ./configure script. The result is a systemd unit file which tries to pre-execute `/usr/local/bin/rm`:

```
[root@fedora24 ~]# systemctl status zfs-share.service
● zfs-share.service - ZFS file system shares
   Loaded: loaded (/usr/lib/systemd/system/zfs-share.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Tue 2017-01-03 22:40:11 CET; 2min 10s ago
  Process: 787 ExecStart=/usr/local/sbin/zfs share -a (code=exited, status=1/FAILURE)
  Process: 769 ExecStartPre=/usr/local/bin/rm -f /etc/dfs/sharetab (code=exited, status=203/EXEC)
 Main PID: 787 (code=exited, status=1/FAILURE)
```

We already hardcode `/sbin/modprobe` in both `zfs-import-scan` and `zfs-import-cache` unit files, and since we don't install `rm` i don't know if we actually need to use "our" `bindir`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
