### PR TITLE
OpenZFS 6999 - fix 'Use of uninitialized value $picky in numeric eq (…

### DIFF
--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -440,7 +440,7 @@ line: while (<$filehandle>) {
 		$function_header_full_indent = 0;
 	}
 	if ($in_function_header && /{$/ ) {
-		if ($picky == 1) {
+		if ($picky) {
 			err("opening brace on same line as function header");
 		}
 		$in_function_header = 0;


### PR DESCRIPTION
…==)' in cstyle

Authored by: Richard PALO <richard@NetBSD.org>
Reviewed by: Garrett D'Amore <garrett@damore.org>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/6999
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/002ec3e