### PR TITLE
OpenZFS 7744 - Holes can lose birth time info if a block has a mix of…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -241,6 +241,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/grow_pool/Makefile
 	tests/zfs-tests/tests/functional/grow_replicas/Makefile
 	tests/zfs-tests/tests/functional/history/Makefile
+	tests/zfs-tests/tests/functional/hole_birth/Makefile
 	tests/zfs-tests/tests/functional/inheritance/Makefile
 	tests/zfs-tests/tests/functional/inuse/Makefile
 	tests/zfs-tests/tests/functional/large_files/Makefile

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -221,6 +221,10 @@ dmu_object_free(objset_t *os, uint64_t object, dmu_tx_t *tx)
 		return (err);
 
 	ASSERT(dn->dn_type != DMU_OT_NONE);
+	/*
+	 * If we don't create this free range, we'll leak indirect blocks when
+	 * we get to freeing the dnode in syncing context.
+	 */
 	dnode_free_range(dn, 0, DMU_OBJECT_END, tx);
 	dnode_free(dn, tx);
 	dnode_rele(dn, FTAG);

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1661,6 +1661,72 @@ dnode_dirty_l1(dnode_t *dn, uint64_t l1blkid, dmu_tx_t *tx)
 	}
 }
 
+/*
+ * Dirty all the in-core level-1 dbufs in the range specified by start_blkid
+ * and end_blkid.
+ */
+static void
+dnode_dirty_l1range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
+    dmu_tx_t *tx)
+{
+	dmu_buf_impl_t db_search;
+	dmu_buf_impl_t *db;
+	avl_index_t where;
+
+	mutex_enter(&dn->dn_dbufs_mtx);
+
+	db_search.db_level = 1;
+	db_search.db_blkid = start_blkid + 1;
+	db_search.db_state = DB_SEARCH;
+	for (;;) {
+
+		db = avl_find(&dn->dn_dbufs, &db_search, &where);
+		if (db == NULL)
+			db = avl_nearest(&dn->dn_dbufs, where, AVL_AFTER);
+
+		if (db == NULL || db->db_level != 1 ||
+		    db->db_blkid >= end_blkid) {
+			break;
+		}
+
+		/*
+		 * Setup the next blkid we want to search for.
+		 */
+		db_search.db_blkid = db->db_blkid + 1;
+		ASSERT3U(db->db_blkid, >=, start_blkid);
+
+		/*
+		 * If the dbuf transitions to DB_EVICTING while we're trying
+		 * to dirty it, then we will be unable to discover it in
+		 * the dbuf hash table. This will result in a call to
+		 * dbuf_create() which needs to acquire the dn_dbufs_mtx
+		 * lock. To avoid a deadlock, we drop the lock before
+		 * dirtying the level-1 dbuf.
+		 */
+		mutex_exit(&dn->dn_dbufs_mtx);
+		dnode_dirty_l1(dn, db->db_blkid, tx);
+		mutex_enter(&dn->dn_dbufs_mtx);
+	}
+
+#ifdef ZFS_DEBUG
+	/*
+	 * Walk all the in-core level-1 dbufs and verify they have been dirtied.
+	 */
+	db_search.db_level = 1;
+	db_search.db_blkid = start_blkid + 1;
+	db_search.db_state = DB_SEARCH;
+	db = avl_find(&dn->dn_dbufs, &db_search, &where);
+	if (db == NULL)
+		db = avl_nearest(&dn->dn_dbufs, where, AVL_AFTER);
+	for (; db != NULL; db = AVL_NEXT(&dn->dn_dbufs, db)) {
+		if (db->db_level != 1 || db->db_blkid >= end_blkid)
+			break;
+		ASSERT(db->db_dirtycnt > 0);
+	}
+#endif
+	mutex_exit(&dn->dn_dbufs_mtx);
+}
+
 void
 dnode_free_range(dnode_t *dn, uint64_t off, uint64_t len, dmu_tx_t *tx)
 {
@@ -1812,6 +1878,8 @@ dnode_free_range(dnode_t *dn, uint64_t off, uint64_t len, dmu_tx_t *tx)
 			last = (blkid + nblks - 1) >> epbs;
 		if (last != first)
 			dnode_dirty_l1(dn, last, tx);
+
+		dnode_dirty_l1range(dn, first, last, tx);
 
 		shift = dn->dn_datablkshift + dn->dn_indblkshift -
 		    SPA_BLKPTRSHIFT;

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -233,9 +233,24 @@ free_verify(dmu_buf_impl_t *db, uint64_t start, uint64_t end, dmu_tx_t *tx)
 }
 #endif
 
