### PR TITLE
OpenZFS 6412 - zfs receive: -u can be ignored sometimes

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3601,7 +3601,8 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 	}
 
 	if (clp) {
-		err |= changelist_postfix(clp);
+		if (!flags->nomount)
+			err |= changelist_postfix(clp);
 		changelist_free(clp);
 	}
 


### PR DESCRIPTION
Authored by: Andriy Gapon <andriy.gapon@clusterhq.com>
Reviewed by: - Matthew Ahrens <mahrens@delphix.com>
Reviewed by: - Paul Dagnelie <pcd@delphix.com>
Approved by: - Richard Lowe <richlowe@richlowe.net>
Ported-by: George Melikov <mail@gmelikov.ru>

OpenZFS-issue: https://www.illumos.org/issues/6412
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/9185393