### PR TITLE
Add travis-ci.org support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: c
+sudo: required
+env:
+  global:
+    - ZFS_TEST_TRAVIS_LOG_MAX_LENGTH=400
+  matrix:
+    - ZFS_TEST_TRAVIS_BUILDER_FROM='[tests/functional/acl/posix]' ZFS_TEST_TRAVIS_BUILDER_TO='[tests/functional/cli_root/zpool_import]'
+    - ZFS_TEST_TRAVIS_BUILDER_FROM='[tests/functional/cli_root/zpool_import]' ZFS_TEST_TRAVIS_BUILDER_TO='[tests/functional/cli_root/zpool_set]'
+    - ZFS_TEST_TRAVIS_BUILDER_FROM='[tests/functional/cli_root/zpool_set]' ZFS_TEST_TRAVIS_BUILDER_TO='[tests/functional/replacement]'
+    - ZFS_TEST_TRAVIS_BUILDER_FROM='[tests/functional/replacement]'
+before_install:
+- sudo apt-get -qq update
+- sudo apt-get install --yes -qq build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r)
+- sudo apt-get install --yes -qq zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libdevmapper-dev parted lsscsi ksh attr acl nfs-kernel-server
+install:
+- git clone --depth=50 https://github.com/zfsonlinux/spl
+- cd spl
+- git checkout master
+- sh autogen.sh
+- ./configure
+- make pkg
+- sudo dpkg -i *.deb
+- cd ..
+- sh autogen.sh
+- ./configure
+- make pkg
+- sudo dpkg -i *.deb
+script:
+- travis_wait 50 ./scripts/zfs-tests-travis.sh
+after_failure: find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$ZFS_TEST_TRAVIS_LOG_MAX_LENGTH {} \;
+after_success: find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$ZFS_TEST_TRAVIS_LOG_MAX_LENGTH {} \;