+/*
+ * We don't usually free the indirect blocks here.  If in one txg we have a
+ * free_range and a write to the same indirect block, it's important that we
+ * preserve the hole's birth times. Therefore, we don't free any any indirect
+ * blocks in free_children().  If an indirect block happens to turn into all
+ * holes, it will be freed by dbuf_write_children_ready, which happens at a
+ * point in the syncing process where we know for certain the contents of the
+ * indirect block.
+ *
+ * However, if we're freeing a dnode, its space accounting must go to zero
+ * before we actually try to free the dnode, or we will trip an assertion. In
+ * addition, we know the case described above cannot occur, because the dnode is
+ * being freed.  Therefore, we free the indirect blocks immediately in that
+ * case.
+ */
 static void
 free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
-    dmu_tx_t *tx)
+    boolean_t free_indirects, dmu_tx_t *tx)
 {
 	dnode_t *dn;
 	blkptr_t *bp;
@@ -286,26 +301,16 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 			rw_exit(&dn->dn_struct_rwlock);
 			ASSERT3P(bp, ==, subdb->db_blkptr);
 
-			free_children(subdb, blkid, nblks, tx);
+			free_children(subdb, blkid, nblks, free_indirects, tx);
 			dbuf_rele(subdb, FTAG);
 		}
 	}
 
-	/* If this whole block is free, free ourself too. */
-	for (i = 0, bp = db->db.db_data; i < 1ULL << epbs; i++, bp++) {
-		if (!BP_IS_HOLE(bp))
-			break;
-	}
-	if (i == 1 << epbs) {
-		/* didn't find any non-holes */
+	if (free_indirects) {
+		for (i = 0, bp = db->db.db_data; i < 1 << epbs; i++, bp++)
+			ASSERT(BP_IS_HOLE(bp));
 		bzero(db->db.db_data, db->db.db_size);
 		free_blocks(dn, db->db_blkptr, 1, tx);
-	} else {
-		/*
-		 * Partial block free; must be marked dirty so that it
-		 * will be written out.
-		 */
-		ASSERT(db->db_dirtycnt > 0);
 	}
 
 	DB_DNODE_EXIT(db);
@@ -318,7 +323,7 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
  */
 static void
 dnode_sync_free_range_impl(dnode_t *dn, uint64_t blkid, uint64_t nblks,
-    dmu_tx_t *tx)
+    boolean_t free_indirects, dmu_tx_t *tx)
 {
 	blkptr_t *bp = dn->dn_phys->dn_blkptr;
 	int dnlevel = dn->dn_phys->dn_nlevels;
@@ -359,7 +364,7 @@ dnode_sync_free_range_impl(dnode_t *dn, uint64_t blkid, uint64_t nblks,
 			    TRUE, FALSE, FTAG, &db));
 			rw_exit(&dn->dn_struct_rwlock);
 
-			free_children(db, blkid, nblks, tx);
+			free_children(db, blkid, nblks, free_indirects, tx);
 			dbuf_rele(db, FTAG);
 		}
 	}
@@ -379,6 +384,7 @@ dnode_sync_free_range_impl(dnode_t *dn, uint64_t blkid, uint64_t nblks,
 typedef struct dnode_sync_free_range_arg {
 	dnode_t *dsfra_dnode;
 	dmu_tx_t *dsfra_tx;
+	boolean_t dsfra_free_indirects;
 } dnode_sync_free_range_arg_t;
 
 static void
@@ -388,7 +394,8 @@ dnode_sync_free_range(void *arg, uint64_t blkid, uint64_t nblks)
 	dnode_t *dn = dsfra->dsfra_dnode;
 
 	mutex_exit(&dn->dn_mtx);
-	dnode_sync_free_range_impl(dn, blkid, nblks, dsfra->dsfra_tx);
+	dnode_sync_free_range_impl(dn, blkid, nblks,
+	    dsfra->dsfra_free_indirects, dsfra->dsfra_tx);
 	mutex_enter(&dn->dn_mtx);
 }
 
@@ -682,6 +689,11 @@ dnode_sync(dnode_t *dn, dmu_tx_t *tx)
 		dnode_sync_free_range_arg_t dsfra;
 		dsfra.dsfra_dnode = dn;
 		dsfra.dsfra_tx = tx;
