### PR TITLE
Do not dump duplicate configurations or Uberblocks with zdb -lu

### DIFF
--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -177,13 +177,16 @@ transaction type.
 .ad
 .sp .6
 .RS 4n
-Read the vdev labels from the specified device. \fBzdb -l\fR will return 0 if
-valid label was found, 1 if error occured, and 2 if no valid labels were found.
+Read the vdev labels from the specified device and dump the unique
+configuration nvlist(s). \fBzdb -l\fR will return 1 if an error occured, 2 if
+no configuration nvlist could be unpacked (errors or not), and 0 otherwise.
+Specify multiple times to increase verbosity.
 .P
 If the \fB-u\fR option is also specified, also display the uberblocks on this
-device.
+device.  Specify multiple times to increase verbosity.
 .P
-If the \fB-q\fR option is also specified, don't print the labels.
+If the \fB-q\fR option is also specified, don't dump the configurations or the
+uberblocks.
 .RE
 
 .sp

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -71,7 +71,8 @@ tests = [ 'clean_mirror_001_pos', 'clean_mirror_002_pos',
     'clean_mirror_003_pos', 'clean_mirror_004_pos']
 
 [tests/functional/cli_root/zdb]
-tests = ['zdb_001_neg', 'zdb_002_pos']
+tests = ['zdb_001_neg', 'zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos',
+    'zdb_005_pos']
 pre =
 post =
 

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
@@ -1,4 +1,7 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zdb
 dist_pkgdata_SCRIPTS = \
 	zdb_001_neg.ksh \
