### PR TITLE
GZIP compression offloading with QAT accelerator

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -4,6 +4,7 @@ dnl #
 AC_DEFUN([ZFS_AC_CONFIG_KERNEL], [
 	ZFS_AC_KERNEL
 	ZFS_AC_SPL
+	ZFS_AC_QAT
 	ZFS_AC_TEST_MODULE
 	ZFS_AC_KERNEL_CONFIG
 	ZFS_AC_KERNEL_DECLARE_EVENT_CLASS
@@ -465,6 +466,95 @@ AC_DEFUN([ZFS_AC_SPL], [
 
 	AC_MSG_RESULT([$SPL_SYMBOLS])
 	AC_SUBST(SPL_SYMBOLS)
+])
+
+dnl #
+dnl # Detect the QAT module to be built against
+dnl # QAT provides hardware acceleration for data compression:
+dnl # 	https://01.org/intel-quickassist-technology
+dnl # * Download and install QAT driver from the above link
+dnl # * Start QAT driver in your system:
+dnl # 	service qat_service start
+dnl # * Enable QAT in ZFS, e.g.:
+dnl # 	./configure --with-qat=<qat-driver-path>/QAT1.6
+dnl #	make
+dnl # * Set GZIP compression in ZFS dataset:
+dnl # 	zfs set compression = gzip <dataset>
+dnl # Then the data written to this ZFS pool is compressed
+dnl # by QAT accelerator automatically, and de-compressed by
+dnl # QAT when read from the pool.
+dnl # * Get QAT hardware statistics by:
+dnl #	cat /proc/icp_dh895xcc_dev/qat
+dnl # * To disable QAT:
+dnl # 	insmod zfs.ko zfs_qat_disable=1
+dnl #
+AC_DEFUN([ZFS_AC_QAT], [
+	AC_ARG_WITH([qat],
+		AS_HELP_STRING([--with-qat=PATH],
+		[Path to qat source]),
+		AS_IF([test "$withval" = "yes"],
+			AC_MSG_ERROR([--with-qat=PATH requires a PATH]),
+			[qatsrc="$withval"]))
+
+	AC_ARG_WITH([qat-obj],
+		AS_HELP_STRING([--with-qat-obj=PATH],
+		[Path to qat build objects]),
+		[qatbuild="$withval"])
+
+	AS_IF([test ! -z "${qatsrc}"], [
+		AC_MSG_CHECKING([qat source directory])
+		AC_MSG_RESULT([$qatsrc])
+		QAT_SRC="${qatsrc}/quickassist"
+		AS_IF([ test ! -e "$QAT_SRC/include/cpa.h"], [
+			AC_MSG_ERROR([
+		*** Please make sure the qat driver package is installed
+		*** and specify the location of the qat source with the
+		*** '--with-qat=PATH' option then try again. Failed to
+		*** find cpa.h in:
+		${QAT_SRC}/include])
+		])
+	])
+
+	AS_IF([test ! -z "${qatsrc}"], [
+		AC_MSG_CHECKING([qat build directory])
+		AS_IF([test -z "$qatbuild"], [
+			qatbuild="${qatsrc}/build"
+		])
+
+		AC_MSG_RESULT([$qatbuild])
+		QAT_OBJ=${qatbuild}
+		AS_IF([ ! test -e "$QAT_OBJ/icp_qa_al.ko"], [
+			AC_MSG_ERROR([
+		*** Please make sure the qat driver is installed then try again.
+		*** Failed to find icp_qa_al.ko in:
+		$QAT_OBJ])
+		])
+
+		AC_SUBST(QAT_SRC)
+		AC_SUBST(QAT_OBJ)
+
+		AC_DEFINE(HAVE_QAT, 1,
+		[qat is enabled and existed])
+	])
+
+	dnl #
+	dnl # Detect the name used for the QAT Module.symvers file.
+	dnl #
+	AS_IF([test ! -z "${qatsrc}"], [
+		AC_MSG_CHECKING([qat file for module symbols])
+		QAT_SYMBOLS=$QAT_SRC/lookaside/access_layer/src/Module.symvers
+
+		AS_IF([test -r $QAT_SYMBOLS], [
+			AC_MSG_RESULT([$QAT_SYMBOLS])
+			AC_SUBST(QAT_SYMBOLS)
+		],[
+                       AC_MSG_ERROR([
+			*** Please make sure the qat driver is installed then try again.
+			*** Failed to find Module.symvers in:
+			$QAT_SYMBOLS])
+			])
+		])
+	])
 ])
 
 dnl #

