### PR TITLE
OpenZFS 6642 - testrunner output can be displayed in the wrong order

### DIFF
--- a/tests/test-runner/cmd/test-runner.py
+++ b/tests/test-runner/cmd/test-runner.py
@@ -12,7 +12,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 import ConfigParser
@@ -272,8 +272,10 @@ class Cmd(object):
         else:
             logger.debug('%s%s%s' % (msga, pad, msgb))
 
-        lines = self.result.stdout + self.result.stderr
-        for dt, line in sorted(lines):
+        lines = sorted(self.result.stdout + self.result.stderr,
+                       cmp=lambda x, y: cmp(x[0], y[0]))
+
+        for dt, line in lines:
             logger.debug('%s %s' % (dt.strftime("%H:%M:%S.%f ")[:11], line))
 
         if len(self.result.stdout):
@@ -286,7 +288,7 @@ class Cmd(object):
                     os.write(err.fileno(), '%s\n' % line)
         if len(self.result.stdout) and len(self.result.stderr):
             with open(os.path.join(self.outputdir, 'merged'), 'w') as merged:
-                for _, line in sorted(lines):
+                for _, line in lines:
                     os.write(merged.fileno(), '%s\n' % line)
 
 


### PR DESCRIPTION
6643 zfstest should enforce the required privileges before running.
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Jonathan Mackenzie <jonathan.mackenzie@delphix.com>
Reviewed by: Yuri Pankov <yuri.pankov@nexenta.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: Brian Behlendorf <behlendorf1@llnl.gov>

Porting notes:
- The 6643 changes were dropped a different version of this script
  is used to configure the environment under Linux.