### PR TITLE
[ABD] use fletcher_4 routines natively with `abd_iterate_func()`

### DIFF
--- a/include/sys/zio_checksum.h
+++ b/include/sys/zio_checksum.h
@@ -29,6 +29,7 @@
 
 #include <sys/zio.h>
 #include <zfeature_common.h>
+#include <zfs_fletcher.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -56,6 +57,28 @@ typedef enum zio_checksum_flags {
 	/* Strong enough for nopwrite? */
 	ZCHECKSUM_FLAG_NOPWRITE = (1 << 5)
 } zio_checksum_flags_t;
+
+typedef enum {
+	ZIO_CHECKSUM_NATIVE,
+	ZIO_CHECKSUM_BYTESWAP
+} zio_byteorder_t;
+
+typedef struct zio_abd_checksum_data {
+	zio_byteorder_t		acd_byteorder;
+	fletcher_4_ctx_t	*acd_ctx;
+	zio_cksum_t 		*acd_zcp;
+	void 			*acd_private;
+} zio_abd_checksum_data_t;
+
+typedef void zio_abd_checksum_init_t(zio_abd_checksum_data_t *);
+typedef void zio_abd_checksum_fini_t(zio_abd_checksum_data_t *);
+typedef int zio_abd_checksum_iter_t(void *, size_t, void *);
+
+typedef const struct zio_abd_checksum_func {
+	zio_abd_checksum_init_t *acf_init;
+	zio_abd_checksum_fini_t *acf_fini;
+	zio_abd_checksum_iter_t *acf_iter;
+} zio_abd_checksum_func_t;
 
 /*
  * Information about each checksum function.
@@ -98,6 +121,10 @@ extern zio_checksum_t abd_checksum_edonr_native;
 extern zio_checksum_t abd_checksum_edonr_byteswap;
 extern zio_checksum_tmpl_init_t abd_checksum_edonr_tmpl_init;
 extern zio_checksum_tmpl_free_t abd_checksum_edonr_tmpl_free;
+
+extern zio_abd_checksum_func_t fletcher_4_abd_ops;
+extern zio_checksum_t abd_fletcher_4_native;
+extern zio_checksum_t abd_fletcher_4_byteswap;
 
 extern int zio_checksum_equal(spa_t *, blkptr_t *, enum zio_checksum,
     void *, uint64_t, uint64_t, zio_bad_cksum_t *);


### PR DESCRIPTION
- export ABD compatible interface from fletcher_4

- add ABD fletcher_4 tests for data and metadata ABD types.

Reviewed-by: David Quigley <david.quigley@intel.com>
Rebased-by: David Quigley<david.quigley@intel.com>
Signed-off-by: Gvozden Neskovic <neskovic@gmail.com>