### PR TITLE
Check ashift validity in 'zpool add'

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -70,6 +70,7 @@
 #include <libintl.h>
 #include <libnvpair.h>
 #include <limits.h>
+#include <sys/spa.h>
 #include <scsi/scsi.h>
 #include <scsi/sg.h>
 #include <stdio.h>
@@ -721,8 +722,18 @@ make_leaf_vdev(nvlist_t *props, const char *arg, uint64_t is_log)
 		char *value = NULL;
 
 		if (nvlist_lookup_string(props,
-		    zpool_prop_to_name(ZPOOL_PROP_ASHIFT), &value) == 0)
+		    zpool_prop_to_name(ZPOOL_PROP_ASHIFT), &value) == 0) {
 			zfs_nicestrtonum(NULL, value, &ashift);
+			if (ashift != 0 &&
+			    (ashift < ASHIFT_MIN || ashift > ASHIFT_MAX)) {
+				(void) fprintf(stderr,
+				    gettext("property 'ashift' value %" PRIu64
+				    " is invalid: only values between %" PRId32
+				    " and %" PRId32 " are allowed.\n"),
+				    ashift, ASHIFT_MIN, ASHIFT_MAX);
+				return (NULL);
+			}
+		}
 	}
 
 	/*

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -727,9 +727,9 @@ make_leaf_vdev(nvlist_t *props, const char *arg, uint64_t is_log)
 			if (ashift != 0 &&
 			    (ashift < ASHIFT_MIN || ashift > ASHIFT_MAX)) {
 				(void) fprintf(stderr,
-				    gettext("property 'ashift' value %" PRIu64
-				    " is invalid: only values between %" PRId32
-				    " and %" PRId32 " are allowed.\n"),
+				    gettext("invalid 'ashift=%" PRIu64 "' "
+				    "property: only values between %" PRId32 " "
+				    "and %" PRId32 " are allowed.\n"),
 				    ashift, ASHIFT_MIN, ASHIFT_MAX);
 				return (NULL);
 			}

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -732,7 +732,8 @@ typedef enum vdev_aux {
 	VDEV_AUX_IO_FAILURE,	/* experienced I/O failure		*/
 	VDEV_AUX_BAD_LOG,	/* cannot read log chain(s)		*/
 	VDEV_AUX_EXTERNAL,	/* external diagnosis			*/
-	VDEV_AUX_SPLIT_POOL	/* vdev was split off into another pool	*/
+	VDEV_AUX_SPLIT_POOL,	/* vdev was split off into another pool	*/
+	VDEV_AUX_BAD_ASHIFT	/* vdev ashift is invalid		*/
 } vdev_aux_t;
 
 /*

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -122,6 +122,17 @@ _NOTE(CONSTCOND) } while (0)
 #define	SPA_MAXBLOCKSIZE	(1ULL << SPA_MAXBLOCKSHIFT)
 
 /*
+ * Alignment Shift (ashift) is an immutable, internal top-level vdev property
+ * which can only be set at vdev creation time. Physical writes are always done
+ * according to it, which makes 2^ashift the smallest possible IO on a vdev.
+ *
+ * We currently allow values ranging from 512 bytes (2^9 = 512) to 8 KiB
+ * (2^13 = 8,192).
+ */
+#define	ASHIFT_MIN		9
+#define	ASHIFT_MAX		13
+
+/*
  * Size of block to hold the configuration data (a packed nvlist)
  */
 #define	SPA_CONFIG_BLOCKSIZE	(1ULL << 14)

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -541,9 +541,9 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			if (intval != 0 &&
 			    (intval < ASHIFT_MIN || intval > ASHIFT_MAX)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' value %d is invalid: only "
-				    "values between %" PRId32 " and %" PRId32
-				    " are allowed.\n"),
+				    "invalid '%s=%d' property: only values "
+				    "between %" PRId32 " and %" PRId32 " "
+				    "are allowed.\n"),
 				    propname, intval, ASHIFT_MIN, ASHIFT_MAX);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -538,10 +538,13 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 				goto error;
 			}
 
-			if (intval != 0 && (intval < 9 || intval > 13)) {
+			if (intval != 0 &&
+			    (intval < ASHIFT_MIN || intval > ASHIFT_MAX)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' number %d is invalid."),
-				    propname, intval);
+				    "property '%s' value %d is invalid: only "
+				    "values between %" PRId32 " and %" PRId32
+				    " are allowed.\n"),
+				    propname, intval, ASHIFT_MIN, ASHIFT_MAX);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -230,7 +230,8 @@ tests = ['zpool_001_neg', 'zpool_002_pos', 'zpool_003_pos']
 # zpool_add_006_pos - https://github.com/zfsonlinux/zfs/issues/3484
 [tests/functional/cli_root/zpool_add]
 tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
