### PR TITLE
Fix build-in regression

### DIFF
--- a/include/sys/trace_acl.h
+++ b/include/sys/trace_acl.h
@@ -138,8 +138,8 @@ DECLARE_EVENT_CLASS(zfs_ace_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_ACE_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_ACE_EVENT(name) \
 DEFINE_EVENT(zfs_ace_class, name, \
 	TP_PROTO(znode_t *zn, zfs_ace_hdr_t *ace, uint32_t mask_matched), \
 	TP_ARGS(zn, ace, mask_matched))

--- a/include/sys/trace_arc.h
+++ b/include/sys/trace_arc.h
@@ -97,8 +97,8 @@ DECLARE_EVENT_CLASS(zfs_arc_buf_hdr_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_ARC_BUF_HDR_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_ARC_BUF_HDR_EVENT(name) \
 DEFINE_EVENT(zfs_arc_buf_hdr_class, name, \
 	TP_PROTO(arc_buf_hdr_t *ab), \
 	TP_ARGS(ab))
@@ -142,8 +142,8 @@ DECLARE_EVENT_CLASS(zfs_l2arc_rw_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_L2ARC_RW_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_L2ARC_RW_EVENT(name) \
 DEFINE_EVENT(zfs_l2arc_rw_class, name, \
 	TP_PROTO(vdev_t *vd, zio_t *zio), \
 	TP_ARGS(vd, zio))
@@ -169,8 +169,8 @@ DECLARE_EVENT_CLASS(zfs_l2arc_iodone_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_L2ARC_IODONE_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_L2ARC_IODONE_EVENT(name) \
 DEFINE_EVENT(zfs_l2arc_iodone_class, name, \
 	TP_PROTO(zio_t *zio, l2arc_write_callback_t *cb), \
 	TP_ARGS(zio, cb))
@@ -283,8 +283,8 @@ DECLARE_EVENT_CLASS(zfs_arc_miss_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_ARC_MISS_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_ARC_MISS_EVENT(name) \
 DEFINE_EVENT(zfs_arc_miss_class, name, \
 	TP_PROTO(arc_buf_hdr_t *hdr, \
 	    const blkptr_t *bp, uint64_t size, const zbookmark_phys_t *zb), \
@@ -344,8 +344,8 @@ DECLARE_EVENT_CLASS(zfs_l2arc_evict_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_L2ARC_EVICT_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_L2ARC_EVICT_EVENT(name) \
 DEFINE_EVENT(zfs_l2arc_evict_class, name, \
 	TP_PROTO(l2arc_dev_t *dev, \
 	    list_t *buflist, uint64_t taddr, boolean_t all), \

--- a/include/sys/trace_dbgmsg.h
+++ b/include/sys/trace_dbgmsg.h
@@ -68,8 +68,8 @@ DECLARE_EVENT_CLASS(zfs_dprintf_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_DPRINTF_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_DPRINTF_EVENT(name) \
 DEFINE_EVENT(zfs_dprintf_class, name, \
 	TP_PROTO(const char *file, const char *function, int line, \
 	    const char *msg), \
@@ -109,22 +109,20 @@ DECLARE_EVENT_CLASS(zfs_set_error_class,
 );
 /* END CSTYLED */
 
+/* BEGIN CSTYLED */
 #ifdef TP_CONDITION
 #define	DEFINE_SET_ERROR_EVENT(name) \
-/* BEGIN CSTYLED */
 DEFINE_EVENT_CONDITION(zfs_set_error_class, name, \
 	TP_PROTO(const char *file, const char *function, int line, \
 	    uintptr_t error), \
 	TP_ARGS(file, function, line, error), \
 	TP_CONDITION(error))
-/* END CSTYLED */
 #else
 #define	DEFINE_SET_ERROR_EVENT(name) \
-/* BEGIN CSTYLED */
 DEFINE_EVENT(zfs_set_error_class, name, \
 	TP_PROTO(const char *file, const char *function, int line, \
 	    uintptr_t error), \
 	TP_ARGS(file, function, line, error))
-/* END CSTYLED */
 #endif
+/* END CSTYLED */
 DEFINE_SET_ERROR_EVENT(zfs_set__error);

--- a/include/sys/trace_dbuf.h
+++ b/include/sys/trace_dbuf.h
@@ -88,8 +88,8 @@ DECLARE_EVENT_CLASS(zfs_dbuf_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_DBUF_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_DBUF_EVENT(name) \
 DEFINE_EVENT(zfs_dbuf_class, name, \
 	TP_PROTO(dmu_buf_impl_t *db, zio_t *zio), \
 	TP_ARGS(db, zio))
@@ -106,8 +106,8 @@ DECLARE_EVENT_CLASS(zfs_dbuf_evict_one_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_DBUF_EVICT_ONE_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_DBUF_EVICT_ONE_EVENT(name) \
 DEFINE_EVENT(zfs_dbuf_evict_one_class, name, \
 	TP_PROTO(dmu_buf_impl_t *db, multilist_sublist_t *mls), \
 	TP_ARGS(db, mls))

--- a/include/sys/trace_dmu.h
+++ b/include/sys/trace_dmu.h
@@ -104,8 +104,8 @@ DECLARE_EVENT_CLASS(zfs_delay_mintime_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_DELAY_MINTIME_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_DELAY_MINTIME_EVENT(name) \
 DEFINE_EVENT(zfs_delay_mintime_class, name, \
 	TP_PROTO(dmu_tx_t *tx, uint64_t dirty, uint64_t min_tx_time), \
 	TP_ARGS(tx, dirty, min_tx_time))

--- a/include/sys/trace_dnode.h
+++ b/include/sys/trace_dnode.h
@@ -104,8 +104,8 @@ DECLARE_EVENT_CLASS(zfs_dnode_move_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_DNODE_MOVE_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_DNODE_MOVE_EVENT(name) \
 DEFINE_EVENT(zfs_dnode_move_class, name, \
 	TP_PROTO(dnode_t *dn, int64_t refcount, uint32_t dbufs), \
 	TP_ARGS(dn, refcount, dbufs))

--- a/include/sys/trace_multilist.h
+++ b/include/sys/trace_multilist.h
@@ -62,8 +62,8 @@ DECLARE_EVENT_CLASS(zfs_multilist_insert_remove_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_MULTILIST_INSERT_REMOVE_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_MULTILIST_INSERT_REMOVE_EVENT(name) \
 DEFINE_EVENT(zfs_multilist_insert_remove_class, name, \
 	TP_PROTO(multilist_t *ml, unsigned int sublist_idx, void *obj), \
 	TP_ARGS(ml, sublist_idx, obj))

--- a/include/sys/trace_txg.h
+++ b/include/sys/trace_txg.h
@@ -54,8 +54,8 @@ DECLARE_EVENT_CLASS(zfs_txg_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_TXG_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_TXG_EVENT(name) \
 DEFINE_EVENT(zfs_txg_class, name, \
 	TP_PROTO(dsl_pool_t *dp, uint64_t txg), \
 	TP_ARGS(dp, txg))

--- a/include/sys/trace_zil.h
+++ b/include/sys/trace_zil.h
@@ -113,8 +113,8 @@ DECLARE_EVENT_CLASS(zfs_zil_class,
 );
 /* END CSTYLED */
 
-#define	DEFINE_ZIL_EVENT(name) \
 /* BEGIN CSTYLED */
+#define	DEFINE_ZIL_EVENT(name) \
 DEFINE_EVENT(zfs_zil_class, name, \
 	TP_PROTO(zilog_t *zilog), \
 	TP_ARGS(zilog))


### PR DESCRIPTION
Accidentally introduced by 4ea3f86.  The BEGIN CSTYLE block cannot
appear half way through a continued #define.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #5643
