### PR TITLE
Fix coverity scan defects: CID 155928

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2303,7 +2303,7 @@ dump_nvlist_stats(nvlist_t *nvl, size_t cap)
 {
 	zdb_nvl_stats_t stats = { 0 };
 	size_t size, sum = 0, total;
-	size_t noise, average;
+	size_t noise;
 
 	/* requires nvlist with non-unique names for stat collection */
 	VERIFY0(nvlist_alloc(&stats.zns_string, 0, 0));
@@ -2344,15 +2344,18 @@ dump_nvlist_stats(nvlist_t *nvl, size_t cap)
 	(void) printf("%12s %4d %6d bytes (%5.2f%%)\n\n", "nvlists:",
 	    stats.zns_list_count, (int)size, 100.0 * size / total);
 
-	average = stats.zns_leaf_total / stats.zns_leaf_count;
-	(void) printf("%12s %4d %6d bytes average\n",
-	    "leaf vdevs:", stats.zns_leaf_count, (int)average);
-	(void) printf("%24d bytes largest\n", (int)stats.zns_leaf_largest);
+	if (stats.zns_leaf_count > 0) {
+		size_t average = stats.zns_leaf_total / stats.zns_leaf_count;
 
-	if (dump_opt['l'] >= 3)
-		(void) printf("  space for %d additional leaf vdevs\n",
-		    (int)((cap - total) / average));
+		(void) printf("%12s %4d %6d bytes average\n", "leaf vdevs:",
+		    stats.zns_leaf_count, (int)average);
+		(void) printf("%24d bytes largest\n",
+		    (int)stats.zns_leaf_largest);
 
+		if (dump_opt['l'] >= 3 && average > 0)
+			(void) printf("  space for %d additional leaf vdevs\n",
+			    (int)((cap - total) / average));
+	}
 	(void) printf("\n");
 
 	nvlist_free(stats.zns_string);


### PR DESCRIPTION
### Description
Address Coverity scan defect CID 155928: Integer handling issues (DIVIDE_BY_ZERO)

### Motivation and Context
In the current vdev label, the leaf count is always non-zero but it doesn't hurt to check the count for future proofing.

### How Has This Been Tested?
Tested with zdb(8) and ztest(1)
Testing environment: centos 7.2, x86_64, kernel 3.10

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
