### PR TITLE
Fix pool_names_001_pos test case

### DIFF
--- a/tests/zfs-tests/tests/functional/pool_names/pool_names_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/pool_names/pool_names_001_pos.ksh
@@ -108,6 +108,7 @@ do
 	log_must $ZFS snapshot $name/$name@$name
 	log_must $ZFS clone $name/$name@$name $name/clone_$name
 	log_must $ZFS create -V 150m $name/$name/$name
+	block_device_wait
 
 	log_must $ZPOOL destroy $name
 done


### PR DESCRIPTION
After volume creation wait until the new block devices have settled
before destroying them.  Failure to do some can result in EBUSY
being returned and the test case failing.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #5636
