### PR TITLE
Properly update data_size and metadata_size for deferred l2arc frees

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6830,16 +6830,28 @@ l2arc_do_free_on_write(void)
 {
 	list_t *buflist;
 	l2arc_data_free_t *df, *df_prev;
+	arc_buf_contents_t type;
+	size_t size;
 
 	mutex_enter(&l2arc_free_on_write_mtx);
 	buflist = l2arc_free_on_write;
 
 	for (df = list_tail(buflist); df; df = df_prev) {
+		type = df->l2df_type;
+		size = df->l2df_size;
+
 		df_prev = list_prev(buflist, df);
 		ASSERT3P(df->l2df_abd, !=, NULL);
 		abd_free(df->l2df_abd);
 		list_remove(buflist, df);
 		kmem_free(df, sizeof (l2arc_data_free_t));
+
+		if (type == ARC_BUFC_METADATA) {
+			arc_space_return(size, ARC_SPACE_META);
+		} else {
+			ASSERT(type == ARC_BUFC_DATA);
+			arc_space_return(size, ARC_SPACE_DATA);
+		}
 	}
 
 	mutex_exit(&l2arc_free_on_write_mtx);
@@ -7348,7 +7360,8 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 				to_write = abd_alloc_for_io(size,
 				    HDR_ISTYPE_METADATA(hdr));
 				abd_copy(to_write, hdr->b_l1hdr.b_pabd, size);
-				l2arc_free_abd_on_write(to_write, size,
+				/* Use size of 0 to suppress accounting update */
+				l2arc_free_abd_on_write(to_write, 0,
 				    arc_buf_type(hdr));
 			}
 			wzio = zio_write_phys(pio, dev->l2ad_vdev,


### PR DESCRIPTION
Prior to the compressed ARC, arcstat_data_size and arcstat_metadata_size
were immediately updated in arc_buf_destroy() via arc_space_return().
The compressed ARC, however, refactored the freeing process with the
introduction of arc_buf_destroy_impl() and lost the updating of these
stats for deferred l2arc frees.

This patch restores the stats updates and does so by pushing them down
to l2arc_do_free_on_write() which is where the delayed frees actually
take place.

Failure to update these stats would cause problems on any system using
l2arc as, over time, more and more deferred frees occurred.  Eventually,
metadata_size and/or data_size would grow so large that no more "real"
data could be placed in the ARC.

<!--- Provide a general summary of your changes in the Title above -->

### Description
See the commit log message.

### Motivation and Context
Outlined in the commit message.  This likely fixes a number of open issues that have come up following the introduction of compressed ARC.

### How Has This Been Tested?
Create a pool with an l2arc device and, in order to speed up testing, restrict the ARC to 1GiB.  Perform a write-heavy workload to the pool until the ```l2_free_on_write``` value starts growing.  After it's grown for awhile, stop the writing and export the pool.  Examine the sizes of the various ARC_... lists with "crash" on the live system.  Prior to this fix, either or both of ```size``` or ```metadata_size``` would not match that which is actually stored in the ARC.  With this fix, the values match precisely.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
