### PR TITLE
Added auto-replace FMA test for the ZFS Test Suite

### DIFF
--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -22,7 +22,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012 by Delphix. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2016, Intel Corporation.
+ * Copyright (c) 2016, 2017, Intel Corporation.
  */
 
 /*
@@ -89,6 +89,7 @@
 
 #define	DEV_BYID_PATH	"/dev/disk/by-id/"
 #define	DEV_BYPATH_PATH	"/dev/disk/by-path/"
+#define	DEV_BYVDEV_PATH	"/dev/disk/by-vdev/"
 
 typedef void (*zfs_process_func_t)(zpool_handle_t *, nvlist_t *, boolean_t);
 
@@ -192,6 +193,8 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 	int is_dm = 0;
 	uint_t c;
 	vdev_stat_t *vs;
+	int is_sd = 0;
+	char *sd_physpath;
 
 	if (nvlist_lookup_string(vdev, ZPOOL_CONFIG_PATH, &path) != 0)
 		return;
@@ -259,6 +262,15 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 	}
 
 	/*
+	 * vdev_id alias rule for using scsi_debug devices (FMA automated
+	 * testing)
+	 */
+	sd_physpath = "scsidebug";
+	if (strcmp(sd_physpath, physpath) == 0)
+		is_sd = 1;
+
+
+	/*
 	 * If the pool doesn't have the autoreplace property set, then use
 	 * vdev online to trigger a FMA fault by posting an ereport.
 	 */
@@ -272,10 +284,13 @@ zfs_process_add(zpool_handle_t *zhp, nvlist_t *vdev, boolean_t labeled)
 	}
 
 	/*
-	 * convert physical path into its current device node
+	 * Convert physical path into its current device node
+	 * Rawpath needs to be /dev/disk/by-vdev for a scsi_debug device since
+	 * by-path is not present
 	 */
-	(void) snprintf(rawpath, sizeof (rawpath), "%s%s", DEV_BYPATH_PATH,
-	    physpath);
+	(void) snprintf(rawpath, sizeof (rawpath), "%s%s",
+	    is_sd ? DEV_BYVDEV_PATH : DEV_BYPATH_PATH, physpath);
+
 	if (realpath(rawpath, devpath) == NULL && !is_dm) {
 		zed_log_msg(LOG_INFO, "  realpath: %s failed (%s)",
 		    rawpath, strerror(errno));

--- a/cmd/zed/zed_disk_event.c
+++ b/cmd/zed/zed_disk_event.c
@@ -11,7 +11,7 @@
  */
 
 /*
- * Copyright (c) 2016, Intel Corporation.
+ * Copyright (c) 2016, 2017, Intel Corporation.
  */
 
 #ifdef HAVE_LIBUDEV
@@ -310,6 +310,33 @@ zed_udev_monitor(void *arg)
 				}
 			}
 			free(tmp2);
