### PR TITLE
OpenZFS 6603 - zfeature_register() should verify ZFEATURE_FLAG_PER_DA…

### DIFF
--- a/module/zfs/zfeature_common.c
+++ b/module/zfs/zfeature_common.c
@@ -133,6 +133,18 @@ zfeature_depends_on(spa_feature_t fid, spa_feature_t check) {
 	return (B_FALSE);
 }
 
+static boolean_t
+deps_contains_feature(const spa_feature_t *deps, const spa_feature_t feature)
+{
+	int i;
+
+	for (i = 0; deps[i] != SPA_FEATURE_NONE; i++)
+		if (deps[i] == feature)
+			return (B_TRUE);
+
+	return (B_FALSE);
+}
+
 static void
 zfeature_register(spa_feature_t fid, const char *guid, const char *name,
     const char *desc, zfeature_flags_t flags, const spa_feature_t *deps)
@@ -149,6 +161,9 @@ zfeature_register(spa_feature_t fid, const char *guid, const char *name,
 
 	if (deps == NULL)
 		deps = nodeps;
+
+	VERIFY(((flags & ZFEATURE_FLAG_PER_DATASET) == 0) ||
+	    (deps_contains_feature(deps, SPA_FEATURE_EXTENSIBLE_DATASET)));
 
 	feature->fi_feature = fid;
 	feature->fi_guid = guid;


### PR DESCRIPTION
…TASET implies SPA_FEATURE_EXTENSIBLE_DATASET

Authored by: ilovezfs <ilovezfs@icloud.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Richard Laager <rlaager@wiktel.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: George Melikov <mail@gmelikov.ru>

OpenZFS-issue: https://www.illumos.org/issues/6603
OpenZFS-commit: https://github.com/illumos/illumos-gate/commit/0803e91

<!--- Provide a general summary of your changes in the Title above -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
