### PR TITLE
Fix harmless "BARRIER is deprecated" kernel warning on Centos 6.8

### DIFF
--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -343,12 +343,12 @@ bio_set_op_attrs(struct bio *bio, unsigned rw, unsigned flags)
 static inline void
 bio_set_flush(struct bio *bio)
 {
-#if defined(WRITE_BARRIER)	/* < 2.6.37 */
-	bio_set_op_attrs(bio, 0, WRITE_BARRIER);
+#if defined(REQ_PREFLUSH)	/* >= 4.10 */
+	bio_set_op_attrs(bio, 0, REQ_PREFLUSH);
 #elif defined(WRITE_FLUSH_FUA)	/* >= 2.6.37 and <= 4.9 */
 	bio_set_op_attrs(bio, 0, WRITE_FLUSH_FUA);
-#elif defined(REQ_PREFLUSH)	/* >= 4.10 */
-	bio_set_op_attrs(bio, 0, REQ_PREFLUSH);
+#elif defined(WRITE_BARRIER)	/* < 2.6.37 */
+	bio_set_op_attrs(bio, 0, WRITE_BARRIER);
 #else
 #error	"Allowing the build will cause bio_set_flush requests to be ignored."
 #endif
@@ -373,9 +373,6 @@ bio_set_flush(struct bio *bio)
  * in all cases but may have a performance impact for some kernels.  It
  * has the advantage of minimizing kernel specific changes in the zvol code.
  *
- * Note that 2.6.32 era kernels provide both BIO_RW_BARRIER and REQ_FLUSH,
- * where BIO_RW_BARRIER is the correct interface.  Therefore, it is important
- * that the HAVE_BIO_RW_BARRIER check occur before the REQ_FLUSH check.
  */
 static inline boolean_t
 bio_is_flush(struct bio *bio)
@@ -386,10 +383,10 @@ bio_is_flush(struct bio *bio)
 	return (bio->bi_opf & REQ_PREFLUSH);
 #elif defined(REQ_PREFLUSH) && !defined(HAVE_BIO_BI_OPF)
 	return (bio->bi_rw & REQ_PREFLUSH);
-#elif defined(HAVE_BIO_RW_BARRIER)
-	return (bio->bi_rw & (1 << BIO_RW_BARRIER));
 #elif defined(REQ_FLUSH)
 	return (bio->bi_rw & REQ_FLUSH);
+#elif defined(HAVE_BIO_RW_BARRIER)
+	return (bio->bi_rw & (1 << BIO_RW_BARRIER));
 #else
 #error	"Allowing the build will cause flush requests to be ignored."
 #endif


### PR DESCRIPTION
### Description
A one time warning after module load that "BARRIER is deprecated" was seen
on the heavily patched 2.6.32-642.13.1.el6.x86_64 Centos 6.8 kernel.  It seems
that kernel had both the old BARRIER and the newer FLUSH/FUA interfaces
defined.  This fixes the warning by preferring the newer FLUSH/FUA interface
if it's available.

Fixes https://github.com/zfsonlinux/zfs/issues/5739


### Motivation and Context
Removes a scary kernel warning:

```WARNING: at block/blk-core.c:1397 blk_queue_bio+0x585/0x610() (Tainted: P           -- ------------   )
Hardware name: HVM domU
block: BARRIER is deprecated, use FLUSH/FUA instead
Modules linked in: zfs(P)(U) zcommon(P)(U) zunicode(P)(U) znvpair(P)(U) zavl(P)(U) splat(U) spl(U) sg sd_mod scsi_debug crc_t10dif ext2 zlib_deflate ipt_REJECT nf_conntrack_ipv4 nf_defrag_ipv4 iptable_filter ip_tables ip6t_REJECT nf_conntrack_ipv6 nf_defrag_ipv6 xt_state nf_conntrack ip6table_filter ip6_tables ipv6 xen_netfront i2c_piix4 i2c_core ext4 jbd2 mbcache xen_blkfront pata_acpi ata_generic ata_piix dm_mirror dm_region_hash dm_log dm_mod [last unloaded: spl]
Pid: 1200, comm: txg_sync Tainted: P           -- ------------    2.6.32-642.13.1.el6.x86_64 #1
Call Trace:
 [<ffffffff8107c6f1>] ? warn_slowpath_common+0x91/0xe0
 [<ffffffff8107c7f6>] ? warn_slowpath_fmt+0x46/0x60
 [<ffffffff8128d856>] ? throtl_find_tg+0x46/0x60
 [<ffffffff8127fb35>] ? blk_queue_bio+0x585/0x610
 [<ffffffffa03bf19b>] ? spl_kmem_cache_alloc+0x6b/0x8c0 [spl]
...
```

### How Has This Been Tested?
Tested on centos 6.8 with newest kernel (2.6.32-642.13.1.el6.x86_64).  Imported a pool and verified it hit the warning.  Rebooted and re-ran the test with my fix and did not see the warning.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