-    'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg']
+    'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg',
+    'add-o_ashift']
 
 [tests/functional/cli_root/zpool_attach]
 tests = ['zpool_attach_001_neg']

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/Makefile.am
@@ -12,4 +12,5 @@ dist_pkgdata_SCRIPTS = \
 	zpool_add_006_pos.ksh \
 	zpool_add_007_neg.ksh \
 	zpool_add_008_neg.ksh \
-	zpool_add_009_neg.ksh
+	zpool_add_009_neg.ksh \
+	add-o_ashift.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/add-o_ashift.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/add-o_ashift.ksh
@@ -1,0 +1,106 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_create/zpool_create.shlib
+
+#
+# DESCRIPTION:
+#	'zpool add -o ashift=<n> ...' should work with different ashift
+#	values.
+#
+# STRATEGY:
+#	1. Create a pool with default values.
+#	2. Verify 'zpool add -o ashift=<n>' works with allowed values (9-13).
+#	3. Verify 'zpool add -o ashift=<n>' doesn't accept other invalid values.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	log_must $RM $disk1 $disk2
+}
+
+#
+# Verify every label in device $1 contains ashift value $2
+# $1 device
+# $2 ashift value
+#
+function verify_device_ashift
+{
+	typeset device=$1
+	typeset value=$2
+	typeset ashift
+
+	$ZDB -e -l $device | $GREP " ashift:" | {
+		while read ashift ; do
+			if [[ "ashift: $value" != "$ashift" ]]; then
+				return 1
+			fi
+		done
+	}
+
+	return 0
+}
+
+log_assert "zpool add -o ashift=<n>' works with different ashift values"
+log_onexit cleanup
+
+disk1=$TEST_BASE_DIR/$FILEDISK0
+disk2=$TEST_BASE_DIR/$FILEDISK1
+log_must $MKFILE $SIZE $disk1
+log_must $MKFILE $SIZE $disk2
+
+typeset ashifts=("9" "10" "11" "12" "13")
+for ashift in ${ashifts[@]}
+do
+	log_must $ZPOOL create $TESTPOOL $disk1
+	log_must $ZPOOL add -o ashift=$ashift $TESTPOOL $disk2
+	verify_device_ashift $disk2 $ashift
+	if [[ $? -ne 0 ]]
+	then
+		log_fail "Device was added without setting ashift value to "\
+		    "$ashift"
+	fi
+	# clean things for the next run
+	log_must $ZPOOL destroy $TESTPOOL
+	log_must $ZPOOL labelclear $disk1
+	log_must $ZPOOL labelclear $disk2
+done
+
+typeset badvals=("off" "on" "1" "8" "14" "1b" "ff" "-")
+for badval in ${badvals[@]}
+do
+	log_must $ZPOOL create $TESTPOOL $disk1
+	log_mustnot $ZPOOL add -o ashift="$badval" $disk2
+	log_must $ZPOOL destroy $TESTPOOL
+	log_must $ZPOOL labelclear $disk1
+	log_must $ZPOOL labelclear $disk2
+done
+
+log_pass "zpool add -o ashift=<n>' works with different ashift values"


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

