### PR TITLE
Fix initramfs hook for merged /usr/lib and /lib

### DIFF
--- a/contrib/initramfs/hooks/zfs
+++ b/contrib/initramfs/hooks/zfs
@@ -55,7 +55,7 @@ mkdir -p "$DESTDIR/etc/"
 # automatically detected. The `find` utility and extended `cp` options are
 # used here because libgcc_s.so could be in a subdirectory of /lib for
 # multi-arch installations.
-cp --target-directory="$DESTDIR" --parents $(find /lib -type f -name libgcc_s.so.1)
+cp --target-directory="$DESTDIR" --parents $(find /lib/ -type f -name libgcc_s.so.1)
 
 for ii in $COPY_EXEC_LIST
 do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Under a merged `/lib` -> `/usr/lib` which renders `/lib` as a symlink,
`find /lib -type f -name libgcc_s.so.1` will not return a result as
`find` will not traverse the symlink. Modifying it to `find /lib/ -type
f -name libgcc_s.so.1` should work for both symlinked and non-symlinked
`/lib` directories.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wanted to remove the following error message on every `update-initramfs`
```
Calling hook zfs
cp: missing file operand
Try 'cp --help' for more information.
``` 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
