### PR TITLE
Clear enclosure sysfs path from VDEV label when sysfs path isn't present

### DIFF
--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -476,7 +476,6 @@ update_vdev_config_dev_strs(nvlist_t *nv)
 	    !strncasecmp(env, "YES", 3) || !strncasecmp(env, "ON", 2))) {
 		(void) nvlist_remove_all(nv, ZPOOL_CONFIG_DEVID);
 		(void) nvlist_remove_all(nv, ZPOOL_CONFIG_PHYS_PATH);
-		(void) nvlist_remove_all(nv, ZPOOL_CONFIG_VDEV_ENC_SYSFS_PATH);
 		return;
 	}
 
@@ -504,6 +503,9 @@ update_vdev_config_dev_strs(nvlist_t *nv)
 		if (spath)
 			nvlist_add_string(nv, ZPOOL_CONFIG_VDEV_ENC_SYSFS_PATH,
 			    spath);
+		else
+			nvlist_remove_all(nv, ZPOOL_CONFIG_VDEV_ENC_SYSFS_PATH);
+
 		free(upath);
 		free(spath);
 	} else {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
This clears `vdev_enc_sysfs_path` from the label if the VDEV's
`/sys/class/block/<dev>/device/enclosure_device` path isn't present.  This
is important in the case where a disk that is labeled with `vdev_enc_sysfs_path`
is pulled out and put into another enclosure.  In that case, it's possible that
the old sysfs path would be used to turn on the fault LED for the disk's old
slot position, assuming the new slot didn't have a LED sysfs entry.

### How Has This Been Tested?
Verified in zdb that `vdev_enc_sysfs_path` was not set when ses.ko wasn't loaded.  Verified it was set when ses.ko was loaded.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
