### PR TITLE
Revert "Disable slow tests for kmemleak"

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
@@ -48,6 +48,11 @@
 
 verify_runnable "both"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5479
+if is_kmemleak; then
+	log_unsupported "Test case often fail when kmemleak is enabled"
+fi
+
 #
 # According to parameters, 1st, create suitable testing environment. 2nd,
 # run 'zfs destroy $opt <dataset>'. 3rd, check the system status.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
@@ -45,11 +45,6 @@
 
 verify_runnable "global"
 
-# See issue: https://github.com/zfsonlinux/zfs/issues/5479
-if is_kmemleak; then
-	log_unsupported "Test case runs slowly when kmemleak is enabled"
-fi
-
 function cleanup
 {
         poolexists $TESTPOOL1 && \
@@ -59,6 +54,7 @@ function cleanup
 		log_must $RM -f $file
         done
 }
+
 
 log_assert "Verify 'zpool clear' can clear errors of a storage pool."
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_024_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_024_pos.ksh
@@ -39,11 +39,6 @@
 
 verify_runnable "global"
 
-# See issue: https://github.com/zfsonlinux/zfs/issues/5479
-if is_kmemleak; then
-	log_unsupported "Test case runs slowly when kmemleak is enabled"
-fi
-
 function cleanup
 {
 	if [[ -n "$child_pids" ]]; then

--- a/tests/zfs-tests/tests/functional/delegate/zfs_allow_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/delegate/zfs_allow_010_pos.ksh
@@ -44,6 +44,11 @@
 
 verify_runnable "both"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5479
+if is_kmemleak; then
+	log_unsupported "Test case often fail when kmemleak is enabled"
+fi
+
 log_assert "Verify privileged user has correct permissions once which was "\
 	"delegated to him in datasets"
 log_onexit restore_root_datasets

--- a/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
@@ -45,11 +45,6 @@
 
 verify_runnable "global"
 
-# See issue: https://github.com/zfsonlinux/zfs/issues/5479
-if is_kmemleak; then
-	log_unsupported "Test case runs slowly when kmemleak is enabled"
-fi
-
 log_assert "Test properties are inherited correctly"
 
 #

--- a/tests/zfs-tests/tests/functional/snapused/snapused_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapused/snapused_004_pos.ksh
@@ -51,6 +51,11 @@
 
 verify_runnable "both"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5479
+if is_kmemleak; then
+	log_unsupported "Test case often fail when kmemleak is enabled"
+fi
+
 function cleanup
 {
 	log_must $ZFS destroy -rR $USEDTEST


### PR DESCRIPTION
New kmemleak kernel is much faster, so this is no longer needed.