### PR TITLE
OpenZFS 6754 - zfs-tests: get_substr() function is redundant

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -23,10 +23,8 @@
 #
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
-#
-
-#
 # Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+# Copyright 2016 Nexenta Systems, Inc.
 #
 
 . ${STF_TOOLS}/include/logapi.shlib
@@ -2724,21 +2722,6 @@ function get_rootpool
 	else
 		log_fail "This is not a zfsroot system."
 	fi
-}
-
-#
-# Get the sub string from specified source string
-#
-# $1 source string
-# $2 start position. Count from 1
-# $3 offset
-#
-function get_substr #src_str pos offset
-{
-	typeset pos offset
-
-	$ECHO $1 | \
-		$NAWK -v pos=$2 -v offset=$3 '{print substr($0, pos, offset)}'
 }
 
 #


### PR DESCRIPTION
Authored by: Yuri Pankov <yuri.pankov@gmail.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>
Approved by: Matthew Ahrens <mahrens@delphix.com>
Ported-by: George Melikov <mail@gmelikov.ru>

OpenZFS-issue: https://www.illumos.org/issues/6754
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/01ff411

Porting notes:
deleted by us:   usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_aclmode_001_pos.ksh
deleted by us:   usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_inherit_003_pos.ksh
deleted by us:   usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_rwx_002_pos.ksh