### PR TITLE
Retire .write/.read file operations

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -440,9 +440,9 @@ pre =
 tests = ['inuse_004_pos']
 post =
 
-# DISABLED: needs investigation
-#[tests/functional/large_files]
-#tests = ['large_files_001_pos']
+[tests/functional/large_files]
+tests = ['large_files_001_pos']
+tests = ['large_files_002_pos']
 
 # DISABLED: needs investigation
 #[tests/functional/largest_pool]

--- a/tests/zfs-tests/tests/functional/large_files/Makefile.am
+++ b/tests/zfs-tests/tests/functional/large_files/Makefile.am
@@ -2,4 +2,5 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/large_files
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	large_files_001_pos.ksh
+	large_files_001_pos.ksh \
+	large_files_002_pos.ksh

--- a/tests/zfs-tests/tests/functional/large_files/large_files_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/large_files/large_files_002_pos.ksh
@@ -1,0 +1,55 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2015 by Lawrence Livermore National Security, LLC.
+# All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify 'ulimit -f' file size restrictions are enforced.
+#
+# STRATEGY:
+# 1. Set ulimit file size to unlimited, verify files can be created.
+# 2. Reduce ulimit file size, verify the expected error is returned.
+#
+
+verify_runnable "both"
+
+log_assert "Verify 'ulimit -f' maximum file size is enforced"
+
+# Verify 'ulimit -f unlimited' works
+log_must ulimit -f unlimited
+log_must sh -c 'yes | head -n2097152 >$TESTDIR/ulimit_write_file'
+log_must sh -c '$TRUNCATE -s2M $TESTDIR/ulimit_trunc_file'
+log_must $RM $TESTDIR/ulimit_write_file $TESTDIR/ulimit_trunc_file
+
+# Verify 'ulimit -f <size>' works
+log_must ulimit -f 1024
+log_mustnot sh -c 'yes | head -n2097152 >$TESTDIR/ulimit_write_file'
+log_mustnot sh -c '$TRUNCATE -s2M $TESTDIR/ulimit_trunc_file'
+log_must $RM $TESTDIR/ulimit_write_file $TESTDIR/ulimit_trunc_file
+
+log_pass "Successfully enforced 'ulimit -f' maximum file size"


### PR DESCRIPTION
The .write/.read file operations callbacks can be retired since
support for .read_iter/.write_iter and .aio_read/.aio_write has
been added.  The vfs_write()/vfs_read() entry functions will
select the correct interface for the kernel.  This is desirable
because all VFS write/read operations now rely on common code.

This change also add the generic write checks to make sure that
ulimits are enforced correctly on write.  A similar check was
added to zpl_fallocate() so the truncate case is also handled
properly.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)