### PR TITLE
Enable zfs-test zpool_expand_002_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -277,10 +277,10 @@ post =
 tests = ['zpool_detach_001_neg']
 
 # DISABLED: Requires full FMA support in ZED
-# zpool_expand_* - https://github.com/zfsonlinux/zfs/issues/2437
-#[tests/functional/cli_root/zpool_expand]
-#tests = ['zpool_expand_001_pos', 'zpool_expand_002_pos',
-#    'zpool_expand_003_neg']
+# zpool_expand_001_pos - https://github.com/zfsonlinux/zfs/issues/2437
+# zpool_expand_003_pos - https://github.com/zfsonlinux/zfs/issues/2437
+[tests/functional/cli_root/zpool_expand]
+tests = ['zpool_expand_002_pos']
 
 # DISABLED:
 # zpool_export_004_pos - https://github.com/zfsonlinux/zfs/issues/3484

--- a/tests/zfs-tests/include/default.cfg.in
+++ b/tests/zfs-tests/include/default.cfg.in
@@ -26,6 +26,7 @@
 
 #
 # Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2017 Lawrence Livermore National Security, LLC.
 #
 
 . $STF_SUITE/include/commands.cfg
@@ -128,6 +129,12 @@ export TESTDIR=${TEST_BASE_DIR%%/}/testdir$$
 export TESTDIR0=${TEST_BASE_DIR%%/}/testdir0$$
 export TESTDIR1=${TEST_BASE_DIR%%/}/testdir1$$
 export TESTDIR2=${TEST_BASE_DIR%%/}/testdir2$$
+
+# some temp files
+export TEMPFILE=${TEST_BASE_DIR%%/}/tempfile$$
+export TEMPFILE0=${TEST_BASE_DIR%%/}/tempfile0$$
+export TEMPFILE1=${TEST_BASE_DIR%%/}/tempfile1$$
+export TEMPFILE2=${TEST_BASE_DIR%%/}/tempfile2$$
 
 export ZFSROOT=
 

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -27,6 +27,7 @@
 
 #
 # Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+# Copyright (c) 2017 Lawrence Livermore National Security, LLC.
 #
 
 . ${STF_TOOLS}/include/logapi.shlib
@@ -1043,6 +1044,8 @@ function get_prop # property dataset
 # Simple function to get the specified property of pool. If unable to
 # get the property then exits.
 #
+# Note property is in 'parsable' format (-p)
+#
 function get_pool_prop # property pool
 {
 	typeset prop_val
@@ -1050,7 +1053,7 @@ function get_pool_prop # property pool
 	typeset pool=$2
 
 	if poolexists $pool ; then
-		prop_val=$($ZPOOL get $prop $pool 2>/dev/null | $TAIL -1 | \
+		prop_val=$($ZPOOL get -pH $prop $pool 2>/dev/null | $TAIL -1 | \
 			$AWK '{print $3}')
 		if [[ $? -ne 0 ]]; then
 			log_note "Unable to get $prop property for pool " \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand.cfg
@@ -29,10 +29,7 @@
 #
 
 
-export org_size=1g
-export exp_size=2g
+export org_size=$MINVDEVSIZE
+export exp_size=$((2*$org_size))
 
 export VFS=$TESTPOOL/$TESTFS
-
-export EX_1GB=1073741824
-export EX_3GB=3221225472

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
@@ -102,30 +102,33 @@ for type in " " mirror raidz raidz2; do
 	if [[ $zfs_expand_size > $zfs_prev_size ]]; then
 	# check for zpool history for the pool size expansion
 		if [[ $type == " " ]]; then
+			typeset expansion_size=$(($exp_size-$org_size))
 			typeset	size_addition=$($ZPOOL history -il $TESTPOOL1 |\
 			    $GREP "pool '$TESTPOOL1' size:" | \
 			    $GREP "vdev online" | \
-			    $GREP "(+${EX_1GB}" | wc -l)
+			    $GREP "(+${expansion_size}" | wc -l)
 
 			if [[ $size_addition -ne $i ]]; then
 				log_fail "pool $TESTPOOL1 is not autoexpand " \
 				    "after LUN expansion"
 			fi
 		elif [[ $type == "mirror" ]]; then
+			typeset expansion_size=$(($exp_size-$org_size))
 			$ZPOOL history -il $TESTPOOL1 | \
 			    $GREP "pool '$TESTPOOL1' size:" | \
 			    $GREP "vdev online" | \
-			    $GREP "(+${EX_1GB})" >/dev/null 2>&1
+			    $GREP "(+${expansion_size})" >/dev/null 2>&1
 
 			if [[ $? -ne 0 ]] ; then
 				log_fail "pool $TESTPOOL1 is not autoexpand " \
 				    "after LUN expansion"
 			fi
 		else
+			typeset expansion_size=$((3*($exp_size-$org_size)))
 			$ZPOOL history -il $TESTPOOL1 | \
 			    $GREP "pool '$TESTPOOL1' size:" | \
 			    $GREP "vdev online" | \
-			    $GREP "(+${EX_3GB})" >/dev/null 2>&1
+			    $GREP "(+${expansion_size})" >/dev/null 2>&1
 
 			if [[ $? -ne 0 ]]; then
 				log_fail "pool $TESTPOOL is not autoexpand " \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Use -pH flags in get_pool_prop so that size or other numeric properties
can be compared.  The zpool_expand test suite is the only one which uses
get_pool_prop for a numeric property which would be affected by this.

Add TEMPFILE and TEMPFILE{0,1,2} to default.cfg for tests that benefit
from building pools on top of files, such as this one where expansion
is necessary but the entries in DISKS may not point to entities that
can be expanded..

Base the pool used for testing on file-type VDEVs instead of using zvols
within an underlying pool.  This is simpler and avoids issues that come up
when pools are backed by other pools.

### Motivation and Context
The zpool_expand test suite is currently disabled on linux.  This restores some testing of pools whose LUNs expand.

### How Has This Been Tested?
Tested locally by running a small subset of the tests enabled in linux.run including the test I enabled, on RHEL6, using zfs-test.sh in-tree.  Checked for impacts on other tests due to the introduction of TEMPFILE and change to get_pool_prop by code inspection / grep.
Relying on buildbot to run the full test suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
