### PR TITLE
Fix ZFS Test Suite failures caused by ksh brace expansion feature

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -118,10 +118,8 @@ tests = ['zfs_get_001_pos', 'zfs_get_002_pos', 'zfs_get_003_pos',
     'zfs_get_005_neg', 'zfs_get_007_neg', 'zfs_get_008_pos',
     'zfs_get_009_pos', 'zfs_get_010_neg']
 
-# DISABLED:
-# zfs_inherit_003_pos - https://github.com/zfsonlinux/zfs/issues/5669
 [tests/functional/cli_root/zfs_inherit]
-tests = ['zfs_inherit_001_neg', 'zfs_inherit_002_neg']
+tests = ['zfs_inherit_001_neg', 'zfs_inherit_002_neg', 'zfs_inherit_003_pos']
 
 # DISABLED:
 # zfs_mount_006_pos - https://github.com/zfsonlinux/zfs/issues/4990

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1035,7 +1035,7 @@ function get_prop # property dataset
 		return 1
 	fi
 
-	$ECHO $prop_val
+	$ECHO "$prop_val"
 	return 0
 }
 
@@ -1062,7 +1062,7 @@ function get_pool_prop # property pool
 		return 1
 	fi
 
-	$ECHO $prop_val
+	$ECHO "$prop_val"
 	return 0
 }
 


### PR DESCRIPTION
### Description
https://github.com/zfsonlinux/zfs/issues/5669 seems to be caused by ksh "brace expansion" feature:

```sh
# echo $KSH_VERSION
Version AJM 93u+ 2012-08-01
# set +o braceexpand
# propval='{,}EDlNb?T.OtFO%'
# echo "$propval"
{,}EDlNb?T.OtFO%
# echo $propval
EDlNb?T.OtFO% EDlNb?T.OtFO%
# 
```

Before we fix that specific issue i think i'd be interesting too see how many test cases fail reliably when this kind of values get generated by "_user_property_" functions in "_$STF_SUITE/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib_".

I'm going to borrow the buildbot to test this because it's much faster than my local dev machine, then update this PR to fix all reliable failures.

### Motivation and Context
Fix https://github.com/zfsonlinux/zfs/issues/5669

### How Has This Been Tested?
Buildbot

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.