### PR TITLE
clean up by-dnode code in dmu_tx.c

### DIFF
--- a/include/sys/dmu_tx.h
+++ b/include/sys/dmu_tx.h
@@ -171,7 +171,7 @@ extern dmu_tx_t *dmu_tx_create_assigned(struct dsl_pool *dp, uint64_t txg);
 dmu_tx_t *dmu_tx_create_dd(dsl_dir_t *dd);
 int dmu_tx_is_syncing(dmu_tx_t *tx);
 int dmu_tx_private_ok(dmu_tx_t *tx);
-void dmu_tx_add_new_object(dmu_tx_t *tx, objset_t *os, dnode_t *dn);
+void dmu_tx_add_new_object(dmu_tx_t *tx, dnode_t *dn);
 void dmu_tx_willuse_space(dmu_tx_t *tx, int64_t delta);
 void dmu_tx_dirty_buf(dmu_tx_t *tx, struct dmu_buf_impl *db);
 int dmu_tx_holds(dmu_tx_t *tx, uint64_t object);

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -131,7 +131,7 @@ dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot, int blocksize,
 	dnode_allocate(dn, ot, blocksize, 0, bonustype, bonuslen, dn_slots, tx);
 	mutex_exit(&os->os_obj_lock);
 
-	dmu_tx_add_new_object(tx, os, dn);
+	dmu_tx_add_new_object(tx, dn);
 	dnode_rele(dn, FTAG);
 
 	return (object);
@@ -168,7 +168,7 @@ dmu_object_claim_dnsize(objset_t *os, uint64_t object, dmu_object_type_t ot,
 		return (err);
 
 	dnode_allocate(dn, ot, blocksize, 0, bonustype, bonuslen, dn_slots, tx);
-	dmu_tx_add_new_object(tx, os, dn);
+	dmu_tx_add_new_object(tx, dn);
 
 	dnode_rele(dn, FTAG);
 

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -119,7 +119,7 @@ dmu_tx_hold_dnode_impl(dmu_tx_t *tx, dnode_t *dn, enum dmu_tx_hold_type type,
 	dmu_tx_hold_t *txh;
 
 	if (dn != NULL) {
-		refcount_add(&dn->dn_holds, tx);
+		(void) refcount_add(&dn->dn_holds, tx);
 		if (tx->tx_txg != 0) {
 			mutex_enter(&dn->dn_mtx);
 			/*
@@ -175,7 +175,7 @@ dmu_tx_hold_object_impl(dmu_tx_t *tx, objset_t *os, uint64_t object,
 }
 
 void
-dmu_tx_add_new_object(dmu_tx_t *tx, objset_t *os, dnode_t *dn)
+dmu_tx_add_new_object(dmu_tx_t *tx, dnode_t *dn)
 {
 	/*
 	 * If we're syncing, they can manipulate any object anyhow, and

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -1207,7 +1207,8 @@ zap_add_impl(zap_t *zap, const char *key,
 	}
 	ASSERT(zap == zn->zn_zap);
 	zap_name_free(zn);
-	zap_unlockdir(zap, tag);
+	if (zap != NULL)	/* may be NULL if fzap_add() failed */
+		zap_unlockdir(zap, tag);
 	return (err);
 }
 


### PR DESCRIPTION
### Description

https://github.com/zfsonlinux/zfs/commit/0eef1bde31d67091d3deed23fe2394f5a8bf2276
introduced some changes which we slightly improved the style of when
porting to illumos.

There is also one minor error-handling fix, in zap_add() the "zap" may
become NULL in case of an error re-opening the ZAP.

Originally suggested at: https://github.com/openzfs/openzfs/pull/276

Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
