### PR TITLE
OpenZFS 7736 - ZFS Performance tests should log FIO summary output

### DIFF
--- a/tests/zfs-tests/tests/perf/perf.shlib
+++ b/tests/zfs-tests/tests/perf/perf.shlib
@@ -61,8 +61,9 @@ function do_fio_run
 	for threads in $PERF_NTHREADS; do
 		for sync in $PERF_SYNC_TYPES; do
 			for iosize in $PERF_IOSIZES; do
+				typeset sync_str=$(get_sync_str $sync)
 				log_note "Running with $threads" \
-				    "$(get_sync_str $sync) threads, $iosize ios"
+				    "$sync_str threads, $iosize ios"
 
 				if $do_recreate; then
 					recreate_perfpool
@@ -86,8 +87,16 @@ function do_fio_run
 				# Start the data collection
 				do_collect_scripts $threads $sync $iosize
 
+				# This will be part of the output filename.
+				typeset suffix="$sync_str.$iosize-ios.$threads-threads"
+
+				# Define output file
+				typeset logbase="$(get_perf_output_dir)/$($BASENAME \
+				    $SUDO_COMMAND)"
+				typeset outfile="$logbase.fio.$suffix"
+
 				# Start the load
-				log_must $FIO $FIO_SCRIPTS/$script
+				log_must $FIO --output $outfile $FIO_SCRIPTS/$script
 			done
 		done
 	done


### PR DESCRIPTION
Authored by: Ahmed G <ahmedg@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Stephen Blinick <stephen.blinick@delphix.com>
Approved by: Dan McDonald <danmcd@omniti.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

Porting Notes:
Using $FIO until 7290 is ported.

OpenZFS-issue: https://www.illumos.org/issues/7736
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/7a61309
Requires-builders: all