+		dsfra.dsfra_free_indirects = freeing_dnode;
+		if (freeing_dnode) {
+			ASSERT(range_tree_contains(dn->dn_free_ranges[txgoff],
+			    0, dn->dn_maxblkid + 1));
+		}
 		mutex_enter(&dn->dn_mtx);
 		range_tree_vacate(dn->dn_free_ranges[txgoff],
 		    dnode_sync_free_range, &dsfra);

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -20,7 +20,8 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2014 Integros [integros.com]
  */
 
 /* Portions Copyright 2007 Jeremy Teo */
@@ -1625,7 +1626,8 @@ zfs_trunc(znode_t *zp, uint64_t end)
 		return (0);
 	}
 
-	error = dmu_free_long_range(zsb->z_os, zp->z_id, end,  -1);
+	error = dmu_free_long_range(zsb->z_os, zp->z_id, end,
+	    DMU_OBJECT_END);
 	if (error) {
 		zfs_range_unlock(rl);
 		return (error);

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -297,6 +297,9 @@ tests = ['zpool_get_001_pos', 'zpool_get_002_pos', 'zpool_get_003_pos',
 [tests/functional/cli_root/zpool_history]
 tests = ['zpool_history_001_neg', 'zpool_history_002_pos']
 
+[tests/functional/hole_birth]
+tests = ['hole_birth_7176', 'hole_birth_4809', 'hole_birth_4996']
+
 # DISABLED:
 # zpool_import_002_pos - https://github.com/zfsonlinux/zfs/issues/5202
 # zpool_import_012_pos - sharenfs issue

--- a/tests/zfs-tests/tests/functional/Makefile.am
+++ b/tests/zfs-tests/tests/functional/Makefile.am
@@ -19,6 +19,7 @@ SUBDIRS = \
 	grow_pool \
 	grow_replicas \
 	history \
+	hole_birth \
 	inheritance \
 	inuse \
 	large_files \

--- a/tests/zfs-tests/tests/functional/hole_birth/Makefile.am
+++ b/tests/zfs-tests/tests/functional/hole_birth/Makefile.am
@@ -1,0 +1,9 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/hole_birth
+dist_pkgdata_SCRIPTS = \
+	hole_birth.cfg \
+	hole_birth.kshlib \
+	setup.ksh \
+	cleanup.ksh \
+	hole_birth_7176.ksh \
+	hole_birth_4809.ksh  \
+	hole_birth_4996.ksh

--- a/tests/zfs-tests/tests/functional/hole_birth/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/cleanup.ksh
@@ -1,0 +1,45 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013, 2014 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+verify_runnable "both"
+
+if is_global_zone ; then
+	destroy_pool $POOL
+	destroy_pool $POOL2
+else
+	cleanup_pool $POOL
+	cleanup_pool $POOL2
+fi
+log_must $RM -rf $BACKDIR $TESTDIR
+
+log_pass

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth.cfg
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth.cfg
@@ -1,0 +1,37 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+export BACKDIR=${TEST_BASE_DIR%%/}/backdir-hole_birth
+
+export DISK1=$($ECHO $DISKS | $AWK '{print $1}')
+export DISK2=$($ECHO $DISKS | $AWK '{print $2}')
+
+export POOL=$TESTPOOL
+export POOL2=$TESTPOOL1
+export FS=$TESTFS

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth.kshlib
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth.kshlib
@@ -1,0 +1,495 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.cfg
+
+#
+# Set up test model which includes various datasets
+#
+#               @final
+#               @snapB
+#               @init
+#               |
+#   ______ pclone
+#  |      /
+#  |@psnap
+#  ||                         @final
+#  ||@final       @final      @snapC
+#  ||@snapC       @snapC      @snapB
+#  ||@snapA       @snapB      @snapA
+#  ||@init        @init       @init
+#  |||            |           |
+# $pool -------- $FS ------- fs1 ------- fs2
+#    \             \\_____     \          |
+#     vol           vol   \____ \         @fsnap
+#      |              |        \ \              \
+#      @init          @vsnap   |  ------------ fclone
+#      @snapA         @init \  |                    |
+#      @final         @snapB \ |                    @init
+#                     @snapC  vclone                @snapA
+#                     @final       |                @final
+#                                 @init
+#                                 @snapC
+#                                 @final
+#
+# $1 pool name
+#
+function setup_test_model
+{
+	typeset pool=$1
+
+	return 0
+}
+
+#
+# Cleanup the BACKDIR and given pool content and all the sub datasets
+#
+# $1 pool name
+#
+function cleanup_pool
+{
+	typeset pool=$1
+	log_must $RM -rf $BACKDIR/*
+
+	if is_global_zone ; then
+		log_must $ZFS destroy -Rf $pool
+	else
+		typeset list=$($ZFS list -H -r -t filesystem,snapshot,volume -o name $pool)
+		for ds in $list ; do
+			if [[ $ds != $pool ]] ; then
+				if datasetexists $ds ; then
+					log_must $ZFS destroy -Rf $ds
+				fi
+			fi
+		done
+	fi
+
+	typeset mntpnt=$(get_prop mountpoint $pool)
+	if ! ismounted $pool ; then
+		# Make sure mountpoint directory is empty
+		if [[ -d $mntpnt ]]; then
+			log_must $RM -rf $mntpnt/*
+		fi
+
+		log_must $ZFS mount $pool
+	fi
+	if [[ -d $mntpnt ]]; then
+		log_must $RM -rf $mntpnt/*
+	fi
+
+	return 0
+}
+
+function cmp_md5s {
+	typeset file1=$1
+	typeset file2=$2
+
+	eval md5sum $file1 | awk '{ print $1 }'	> $BACKDIR/md5_file1
+	eval md5sum $file2 | awk '{ print $1 }'	> $BACKDIR/md5_file2
+	$DIFF $BACKDIR/md5_file1 $BACKDIR/md5_file2
+        typeset -i ret=$?
+
+        $RM -f $BACKDIR/md5_file1 $BACKDIR/md5_file2
+
+        return $ret
+
+}
+
+#
+# Detect if the given two filesystems have same sub-datasets
+#
+# $1 source filesystem
+# $2 destination filesystem
+#
+function cmp_ds_subs
+{
+	typeset src_fs=$1
+	typeset dst_fs=$2
+
+	$ZFS list -r -H -t filesystem,snapshot,volume -o name $src_fs > $BACKDIR/src1
+	$ZFS list -r -H -t filesystem,snapshot,volume -o name $dst_fs > $BACKDIR/dst1
+
+	eval $SED -e 's:^$src_fs:PREFIX:g' < $BACKDIR/src1 > $BACKDIR/src
+	eval $SED -e 's:^$dst_fs:PREFIX:g' < $BACKDIR/dst1 > $BACKDIR/dst
+
+	$DIFF $BACKDIR/src $BACKDIR/dst
+	typeset -i ret=$?
+
+	$RM -f $BACKDIR/src $BACKDIR/dst $BACKDIR/src1 $BACKDIR/dst1
+
+	return $ret
+}
+
+#
+# Compare all the directores and files in two filesystems
+#
+# $1 source filesystem
+# $2 destination filesystem
+#
+function cmp_ds_cont
+{
+	typeset src_fs=$1
+	typeset dst_fs=$2
+
+	typeset srcdir dstdir
+	srcdir=$(get_prop mountpoint $src_fs)
+	dstdir=$(get_prop mountpoint $dst_fs)
+
+	$DIFF -r $srcdir $dstdir > /dev/null 2>&1
+	echo $?
+}
+
+#
+# Compare the given two dataset properties
+#
+# $1 dataset 1
+# $2 dataset 2
+#
+function cmp_ds_prop
+{
+	typeset dtst1=$1
+	typeset dtst2=$2
+
+	for item in "type" "origin" "volblocksize" "aclinherit" "acltype" \
+	    "atime" "canmount" "checksum" "compression" "copies" "devices" \
+	    "dnodesize" "exec" "quota" "readonly" "recordsize" "reservation" \
+	    "setuid" "snapdir" "version" "volsize" "xattr" "zoned" \
+	    "mountpoint";
+	do
+		$ZFS get -H -o property,value,source $item $dtst1 >> \
+		    $BACKDIR/dtst1
+		$ZFS get -H -o property,value,source $item $dtst2 >> \
+		    $BACKDIR/dtst2
+	done
+
+	eval $SED -e 's:$dtst1:PREFIX:g' < $BACKDIR/dtst1 > $BACKDIR/dtst1
+	eval $SED -e 's:$dtst2:PREFIX:g' < $BACKDIR/dtst2 > $BACKDIR/dtst2
+
+	$DIFF $BACKDIR/dtst1 $BACKDIR/dtst2
+	typeset -i ret=$?
+
+	$RM -f $BACKDIR/dtst1 $BACKDIR/dtst2
+
+	return $ret
+
+}
+
+#
+# Random create directories and files
+#
+# $1 directory
+#
+function random_tree
+{
+	typeset dir=$1
+
+	if [[ -d $dir ]]; then
+		$RM -rf $dir
+	fi
+	$MKDIR -p $dir
+	typeset -i ret=$?
+
+	typeset -i nl nd nf
+	((nl = RANDOM % 6 + 1))
+	((nd = RANDOM % 3 ))
+	((nf = RANDOM % 5 ))
+	$MKTREE -b $dir -l $nl -d $nd -f $nf
+	((ret |= $?))
+
+	return $ret
+}
+
+#
+# Put data in filesystem and take snapshot
+#
+# $1 snapshot name
+#
+function snapshot_tree
+{
+	typeset snap=$1
+	typeset ds=${snap%%@*}
+	typeset type=$(get_prop "type" $ds)
+
+	typeset -i ret=0
+	if [[ $type == "filesystem" ]]; then
+		typeset mntpnt=$(get_prop mountpoint $ds)
+		((ret |= $?))
+
+		if ((ret == 0)) ; then
+			eval random_tree $mntpnt/${snap##$ds}
+			((ret |= $?))
+		fi
+	fi
+
+	if ((ret == 0)) ; then
+		$ZFS snapshot $snap
+		((ret |= $?))
+	fi
+
+	return $ret
+}
+
+#
+# Destroy the given snapshot and stuff
+#
+# $1 snapshot
+#
+function destroy_tree
+{
+	typeset -i ret=0
+	typeset snap
+	for snap in "$@" ; do
+		$ZFS destroy $snap
+		ret=$?
+
+		typeset ds=${snap%%@*}
+		typeset type=$(get_prop "type" $ds)
+		if [[ $type == "filesystem" ]]; then
+			typeset mntpnt=$(get_prop mountpoint $ds)
+			((ret |= $?))
+
+			if ((ret != 0)); then
+				$RM -r $mntpnt/$snap
+				((ret |= $?))
+			fi
+		fi
+
+		if ((ret != 0)); then
+			return $ret
+		fi
+	done
+
+	return 0
+}
+
+#
+# Setup filesystems for the resumable send/receive tests
+#
+# $1 The pool to set up with the "send" filesystems
+# $2 The pool for receive
+#
+function test_fs_setup_4809
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=4k $sendfs); then
+		# initial create
+		log_must truncate -s 1G /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		# permute
+		log_must truncate -s 4194304 /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=152 seek=384 conv=notrunc
+		sleep 5
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}
+
+function test_fs_setup_4809_1
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=4k $sendfs); then
+		# initial create
+		log_must truncate -s 1G /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		# permute
+		log_must truncate -s 4194304 /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=152 seek=384 conv=notrunc
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}
+
+#
+# Setup filesystems for the resumable send/receive tests
+#
+# $1 The pool to set up with the "send" filesystems
+# $2 The pool for receive
+#
+function test_fs_setup_4996
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=512 $sendfs); then
+		# initial create
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1 seek=1
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		# permute
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1
+		sleep 5
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1 seek=3
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}
+
+#
+# Setup filesystems for the resumable send/receive tests
+#
+# $1 The pool to set up with the "send" filesystems
+# $2 The pool for receive
+#
+function test_fs_setup_5030
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=4k $sendfs); then
+		# initial create
+		log_must truncate -s 1G /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		# permute
+		log_must truncate -s 4194304 /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=152 seek=384 conv=notrunc
+		sleep 5
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}
+
+#
+# Setup filesystems for the resumable send/receive tests
+#
+# $1 The pool to set up with the "send" filesystems
+# $2 The pool for receive
+#
+function test_fs_setup_7176
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=512 $sendfs); then
+		# initial create
+		log_must truncate --size=300M /$sendfs/file1
+#		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=512 count=128k conv=notrunc
+#		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		log_must truncate --size=10M /$sendfs/file1
+		sleep 5
+
+		# permute
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=512 count=1 seek=96k conv=notrunc
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth_4809.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth_4809.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	zfs send -R send replication stream up to the named snap.
+#
+# STRATEGY:
+#	1. Back up all the data from POOL/FS
+#	2. Verify all the datasets and data can be recovered in POOL2
+#	3. Back up all the data from root filesystem POOL2
+#	4. Verify all the data can be recovered, too
+#
+
+verify_runnable "both"
+
+log_assert "hole_birth bug ZoL #4809 test"
+log_onexit cleanup_pool $POOL2
+
+test_fs_setup_4809_1 $POOL $POOL2
+
+sendfs=$POOL/sendfs
+recvfs=$POOL2/recvfs
+
+log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+
+log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+
+log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL2
+log_must cleanup_pool $POOL2
+
+log_pass "hole_birth bug ZoL #4809 test"

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth_4996.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth_4996.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	zfs send -R send replication stream up to the named snap.
+#
+# STRATEGY:
+#	1. Back up all the data from POOL/FS
+#	2. Verify all the datasets and data can be recovered in POOL2
+#	3. Back up all the data from root filesystem POOL2
+#	4. Verify all the data can be recovered, too
+#
+
+verify_runnable "both"
+
+log_assert "hole_birth bug ZoL #4996 test"
+log_onexit cleanup_pool $POOL2
+
+test_fs_setup_4996 $POOL $POOL2
+
+sendfs=$POOL/sendfs
+recvfs=$POOL2/recvfs
+
+log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+
+log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+
+log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL2
+log_must cleanup_pool $POOL2
+
+log_pass "hole_birth bug ZoL #4996 test"

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth_5030.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth_5030.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	zfs send -R send replication stream up to the named snap.
+#
+# STRATEGY:
+#	1. Back up all the data from POOL/FS
+#	2. Verify all the datasets and data can be recovered in POOL2
+#	3. Back up all the data from root filesystem POOL2
+#	4. Verify all the data can be recovered, too
+#
+
+verify_runnable "both"
+
+log_assert "hole_birth bug ZoL #5030 test"
+log_onexit cleanup_pool $POOL2
+
+test_fs_setup_5030 $POOL $POOL2
+
+sendfs=$POOL/sendfs
+recvfs=$POOL2/recvfs
+
+log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+
+log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+
+log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL2
+log_must cleanup_pool $POOL2
+
+log_pass "hole_birth bug ZoL #5030 test"

--- a/tests/zfs-tests/tests/functional/hole_birth/hole_birth_7176.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/hole_birth_7176.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	zfs send -R send replication stream up to the named snap.
+#
+# STRATEGY:
+#	1. Back up all the data from POOL/FS
+#	2. Verify all the datasets and data can be recovered in POOL2
+#	3. Back up all the data from root filesystem POOL2
+#	4. Verify all the data can be recovered, too
+#
+
+verify_runnable "both"
+
+log_assert "hole_birth bug illumos #7176 test"
+log_onexit cleanup_pool $POOL2
+
+test_fs_setup_7176 $POOL $POOL2
+
+sendfs=$POOL/sendfs
+recvfs=$POOL2/recvfs
+
+log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+
+log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+
+log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL2
+log_must cleanup_pool $POOL2
+
+log_pass "hole_birth bug illumos #7176 test"

--- a/tests/zfs-tests/tests/functional/hole_birth/setup.ksh
+++ b/tests/zfs-tests/tests/functional/hole_birth/setup.ksh
@@ -1,0 +1,45 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013, 2014 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+verify_runnable "both"
+verify_disk_count "$DISKS" 2
+
+if is_global_zone ; then
+	log_must $ZPOOL create $POOL $DISK1
+	log_must $ZPOOL create $POOL2 $DISK2
+fi
+log_must $MKDIR $BACKDIR $TESTDIR
+
+log_must setup_test_model $POOL
+
+log_pass


### PR DESCRIPTION
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>

The problem here is that when you truncate and write a file in the same
transaction group, the dbuf for the indirect block will be zeroed out to
deal with the truncation, and then written for the write.

During this process, we will lose hole birth time information for any
holes in the range. This is partly fixed by:

    6513 partially filled holes lose birth time

which introduced dbuf_write_children_ready and would be the correct
time to do this processing; however, in the case where a dnode is being
freed, the old code includes necessary space accounting logic. We need a
hybrid approach between determining whether the block should be
converted to a higher-level hole in the zio pipeline, and doing it when
the dnode is being synced out.

Upstream bugs: DLPX-46861

Porting Notes:
- This commit also adds tests for various hole_birth issues; these were
  compiled, corrected, and added by @rincebrain.  These test cases
  should be pushed upstream to OpenZFS.