### PR TITLE
OpenZFS 7762 - avoid division by zero in property_alias_001_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/property_alias_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/property_alias_001_pos.ksh
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2016, 2017 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
 
@@ -107,7 +111,7 @@ for ds in $pool $fs $vol; do
 			done
 			;;
 		reservation|reserv )
-			(( reservsize = $avail_space % $RANDOM ))
+			(( reservsize = $avail_space % (( $RANDOM + 1 )) ))
 			for val in "0" "$reservsize" "none"; do
 				set_and_check $ds ${rw_prop[i]} $val ${chk_prop[i]}
 			done


### PR DESCRIPTION
Authored by: Prakash Surya <prakash.surya@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>
Reviewed by: Matt Ahrens <mahrens@delphix.com>
Approved by: Dan McDonald <danmcd@omniti.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/7762
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/ebaf15cbf77990ba1195796dfd9cb9dbd61d8ac9
