### PR TITLE
OpenZFS 7496 - cmp_ds_cont has never worked

### DIFF
--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -187,7 +187,7 @@ function cmp_ds_cont
 	dstdir=$(get_prop mountpoint $dst_fs)
 
 	$DIFF -r $srcdir $dstdir > /dev/null 2>&1
-	echo $?
+	return $?
 }
 
 #

--- a/tests/zfs-tests/tests/functional/rsend/rsend_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_007_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
@@ -76,7 +76,6 @@ log_must eval "$ZFS send -R $POOL@final > $BACKDIR/pool-final-R"
 log_must eval "$ZFS receive -d -F $POOL2 < $BACKDIR/pool-final-R"
 dstds=$(get_dst_ds $POOL $POOL2)
 log_must cmp_ds_subs $POOL $dstds
-log_must cmp_ds_cont $POOL $dstds
 
 #
 # Verify zfs send -R -I should succeed
@@ -94,6 +93,5 @@ else
 	$ZFS receive -d -F $dstds < $BACKDIR/pool-init-final-IR
 fi
 log_must cmp_ds_subs $POOL $dstds
-log_must cmp_ds_cont $POOL $dstds
 
 log_pass "Rename parent filesystem name will not change the dependent order."

--- a/tests/zfs-tests/tests/functional/rsend/rsend_011_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_011_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
@@ -116,9 +116,7 @@ fi
 log_must cmp_ds_subs $POOL $dstds
 typeset -i i=0
 while ((i < ${#pair[@]})); do
-	log_must cmp_ds_cont ${pair[$i]} ${pair[((i+1))]}
 	log_must cmp_ds_prop ${pair[$i]} ${pair[((i+1))]}
-
 	((i += 2))
 done
 


### PR DESCRIPTION
Authored by: John Wren Kennedy <john.kennedy@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Approved by: Gordon Ross <gordon.w.ross@gmail.com>
Ported-by: George Melikov <mail@gmelikov.ru>

OpenZFS-issue: https://www.illumos.org/issues/7496
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/5dc1fd7