+		}
+
+		/*
+		 * Special case an EC_DEV_ADD for scsi_debug devices
+		 *
+		 * These devices require a udevadm trigger command after
+		 * creation in order to register the vdev_id scsidebug alias
+		 * rule (adds a persistent path (phys_path) used for fault
+		 * management automated tests in the ZFS test suite.
+		 *
+		 * After udevadm trigger command, event registers as a "change"
+		 * event but needs to instead be handled as another "add" event
+		 * to allow for disk labeling and partitioning to occur.
+		 */
+		if (strcmp(class, EC_DEV_STATUS) == 0 &&
+		    udev_device_get_property_value(dev, "ID_VDEV") &&
+		    udev_device_get_property_value(dev, "ID_MODEL")) {
+			const char *id_model = NULL;
+			const char *id_model_sd;
+			id_model_sd = "scsi_debug";
+
+			id_model = udev_device_get_property_value(dev,
+			    "ID_MODEL");
+			if (strcmp(id_model, id_model_sd) == 0) {
+				class = EC_DEV_ADD;
+				subclass = ESC_DISK;
+			}
 		}
 
 		if ((nvl = dev_event_nvlist(dev)) != NULL) {

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -411,7 +411,7 @@ tests = ['devices_003_pos']
 tests = ['exec_001_pos']
 
 [tests/functional/fault]
-tests = ['auto_online_001_pos']
+tests = ['auto_online_001_pos', 'auto_replace_001_pos']
 
 [tests/functional/features/async_destroy]
 tests = ['async_destroy_001_pos']

--- a/tests/zfs-tests/include/default.cfg.in
+++ b/tests/zfs-tests/include/default.cfg.in
@@ -209,6 +209,8 @@ if is_linux; then
 	ZVOL_RDEVDIR="/dev/zvol"
 	DEV_RDSKDIR="/dev"
 	DEV_MPATHDIR="/dev/mapper"
+	ZEDLET_DIR="/var/tmp/zed"
+	ZFS_INTREE_DIR="/var/tmp/zfs"
 
 	NEWFS_DEFAULT_FS="ext2"
 else
@@ -226,4 +228,5 @@ else
 	NEWFS_DEFAULT_FS="ufs"
 fi
 export unpack_opts pack_opts verbose unpack_preserve pack_preserve \
-       ZVOL_DEVDIR ZVOL_RDEVDIR NEWFS_DEFAULT_FS DEV_RDSKDIR DEV_MPATHDIR
+       ZVOL_DEVDIR ZVOL_RDEVDIR NEWFS_DEFAULT_FS DEV_RDSKDIR DEV_MPATHDIR \
+       ZEDLET_DIR ZFS_INTREE_DIR

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1679,13 +1679,18 @@ function scan_scsi_hosts
 {
 	typeset hostnum=${1}
 
-	if [[ -z $hostnum ]]; then
-		for host in /sys/class/scsi_host/host*; do
-			echo '- - -' > $host/scan
-		done
-	else
-		echo "/sys/class/scsi_host/host$hostnum/scan"
-		echo '- - -' > "/sys/class/scsi_host/host$hostnum/scan"
+	if is_linux; then
+		if [[ -z $hostnum ]]; then
+			for host in /sys/class/scsi_host/host*; do
+				log_must eval "$ECHO '- - -' > $host/scan"
+			done
+		else
+			log_must eval \
+			    "$ECHO /sys/class/scsi_host/host$hostnum/scan" \
+			    > /dev/null
+			log_must eval \
+			    "$ECHO '- - -' > /sys/class/scsi_host/host$hostnum/scan"
+		fi
 	fi
 }
 #
@@ -1758,7 +1763,7 @@ function on_off_disk # disk state{online,offline} host
 			fi
 		elif [[ $state == "online" ]]; then
 			#force a full rescan
-			log_must scan_scsi_hosts $host
+			scan_scsi_hosts $host
 			block_device_wait
 			if is_mpath_device $disk; then
 				dm_name="$($READLINK $DEV_DSKDIR/$disk \
@@ -3028,6 +3033,40 @@ function get_persistent_disk_name #device
 }
 
 #
+# Load scsi_debug module with specified parameters
+#
+function load_scsi_debug # dev_size_mb add_host num_tgts max_luns
+{
+	typeset devsize=$1
+	typeset hosts=$2
+	typeset tgts=$3
+	typeset luns=$4
+
+	[[ -z $devsize ]] || [[ -z $hosts ]] || [[ -z $tgts ]] || \
+	    [[ -z $luns ]] && log_fail "Arguments invalid or missing"
+
+	if is_linux; then
+		$MODLOAD -n scsi_debug
+		if (($? != 0)); then
+			log_unsupported "Platform does not have scsi_debug"
+			    "module"
+		fi
+		$LSMOD | $EGREP scsi_debug > /dev/zero
+		if (($? == 0)); then
+			log_fail "scsi_debug module already installed"
+		else
+			log_must $MODLOAD scsi_debug dev_size_mb=$devsize \
+			    add_host=$hosts num_tgts=$tgts max_luns=$luns
+			block_device_wait
+			$LSSCSI | $EGREP scsi_debug > /dev/null
+			if (($? == 1)); then
+				log_fail "scsi_debug module install failed"
+			fi
+		fi
+	fi
+}
+
+#
 # Get the package name
 #
 function get_package_name
@@ -3221,4 +3260,50 @@ function wait_freeing #pool
 		[[ "0" == "$($ZPOOL list -Ho freeing $pool)" ]] && break
 		log_must $SLEEP 1
 	done