--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -104,6 +104,9 @@ AC_DEFUN([ZFS_AC_CONFIG], [
 	    [test "x$enable_linux_builtin" != xyes ])
 	AM_CONDITIONAL([WANT_DEVNAME2DEVID],
 	    [test "x$user_libudev" = xyes ])
+	AM_CONDITIONAL([CONFIG_QAT],
+	    [test "$ZFS_CONFIG" = kernel -o "$ZFS_CONFIG" = all] &&
+	    [test "x$qatsrc" != x ])
 ])
 
 dnl #

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -11,6 +11,8 @@ INSTALL_MOD_DIR ?= extra
 ZFS_MODULE_CFLAGS += -include @SPL_OBJ@/spl_config.h
 ZFS_MODULE_CFLAGS += -include @abs_top_builddir@/zfs_config.h
 ZFS_MODULE_CFLAGS += -I@abs_top_srcdir@/include -I@SPL@/include -I@SPL@
+@CONFIG_QAT_TRUE@ZFS_MODULE_CFLAGS += -I@QAT_SRC@/include
+@CONFIG_QAT_TRUE@KBUILD_EXTRA_SYMBOLS += @QAT_SYMBOLS@
 export ZFS_MODULE_CFLAGS
 
 SUBDIR_TARGETS = icp

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -114,6 +114,7 @@ $(MODULE)-objs += zrlock.o
 $(MODULE)-objs += zvol.o
 $(MODULE)-objs += dsl_destroy.o
 $(MODULE)-objs += dsl_userhold.o
+$(MODULE)-objs += qat_compress.o
 
 $(MODULE)-$(CONFIG_X86) += vdev_raidz_math_sse2.o
 $(MODULE)-$(CONFIG_X86) += vdev_raidz_math_ssse3.o

--- a/module/zfs/gzip.c
+++ b/module/zfs/gzip.c
@@ -28,6 +28,7 @@
 
 #include <sys/debug.h>
 #include <sys/types.h>
+#include "qat_compress.h"
 
 #ifdef _KERNEL
 
@@ -56,6 +57,14 @@ gzip_compress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 
 	ASSERT(d_len <= s_len);
 
