### PR TITLE
Fix atomic_sub_64() i386 assembly implementation

### DIFF
--- a/lib/libspl/asm-i386/atomic.S
+++ b/lib/libspl/asm-i386/atomic.S
@@ -507,7 +507,7 @@
 	movl	16(%esp), %ebx
 	movl	20(%esp), %ecx
 	subl	%eax, %ebx
-	adcl	%edx, %ecx
+	sbbl	%edx, %ecx
 	lock
 	cmpxchg8b (%edi)
 	jne	1b


### PR DESCRIPTION
The atomic_sub_64() should use sbbl instead of adcl.  In user
space these atomics are used for statistics tracking and aren't
critical which explain how this was overlooked.  The kernel
space implementation of these atomics are layered on the
architecture specific implementations provided by the kernel.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #5671