### PR TITLE
Allow c99 when building ZFS in the kernel tree

### DIFF
--- a/copy-builtin
+++ b/copy-builtin
@@ -59,8 +59,11 @@ EOF
 
 {
 	cat <<-"EOF"
-	ZFS_MODULE_CFLAGS  = -I$(srctree)/include/zfs -I$(srctree)/include/spl 
-	ZFS_MODULE_CFLAGS += -include $(srctree)/spl_config.h -include $(srctree)/zfs_config.h
+	ZFS_MODULE_CFLAGS  = -I$(srctree)/include/zfs
+	ZFS_MODULE_CFLAGS += -I$(srctree)/include/spl
+	ZFS_MODULE_CFLAGS += -include $(srctree)/spl_config.h
+	ZFS_MODULE_CFLAGS += -include $(srctree)/zfs_config.h
+	ZFS_MODULE_CLFAGS += -std=gnu99
 	export ZFS_MODULE_CFLAGS
 
 	obj-$(CONFIG_ZFS) :=


### PR DESCRIPTION
Commit 4a5d7f82 enabled building c99 out of the kernel tree.
However, when building as part of the kernel different Makefiles
are used and -std=gnu99 must additionially be added there.

