### PR TITLE
OpenZFS 7348 - cstyle can't handle ellipsis on continuation line

### DIFF
--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -19,6 +19,7 @@
 #
 # CDDL HEADER END
 #
+# Copyright 2016 Nexenta Systems, Inc.
 #
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
@@ -399,7 +400,7 @@ line: while (<$filehandle>) {
 		$prev = $line;
 		next line;
 	}
-	if ($in_function_header && ! /^    ./ ) {
+	if ($in_function_header && ! /^    (\w|\.)/ ) {
 		if (/^{}$/ # empty functions
 		|| /;/ #run function with multiline arguments
 		|| /#/ #preprocessor commands
@@ -507,7 +508,7 @@ line: while (<$filehandle>) {
 		err("spaces instead of tabs");
 	}
 	if (/^ / && !/^ \*[ \t\/]/ && !/^ \*$/ &&
-	    (!/^    \w/ || $in_function != 0)) {
+	    (!/^    (\w|\.)/ || $in_function != 0)) {
 		err("indent by spaces instead of tabs");
 	}
 	if (/^\t+ [^ \t\*]/ || /^\t+  \S/ || /^\t+   \S/) {


### PR DESCRIPTION
Authored by: Hans Rosenfeld <hans.rosenfeld@nexenta.com>
Reviewed by: Yuri Pankov <yuri.pankov@nexenta.com>
Reviewed by: Jason King <jason.brian.king@gmail.com>
Reviewed by: Igor Kozhukhov <ikozhukhov@gmail.com>
Reviewed by: Robert Mustacchi <rm@joyent.com>
Approved by: Dan McDonald <danmcd@omniti.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/7348
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/c667d21