### PR TITLE
OpenZFS 7260 - disable libdiskmgmt in zfstest unless it's required

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_005_pos.ksh
@@ -24,6 +24,11 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_add/zpool_add.kshlib
 
@@ -71,10 +76,10 @@ log_must poolexists "$TESTPOOL"
 
 create_pool "$TESTPOOL1" "${disk}${SLICE_PREFIX}${SLICE1}"
 log_must poolexists "$TESTPOOL1"
-log_mustnot $ZPOOL add -f "$TESTPOOL" ${disk}${SLICE_PREFIX}${SLICE1}
 
+unset NOINUSE_CHECK
+log_mustnot $ZPOOL add -f "$TESTPOOL" ${disk}s${SLICE1}
 log_mustnot $ZPOOL add -f "$TESTPOOL" $mnttab_dev
-
 log_mustnot $ZPOOL add -f "$TESTPOOL" $vfstab_dev
 
 log_must $ECHO "y" | $NEWFS ${DEV_DSKDIR}/$dump_dev > /dev/null 2>&1

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_002_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -84,6 +84,7 @@ log_must $MKFILE $SIZE /var/tmp/$FILEDISK0
 log_must $MKFILE $SIZE /var/tmp/$FILEDISK1
 log_must $MKFILE $SIZE /var/tmp/$FILEDISK2
 
+unset NOINUSE_CHECK
 log_must $ZPOOL export $TESTPOOL
 log_note "'zpool create' without '-f' will fail " \
 	"while device is belong to an exported pool."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_008_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -129,6 +129,7 @@ destroy_pool $TESTPOOL
 log_must labelvtoc $disk
 log_must create_overlap_slice $disk
 
+unset NOINUSE_CHECK
 log_mustnot $ZPOOL create $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE0}
 log_must $ZPOOL create -f $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE0}
 destroy_pool $TESTPOOL

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_009_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -66,6 +66,7 @@ log_assert "Create a pool with same devices twice or create two pools with " \
 	"same devices, 'zpool create' should fail."
 log_onexit cleanup
 
+unset NOINUSE_CHECK
 typeset opt
 for opt in "" "mirror" "raidz" "raidz1"; do
 	typeset disk="$DISKS"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_011_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_011_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -105,6 +105,7 @@ set -A arg "$TESTPOOL $pooldev2" \
         "$TESTPOOL1 ${disk}s10" \
 	"$TESTPOOL1 spare $pooldev2"
 
+unset NOINUSE_CHECK
 typeset -i i=0
 while (( i < ${#arg[*]} )); do
         log_mustnot $ZPOOL create ${arg[i]}

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -63,9 +63,9 @@ function cleanup
 			destroy_pool $pool
 		fi
 	done
-
 }
 
+unset NOINUSE_CHECK
 if [[ -n $DISK ]]; then
         disk=$DISK
 else

--- a/tests/zfs-tests/tests/functional/inuse/inuse_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_001_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -79,6 +79,7 @@ dumpdev=`$DUMPADM | $GREP "Dump device" | $AWK '{print $3}'`
     log_untested "Dump device has not been been configured to $diskslice"
 
 log_note "Attempt to zpool the dump device"
+unset NOINUSE_CHECK
 log_mustnot $ZPOOL create $TESTPOOL "$diskslice"
 log_mustnot poolexists $TESTPOOL
 

--- a/tests/zfs-tests/tests/functional/inuse/inuse_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_003_pos.ksh
@@ -26,11 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
-#
-
-#
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -141,6 +137,7 @@ log_note "$UFSDUMP 0bf 512 $rawdisk0 $disk1"
 $UFSDUMP 0bf 512 $rawdisk0 $disk1 &
 PIDUFSDUMP=$!
 
+unset NOINUSE_CHECK
 log_note "Attempt to zpool the source device in use by ufsdump"
 log_mustnot $ZPOOL create $TESTPOOL1 "$disk1"
 log_mustnot poolexists $TESTPOOL1

--- a/tests/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -76,6 +76,7 @@ set -A vdevs "" "mirror" "raidz" "raidz1" "raidz2"
 
 typeset -i i=0
 
+unset NOINUSE_CHECK
 while (( i < ${#vdevs[*]} )); do
 
 	for num in 0 1 2 3 ; do

--- a/tests/zfs-tests/tests/functional/inuse/inuse_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_006_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -79,6 +79,7 @@ typeset -i i=0
 
 PREVDUMPDEV=`$DUMPADM | $GREP "Dump device" | $AWK '{print $3}'`
 
+unset NOINUSE_CHECK
 while (( i < ${#vdevs[*]} )); do
 
 	for num in 0 1 2 3 ; do

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
@@ -65,6 +65,7 @@ savedumpdev=$(get_dumpdevice)
 
 safe_dumpadm $voldev
 
+unset NOINUSE_CHECK
 $ECHO "y" | $NEWFS -v $voldev > /dev/null 2>&1
 if (( $? == 0 )) ; then
 	log_fail "newfs on dump zvol succeeded unexpectedly"

--- a/zfs-script-config.sh.in
+++ b/zfs-script-config.sh.in
@@ -40,6 +40,7 @@ export ZPIOS_SH=${SCRIPTDIR}/zpios.sh
 export ZPIOS_SURVEY_SH=${SCRIPTDIR}/zpios-survey.sh
 
 # Test Suite Specific Commands
+export NOINUSE_CHECK=1
 export TEST_RUNNER=${TESTSDIR}/test-runner/cmd/test-runner.py
 export STF_TOOLS=${TESTSDIR}/test-runner
 export STF_SUITE=${TESTSDIR}/zfs-tests


### PR DESCRIPTION
Authored by: John Wren Kennedy <john.kennedy@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Igor Kozhukhov <ikozhukhov@gmail.com>
Reviewed by: Yuri Pankov <yuri.pankov@nexenta.com>
Approved by: Dan McDonald <danmcd@omniti.com>
Ported-by: George Melikov <mail@gmelikov.ru>

OpenZFS-issue: https://www.illumos.org/issues/7260
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/447b1e1