--- a/scripts/zfs-tests-travis.sh
+++ b/scripts/zfs-tests-travis.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# This script splits linux.run file for zfs-tests to run only part 
+# of it in each travis-ci job.
+#
+# Copyright (c) 2017 George Melikov. All rights reserved.
+#
+# env variables example:
+#ZFS_TEST_TRAVIS_BUILDER_FROM='[tests/functional/acl/posix]'
+#ZFS_TEST_TRAVIS_BUILDER_TO='[tests/functional/poolversion]'
+#
+#ZFS_TEST_TRAVIS_BUILDER_FROM - first test to run
+#ZFS_TEST_TRAVIS_BUILDER_TO - previous test will be run, and this test 
+# will be used to remove all after it's line (included). If not defined -
+# don't remove any.
+#
+
+RUNFILE="/usr/share/zfs/runfiles/linux.run"
+ZFS_TEST_TRAVIS_PATH="/usr/share/zfs/zfs-tests.sh"
+
+#
+# Output a useful usage message.
+#
+usage() {
+cat << EOF
+USAGE:
+$0 [-f FROM] [-t TO] [-z ZFSTESTS_PATH]
+
+DESCRIPTION:
+	Split tests and launch ZFS Test Suite
+
+OPTIONS:
+	-h          Show this message
+	-f          First test
+	-t          Last test (will be excluded)
+	-z          Path to ZFS Test Suite
+
+EXAMPLES:
+# Run the default (linux) suite of tests and output the configuration used.
+$0 -f '[tests/functional/acl/posix]' -t '[tests/functional/poolversion]'
+-z /usr/share/zfs/zfs-tests.sh
+EOF
+}
+
+#
+# Main function
+#
+main() {
+# prepare temporary files
+ZFS_TEST_COUNT_DEFAULTEND_LINE=$(awk -vn1=2 '/^\[/{++n; if (n==n1) { print NR; exit}}' ./tests/runfiles/linux.run)
+awk "NR < $ZFS_TEST_COUNT_DEFAULTEND_LINE" $RUNFILE > /tmp/linux.run.header
+awk "NR >= $ZFS_TEST_COUNT_DEFAULTEND_LINE" $RUNFILE > /tmp/linux.run.tmp
+
+#find lines numbers
+ZFS_TEST_COUNT_TESTS_FIRSTTEST_LINE=$(grep -nwF $ZFS_TEST_TRAVIS_BUILDER_FROM /tmp/linux.run.tmp | cut -f1 -d:)
+# remove all before needed tests
+awk "NR >= $ZFS_TEST_COUNT_TESTS_FIRSTTEST_LINE" /tmp/linux.run.tmp > /tmp/linux.run.tmp_ && mv /tmp/linux.run.tmp{_,}
+
+# if last test is defined - delete all after it
+if [ -n "$ZFS_TEST_TRAVIS_BUILDER_TO" ] ; then 
+	ZFS_TEST_COUNT_TESTS_LASTTEST_LINE=$(grep -nwF $ZFS_TEST_TRAVIS_BUILDER_TO /tmp/linux.run.tmp | cut -f1 -d:)
+	awk "NR < $ZFS_TEST_COUNT_TESTS_LASTTEST_LINE" /tmp/linux.run.tmp > /tmp/linux.run.tmp_ && mv /tmp/linux.run.tmp{_,}
+fi
+
+# merge tests with [DEFAULT] section
+cat /tmp/linux.run.header /tmp/linux.run.tmp > /tmp/linux.run
+
+# run zfs-tests
+$ZFS_TEST_TRAVIS_PATH -v -r /tmp/linux.run
+}
+
+
+
+while getopts 'hvqxkfd:s:r:?' OPTION; do
+	case $OPTION in
+	h)
+		usage
+		exit 1
+		;;
+	f)
+		ZFS_TEST_TRAVIS_BUILDER_FROM="$OPTARG"
+		;;
+	t)
+		ZFS_TEST_TRAVIS_BUILDER_TO="$OPTARG"
+		;;
+	z)
+		ZFS_TEST_TRAVIS_PATH="$OPTARG"
+		;;
+	?)
+		usage
+		exit
+		;;
+	esac
+done
+
+main

--- a/tests/test-runner/cmd/test-runner.py
+++ b/tests/test-runner/cmd/test-runner.py
@@ -702,7 +702,7 @@ class TestRun(object):
 
     def summary(self):
         if Result.total is 0:
-            return
+            return 1
 
         print '\nResults Summary'
         for key in Result.runresults.keys():
@@ -715,6 +715,11 @@ class TestRun(object):
         print 'Percent passed:\t%.1f%%' % ((float(Result.runresults['PASS']) /
                                             float(Result.total)) * 100)
         print 'Log directory:\t%s' % self.outputdir
+
+        if Result.runresults['FAIL'] > 0:
+            return 1
+        else:
+            return 0
 
 
 def verify_file(pathname):
@@ -871,8 +876,7 @@ def main():
 
     testrun.complete_outputdirs()
     testrun.run(options)
-    testrun.summary()
-    exit(0)
+    exit(testrun.summary())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR add/modify:
- .travis.yml (Travis-ci config)
- zfs-tests-travis.sh (splits tests to several parts for each job)
- test-runner.py (return non-zero exit code if failed tests exist) - this change may break buildbot, I'll rewrite error catch to grep if it's so

One last problem - we need to see full log if some test fails. Travis-ci has 4mb limit to it's standart log. We have two ways:
- somehow filter log (now it runs `find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cat {} \;`)
- send logs to external storage, some hand-made `curl`, S3 etc, Travis-ci has many variants.

This PR will be ready then we solve this problem.

Initial idea - #5765.

### Motivation and Context
Travis-ci.org can build and test ZoL with all zfs-tests in 40 minutes.

### How Has This Been Tested?
See https://travis-ci.org/gmelikov/zfs/builds/200727046 for example build.
