### PR TITLE
[WIP] linux 4.11 compat: avoid refcount_t name conflict

### DIFF
--- a/include/sys/refcount.h
+++ b/include/sys/refcount.h
@@ -41,6 +41,17 @@ extern "C" {
  */
 #define	FTAG ((char *)__func__)
 
+/*
+ * Starting with 4.11, torvalds/linux@f405df5, the linux kernel defines a
+ * refcount_t type of its own.  The macro below effectively changes references
+ * in the ZFS code from refcount_t to zfs_refcount_t at compile time, so that
+ * existing code need not be altered, reducing conflicts when landing openZFS
+ * patches.
+ */
+
+#define	refcount_t	zfs_refcount_t
+#define	refcount_add	zfs_refcount_add
+
 #ifdef	ZFS_DEBUG
 typedef struct reference {
 	list_node_t ref_link;
@@ -56,7 +67,7 @@ typedef struct refcount {
 	list_t rc_removed;
 	uint64_t rc_count;
 	uint64_t rc_removed_count;
-} refcount_t;
+} zfs_refcount_t;
 
 /* Note: refcount_t must be initialized with refcount_create[_untracked]() */
 
@@ -67,7 +78,7 @@ void refcount_destroy(refcount_t *rc);
 void refcount_destroy_many(refcount_t *rc, uint64_t number);
 int refcount_is_zero(refcount_t *rc);
 int64_t refcount_count(refcount_t *rc);
-int64_t refcount_add(refcount_t *rc, void *holder_tag);
+int64_t zfs_refcount_add(refcount_t *rc, void *holder_tag);
 int64_t refcount_remove(refcount_t *rc, void *holder_tag);
 int64_t refcount_add_many(refcount_t *rc, uint64_t number, void *holder_tag);
 int64_t refcount_remove_many(refcount_t *rc, uint64_t number, void *holder_tag);
@@ -92,7 +103,7 @@ typedef struct refcount {
 #define	refcount_destroy_many(rc, number) ((rc)->rc_count = 0)
 #define	refcount_is_zero(rc) ((rc)->rc_count == 0)
 #define	refcount_count(rc) ((rc)->rc_count)
-#define	refcount_add(rc, holder) atomic_inc_64_nv(&(rc)->rc_count)
+#define	zfs_refcount_add(rc, holder) atomic_inc_64_nv(&(rc)->rc_count)
 #define	refcount_remove(rc, holder) atomic_dec_64_nv(&(rc)->rc_count)
 #define	refcount_add_many(rc, number, holder) \
 	atomic_add_64_nv(&(rc)->rc_count, number)

--- a/module/zfs/refcount.c
+++ b/module/zfs/refcount.c
@@ -143,7 +143,7 @@ refcount_add_many(refcount_t *rc, uint64_t number, void *holder)
 }
 
 int64_t
-refcount_add(refcount_t *rc, void *holder)
+zfs_refcount_add(refcount_t *rc, void *holder)
 {
 	return (refcount_add_many(rc, 1, holder));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Rename the ZFS type refcount_t to zfs_refcount_t.

Rather than touching all the ZFS code that uses refcount_t, use a preprocessor
macro to rename the type at compile time to zfs_refcount_t.  The ZFS code
never refers to the linux type with the conflicting name so this does not break
anything.

Similarly rename refcount_add() which also conflicts.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Linux 4.11 introduces a new type, refcount_t, which conflicts with the
type of the same name defined within ZFS.  The build fails when building
against that kernel or later.

Issue #5823 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Built and ran ztest on my desktop.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