+	if (use_qat(s_len)) {
+		if (qat_compress(0, s_start, s_len, d_start, d_len, &dstlen) !=
+		    CPA_STATUS_SUCCESS)
+			return (s_len);
+
+		return ((size_t)dstlen);
+	}
+
 	if (compress_func(d_start, &dstlen, s_start, s_len, n) != Z_OK) {
 		if (d_len != s_len)
 			return (s_len);
@@ -74,6 +83,14 @@ gzip_decompress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 	zlen_t dstlen = d_len;
 
 	ASSERT(d_len >= s_len);
+
+	if (use_qat(s_len)) {
+		if (qat_compress(1, s_start, s_len, d_start, d_len, &dstlen) !=
+		    CPA_STATUS_SUCCESS)
+			return (-1);
+
+		return (0);
+	}
 
 	if (uncompress_func(d_start, &dstlen, s_start, s_len) != Z_OK)
 		return (-1);

--- a/module/zfs/qat_compress.c
+++ b/module/zfs/qat_compress.c
@@ -1,0 +1,399 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+#if defined(_KERNEL) && defined(HAVE_QAT)
+#include <linux/slab.h>
+#include <linux/vmalloc.h>
+#include <linux/pagemap.h>
+#include <linux/completion.h>
+#include <sys/zfs_context.h>
+#include "qat_compress.h"
+
+#define	TIMEOUT_MS		500 /* 0.5 seconds */
+#define	INST_NUM		6
+#define	GZIP_HEAD_SZ		2
+#define	GZIP_FOOT_SZ		4
+#define	QAT_MIN_BUF_SIZE	4096
+
+static CpaInstanceHandle dc_inst_handles[INST_NUM];
+static CpaDcSessionHandle session_handles[INST_NUM];
+static Cpa16U num_inst = 0;
+static Cpa16U inst = 0;
+int qat_init_done = 0;
+int zfs_qat_disable = B_FALSE;
+
+#define	PHYS_CONTIG_ALLOC(pp_mem_addr, size_bytes)	\
+	mem_alloc_contig((void *)(pp_mem_addr), (size_bytes))
+
+#define	PHYS_CONTIG_FREE(p_mem_addr)	\
+	mem_free_contig((void *)&(p_mem_addr))
+
+static inline struct page *mem_to_page(void *addr)
+{
+	if (!is_vmalloc_addr(addr))
+		return (virt_to_page(addr));
+
+	return (vmalloc_to_page(addr));
+}
+
+static void qat_dc_callback(void *p_callback, CpaStatus status)
+{
+	if (NULL != p_callback)
+		complete((struct completion *)p_callback);
+}
+
+static inline CpaStatus mem_alloc_contig(void **pp_mem_addr,
+						Cpa32U size_bytes)
+{
+	*pp_mem_addr = kmalloc_node(size_bytes, GFP_KERNEL, 0);
+	if (NULL == *pp_mem_addr)
+		return (CPA_STATUS_RESOURCE);
+	return (CPA_STATUS_SUCCESS);
+}
+
+static inline void mem_free_contig(void **pp_mem_addr)
+{
+	if (NULL != *pp_mem_addr) {
+		kfree(*pp_mem_addr);
+		*pp_mem_addr = NULL;
+	}
+}
+
+int
+qat_init(void)
+{
+	CpaStatus status = CPA_STATUS_SUCCESS;
+	Cpa32U sess_size = 0;
+	Cpa32U ctx_size = 0;
+	Cpa32U buff_meta_size = 0;
+	CpaDcSessionSetupData sd = {0};
+	int i;
+
+	if (zfs_qat_disable == B_TRUE || qat_init_done != 0)
+		return (0);
+
+	status = cpaDcGetNumInstances(&num_inst);
+	if (status != CPA_STATUS_SUCCESS || num_inst == 0)
+		return (-1);
+	status = cpaDcGetInstances(num_inst, &dc_inst_handles[0]);
+	if (status != CPA_STATUS_SUCCESS)
+		return (-1);
+
+	for (i = 0; i < num_inst; i++) {
+		cpaDcSetAddressTranslation(dc_inst_handles[i],
+		    (void*)virt_to_phys);
+
+		status = cpaDcBufferListGetMetaSize(dc_inst_handles[i], 1,
+		    &buff_meta_size);
+
+		status = cpaDcStartInstance(dc_inst_handles[i], 0, NULL);
+		if (status != CPA_STATUS_SUCCESS)
+			goto fail;
+
+		sd.compLevel = CPA_DC_L1;
+		sd.compType = CPA_DC_DEFLATE;
+		sd.huffType = CPA_DC_HT_STATIC;
+		sd.sessDirection = CPA_DC_DIR_COMBINED;
+		sd.sessState = CPA_DC_STATELESS;
+		sd.deflateWindowSize = 7;
+		sd.checksum = CPA_DC_ADLER32;
+		status = cpaDcGetSessionSize(dc_inst_handles[i],
+		    &sd, &sess_size, &ctx_size);
+		if (status != CPA_STATUS_SUCCESS)
+			goto fail;
+
+		PHYS_CONTIG_ALLOC(&session_handles[i], sess_size);
+		if (session_handles[i] == NULL)
+			goto fail;
+
+		status = cpaDcInitSession(dc_inst_handles[i],
+		    session_handles[i],
+		    &sd, NULL, qat_dc_callback);
+		if (status != CPA_STATUS_SUCCESS)
+			goto fail;
+	}
+
+	qat_init_done = 1;
+	return (0);
+fail:
+
+	for (i = 0; i < num_inst; i++) {
+		cpaDcStopInstance(dc_inst_handles[i]);
+		PHYS_CONTIG_FREE(session_handles[i]);
+	}
+
+	return (-1);
+}
+
+void
+qat_fini(void)
+{
+	int i = 0;
+	if (zfs_qat_disable == B_TRUE || qat_init_done == 0)
+		return;
+
+	for (i = 0; i < num_inst; i++) {
+		cpaDcStopInstance(dc_inst_handles[i]);
+		PHYS_CONTIG_FREE(session_handles[i]);
+	}
+	num_inst = 0;
+	qat_init_done = 0;
+}
+
+int
+use_qat(size_t s_len)
+{
+	if (zfs_qat_disable == B_TRUE ||
+	    qat_init_done == 0 ||
+	    s_len <= QAT_MIN_BUF_SIZE) {
+		return (0);
+	}
+	return (1);
+}
+
+int
+qat_compress(int dir, char *src, int src_len,
+	    char *dst, int dst_len, size_t *c_len)
+{
+	CpaInstanceHandle dc_inst_handle;
+	CpaDcSessionHandle session_handle;
+	CpaBufferList *buf_list_src = NULL;
+	CpaBufferList *buf_list_dst = NULL;
+	CpaFlatBuffer *flat_buf_src = NULL;
+	CpaFlatBuffer *flat_buf_dst = NULL;
+	Cpa8U *buffer_meta_src = NULL;
+	Cpa8U *buffer_meta_dst = NULL;
+	Cpa32U buffer_meta_size = 0;
+	CpaDcRqResults dc_results;
+	CpaStatus status;
+	Cpa32U hdr_sz = 0;
+	Cpa32U compressed_sz;
+	Cpa32U num_src_buf = (src_len >> PAGE_SHIFT) + 1;
+	Cpa32U num_dst_buf = (dst_len >> PAGE_SHIFT) + 1;
+	Cpa32U bytes_left;
+	char *data;
+	struct page *in_page, *out_page;
+	struct page **in_pages = NULL;
+	struct page **out_pages = NULL;
+	struct completion complete;
+	size_t ret = -1;
+	int page_num = 0;
+	int i;
+
+	Cpa32U src_buffer_list_mem_size = sizeof (CpaBufferList) +
+	    (num_src_buf * sizeof (CpaFlatBuffer));
+	Cpa32U dst_buffer_list_mem_size = sizeof (CpaBufferList) +
+	    (num_dst_buf * sizeof (CpaFlatBuffer));
+
+	if (!is_vmalloc_addr(src) || !is_vmalloc_addr(src + src_len - 1) ||
+	    !is_vmalloc_addr(dst) || !is_vmalloc_addr(dst + dst_len - 1))
+		return (-1);
+
+	if (PHYS_CONTIG_ALLOC(&in_pages,
+	    num_src_buf * sizeof (struct page *)) != CPA_STATUS_SUCCESS)
+		goto fail;
+
+	if (PHYS_CONTIG_ALLOC(&out_pages,
+	    num_dst_buf * sizeof (struct page *)) != CPA_STATUS_SUCCESS)
+		goto fail;
+
+	inst = (inst + 1) % num_inst;
+	dc_inst_handle = dc_inst_handles[inst];
+	session_handle = session_handles[inst];
+
+	cpaDcBufferListGetMetaSize(dc_inst_handle, num_src_buf,
+	    &buffer_meta_size);
+	if (PHYS_CONTIG_ALLOC(&buffer_meta_src, buffer_meta_size) !=
+	    CPA_STATUS_SUCCESS)
+		goto fail;
+
+	cpaDcBufferListGetMetaSize(dc_inst_handle, num_dst_buf,
+	    &buffer_meta_size);
+	if (PHYS_CONTIG_ALLOC(&buffer_meta_dst, buffer_meta_size) !=
+	    CPA_STATUS_SUCCESS)
+		goto fail;
+
+	/* build source buffer list */
+	if (PHYS_CONTIG_ALLOC(&buf_list_src, src_buffer_list_mem_size) !=
+	    CPA_STATUS_SUCCESS)
+		goto fail;
+
+	flat_buf_src = (CpaFlatBuffer *)(buf_list_src + 1);
+
+	buf_list_src->pBuffers = flat_buf_src; /* always point to first one */
+
+	/* build destination buffer list */
+	if (PHYS_CONTIG_ALLOC(&buf_list_dst, dst_buffer_list_mem_size) !=
+	    CPA_STATUS_SUCCESS)
+		goto fail;
+
+	flat_buf_dst = (CpaFlatBuffer *)(buf_list_dst + 1);
+
+	buf_list_dst->pBuffers = flat_buf_dst; /* always point to first one */
+
+	buf_list_src->numBuffers = 0;
+	buf_list_src->pPrivateMetaData = buffer_meta_src;
+	bytes_left = src_len;
+	data = src;
+	page_num = 0;
+	while (bytes_left > 0) {
+		in_page = mem_to_page(data);
+		in_pages[page_num] = in_page;
+		flat_buf_src->pData = kmap(in_page);
+		flat_buf_src->dataLenInBytes =
+		    min((long)bytes_left, (long)PAGE_SIZE);
+
+		bytes_left -= flat_buf_src->dataLenInBytes;
+		data += flat_buf_src->dataLenInBytes;
+		flat_buf_src++;
+		buf_list_src->numBuffers++;
+		page_num++;
+	}
+
+	buf_list_dst->numBuffers = 0;
+	buf_list_dst->pPrivateMetaData = buffer_meta_dst;
+	bytes_left = dst_len;
+	data = dst;
+	page_num = 0;
+	while (bytes_left > 0) {
+		out_page = mem_to_page(data);
+		flat_buf_dst->pData = kmap(out_page);
+		out_pages[page_num] = out_page;
+		flat_buf_dst->dataLenInBytes =
+		    min((long)bytes_left, (long)PAGE_SIZE);
+
+		bytes_left -= flat_buf_dst->dataLenInBytes;
+		data += flat_buf_dst->dataLenInBytes;
+		flat_buf_dst++;
+		buf_list_dst->numBuffers++;
+		page_num++;
+	}
+
+	init_completion(&complete);
+
+	if (dir == 0) /* compress */ {
+		cpaDcGenerateHeader(session_handle,
+		    buf_list_dst->pBuffers, &hdr_sz);
+		buf_list_dst->pBuffers->pData += hdr_sz;
+		buf_list_dst->pBuffers->dataLenInBytes -= hdr_sz;
+		status = cpaDcCompressData(dc_inst_handle, session_handle,
+		    buf_list_src, buf_list_dst,
+		    &dc_results, CPA_DC_FLUSH_FINAL,
+		    &complete);
+		if (CPA_STATUS_SUCCESS != status) {
+			printk(KERN_INFO
+			    "cpaDcCompressData failed. (status = %d)\n",
+			    status);
+			goto fail;
+		}
+		/* we now wait until the completion of the operation. */
+		if (!wait_for_completion_interruptible_timeout(&complete,
+		    TIMEOUT_MS)) {
+			printk(KERN_ERR
+			    "timeout or interruption in cpaDcCompressData\n");
+			status = CPA_STATUS_FAIL;
+			goto fail;
+		}
+
+		if (dc_results.status != CPA_STATUS_SUCCESS) {
+			printk(KERN_INFO "cpaDcCompressData failed %d.\n",
+			    dc_results.status);
+			goto fail;
+		}
+
+		compressed_sz = dc_results.produced;
+		if (compressed_sz + hdr_sz + GZIP_FOOT_SZ > dst_len) {
+			printk(KERN_INFO "overflow\n");
+			goto fail;
+		}
+
+		flat_buf_dst = (CpaFlatBuffer *)(buf_list_dst + 1);
+		/* move to the last page */
+		flat_buf_dst += (compressed_sz + hdr_sz) >> PAGE_SHIFT;
+
+		/* no space for gzip foot in the last page */
+		if (((compressed_sz + hdr_sz) % PAGE_SIZE)
+		    + GZIP_FOOT_SZ > PAGE_SIZE)
+			goto fail;
+
+		flat_buf_dst->pData += (compressed_sz + hdr_sz) % PAGE_SIZE;
+		flat_buf_dst->dataLenInBytes = GZIP_FOOT_SZ;
+
+		dc_results.produced = 0;
+		/* write RFC1952 gzip footer to destination buffer */
+		status = cpaDcGenerateFooter(session_handle,
+		    flat_buf_dst, &dc_results);
+		*c_len = compressed_sz + dc_results.produced + hdr_sz;
+
+		if (*c_len < PAGE_SIZE)
+			*c_len = 8 * PAGE_SIZE;
+	} else /* de-compress */ {
+		buf_list_src->pBuffers->pData += GZIP_HEAD_SZ;
+		buf_list_src->pBuffers->dataLenInBytes -= GZIP_HEAD_SZ;
+		status = cpaDcDecompressData(dc_inst_handle,
+		    session_handle,
+		    buf_list_src,
+		    buf_list_dst,
+		    &dc_results,
+		    CPA_DC_FLUSH_FINAL,
+		    &complete);
+
+		if (CPA_STATUS_SUCCESS != status) {
+			printk(KERN_INFO
+			    "cpaDcDecompressData failed. (status = %d)\n",
+			    dc_results.status);
+			goto fail;
+		}
+		/* we now wait until the completion of the operation. */
+		if (!wait_for_completion_interruptible_timeout(&complete,
+		    TIMEOUT_MS)) {
+			printk(KERN_ERR
+			    "timeout or interruption in cpaDcCompressData\n");
+			goto fail;
+		}
+
+		if (dc_results.status != CPA_STATUS_SUCCESS)
+			goto fail;
+
+		*c_len = dc_results.produced;
+	}
+
+	ret = 0;
+fail:
+	if (in_pages) {
+		for (i = 0; i < buf_list_src->numBuffers; i++)
+			kunmap(in_pages[i]);
+		PHYS_CONTIG_FREE(in_pages);
+	}
+	if (out_pages) {
+		for (i = 0; i < buf_list_dst->numBuffers; i++)
+			kunmap(out_pages[i]);
+		PHYS_CONTIG_FREE(out_pages);
+	}
+	PHYS_CONTIG_FREE(buffer_meta_src);
+	PHYS_CONTIG_FREE(buffer_meta_dst);
+	PHYS_CONTIG_FREE(buf_list_src);
+	PHYS_CONTIG_FREE(buf_list_dst);
+	return (ret);
+}
+module_param(zfs_qat_disable, int, 0644);
+MODULE_PARM_DESC(zfs_qat_disable, "Disable QAT compression");
+#endif

--- a/module/zfs/qat_compress.h
+++ b/module/zfs/qat_compress.h
@@ -1,0 +1,43 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+#ifndef	_SYS_QAT_COMPRESS_H
+#define	_SYS_QAT_COMPRESS_H
+
+#if defined(_KERNEL) && defined(HAVE_QAT)
+
+#include "cpa.h"
+#include "dc/cpa_dc.h"
+extern int qat_init_done;
+extern int qat_init(void);
+extern void qat_fini(void);
+extern int use_qat(size_t s_len);
+extern int qat_compress(int dir, char *src, int src_len,
+				char *dst, int dst_len,
+				size_t *c_len);
+#else
+#define	CPA_STATUS_SUCCESS	0
+#define	qat_init()
+#define	qat_fini()
+#define	use_qat(s_len)	0
+#define	qat_compress(dir, s, sl, d, dl, cl)	0
+#endif
+#endif

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -55,6 +55,7 @@
 #include <sys/kstat.h>
 #include "zfs_prop.h"
 #include <sys/zfeature.h>
+#include "qat_compress.h"
 
 /*
  * SPA locking
@@ -1863,6 +1864,7 @@ spa_init(int mode)
 	zpool_feature_init();
 	spa_config_load();
 	l2arc_start();
+	qat_init();
 }
 
 void
@@ -1884,6 +1886,7 @@ spa_fini(void)
 	unique_fini();
 	refcount_fini();
 	fm_fini();
+	qat_fini();
 
 	avl_destroy(&spa_namespace_avl);
 	avl_destroy(&spa_spare_avl);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This patch implement the hardware accelerator method in GZIP compression in ZFS. When the ZFS pool is enabled GZIP compression, the compression API will be automatically transferred to the hardware accelerator to free up CPU resource and speed up the compression time.
GZIP-qat follows the standard GZIP format, that means the file compressed by QAT hardware can be decompressed by software GZIP if the system doesn't contain the hardware accelerator, or vise versa.
This method supports decompression as well.
### Description
<!--- Describe your changes in detail -->

1. To enable Intel QAT hardware acceleration in ZOL you need have QAT hardware and driver installed:  
 * QAT hardware DH8950: http://ark.intel.com/products/79483/Intel-QuickAssist-Adapter-8950
 * QAT driver: https://01.org/intel-quickassist-technology

2. Enable QAT in autoconf, e.g.:
 ./configure --with-qat=qat-install-dir/QAT1.6
 make
3. Set GZIP compression in ZFS dataset: "compression = gzip"
 The data written to ZFS pool will be compressed by QAT hardware automatically with GZIP format.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
GZIP compression has pretty good compression ratio, but it consumes a lot of CPU time, to enable GZIP compression in ZFS is not practical, hardware offloading is a good method to solve the problem, to free-up the CPU computation resources, and reach a pretty good compression ratio. And most importantly all the changes are totally transparent to the end users (from the application level).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
To test this feature, QAT hardware is required. 
Run FIO test on ZFS pool, by specify different compression methods - "off", "gzip", "lz4", "lzjb", "zle", for the gzip compression if QAT is installed, it is offloaded ("gzip-qat"). File format is Calgary corpus.
Hardware configuration:  
- Intel Xeon server (Haswell E5-2699 v3, 72 HT-core)
- 2x DH8950 QAT PCIe card for compression acceleration
- 6x SSD (LSI HBA connected to server).

Compression | BW(MB/s) | CPU-sy%@72cores | Compr-ratio%(less is better)
---------- | ---------- | ------------- | -------
off |                   1934 |                 8.78 |                         100
**gzip-qat** |               **3782** |                **16.35** |                        **40** 
gzip-sw |             299 |                  76.42 |                        38 
lz4 |                   3381 |               34.96 |                        58 
lzjb |                 3808 |                49.88 |                        53 
zle |                   2790 |                 27.1 |                         69 

The benchmark result shows QAT accelerator can dramatically reduce the CPU utilization, and boost ZFS performance.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
