### PR TITLE
Fix undefined reference to `libzfs_fru_compare'

### DIFF
--- a/cmd/zed/agents/zfs_diagnosis.c
+++ b/cmd/zed/agents/zfs_diagnosis.c
@@ -377,7 +377,7 @@ zfs_case_solve(fmd_hdl_t *hdl, zfs_case_t *zcp, const char *faultname,
 	nvlist_t *detector, *fault;
 	boolean_t serialize;
 	nvlist_t *fru = NULL;
-#ifdef _HAS_FMD_TOPO
+#ifdef HAVE_LIBTOPO
 	nvlist_t *fmri;
 	topo_hdl_t *thp;
 	int err;
@@ -400,7 +400,7 @@ zfs_case_solve(fmd_hdl_t *hdl, zfs_case_t *zcp, const char *faultname,
 		    zcp->zc_data.zc_vdev_guid);
 	}
 
-#ifdef _HAS_FMD_TOPO
+#ifdef HAVE_LIBTOPO
 	/*
 	 * We also want to make sure that the detector (pool or vdev) properly
 	 * reflects the diagnosed state, when the fault corresponds to internal

--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -177,7 +177,7 @@ find_by_guid(libzfs_handle_t *zhdl, uint64_t pool_guid, uint64_t vdev_guid,
 	return (zhp);
 }
 
-#ifdef _HAS_FMD_TOPO
+#ifdef HAVE_LIBTOPO
 static int
 search_pool(zpool_handle_t *zhp, void *data)
 {
@@ -218,7 +218,7 @@ find_by_fru(libzfs_handle_t *zhdl, const char *fru, nvlist_t **vdevp)
 	*vdevp = cb.cb_vdev;
 	return (cb.cb_zhp);
 }
-#endif /* _HAS_FMD_TOPO */
+#endif /* HAVE_LIBTOPO */
 
 /*
  * Given a vdev, attempt to replace it with every known spare until one
@@ -289,7 +289,7 @@ zfs_vdev_repair(fmd_hdl_t *hdl, nvlist_t *nvl)
 	zfs_retire_data_t *zdp = fmd_hdl_getspecific(hdl);
 	zfs_retire_repaired_t *zrp;
 	uint64_t pool_guid, vdev_guid;
-#ifdef _HAS_FMD_TOPO
+#ifdef HAVE_LIBTOPO
 	nvlist_t *asru;
 #endif
 
@@ -315,7 +315,7 @@ zfs_vdev_repair(fmd_hdl_t *hdl, nvlist_t *nvl)
 			return;
 	}
 
-#ifdef _HAS_FMD_TOPO
+#ifdef HAVE_LIBTOPO
 	asru = fmd_nvl_alloc(hdl, FMD_SLEEP);
 
 	(void) nvlist_add_uint8(asru, FM_VERSION, ZFS_SCHEME_VERSION0);
@@ -477,7 +477,7 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 		}
 
 		if (is_disk) {
-#ifdef _HAS_FMD_TOPO
+#ifdef HAVE_LIBTOPO
 			/*
 			 * This is a disk fault.  Lookup the FRU, convert it to
 			 * an FMRI string, and attempt to find a matching vdev.

--- a/lib/libzfs/libzfs_fru.c
+++ b/lib/libzfs/libzfs_fru.c
@@ -456,6 +456,15 @@ libzfs_fru_clear(libzfs_handle_t *hdl, boolean_t final)
 #else /* HAVE_LIBTOPO */
 
 /*
+ * Compare to two FRUs, ignoring any authority information.
+ */
+boolean_t
+libzfs_fru_compare(libzfs_handle_t *hdl, const char *a, const char *b)
+{
+	return (B_FALSE);
+}
+
+/*
  * Clear memory associated with the FRU hash.
  */
 void


### PR DESCRIPTION
Add trivial libzfs_fru_compare() function which can be used when
HAVE_LIBTOPO is not defined.  The only caller is find_vdev() and
this function should never be reached because search_fru must be
NULL unless HAVE_LIBTOPO is defined.

Rename _HAS_FMD_TOPO to existing HAVE_LIBTOPO which was originally 
added for this purpose.  This macro will never be defined.

Issue #5402 