### PR TITLE
Disable racy snapshot_008_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -592,11 +592,12 @@ tests = ['slog_001_pos', 'slog_002_pos', 'slog_003_pos', 'slog_004_pos',
 # clone_001_pos - https://github.com/zfsonlinux/zfs/issues/3484
 # rollback_003_pos - Hangs in unmount and spins.
 # snapshot_016_pos - Problem with automount
+# snapshot_008_pos - https://github.com/zfsonlinux/zfs/issues/5784
 [tests/functional/snapshot]
 tests = ['rollback_001_pos', 'rollback_002_pos',
     'snapshot_001_pos', 'snapshot_002_pos',
     'snapshot_003_pos', 'snapshot_004_pos', 'snapshot_005_pos',
-    'snapshot_006_pos', 'snapshot_007_pos', 'snapshot_008_pos',
+    'snapshot_006_pos', 'snapshot_007_pos',
     'snapshot_009_pos', 'snapshot_010_pos', 'snapshot_011_pos',
     'snapshot_012_pos', 'snapshot_013_pos', 'snapshot_014_pos',
     'snapshot_015_pos', 'snapshot_017_pos']


### PR DESCRIPTION
Sometimes zfstests check freed space just after `zfs destroy snapshot` and get wrong output, because the space being freed asynchronously in the background.

See #5740 and #5784