### PR TITLE
Remove lint ifdef checks in zdb and dbuf

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -83,17 +83,10 @@ zdb_ot_name(dmu_object_type_t type)
 		return ("UNKNOWN");
 }
 
-#ifndef lint
 extern int reference_tracking_enable;
 extern int zfs_recover;
 extern uint64_t zfs_arc_max, zfs_arc_meta_limit;
 extern int zfs_vdev_async_read_max_active;
-#else
-int reference_tracking_enable;
-int zfs_recover;
-uint64_t zfs_arc_max, zfs_arc_meta_limit;
-int zfs_vdev_async_read_max_active;
-#endif
 
 const char cmdname[] = "zdb";
 uint8_t dump_opt[256];

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -78,12 +78,10 @@ uint_t zfs_dbuf_evict_key;
 static boolean_t dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx);
 static void dbuf_write(dbuf_dirty_record_t *dr, arc_buf_t *data, dmu_tx_t *tx);
 
-#ifndef __lint
 extern inline void dmu_buf_init_user(dmu_buf_user_t *dbu,
     dmu_buf_evict_func_t *evict_func_sync,
     dmu_buf_evict_func_t *evict_func_async,
     dmu_buf_t **clear_on_evict_dbufp);
-#endif /* ! __lint */
 
 /*
  * Global data structures and functions for the dbuf cache.


### PR DESCRIPTION
Removed ifndef checks for lint and __lint from dbuf and zdb.