### PR TITLE
Disable rsend_009_pos

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -567,11 +567,11 @@ tests = ['reservation_001_pos', 'reservation_002_pos', 'reservation_003_pos',
 
 # DISABLED:
 # rsend_008_pos - Fails for OpenZFS on illumos
+# rsend_009_pos - https://github.com/zfsonlinux/zfs/issues/5887
 # rsend_020_pos - ASSERTs in dump_record()
 [tests/functional/rsend]
 tests = ['rsend_001_pos', 'rsend_002_pos', 'rsend_003_pos', 'rsend_004_pos',
     'rsend_005_pos', 'rsend_006_pos', 'rsend_007_pos',
-    'rsend_009_pos',
     'rsend_010_pos', 'rsend_011_pos', 'rsend_012_pos',
     'rsend_013_pos', 'rsend_014_pos', 'rsend_019_pos',
     'rsend_021_pos', 'rsend_022_pos', 'rsend_024_pos']


### PR DESCRIPTION
Test rsend_009_pos has been observed to fail pretty frequently
when testing using a kmemleak enabled kernel.  For the moment
disable this test case until the underlying issue is resolved.

Issue #5887 