+}
+
+#
+# Check if ZED is currently running, if not start ZED.
+#
+function zed_start
+{
+	if is_linux; then
+		# ZEDLET_DIR=/var/tmp/zed
+		if [[ ! -d /var/tmp/zed ]]; then
+			log_must $MKDIR  /var/tmp/zed
+		fi
+
+		# Verify the ZED is not already running.
+		$PGREP -x zed > /dev/null
+		if (($? == 0)); then
+			log_fail "ZED already running"
+		fi
+
+		log_must $CP ${ZEDLETDIR}/all-syslog.sh $ZEDLET_DIR
+
+		log_note "Starting ZED"
+		# run ZED in the background and redirect foreground logging
+		# output to zedlog
+		log_must eval "$ZED -vF -d $ZEDLET_DIR -p $ZEDLET_DIR/zed.pid" \
+		    "-s $ZEDLET_DIR/state 2>${ZEDLET_DIR}/zedlog &"
+	fi
+}
+
+#
+# Kill ZED process
+#
+function zed_stop
+{
+	if is_linux; then
+		if [[ -f ${ZEDLET_DIR}/zed.pid ]]; then
+			zedpid=$($CAT ${ZEDLET_DIR}/zed.pid)
+			log_must $KILL $zedpid
+		fi
+		log_must $RM ${ZEDLET_DIR}/all-syslog.sh
+		log_must $RM ${ZEDLET_DIR}/zed.pid
+		log_must $RM ${ZEDLET_DIR}/zedlog
+		log_must $RM ${ZEDLET_DIR}/state
+		log_must $RMDIR $ZEDLET_DIR
+
+	fi
 }

--- a/tests/zfs-tests/tests/functional/fault/Makefile.am
+++ b/tests/zfs-tests/tests/functional/fault/Makefile.am
@@ -3,4 +3,5 @@ dist_pkgdata_SCRIPTS = \
 	fault.cfg \
 	setup.ksh \
 	cleanup.ksh \
-	auto_online_001_pos.ksh
+	auto_online_001_pos.ksh \
+	auto_replace_001_pos.ksh

--- a/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
@@ -1,0 +1,156 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright (c) 2017 by Intel Corporation. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/fault/fault.cfg
+
+#
+# DESCRIPTION:
+# Testing Fault Management Agent ZED Logic - Automated Auto-Replace Test.
+#
+# STRATEGY:
+# 1. Update /etc/zfs/vdev_id.conf with scsidebug alias rule for a persistent
+#    path. This creates keys ID_VDEV and ID_VDEV_PATH and sets
+#    phys_path="scsidebug".
+# 2. Create a pool & set autoreplace=on (auto-replace is opt-in)
+# 2. Export a pool
+# 3. Offline disk by removing scsi_debug module
+# 4. Import pool with missing disk
+# 5. Online disk by loading scsi_debug module again and re-registering vdev_id
+#    rule.
+# 6. ZED polls for an event change for new disk to be automatically
+#    added back to the pool
+#
+# Creates a raidz1 zpool using persistent disk path names
+# (ie not /dev/sdc)
+#
+# Auto-replace is opt in, and matches by phys_path.
+#
+
+verify_runnable "both"
+
+if ! is_physical_device $DISKS; then
+	log_unsupported "Unsupported disks for this test."
+fi
+
+function setup
+{
+	$LSMOD | $EGREP scsi_debug > /dev/null
+	if (($? == 1)); then
+		load_scsi_debug $SDSIZE $SDHOSTS $SDTGTS $SDLUNS
+	fi
+	# Register vdev_id alias rule for scsi_debug device to create a
+	# persistent path
+	SD=$($LSSCSI | $NAWK '/scsi_debug/ {print $6; exit}' \
+	    | $NAWK -F / '{print $3}')
+	SDDEVICE_ID=$(get_persistent_disk_name $SD)
+	log_must eval "$ECHO "alias scsidebug /dev/disk/by-id/$SDDEVICE_ID" \
+	    >> $VDEVID_CONF_INTREE"
+	block_device_wait
+
+	SDDEVICE=$($UDEVADM info -q all -n $DEV_DSKDIR/$SD | $EGREP ID_VDEV \
+	    | $NAWK '{print $2; exit}' | $NAWK -F = '{print $2; exit}')
+	[[ -z $SDDEVICE ]] && log_fail "vdev rule was not registered properly"
+}
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "Testing automated auto-replace FMA test"
+
+log_onexit cleanup
+
+# Clear disk labels
+for i in {0..2}
+do
+	log_must $ZPOOL labelclear -f /dev/disk/by-id/"${devs_id[i]}"
+done
+
+setup
+if is_loop_device $DISK1; then
+	log_must $ZPOOL create -f $TESTPOOL raidz1 $SDDEVICE $DISK1 $DISK2 \
+	    $DISK3
+elif ( is_real_device $DISK1 || is_mpath_device $DISK1 ); then
+	log_must $ZPOOL create -f $TESTPOOL raidz1 $SDDEVICE ${devs_id[0]} \
+	    ${devs_id[1]} ${devs_id[2]}
+else
+	log_fail "Disks are not supported for this test"
+fi
+
+# Auto-replace is opt-in so need to set property
+log_must $ZPOOL set autoreplace=on $TESTPOOL
+
+# Add some data to the pool
+log_must $MKFILE $FSIZE /$TESTPOOL/data
+
+log_must $ZPOOL export -F $TESTPOOL
+
+# Offline disk
+on_off_disk $SD "offline"
+block_device_wait
+log_must $MODUNLOAD scsi_debug
+
+# Reimport pool with drive missing
+log_must $ZPOOL import $TESTPOOL
+check_state $TESTPOOL "" "degraded"
+if (($? != 0)); then
+	log_fail "$TESTPOOL is not degraded"
+fi
+
+# Clear zpool events
+$ZPOOL events -c $TESTPOOL
+
+# Create another scsi_debug device
+setup
+
+log_note "Delay for ZED auto-replace"
+typeset -i timeout=0
+while true; do
+	if ((timeout == $MAXTIMEOUT)); then
+		log_fail "Timeout occured"
+	fi
+	((timeout++))
+	$SLEEP 1
+	$ZPOOL events $TESTPOOL | $EGREP sysevent.fs.zfs.resilver_finish \
+	    > /dev/null
+	if (($? == 0)); then
+		log_note "Auto-replace should be complete"
+		$SLEEP 1
+		break
+	fi
+done
+
+# Validate auto-replace was successful
+check_state $TESTPOOL "" "online"
+if (($? != 0)); then
+	log_fail "$TESTPOOL is not back online"
+fi
+$SLEEP 2
+
+log_must $ZPOOL destroy $TESTPOOL
+
+log_pass "Auto-replace test successful"

