### PR TITLE
OpenZFS 6871 - libzpool implementation of thread_create should enforc…

### DIFF
--- a/cmd/raidz_test/raidz_test.c
+++ b/cmd/raidz_test/raidz_test.c
@@ -704,7 +704,7 @@ run_sweep(void)
 
 		VERIFY3P(zk_thread_create(NULL, 0,
 		    (thread_func_t)sweep_thread,
-		    (void *) opts, TS_RUN, NULL, 0, 0,
+		    (void *) opts, 0, NULL, TS_RUN, 0,
 		    PTHREAD_CREATE_JOINABLE), !=, NULL);
 	}
 

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -6240,7 +6240,7 @@ ztest_run(ztest_shared_t *zs)
 	 * Create a thread to periodically resume suspended I/O.
 	 */
 	VERIFY3P((resume_thread = zk_thread_create(NULL, 0,
-	    (thread_func_t)ztest_resume_thread, spa, TS_RUN, NULL, 0, 0,
+	    (thread_func_t)ztest_resume_thread, spa, 0, NULL, TS_RUN, 0,
 	    PTHREAD_CREATE_JOINABLE)), !=, NULL);
 
 #if 0
@@ -6296,7 +6296,7 @@ ztest_run(ztest_shared_t *zs)
 
 		VERIFY3P(thread = zk_thread_create(NULL, 0,
 		    (thread_func_t)ztest_thread,
-		    (void *)(uintptr_t)t, TS_RUN, NULL, 0, 0,
+		    (void *)(uintptr_t)t, 0, NULL, TS_RUN, 0,
 		    PTHREAD_CREATE_JOINABLE), !=, NULL);
 		tid[t] = thread->t_tid;
 	}

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -262,7 +262,7 @@ typedef struct kthread {
 extern kthread_t *zk_thread_current(void);
 extern void zk_thread_exit(void);
 extern kthread_t *zk_thread_create(caddr_t stk, size_t  stksize,
-	thread_func_t func, void *arg, size_t len,
+	thread_func_t func, void *arg, uint64_t len,
 	proc_t *pp, int state, pri_t pri, int detachstate);
 extern void zk_thread_join(kt_did_t tid);
 

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -147,13 +147,14 @@ zk_thread_helper(void *arg)
 
 kthread_t *
 zk_thread_create(caddr_t stk, size_t stksize, thread_func_t func, void *arg,
-    size_t len, proc_t *pp, int state, pri_t pri, int detachstate)
+    uint64_t len, proc_t *pp, int state, pri_t pri, int detachstate)
 {
 	kthread_t *kt;
 	pthread_attr_t attr;
 	char *stkstr;
 
 	ASSERT0(state & ~TS_RUN);
+	ASSERT0(len);
 
 	kt = umem_zalloc(sizeof (kthread_t), UMEM_NOFAIL);
 	kt->t_func = func;


### PR DESCRIPTION
…e length is 0

Authored by: Eli Rosenthal <eli.rosenthal@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: George Melikov mail@gmelikov.ru

OpenZFS-issue: https://www.illumos.org/issues/6871
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/8fc9228

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)