### PR TITLE
Suppress cppcheck nullPointer error in zfs_write

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,7 +62,8 @@ lint: cppcheck paxcheck
 
 cppcheck:
 	@if type cppcheck > /dev/null 2>&1; then \
-		cppcheck --quiet --force --error-exitcode=2 ${top_srcdir}; \
+		cppcheck --inline-suppr --quiet --force --error-exitcode=2 \
+		${top_srcdir}; \
 	fi
 
 paxcheck:

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -829,6 +829,7 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 			    aiov->iov_base != abuf->b_data)) {
 				ASSERT(xuio);
 				dmu_write(zsb->z_os, zp->z_id, woff,
+				    // cppcheck-suppress nullPointer
 				    aiov->iov_len, aiov->iov_base, tx);
 				dmu_return_arcbuf(abuf);
 				xuio_stat_wbuf_copied();


### PR DESCRIPTION
Newer versions of cppcheck find the potential
null pointer bug in zfs_write. The function is
difficult to refactor without extensive work.
So suppress the potential null pointer error
for now.

Requires-builders: style
Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>