### PR TITLE
zfstests - snapshot destroy works asynchronously

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3078,3 +3078,17 @@ function sync_pool #pool
 		log_must $SLEEP 2
 	done
 }
+
+#
+# Wait for zpool 'freeing' property drops to zero.
+#
+# $1 pool name
+#
+function wait_freeing #pool
+{
+	typeset pool=${1:-$TESTPOOL}
+	while true; do
+		[[ "0" == "$($ZPOOL list -Ho freeing $pool)" ]] && break
+		log_must $SLEEP 1
+	done
+}

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
@@ -92,6 +92,8 @@ function set_n_check_prop
 		log_mustnot $ZFS set $prop=$expect_value $dataset
 
 		[[ -n $prop ]] && cur_value=$(get_prop $prop $dataset)
+		
+		wait_freeing
 
 		if [[ "$expect_value" != "" && "$cur_value" != "$old_value" ]];
 		then

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_008_pos.ksh
@@ -88,6 +88,8 @@ while [[ $i -lt $COUNT ]]; do
 	(( i = i + 1 ))
 done
 
+wait_freeing $TESTPOOL
+
 new_size=`get_prop available $TESTPOOL`
 
 typeset -i tolerance=0


### PR DESCRIPTION
Sometimes zfstests check freed space just after `zfs destroy snapshot` and get wrong output, because the space being freed asynchronously in the background.


Example:
```
Test: /usr/share/zfs/zfs-tests/tests/functional/snapshot/snapshot_008_pos (run as root) [00:00] [FAIL]
10:54:03.66 ASSERTION: Verify that destroying snapshots returns space to the pool.
10:54:03.67 NOTE: Populate the /var/tmp/testdir23092 directory
10:54:03.67 SUCCESS: /usr/share/zfs/zfs-tests/bin/file_write -o create -f /var/tmp/testdir23092/file1 -b 8192 -c 20 -d 1
10:54:03.68 SUCCESS: /sbin/zfs snapshot testpool.23092/testfs.23092@testsnap23092.1
10:54:03.69 SUCCESS: /usr/share/zfs/zfs-tests/bin/file_write -o create -f /var/tmp/testdir23092/file2 -b 8192 -c 20 -d 2
10:54:03.70 SUCCESS: /sbin/zfs snapshot testpool.23092/testfs.23092@testsnap23092.2
10:54:03.71 SUCCESS: /usr/share/zfs/zfs-tests/bin/file_write -o create -f /var/tmp/testdir23092/file3 -b 8192 -c 20 -d 3
10:54:03.72 SUCCESS: /sbin/zfs snapshot testpool.23092/testfs.23092@testsnap23092.3
10:54:03.72 SUCCESS: /usr/share/zfs/zfs-tests/bin/file_write -o create -f /var/tmp/testdir23092/file4 -b 8192 -c 20 -d 4
10:54:03.73 SUCCESS: /sbin/zfs snapshot testpool.23092/testfs.23092@testsnap23092.4
10:54:03.73 SUCCESS: /usr/share/zfs/zfs-tests/bin/file_write -o create -f /var/tmp/testdir23092/file5 -b 8192 -c 20 -d 5
10:54:03.75 SUCCESS: /sbin/zfs snapshot testpool.23092/testfs.23092@testsnap23092.5
10:54:03.75 SUCCESS: /usr/share/zfs/zfs-tests/bin/file_write -o create -f /var/tmp/testdir23092/file6 -b 8192 -c 20 -d 6
10:54:03.76 SUCCESS: /sbin/zfs snapshot testpool.23092/testfs.23092@testsnap23092.6
10:54:03.76 SUCCESS: /usr/share/zfs/zfs-tests/bin/file_write -o create -f /var/tmp/testdir23092/file7 -b 8192 -c 20 -d 7
10:54:03.77 SUCCESS: /sbin/zfs snapshot testpool.23092/testfs.23092@testsnap23092.7
10:54:03.78 SUCCESS: /usr/share/zfs/zfs-tests/bin/file_write -o create -f /var/tmp/testdir23092/file8 -b 8192 -c 20 -d 8
10:54:03.79 SUCCESS: /sbin/zfs snapshot testpool.23092/testfs.23092@testsnap23092.8
10:54:03.79 SUCCESS: /usr/share/zfs/zfs-tests/bin/file_write -o create -f /var/tmp/testdir23092/file9 -b 8192 -c 20 -d 9
10:54:03.80 SUCCESS: /sbin/zfs snapshot testpool.23092/testfs.23092@testsnap23092.9
10:54:03.81 SUCCESS: /sbin/zfs destroy testpool.23092/testfs.23092@testsnap23092.1
10:54:03.83 SUCCESS: /sbin/zfs destroy testpool.23092/testfs.23092@testsnap23092.2
10:54:03.84 SUCCESS: /sbin/zfs destroy testpool.23092/testfs.23092@testsnap23092.3
10:54:03.85 SUCCESS: /sbin/zfs destroy testpool.23092/testfs.23092@testsnap23092.4
10:54:03.87 SUCCESS: /sbin/zfs destroy testpool.23092/testfs.23092@testsnap23092.5
10:54:03.89 SUCCESS: /sbin/zfs destroy testpool.23092/testfs.23092@testsnap23092.6
10:54:03.90 SUCCESS: /sbin/zfs destroy testpool.23092/testfs.23092@testsnap23092.7
10:54:03.91 SUCCESS: /sbin/zfs destroy testpool.23092/testfs.23092@testsnap23092.8
10:54:03.92 SUCCESS: /sbin/zfs destroy testpool.23092/testfs.23092@testsnap23092.9
10:54:03.93 NOTE: Performing local cleanup via log_onexit (cleanup)
10:54:03.94 Space not freed. (3960835072 != 3962538496)
```

Solution - wait for `freeing` value to be zero.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
