### PR TITLE
Fixup loop declarations from C99

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -846,7 +846,8 @@ dmu_objset_evict_done(objset_t *os)
 	mutex_destroy(&os->os_userused_lock);
 	mutex_destroy(&os->os_obj_lock);
 	mutex_destroy(&os->os_user_ptr_lock);
-	for (int i = 0; i < TXG_SIZE; i++) {
+        int i = 0;
+	for (i; i < TXG_SIZE; i++) {
 		multilist_destroy(os->os_dirty_dnodes[i]);
 	}
 	spa_evicting_os_deregister(os->os_spa, os);
@@ -1367,7 +1368,8 @@ dmu_objset_sync(objset_t *os, zio_t *pio, dmu_tx_t *tx)
 		}
 	}
 
-	for (int i = 0;
+	int i = 0;
+	for (i;
 	    i < multilist_get_num_sublists(os->os_dirty_dnodes[txgoff]); i++) {
 		sync_dnodes_arg_t *sda = kmem_alloc(sizeof (*sda), KM_SLEEP);
 		sda->sda_list = os->os_dirty_dnodes[txgoff];
@@ -1640,7 +1642,8 @@ dmu_objset_do_userquota_updates(objset_t *os, dmu_tx_t *tx)
 		    DMU_OT_USERGROUP_USED, DMU_OT_NONE, 0, tx));
 	}
 
-	for (int i = 0;
+	int i = 0;
+	for (i;
 	    i < multilist_get_num_sublists(os->os_synced_dnodes); i++) {
 		userquota_updates_arg_t *uua =
 		    kmem_alloc(sizeof (*uua), KM_SLEEP);

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -2993,6 +2993,7 @@ dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	int64_t unused_refres_delta;
 	blkptr_t tmp;
+	spa_feature_t f = 0;
 
 	ASSERT(clone->ds_reserved == 0);
 	/*
@@ -3007,7 +3008,7 @@ dsl_dataset_clone_swap_sync_impl(dsl_dataset_t *clone,
 	/*
 	 * Swap per-dataset feature flags.
 	 */
-	for (spa_feature_t f = 0; f < SPA_FEATURES; f++) {
+	for (f; f < SPA_FEATURES; f++) {
 		boolean_t clone_inuse;
 		boolean_t origin_head_inuse;
 

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -1031,10 +1031,11 @@ static uint64_t
 dsl_dir_space_towrite(dsl_dir_t *dd)
 {
 	uint64_t space = 0;
+	int i = 0;
 
 	ASSERT(MUTEX_HELD(&dd->dd_lock));
 
-	for (int i = 0; i < TXG_SIZE; i++) {
+	for (i; i < TXG_SIZE; i++) {
 		space += dd->dd_space_towrite[i & TXG_MASK];
 		ASSERT3U(dd->dd_space_towrite[i & TXG_MASK], >=, 0);
 	}
@@ -1124,6 +1125,7 @@ dsl_dir_tempreserve_impl(dsl_dir_t *dd, uint64_t asize, boolean_t netfree,
 	struct tempreserve *tr;
 	int retval = EDQUOT;
 	uint64_t ref_rsrv = 0;
+	int i = 0;
 
 	ASSERT3U(txg, !=, 0);
 	ASSERT3S(asize, >, 0);
@@ -1135,7 +1137,7 @@ dsl_dir_tempreserve_impl(dsl_dir_t *dd, uint64_t asize, boolean_t netfree,
 	 * when checking for over-quota because they get one free hit.
 	 */
 	uint64_t est_inflight = dsl_dir_space_towrite(dd);
-	for (int i = 0; i < TXG_SIZE; i++)
+	for (i; i < TXG_SIZE; i++)
 		est_inflight += dd->dd_tempreserved[i];
 	uint64_t used_on_disk = dsl_dir_phys(dd)->dd_used_bytes;
 

--- a/module/zfs/multilist.c
+++ b/module/zfs/multilist.c
@@ -72,6 +72,7 @@ static multilist_t *
 multilist_create_impl(size_t size, size_t offset,
     unsigned int num, multilist_sublist_index_func_t *index_func)
 {
+	int i = 0;
 	ASSERT3U(size, >, 0);
 	ASSERT3U(size, >=, offset + sizeof (multilist_node_t));
 	ASSERT3U(num, >, 0);
@@ -87,7 +88,7 @@ multilist_create_impl(size_t size, size_t offset,
 
 	ASSERT3P(ml->ml_sublists, !=, NULL);
 
-	for (int i = 0; i < ml->ml_num_sublists; i++) {
+	for (i; i < ml->ml_num_sublists; i++) {
 		multilist_sublist_t *mls = &ml->ml_sublists[i];
 		mutex_init(&mls->mls_lock, NULL, MUTEX_NOLOCKDEP, NULL);
 		list_create(&mls->mls_list, size, offset);

--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -1041,6 +1041,7 @@ zfsvfs_create(const char *osname, zfsvfs_t **zfvp)
 	objset_t *os;
 	zfsvfs_t *zfsvfs;
 	int error;
+	int i = 0;
 
 	zfsvfs = kmem_zalloc(sizeof (zfsvfs_t), KM_SLEEP);
 
@@ -1072,7 +1073,7 @@ zfsvfs_create(const char *osname, zfsvfs_t **zfvp)
 	zfsvfs->z_hold_trees = vmem_zalloc(sizeof (avl_tree_t) * size,
 	    KM_SLEEP);
 	zfsvfs->z_hold_locks = vmem_zalloc(sizeof (kmutex_t) * size, KM_SLEEP);
-	for (int i = 0; i != size; i++) {
+	for (i; i != size; i++) {
 		avl_create(&zfsvfs->z_hold_trees[i], zfs_znode_hold_compare,
 		    sizeof (znode_hold_t), offsetof(znode_hold_t, zh_node));
 		mutex_init(&zfsvfs->z_hold_locks[i], NULL, MUTEX_DEFAULT, NULL);


### PR DESCRIPTION
Some C99 inline declarations have slipped into the codebase.
Fixup to C89 declarations in function body outside the for loop
definition.

Fix _‘for’ loop initial declarations are only allowed in C99 or C11 mode_ 
errors generated during in-tree build attempt