### PR TITLE
OpenZFS 6880 - zdb incorrectly reports feature count mismatch when fe…

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -3162,7 +3162,8 @@ dump_zpool(spa_t *spa)
 			uint64_t refcount;
 
 			if (!(spa_feature_table[f].fi_flags &
-			    ZFEATURE_FLAG_PER_DATASET)) {
+			    ZFEATURE_FLAG_PER_DATASET) ||
+			    !spa_feature_is_enabled(spa, f)) {
 				ASSERT0(dataset_feature_count[f]);
 				continue;
 			}

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -71,7 +71,7 @@ tests = [ 'clean_mirror_001_pos', 'clean_mirror_002_pos',
     'clean_mirror_003_pos', 'clean_mirror_004_pos']
 
 [tests/functional/cli_root/zdb]
-tests = ['zdb_001_neg']
+tests = ['zdb_001_neg', 'zdb_002_pos']
 pre =
 post =
 

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
@@ -1,3 +1,4 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zdb
 dist_pkgdata_SCRIPTS = \
-	zdb_001_neg.ksh
+	zdb_001_neg.ksh \
+	zdb_002_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_002_pos.ksh
@@ -1,0 +1,51 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2015 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb will accurately count the feature refcount for pools with and without
+# features enabled.
+#
+# Strategy:
+# 1. Create a pool, and collect zdb output for the pool.
+# 2. Verify there are no 'feature refcount mismatch' messages.
+# 3. Repeat for a pool with features disabled.
+#
+
+log_assert "Verify zdb accurately counts feature refcounts."
+log_onexit cleanup
+
+typeset errstr="feature refcount mismatch"
+typeset tmpfile="/var/tmp/zdb-feature-mismatch"
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	grep "$errstr" $tmpfile
+	rm -f $tmpfile
+}
+
+for opt in '' -d; do
+	log_must zpool create -f $opt $TESTPOOL ${DISKS%% *}
+	log_must eval "$ZDB $TESTPOOL >$tmpfile"
+	grep -q "$errstr" $tmpfile && \
+	    log_fail "Found feature refcount mismatches in zdb output."
+	destroy_pool $TESTPOOL
+done
+
+log_pass "zdb accurately counts feature refcounts."


### PR DESCRIPTION
…ature is disabled

Authored by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: George Melikov <mail@gmelikov.ru>

OpenZFS-issue: https://www.illumos.org/issues/6880
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/c5d1600

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
