### PR TITLE
zfs-tests: export FILEDIR and FILES

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -341,6 +341,8 @@ msg ""
 
 export STF_TOOLS
 export STF_SUITE
+export FILEDIR
+export FILES
 export DISKS
 export KEEP
 export __ZFS_POOL_EXCLUDE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Export the variables FILES and FILEDIR in zfs-tests.sh

### Motivation and Context
zfs-tests.sh creates the files listed in $FILES within the
directory $FILEDIR, and advertises them in its message to
standard out, but does not export the two variables so that
tests are aware of them.

### How Has This Been Tested?
Ran a small subset zfs-tests locally and verified they passed.  This same change was part of another WIP commit which passed all but 4 of the enabled zfs-test tests; verified those did not rely on these variables in some way.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
