### PR TITLE
Disable sparse_001_pos on 32-bit systems

### DIFF
--- a/tests/zfs-tests/tests/functional/sparse/sparse_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/sparse/sparse_001_pos.ksh
@@ -45,6 +45,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5727
+if is_32bit; then
+	log_unsupported "Test case slow on 32-bit systems"
+fi
+
 function cleanup
 {
 	[[ -e $TESTDIR ]] && log_must $RM -rf $TESTDIR/*

--- a/tests/zfs-tests/tests/functional/truncate/truncate_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/truncate/truncate_001_pos.ksh
@@ -42,6 +42,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5727
+if is_32bit; then
+	log_unsupported "Test case slow on 32-bit systems"
+fi
+
 function cleanup
 {
 	[[ -e $TESTDIR ]] && log_must $RM -rf $TESTDIR/*


### PR DESCRIPTION
Commit 539d33c seems to have significantly increased the run time
of the sparse_001_pos.ksh test case. This is resulting in frequent
failures on the 32-bit builders.  Disable this test case until
the issue can be analyzed and resolved.

Issue #5727