df83110 added the ability to specify a custom "ashift" value from the command line in 'zpool add' and 'zpool attach'. This commit adds additional checks to the provided ashift to prevent invalid values from being used, which could result in disastrous consequences (https://github.com/zfsonlinux/zfs/issues/4434) for the whole pool.

More context: reading the following comments i understand both `zpool_create` and `zpool_add` expect the "nvroot" parameter to be valid:

```c
/*
 * Create the named pool, using the provided vdev list.  It is assumed
 * that the consumer has already validated the contents of the nvlist, so we
 * don't have to worry about error semantics.
 */
zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
/*
 * Add the given vdevs to the pool.  The caller must have already performed the
 * necessary verification to ensure that the vdev specification is well-formed.
 */
zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
```

![zcallgraph](https://cloud.githubusercontent.com/assets/4585738/23715963/cbfac990-042e-11e7-93ef-085f340749c9.png)

This seems to be false in both cases since the ashift value is parsed in `make_leaf_vdev()` by `zfs_nicestrtonum()`, but is never explicitly validated by `zpool_valid_proplist()`:



```
root@debian-8-zfs:~# cat > gdbcmds <<EOF
> set pagination off
> set breakpoint pending on
> b cmd/zpool/zpool_vdev.c:720
> file zpool
> run add $POOLNAME -o ashift=1e $TMPDIR/zpool2.dat
> EOF
root@debian-8-zfs:~# gdb -q -x gdbcmds
No symbol table is loaded.  Use the "file" command.
Breakpoint 1 (cmd/zpool/zpool_vdev.c:720) pending.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Breakpoint 1, make_leaf_vdev (props=props@entry=0x625ea0, arg=<optimized out>, is_log=is_log@entry=0) at zpool_vdev.c:720
720		if (props != NULL) {
(gdb) bt
#0  make_leaf_vdev (props=props@entry=0x625ea0, arg=<optimized out>, is_log=is_log@entry=0) at zpool_vdev.c:720
#1  0x0000000000414a76 in construct_spec (props=0x625ea0, argc=argc@entry=1, argv=argv@entry=0x7fffffffecc0) at zpool_vdev.c:1592
#2  0x00000000004150b6 in make_root_vdev (zhp=0x625f00, props=<optimized out>, force=0, check_rep=1, replacing=B_FALSE, dryrun=B_FALSE, argc=1, argv=0x7fffffffecc0) at zpool_vdev.c:1721
#3  0x000000000040e39e in zpool_do_add (argc=1, argv=0x625f00) at zpool_main.c:680
#4  0x00000000004056ad in main (argc=6, argv=0x7fffffffec98) at zpool_main.c:7510
(gdb) b zfs_nicestrtonum
Breakpoint 2 at 0x7ffff722c6e0: file libzfs_util.c, line 1540.
(gdb) c
Continuing.

Breakpoint 2, zfs_nicestrtonum (hdl=hdl@entry=0x0, value=0x625ee8 "1e", num=num@entry=0x7fffffff9828) at libzfs_util.c:1540
1540	{
(gdb) fin
Run till exit from #0  zfs_nicestrtonum (hdl=hdl@entry=0x0, value=0x625ee8 "1e", num=num@entry=0x7fffffff9828) at libzfs_util.c:1540
0x0000000000414534 in make_leaf_vdev (props=props@entry=0x625ea0, arg=<optimized out>, is_log=is_log@entry=0) at zpool_vdev.c:725
725				zfs_nicestrtonum(NULL, value, &ashift);
Value returned is $1 = 0
(gdb) p ashift
$2 = 1152921504606846976
(gdb) 
```

"ashift=1e" (an understandable typo) is parsed as 1 exabyte (1152921504606846976). `zpool` drives on, adds the new file vdev and then panics the box:

```
(gdb) p ashift
$2 = 1152921504606846976
(gdb) c
Continuing.
[Inferior 1 (process 1971) exited normally]
(gdb) q
root@debian-8-zfs:~# zdb -C $POOLNAME | grep ashift:
                ashift: 9
                ashift: 1152921504606846976
root@debian-8-zfs:~# [  520.750214] KGDB: Waiting for remote debugger
```

From the kernel debugger:

```
Thread 119 received signal SIGSEGV, Segmentation fault.
[Switching to Thread 1779]
0xffffffffc0408a35 in metaslab_group_histogram_remove (mg=0xffff880029942c00, msp=0xffff88001814f400) at /usr/src/zfs/module/zfs/metaslab.c:765
765			mg->mg_histogram[i + ashift] -=
(gdb) bt
#0  0xffffffffc0408a35 in metaslab_group_histogram_remove (mg=0xffff880029942c00, msp=0xffff88001814f400) at /usr/src/zfs/module/zfs/metaslab.c:765
#1  0xffffffffc0409664 in metaslab_sync (msp=0xffff88001814f400, txg=20) at /usr/src/zfs/module/zfs/metaslab.c:2259
#2  0xffffffffc042bbbd in vdev_sync (vd=0xffff88002a7c8000, txg=20) at /usr/src/zfs/module/zfs/vdev.c:2399
#3  0xffffffffc04166bb in spa_sync (spa=0xffff8800181b6000, txg=20) at /usr/src/zfs/module/zfs/spa.c:6624
#4  0xffffffffc0427111 in txg_sync_thread (dp=0xffff8800181f5000) at /usr/src/zfs/module/zfs/txg.c:545
#5  0xffffffffc02b84ae in thread_generic_wrapper ()
#6  0xffffffff8109ac4f in kthread ()
#7  0xffffffff815cc3f2 in ret_from_fork () at arch/x86/entry/entry_64.S:406
#8  0x0000000000000000 in ?? ()
(gdb) list
760			ASSERT3U(mg->mg_histogram[i + ashift], >=,
761			    msp->ms_sm->sm_phys->smp_histogram[i]);
762			ASSERT3U(mc->mc_histogram[i + ashift], >=,
763			    msp->ms_sm->sm_phys->smp_histogram[i]);
764	
765			mg->mg_histogram[i + ashift] -=
766			    msp->ms_sm->sm_phys->smp_histogram[i];
767			mc->mc_histogram[i + ashift] -=
768			    msp->ms_sm->sm_phys->smp_histogram[i];
769		}
(gdb) p ashift
$1 = 1152921504606846976
```

We are lucky `zpool_create()` detects the invalid ashift with an explicit call to `zpool_valid_proplist()`, even if "nvroot" already contains the invalid value.

Unfortunately `zpool_add()` does not call `zpool_valid_proplist()` (it doesn't even have a "props" argument to begin with).

How do we fix this:

1. pass "props" to `zpool_add()`, validate them with `zpool_valid_proplist()`.
2. validate "ashift" in `make_leaf_vdev()`
3. ???


### Motivation and Context
Fix https://github.com/zfsonlinux/zfs/issues/4434

### How Has This Been Tested?
Test case is provided. Also manual debugging.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.

