### PR TITLE
corrected highlight for zpool man page

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -184,7 +184,7 @@ The \fBzpool\fR command configures \fBZFS\fR storage pools. A storage pool is a 
 .sp
 .LP
 All datasets within a storage pool share the same space. See \fBzfs\fR(8) for information on managing datasets.
-.SS "Virtual Devices (\fBvdev\fRs)"
+.SS "Virtual Devices (vdevs)"
 .sp
 .LP
 A "virtual device" describes a single device or a collection of devices organized according to certain performance and fault characteristics. The following virtual devices are supported:


### PR DESCRIPTION
### Description
Found a highlighting error on the zpool man page, SS is already highlighted and the fB/fR tags break the highlighting prematurely, removing the tags highlights the entire line.

### Motivation and Context
Corrects this instance of highlighting in the manpage

### How Has This Been Tested?
Took tags out, checked manpage again, highlighting looked correct

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Change has been approved by a ZFS on Linux member.
