### PR TITLE
OpenZFS 7603 - xuio_stat_wbuf_* should be declared (void)

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1102,13 +1102,13 @@ xuio_stat_fini(void)
 }
 
 void
-xuio_stat_wbuf_copied()
+xuio_stat_wbuf_copied(void)
 {
 	XUIOSTAT_BUMP(xuiostat_wbuf_copied);
 }
 
 void
-xuio_stat_wbuf_nocopy()
+xuio_stat_wbuf_nocopy(void)
 {
 	XUIOSTAT_BUMP(xuiostat_wbuf_nocopy);
 }


### PR DESCRIPTION
Porting Notes:
- include/sys/dmu.h prototypes were already updated in 0bc8fd7