### PR TITLE
Fix reservation test cases for large disks

### DIFF
--- a/tests/zfs-tests/tests/functional/reservation/reservation.shlib
+++ b/tests/zfs-tests/tests/functional/reservation/reservation.shlib
@@ -70,9 +70,9 @@ function zero_reservation
 #
 function within_limits
 {
-	typeset -l valA=$1
-	typeset -l valB=$2
-	typeset -l delta=$3
+	typeset valA=$1
+	typeset valB=$2
+	typeset delta=$3
 
 	if ((valA <= valB)); then
 		if (((valB - valA) <= delta)); then
@@ -115,14 +115,14 @@ function create_multiple_fs # num_fs base_fs_name base_mnt_name
 #
 function floor_volsize #<largest_volsize> [volblksize]
 {
-	typeset -l largest_volsize=$1
-	typeset -l volblksize=${2:-8192}
+	typeset largest_volsize=$1
+	typeset volblksize=${2:-8192}
 
 	if ((largest_volsize < volblksize)); then
 		log_fail "The largest_volsize must be greater than volblksize."
 	fi
-	typeset -l real_volsize
-	typeset -l n
+	typeset real_volsize
+	typeset n
 
 	((n = largest_volsize / volblksize))
 	((largest_volsize = volblksize * n))
@@ -142,26 +142,26 @@ function floor_volsize #<largest_volsize> [volblksize]
 function volsize_to_reservation
 {
 	typeset vol=$1
-	typeset -i volsize=$2
+	typeset volsize=$2
 
-	typeset -i DN_MAX_INDBLKSHIFT=14
-	typeset -i SPA_BLKPTRSHIFT=7
-	typeset -i SPA_DVAS_PER_BP=3
+	typeset DN_MAX_INDBLKSHIFT=14
+	typeset SPA_BLKPTRSHIFT=7
+	typeset SPA_DVAS_PER_BP=3
 
-	typeset -i DNODES_PER_LEVEL_SHIFT=$((DN_MAX_INDBLKSHIFT - \
+	typeset DNODES_PER_LEVEL_SHIFT=$((DN_MAX_INDBLKSHIFT - \
 	    SPA_BLKPTRSHIFT))
-	typeset -i DNODES_PER_LEVEL=$((1 << $DNODES_PER_LEVEL_SHIFT))
+	typeset DNODES_PER_LEVEL=$((1 << $DNODES_PER_LEVEL_SHIFT))
 
 	if ds_is_volume $vol; then
-		typeset -i ncopies=$(get_prop copies $vol)
-		typeset -i volblocksize=$(get_prop volblocksize $vol)
+		typeset ncopies=$(get_prop copies $vol)
+		typeset volblocksize=$(get_prop volblocksize $vol)
 	else
-		typeset -i ncopies=1
-		typeset -i volblocksize=8192
+		typeset ncopies=1
+		typeset volblocksize=8192
 	fi
-	typeset -i nblocks=$((volsize / volblocksize))
+	typeset nblocks=$((volsize / volblocksize))
 
-	typeset -i numdb=7
+	typeset numdb=7
 	while ((nblocks > 1)); do
 		((nblocks += DNODES_PER_LEVEL - 1))
 		((nblocks /= DNODES_PER_LEVEL))
@@ -186,9 +186,9 @@ function volsize_to_reservation
 function largest_volsize_from_pool
 {
 	typeset pool=$1
-	typeset -i poolsize=$(get_prop available $pool)
-	typeset -i volsize=$poolsize
-	typeset -i nvolsize
+	typeset poolsize=$(get_prop available $pool)
+	typeset volsize=$poolsize
+	typeset nvolsize
 
 	while :; do
 		# knock 50M off the volsize each time through

--- a/tests/zfs-tests/tests/functional/reservation/reservation_017_pos.sh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_017_pos.sh
@@ -70,13 +70,13 @@ sparsevol=$TESTPOOL/$TESTVOL2
 log_must $ZFS create -V 64M $regvol
 log_must $ZFS create -s -V 64M $sparsevol
 
-typeset -i vsize=$(get_prop available $TESTPOOL)
-typeset -i iterate=10
-typeset -i regreserv
-typeset -i sparsereserv
-typeset -i volblocksize=$(get_prop volblocksize $regvol)
-typeset -i blknum=0
-typeset -i randomblknum
+typeset vsize=$(get_prop available $TESTPOOL)
+typeset iterate=10
+typeset regreserv
+typeset sparsereserv
+typeset volblocksize=$(get_prop volblocksize $regvol)
+typeset blknum=0
+typeset randomblknum
 ((blknum = vsize / volblocksize))
 
 while ((iterate > 1)); do

--- a/tests/zfs-tests/tests/functional/reservation/reservation_018_pos.sh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_018_pos.sh
@@ -60,7 +60,7 @@ fs_child=$TESTPOOL/$TESTFS/$TESTFS
 
 space_avail=$(get_prop available $fs)
 reserv_val=$(get_prop reservation $fs)
-typeset -l reservsize=$space_avail
+typeset reservsize=$space_avail
 ((reservsize = reservsize / 2))
 log_must $ZFS set reservation=$reservsize $fs
 


### PR DESCRIPTION
Convert explicit `typeset -i` declarations to `typeset -l` in order
to prevent 32-bit overflow from occurs with disks >2G.