### PR TITLE
Fix loop device becomes read-only

### DIFF
--- a/config/kernel-vfs-rw-iterate.m4
+++ b/config/kernel-vfs-rw-iterate.m4
@@ -1,5 +1,5 @@
 dnl #
-dnl # Linux 4.1.x API
+dnl # Linux 3.16 API
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_VFS_RW_ITERATE],
 	[AC_MSG_CHECKING([whether fops->read/write_iter() are available])
@@ -21,6 +21,26 @@ AC_DEFUN([ZFS_AC_KERNEL_VFS_RW_ITERATE],
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_VFS_RW_ITERATE, 1,
 			[fops->read/write_iter() are available])
+
+		ZFS_AC_KERNEL_NEW_SYNC_READ
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
+dnl # Linux 4.1 API
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_NEW_SYNC_READ],
+	[AC_MSG_CHECKING([whether new_sync_read() is available])
+	ZFS_LINUX_TRY_COMPILE([
+		#include <linux/fs.h>
+	],[
+		new_sync_read(NULL, NULL, 0, NULL);
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_NEW_SYNC_READ, 1,
+			[new_sync_read() is available])
 	],[
 		AC_MSG_RESULT(no)
 	])

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -856,9 +856,15 @@ const struct file_operations zpl_file_operations = {
 	.release	= zpl_release,
 	.llseek		= zpl_llseek,
 #ifdef HAVE_VFS_RW_ITERATE
+#ifdef HAVE_NEW_SYNC_READ
+	.read		= new_sync_read,
+	.write		= new_sync_write,
+#endif
 	.read_iter	= zpl_iter_read,
 	.write_iter	= zpl_iter_write,
 #else
+	.read		= do_sync_read,
+	.write		= do_sync_write,
 	.aio_read	= zpl_aio_read,
 	.aio_write	= zpl_aio_write,
 #endif


### PR DESCRIPTION
Commit 933ec99 removes read and write from f_op because the vfs layer will
select iter_write or aio_write automatically. However, for Linux <= 4.0,
loop_set_fd will actually check f_op->write and set read-only if not exists.
This patch add them back and use the generic do_sync_{read,write} for
aio_{read,write} and new_sync_{read,write} for {read,write}_iter.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
https://github.com/zfsonlinux/zfs/issues/5776

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
