### PR TITLE
Fix powerpc build

### DIFF
--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -98,10 +98,6 @@ extern "C" {
 #endif
 #endif
 
-#if !defined(_BIG_ENDIAN)
-#define	_BIG_ENDIAN
-#endif
-
 #define	_SUNOS_VTOC_16
 
 /* arm arch specific defines */

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -86,6 +86,11 @@ BuildRequires:             kmod-spl-devel = %{version}
 %global KmodsMetaRequires  spl-kmod
 %endif
 
+# LDFLAGS are not sanitized by arch/powerpc/Makefile (unlike other arches)
+%ifarch ppc ppc64 ppc64le
+%global __global_ldflags %{nil}
+%endif
+
 %if 0%{?fedora} >= 17
 %define prefix  /usr
 %endif

--- a/rpm/redhat/zfs-kmod.spec.in
+++ b/rpm/redhat/zfs-kmod.spec.in
@@ -21,6 +21,11 @@ Requires:       spl-kmod\n\
 Requires:       @PACKAGE@ = %{version}\n\
 Conflicts:      @PACKAGE@-dkms\n\n" > %{_sourcedir}/kmod-preamble)
 
+# LDFLAGS are not sanitized by arch/powerpc/Makefile (unlike other arches)
+%ifarch ppc ppc64 ppc64le
+%global __global_ldflags %{nil}
+%endif
+
 %description
 This package contains the ZFS kernel modules.
 


### PR DESCRIPTION
### Description

Unlike other architectures which sanitize the LDFLAGS from the
environment in arch/<arch>/Makefile.  The powerpc Makefile
allows LDFLAGS to be passed through resulting in the following
build failure.

  /usr/bin/ld: unrecognized option '-Wl,-z,relro'

LDFLAGS is set in /usr/lib/rpm/redhat/macros by default.  Clear
the environment variable when building kmods for powerpc.

Additionally, now that ppc64le exists it's not longer safe to
assume a powerpc system is big endian.  Rely on the endianness
provied by the compiler.

### Motivation and Context

Support for the ppc64le architecture.

### How Has This Been Tested?

ZFS Test Suite on a RHEL 7.3 ppc64le system.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)