### PR TITLE
Two minor man-page formatting fixes.

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -887,7 +887,7 @@ time, and will be ignored if \fBzfs_dirty_data_max\fR is later changed.
 The parameter \fBzfs_dirty_data_max_max\fR takes precedence over this
 one. See the section "ZFS TRANSACTION DELAY".
 .sp
-Default value: \fN25\fR.
+Default value: \fB25\fR.
 .RE
 
 .sp

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -118,7 +118,7 @@ zfs \- configures ZFS file systems
 
 .LP
 .nf
-\fBzfs\fR \fBinherit\fR [\fB-rS\fR] \fIproperty\fR \fIfilesystem\fR|\fIvolume|snapshot\fR ...
+\fBzfs\fR \fBinherit\fR [\fB-rS\fR] \fIproperty\fR \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR ...
 .fi
 
 .LP
@@ -267,7 +267,7 @@ zfs \- configures ZFS file systems
 
 .LP
 .nf
-\fBzfs\fR \fBdiff\fR [\fB-FHt\fR] \fIsnapshot\fR \fIsnapshot|filesystem\fR
+\fBzfs\fR \fBdiff\fR [\fB-FHt\fR] \fIsnapshot\fR \fIsnapshot\fR|\fIfilesystem\fR
 
 .SH DESCRIPTION
 .LP
@@ -3341,7 +3341,7 @@ Recursively releases a hold with the given tag on the snapshots of all descenden
 .sp
 .ne 2
 .na
-\fB\fBzfs diff\fR [\fB-FHt\fR] \fIsnapshot\fR \fIsnapshot|filesystem\fR
+\fB\fBzfs diff\fR [\fB-FHt\fR] \fIsnapshot\fR \fIsnapshot\fR|\fIfilesystem\fR
 .ad
 .sp .6
 .RS 4n

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -643,7 +643,7 @@ Identifies the default bootable dataset for the root pool. This property is expe
 .sp
 .ne 2
 .na
-\fB\fBcachefile\fR=fBnone\fR | \fIpath\fR\fR
+\fB\fBcachefile\fR=\fBnone\fR | \fIpath\fR\fR
 .ad
 .sp .6
 .RS 4n


### PR DESCRIPTION
### Description
fB -> \fB in `zpool.8` (Properties -> cachefile)
\fN -> \fB in `zfs-module-parameters.5` (zfs_dirty_data_max_max_percent)

### Motivation and Context
Documentation cleanup.

### How Has This Been Tested?
Visual inspection with `man`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