--- a/tests/zfs-tests/tests/functional/fault/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/fault/cleanup.ksh
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2016 by Intel Corporation. All rights reserved.
+# Copyright (c) 2016, 2017 by Intel Corporation. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -30,29 +30,24 @@ verify_runnable "global"
 
 cleanup_devices $DISKS
 
-if [[ -f ${ZEDLET_DIR}/zed.pid ]]; then
-	zedpid=$($CAT ${ZEDLET_DIR}/zed.pid)
-	log_must $KILL $zedpid
+zed_stop
+
+SD=$($LSSCSI | $NAWK '/scsi_debug/ {print $6; exit}')
+SDDEVICE=$($ECHO $SD | $NAWK -F / '{print $3}')
+
+if [[ -z $SDDEVICE ]]; then
+	log_pass
 fi
 
-log_must $RM ${ZEDLET_DIR}/all-syslog.sh
-log_must $RM ${ZEDLET_DIR}/zed.pid
-log_must $RM ${ZEDLET_DIR}/zedlog
-log_must $RM ${ZEDLET_DIR}/state
-log_must $RMDIR $ZEDLET_DIR
-
-if is_loop_device $DISK1; then
-	SD=$($LSSCSI | $NAWK '/scsi_debug/ {print $6; exit}')
-	SDDEVICE=$($ECHO $SD | $NAWK -F / '{print $3}')
-
-	if [[ -z $SDDEVICE ]]; then
-		log_pass
-	fi
-	#offline disk
+#Offline disk and remove scsi_debug module
+if is_linux; then
 	on_off_disk $SDDEVICE "offline"
 	block_device_wait
-
 	log_must $MODUNLOAD scsi_debug
 fi
+
+#Remove symlink and vdev_id.conf in-tree file
+log_must $RM $VDEVID_CONF_ETC
+log_must $RM $VDEVID_CONF_INTREE
 
 log_pass

--- a/tests/zfs-tests/tests/functional/fault/fault.cfg
+++ b/tests/zfs-tests/tests/functional/fault/fault.cfg
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2016 by Intel Corporation. All rights reserved.
+# Copyright (c) 2016, 2017 by Intel Corporation. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -32,11 +32,17 @@ export DISKSARRAY=$DISKS
 export FSIZE=10M
 export MAXTIMEOUT=20
 
+export SDSIZE=256
+export SDHOSTS=1
+export SDTGTS=1
+export SDLUNS=1
+
 export DISK1=$($ECHO $DISKS | $NAWK '{print $1}')
 export DISK2=$($ECHO $DISKS | $NAWK '{print $2}')
 export DISK3=$($ECHO $DISKS | $NAWK '{print $3}')
 
-export ZEDLET_DIR=/var/tmp/zed
+export VDEVID_CONF_INTREE=/var/tmp/zfs/vdev_id.conf
+export VDEVID_CONF_ETC=/etc/zfs/vdev_id.conf
 
 if is_linux; then
 	set_slice_prefix

