### PR TITLE
OpenZFS 7248 - large block support breaks rsend_009_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -563,14 +563,13 @@ tests = ['reservation_001_pos', 'reservation_002_pos', 'reservation_003_pos',
 
 # DISABLED:
 # rsend_008_pos - Fails for OpenZFS on illumos
-# rsend_009_pos - Fails for OpenZFS on illumos
 # rsend_020_pos - ASSERTs in dump_record()
 [tests/functional/rsend]
 tests = ['rsend_001_pos', 'rsend_002_pos', 'rsend_003_pos', 'rsend_004_pos',
     'rsend_005_pos', 'rsend_006_pos', 'rsend_007_pos',
+    'rsend_009_pos',
     'rsend_010_pos', 'rsend_011_pos', 'rsend_012_pos',
-    'rsend_013_pos', 'rsend_014_pos',
-    'rsend_019_pos',
+    'rsend_013_pos', 'rsend_014_pos', 'rsend_019_pos',
     'rsend_021_pos', 'rsend_022_pos', 'rsend_024_pos']
 
 [tests/functional/scrub_mirror]

--- a/tests/zfs-tests/tests/functional/rsend/rsend_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_009_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
@@ -67,8 +67,7 @@ log_must zpool create spool $TESTDIR/sfile
 # Test out of space on sub-filesystem
 #
 log_must $ZFS create bpool/fs
-mntpnt=$(get_prop mountpoint bpool/fs)
-log_must $MKFILE 30M $mntpnt/file
+log_must $MKFILE 30M /bpool/fs/file
 
 log_must $ZFS snapshot bpool/fs@snap
 log_must eval "$ZFS send -R bpool/fs@snap > $BACKDIR/fs-R"
@@ -80,8 +79,7 @@ log_must ismounted spool
 #
 # Test out of space on top filesystem
 #
-mntpnt2=$(get_prop mountpoint bpool)
-log_must $MV $mntpnt/file $mntpnt2
+log_must $MV /bpool/fs/file /bpool
 log_must $ZFS destroy -rf bpool/fs
 
 log_must $ZFS snapshot bpool@snap


### PR DESCRIPTION
Authored by: John Wren Kennedy <john.kennedy@delphix.com>
7249 rsend_015_pos produces false failures due to race
7250 testrunner can miss options specific to individual tests in runfiles
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Igor Kozhukhov <ikozhukhov@gmail.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: George Melikov <mail@gmelikov.ru>

OpenZFS-issue: https://www.illumos.org/issues/7248
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/f9a78bf