-	zdb_002_pos.ksh
+	zdb_002_pos.ksh \
+	zdb_003_pos.ksh \
+	zdb_004_pos.ksh \
+	zdb_005_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_003_pos.ksh
@@ -1,0 +1,58 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb will not produce redundant dumps of configurations
+#
+# Strategy:
+# 1. Create a pool with two vdevs
+# 2. Copy label 1 from the first vdev to the second vdev
+# 3. Collect zdb -l output for both vdevs
+# 4. Verify that the correct number of configs is dumped for each
+#
+
+log_assert "Verify zdb does not produce redundant dumps of configurations"
+log_onexit cleanup
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+verify_runnable "global"
+verify_disk_count "$DISKS" 2
+
+config_count=(1 2)
+set -A DISK $DISKS
+
+default_mirror_setup_noexit $DISKS
+log_must $DD if=/dev/${DISK[0]} of=/dev/${DISK[1]} bs=1K count=256 conv=notrunc
+
+for x in 0 1 ; do
+	config_count=$($ZDB -l $DEV_RDSKDIR/${DISK[$x]} | $GREP -c features_for_read)
+	(( $? != 0)) && log_fail "failed to get config_count from DISK[$x]"
+	log_note "vdev $x: message_count $config_count"
+	[ $config_count -ne ${config_count[$x]} ] && \
+		log_fail "zdb produces an incorrect number of configuration dumps."
+done
+
+cleanup
+
+log_pass "zdb produces unique dumps of configurations."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_004_pos.ksh
@@ -1,0 +1,78 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb will not produce redundant dumps of uberblocks
+#
+# Strategy:
+# 1. Create a pool with two vdevs, A and B
+# 2. Offline vdev A
+# 3. Do some I/O
+# 4. Export the pool
+# 5. Copy label 1 from vdev A to vdev B
+# 6. Collect zdb -lu output for vdev B
+# 7. Verify labels 0 and 1 have unique Uberblocks, but 2 and 3 have none
+#
+
+log_assert "Verify zdb produces unique dumps of uberblocks"
+log_onexit cleanup
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	for DISK in $DISKS; do
+		$ZPOOL labelclear -f $DEV_RDSKDIR/$DISK
+	done
+}
+
+verify_runnable "global"
+verify_disk_count "$DISKS" 2
+set -A DISK $DISKS
+
+default_mirror_setup_noexit $DISKS
+log_must $ZPOOL offline $TESTPOOL ${DISK[0]}
+log_must $DD if=/dev/urandom of=$TESTDIR/testfile bs=1K count=2
+log_must $ZPOOL export $TESTPOOL
+log_must $DD if=$DEV_RDSKDIR/${DISK[0]} of=$DEV_RDSKDIR/${DISK[1]} bs=1K count=256 conv=notrunc
+
+ubs=$($ZDB -lu $DEV_RDSKDIR/${DISK[1]} | $GREP -e LABEL -e Uberblock -e 'labels = ')
+log_note "vdev 1: ubs $ubs"
+
+ub_dump_counts=$($ZDB -lu $DEV_RDSKDIR/${DISK[1]} | \
+	$AWK '	/LABEL/	{label=$NF; blocks[label]=0};
+		/Uberblock/ {blocks[label]++};
+		END {print blocks[0],blocks[1],blocks[2],blocks[3]}')
+(( $? != 0)) && log_fail "failed to get ub_dump_counts from DISK[1]"
+log_note "vdev 1: ub_dump_counts $ub_dump_counts"
+
+set -A dump_count $ub_dump_counts
+for label in 0 1 2 3; do
+	if [[ $label -lt 2 ]]; then
+ 		[[ ${dump_count[$label]} -eq 0 ]] && \
+		    log_fail "zdb incorrectly dumps duplicate uberblocks"
+	else
+ 		[[ ${dump_count[$label]} -ne 0 ]] && \
+		    log_fail "zdb incorrectly dumps duplicate uberblocks"
+	fi
+done
+
+cleanup
+
+log_pass "zdb produces unique dumps of uberblocks"

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_005_pos.ksh
@@ -1,0 +1,64 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb -l exit codes are correct
+#
+# Strategy:
+# 1. Create a pool
+# 2. Overwrite label 0 on vdev[1] with dd
+# 3. Create an empty file
+# 3. Run zdb -l on vdev[0] and verify exit value 0
+# 4. Run zdb -l on vdev[1] and verify exit value 1
+# 5. Run zdb -l on the empty file and verify exit value 2
+#
+
+log_assert "Verify zdb -l exit codes are correct"
+log_onexit cleanup
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+verify_runnable "global"
+verify_disk_count "$DISKS" 2
+
+set -A DISK $DISKS
+
+default_mirror_setup_noexit $DISKS
+log_must $DD if=/dev/zero of=$DEV_RDSKDIR/${DISK[1]} bs=1K count=256 conv=notrunc
+log_must $TRUNCATE -s 0 $TEMPFILE
+
+$ZDB -l $DEV_RDSKDIR/${DISK[0]}
+[[ $? -ne 0 ]] &&
+	log_fail "zdb -l exit codes are incorrect."
+
+$ZDB -l $DEV_RDSKDIR/${DISK[1]}
+[[ $? -ne 1 ]] &&
+	log_fail "zdb -l exit codes are incorrect."
+
+$ZDB -l $TEMPFILE
+[[ $? -ne 2 ]] &&
+	log_fail "zdb -l exit codes are incorrect."
+
+cleanup
+
+log_pass "zdb -l exit codes are correct."


### PR DESCRIPTION
### Description
While looping over the labels during zdb -l, record the checksum of the config nvlist.  Dump the first configuration which can be unpacked.  For the remaining labels, dump the configuration only if it is different than config(s) previously dumped.

In the same manner, detect Uberblocks which have already been dumped, when zdb is run with -u.  The Uberblock is checked against the Uberblocks in the same slot in other labels.  

See commit message for effect of multiple -l or -u flags.

### Motivation and Context
Current behavior is to dump the configuration and entire uberblock ring for each label.  When they are not all the same, it is not obvious that one or more differ from the others.  When they are all the same, this makes the output unnecessarily long.

### How Has This Been Tested?
There are three new tests to verify the new functionality.  They create a pool with multiple vdevs, and use dd to copy label 0 from one vdev to the other.  One test checks the config output, another the uberblock output, and a third the exit code.  See  zfs-tests/tests/functional/cli_root/zdb/zdb_00{3,4,5}_pos.ksh for details

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the ZFS on Linux code style requirements.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x] Change has been approved by a ZFS on Linux member.