--- a/tests/zfs-tests/tests/functional/fault/setup.ksh
+++ b/tests/zfs-tests/tests/functional/fault/setup.ksh
@@ -20,66 +20,37 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2016 by Intel Corporation. All rights reserved.
+# Copyright (c) 2016, 2017 by Intel Corporation. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/fault/fault.cfg
 
-typeset SDSIZE=256
-typeset SDHOSTS=1
-typeset SDTGTS=1
-typeset SDLUNS=1
-
 [[ -z $UDEVADM ]] && log_fail "Missing UDEVADM command"
-[[ -z $NAWK ]]  && log_fail "Missing NAWK command"
-[[ -z $EGREP ]] && log_fail "Missing EGREP command"
+[[ -z $LSMOD ]]  && log_fail "Missing LSMOD command"
 [[ -z $LSSCSI ]] && log_fail "Missing LSSCSI command"
 [[ -z $MODUNLOAD ]] && log_fail "Missing MODUNLOAD command"
-[[ -z $PGREP ]] && log_fail "Missing PGREP command"
+[[ -z $MODLOAD ]] && log_fail "Missing MODLOAD command"
 
 verify_runnable "global"
-if [[ ! -d /var/tmp/zed ]]; then
-	log_must $MKDIR  /var/tmp/zed
+
+if [[ ! -d $ZFS_INTREE_DIR ]]; then
+	log_must $MKDIR $ZFS_INTREE_DIR
+fi
+if [[ ! -e $VDEVID_CONF_INTREE ]]; then
+	log_must $TOUCH $VDEVID_CONF_INTREE
+fi
+if [[ -e $VDEVID_CONF_ETC ]]; then
+	log_fail "Must not have $VDEVID_CONF_ETC file present on system"
 fi
 
-modprobe -n scsi_debug
-if (($? != 0)); then
-	log_unsupported "Platform does not have scsi_debug module"
-fi
+# create a symlink for /etc/zfs/vdev_id.conf file
+log_must ln -s $VDEVID_CONF_INTREE $VDEVID_CONF_ETC
 
-# Verify the ZED is not already running.
-$PGREP -x zed > /dev/null
-if (($? == 0)); then
-	log_fail "ZED already running"
-fi
+zed_start
 
-log_must $CP ${ZEDLETDIR}/all-syslog.sh $ZEDLET_DIR
-
-log_note "Starting ZED"
-#run ZED in the background and redirect foreground logging output to zedlog
-log_must eval "$ZED -vF -d $ZEDLET_DIR -p $ZEDLET_DIR/zed.pid -s" \
-    "$ZEDLET_DIR/state 2>${ZEDLET_DIR}/zedlog &"
-
-#if using loop devices, create a scsi_debug device to be used with
-#auto-online test
-if is_loop_device $DISK1; then
-	$LSMOD | $EGREP scsi_debug > /dev/zero
-	if (($? == 0)); then
-		log_fail "SCSI_DEBUG module already installed"
-	else
-		log_must $MODLOAD scsi_debug dev_size_mb=$SDSIZE \
-		    add_host=$SDHOSTS num_tgts=$SDTGTS max_luns=$SDLUNS
-		block_device_wait
-		$LSSCSI | $EGREP scsi_debug > /dev/null
-		if (($? == 1)); then
-			log_fail "scsi_debug failed"
-		else
-			SDDEVICE=$($LSSCSI \
-			    | $NAWK '/scsi_debug/ {print $6; exit}')
-			log_must  $FORMAT -s $SDDEVICE mklabel gpt
-		fi
-	fi
-fi
+# create a scsi_debug device to be used with auto-online (if using loop devices)
+# and auto-replace regardless of other devices
+load_scsi_debug $SDSIZE $SDHOSTS $SDTGTS $SDLUNS
 
 log_pass


### PR DESCRIPTION
Also included are updates to auto-online test

Automated auto-replace test to go along with ZED FMA integration (PR 4673)
auto-replace_001.pos works using a scsi_debug device (the only usable virtual
device currently due to whole_disk var needing to be set)

Functionality for automated FMA auto-replace test to work with scsi_debug devs:
Some functionality/exceptions needed to be added for automation of auto-replace
to work correctly.
In the test an alias vdev_id rule is added for any scsi_debug device which
sets the phys_path="scsidebug" after a udevadm trigger command.

A symlink is created for the vdev_id.conf file (in /etc/zfs/ by default) to be
used in-tree for the test suite (/var/tmp/zfs/vdev_id.conf).
"./scripts/zfs-helpers.sh -i" needs to be run before fault tests in the ZTS (to
use udev rules in-tree)

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>
Reviewed-by: Don Brady <don.brady@intel.com>
Reviewed-by: David Quigley <david.quigley@intel.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
