### PR TITLE
OpenZFS 7490 - real checksum errors are silenced when zinject is on

### DIFF
--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -20,8 +20,8 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+ * Copyright 2013 Saso Kiselkov. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -441,12 +441,13 @@ zio_checksum_error(zio_t *zio, zio_bad_cksum_t *info)
 
 	error = zio_checksum_error_impl(spa, bp, checksum, data, size,
 	    offset, info);
-	if (error != 0 && zio_injection_enabled && !zio->io_error &&
-	    (error = zio_handle_fault_injection(zio, ECKSUM)) != 0) {
 
-		info->zbc_injected = 1;
-		return (error);
+	if (zio_injection_enabled && error == 0 && zio->io_error == 0) {
+		error = zio_handle_fault_injection(zio, ECKSUM);
+		if (error != 0)
+			info->zbc_injected = 1;
 	}
+
 	return (error);
 }
 


### PR DESCRIPTION
Authored by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: George Melikov <mail@gmelikov.ru>

OpenZFS-issue: https://www.illumos.org/issues/7490
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/6cedfc3