### PR TITLE
Fix multi-line error messages in blkdev_compat.h

### DIFF
--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -351,8 +351,6 @@ bio_set_flush(struct bio *bio)
 	bio_set_op_attrs(bio, 0, REQ_PREFLUSH);
 #else
 #error	"Allowing the build will cause bio_set_flush requests to be ignored."
-#error	"Please file an issue report at: "
-#error	"https://github.com/zfsonlinux/zfs/issues/new"
 #endif
 }
 
@@ -393,8 +391,7 @@ bio_is_flush(struct bio *bio)
 #elif defined(REQ_FLUSH)
 	return (bio->bi_rw & REQ_FLUSH);
 #else
-#error	"Allowing the build will cause flush requests to be ignored. Please "
-#error	"file an issue report at: https://github.com/zfsonlinux/zfs/issues/new"
+#error	"Allowing the build will cause flush requests to be ignored."
 #endif
 }
 
@@ -413,8 +410,7 @@ bio_is_fua(struct bio *bio)
 #elif defined(REQ_FUA)
 	return (bio->bi_rw & REQ_FUA);
 #else
-#error	"Allowing the build will cause fua requests to be ignored. Please "
-#error	"file an issue report at: https://github.com/zfsonlinux/zfs/issues/new"
+#error	"Allowing the build will cause fua requests to be ignored."
 #endif
 }
 
@@ -445,10 +441,8 @@ bio_is_discard(struct bio *bio)
 #elif defined(REQ_DISCARD)
 	return (bio->bi_rw & REQ_DISCARD);
 #else
-#error	"Allowing the build will cause discard requests to become writes "
-#error	"potentially triggering the DMU_MAX_ACCESS assertion. Please file "
-#error	"an issue report at: https://github.com/zfsonlinux/zfs/issues/new"
-#endif
+#error	"Allowing the build will cause discard requests to become writes."
+#endif /* potentially triggering the DMU_MAX_ACCESS assertion.  */
 }
 
 /*

--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -351,8 +351,8 @@ bio_set_flush(struct bio *bio)
 	bio_set_op_attrs(bio, 0, REQ_PREFLUSH);
 #else
 #error	"Allowing the build will cause bio_set_flush requests to be ignored."
-	"Please file an issue report at: "
-	"https://github.com/zfsonlinux/zfs/issues/new"
+#error	"Please file an issue report at: "
+#error	"https://github.com/zfsonlinux/zfs/issues/new"
 #endif
 }
 
@@ -394,7 +394,7 @@ bio_is_flush(struct bio *bio)
 	return (bio->bi_rw & REQ_FLUSH);
 #else
 #error	"Allowing the build will cause flush requests to be ignored. Please "
-	"file an issue report at: https://github.com/zfsonlinux/zfs/issues/new"
+#error	"file an issue report at: https://github.com/zfsonlinux/zfs/issues/new"
 #endif
 }
 
@@ -414,7 +414,7 @@ bio_is_fua(struct bio *bio)
 	return (bio->bi_rw & REQ_FUA);
 #else
 #error	"Allowing the build will cause fua requests to be ignored. Please "
-	"file an issue report at: https://github.com/zfsonlinux/zfs/issues/new"
+#error	"file an issue report at: https://github.com/zfsonlinux/zfs/issues/new"
 #endif
 }
 
@@ -446,8 +446,8 @@ bio_is_discard(struct bio *bio)
 	return (bio->bi_rw & REQ_DISCARD);
 #else
 #error	"Allowing the build will cause discard requests to become writes "
-	"potentially triggering the DMU_MAX_ACCESS assertion. Please file "
-	"an issue report at: https://github.com/zfsonlinux/zfs/issues/new"
+#error	"potentially triggering the DMU_MAX_ACCESS assertion. Please file "
+#error	"an issue report at: https://github.com/zfsonlinux/zfs/issues/new"
 #endif
 }
 

--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -441,8 +441,9 @@ bio_is_discard(struct bio *bio)
 #elif defined(REQ_DISCARD)
 	return (bio->bi_rw & REQ_DISCARD);
 #else
+/* potentially triggering the DMU_MAX_ACCESS assertion.  */
 #error	"Allowing the build will cause discard requests to become writes."
-#endif /* potentially triggering the DMU_MAX_ACCESS assertion.  */
+#endif
 }
 
 /*


### PR DESCRIPTION
Not specifying #error on all lines of a multi-line error message also throws an error.  Adding additional #error statements to fix.

### Description
Not specifying #error on all lines of a multi-line error message also throws an error.  Adding additional #error statements to fix.

### Motivation and Context
http://build.zfsonlinux.org/builders/Kernel.org%20Built-in%20x86_64%20%28BUILD%29/builds/10280/steps/shell_1/logs/make

```
In file included from ./include/zfs/sys/dmu.h:735:0,
                 from ./include/zfs/sys/dsl_deleg.h:29,
                 from fs/zfs/zcommon/zfs_deleg.c:40:
./include/zfs/linux/blkdev_compat.h: In function ‘bio_is_discard’:
./include/zfs/linux/blkdev_compat.h:409:2: error: #error "Allowing the build will cause discard requests to become writes "
 #error "Allowing the build will cause discard requests to become writes "
  ^
./include/zfs/linux/blkdev_compat.h:410:2: warning: statement with no effect [-Wunused-value]
  "potentially triggering the DMU_MAX_ACCESS assertion. Please file "
  ^
./include/zfs/linux/blkdev_compat.h:413:1: error: expected ‘;’ before ‘}’ token
 }
 ^
./include/zfs/linux/blkdev_compat.h:413:1: warning: no return statement in function returning non-void [-Wreturn-type]
make[3]: *** [fs/zfs/zcommon/zfs_deleg.o] Error 1
make[2]: *** [fs/zfs/zcommon] Error 2
make[1]: *** [fs/zfs] Error 2
make: *** [fs] Error 2
make: *** Waiting for unfinished jobs....
```

### How Has This Been Tested?
Tested using my own C program to verify how the C preprocessor handles the #error statement

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Change has been approved by a ZFS on Linux member.
