### PR TITLE
Accept raidz and mirror with the same redundancy.

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -763,6 +763,19 @@ typedef struct replication_level {
 
 #define	ZPOOL_FUZZ	(16 * 1024 * 1024)
 
+static boolean_t
+is_raidz_mirror(replication_level_t *a, replication_level_t *b,
+    replication_level_t **raidz, replication_level_t **mirror)
+{
+	if (strcmp(a->zprl_type, "raidz") == 0 &&
+	    strcmp(b->zprl_type, "mirror") == 0) {
+		*raidz = a;
+		*mirror = b;
+		return (B_TRUE);
+	}
+	return (B_FALSE);
+}
+
 /*
  * Given a list of toplevel vdevs, return the current replication level.  If
  * the config is inconsistent, then NULL is returned.  If 'fatal' is set, then
@@ -780,6 +793,7 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 	replication_level_t lastrep = {0};
 	replication_level_t rep;
 	replication_level_t *ret;
+	replication_level_t *raidz, *mirror;
 	boolean_t dontreport;
 
 	ret = safe_malloc(sizeof (replication_level_t));
@@ -962,7 +976,35 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 		 * different.
 		 */
 		if (lastrep.zprl_type != NULL) {
-			if (strcmp(lastrep.zprl_type, rep.zprl_type) != 0) {
+			if (is_raidz_mirror(&lastrep, &rep, &raidz, &mirror) ||
+			    is_raidz_mirror(&rep, &lastrep, &raidz, &mirror)) {
+				/*
+				 * Accepted raidz and mirror when they can
+				 * handle the same number of disk failures.
+				 */
+				if (raidz->zprl_parity !=
+				    mirror->zprl_children - 1) {
+					if (ret != NULL)
+						free(ret);
+					ret = NULL;
+					if (fatal)
+						vdev_error(gettext(
+						    "mismatched replication "
+						    "level: "
+						    "%s and %s vdevs with "
+						    "different redundancy, "
+						    "%llu vs. %llu (%llu-way) "
+						    "are present\n"),
+						    raidz->zprl_type,
+						    mirror->zprl_type,
+						    raidz->zprl_parity,
+						    mirror->zprl_children - 1,
+						    mirror->zprl_children);
+					else
+						return (NULL);
+				}
+			} else if (strcmp(lastrep.zprl_type, rep.zprl_type) !=
+			    0) {
 				if (ret != NULL)
 					free(ret);
 				ret = NULL;


### PR DESCRIPTION
### Description
Allow to create a pool with both raidz and mirror members, without giving `-f`, as long as they have matching redundancy.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is intended to address the [observation](https://github.com/zfsonlinux/zfs/pull/5182#issuecomment-288456013) by @ahrens in #5182.
Having e.g. raidz HDD vdevs together with SSD mirrors for dedicated data would be common with metadata allocation classes, but would make sense also generally.

### How Has This Been Tested?
Simple pool creation tests by hand.

I suppose some test cases should be added, but as this broke none, I do not really know where to start...  :smile:

### Types of changes
- [x] Minor feature tweak (non-breaking change which adds functionality)

### Checklist:
- [ ] My code follows the ZFS on Linux code style requirements.
Heavy indentation in the affected function made it look a bit weird.
- [ ] I have updated the documentation accordingly.
The wording under `create` in `zpool.8` does not explicitly say that mixing raidz and mirror is an inconsistent replication strategy that requires `-f` to be used.  In that sense, this change could be considered to relax the code within the limits of the current documentation.  (Of course willing to modify.)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
