### PR TITLE
libspl: Fix incorrect use of platform defines on sparc64

### DIFF
--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -130,7 +130,7 @@ extern "C" {
 #define	_SUNOS_VTOC_16
 
 /* sparc arch specific defines */
-#elif defined(__sparc) || defined(__sparc__) || defined(__sparc64__)
+#elif defined(__sparc) || defined(__sparc__)
 
 #if !defined(__sparc)
 #define	__sparc
@@ -143,7 +143,7 @@ extern "C" {
 #define	_BIG_ENDIAN
 #define	_SUNOS_VTOC_16
 
-#if defined(__sparc64__)
+#if defined(__arch64__)
 #if !defined(_LP64)
 #define	_LP64
 #endif


### PR DESCRIPTION
libspl tries to detect sparc64 by checking whether __sparc64__
is defined. Unfortunately, this assumption is not correct as
sparc64 does not define __sparc64__ but it defines __sparc__
and __arch64__ instead. This leads to sparc64 being detected
as 32-Bit sparc and the build fails because both _ILP32 and
_LP64 are defined in this case.

To fix the problem, remove the checks for __sparc64__ and
just check __arch64__ if a sparc host was previously
detected with __sparc__.

### Description
Fixes the build on Linux/sparc64 which currently fails with:

gcc -DHAVE_CONFIG_H -include ../../../zfs_config.h -I../../../lib/libspl/include  -D_GNU_SOURCE -D__EXTENSIONS__ -D_REENTR
ANT -D_POSIX_PTHREAD_SEMANTICS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DHAVE_LARGE_STACKS=1 -DTEXT_DOMAIN=\"zfs-linu
x-user\" -DLIBEXECDIR=\"/usr/lib/sparc64-linux-gnu\" -DRUNSTATEDIR=\"/var/run\" -DSBINDIR=\"/sbin\" -DSYSCONFDIR=\"/etc\" 
-Wdate-time -D_FORTIFY_SOURCE=2 -DNDEBUG -Wall -Wstrict-prototypes -Wno-unused-but-set-variable -Wno-bool-compare -fno-str
ict-aliasing -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC 
-c -S atomic.c -o atomic.S
In file included from ../../../lib/libspl/include/sys/types.h:30:0,
                 from ../../../lib/libspl/include/atomic.h:30,
                 from atomic.c:27:
../../../lib/libspl/include/sys/isa_defs.h:197:2: error: #error "Both _ILP32 and _LP64 are defined"
 #error "Both _ILP32 and _LP64 are defined"
  ^~~~~
Makefile:623: recipe for target 'all-am' failed

### Motivation and Context
Fixes a build problem.

### How Has This Been Tested?
Tested on Debian sparc64 (unstable) running on a SPARC T5.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
