### PR TITLE
multiple dnode lists per object set.

### DIFF
--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -71,6 +71,19 @@ typedef struct objset_phys {
 
 typedef int (*dmu_objset_upgrade_cb_t)(objset_t *);
 
+#define	OS_DNODE_LISTS	16
+
+struct dnode_list {
+	kmutex_t dnl_lock;
+	list_t dnl_dirty_dnodes[TXG_SIZE];
+	list_t dnl_free_dnodes[TXG_SIZE];
+	list_t dnl_dnodes;
+}
+#ifdef _KERNEL
+____cacheline_aligned
+#endif
+;
+
 struct objset {
 	/* Immutable: */
 	struct dsl_dataset *os_dsl_dataset;
@@ -120,13 +133,12 @@ struct objset {
 
 	/* Protected by os_obj_lock */
 	kmutex_t os_obj_lock;
+	struct dnode_list os_dnode_list[OS_DNODE_LISTS];
+	int os_dirty[TXG_SIZE];
 	uint64_t os_obj_next;
 
 	/* Protected by os_lock */
 	kmutex_t os_lock;
-	list_t os_dirty_dnodes[TXG_SIZE];
-	list_t os_free_dnodes[TXG_SIZE];
-	list_t os_dnodes;
 	list_t os_downgraded_dbufs;
 
 	/* stuff we store for the user */


### PR DESCRIPTION
this is a prototype. premilinary becnchmarks:

threads		before	after
1		28678	28944
2		54282   54667
4		107627  107082
8		189421  199461
16		249655  249601
32		238819  244650
64		244112  251285
128		249444  292213

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
