### PR TITLE
OpenZFS 7990 - libzfs: snapspec_cb() does not need to call zfs_strdup()

### DIFF
--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -312,26 +312,23 @@ static int
 snapspec_cb(zfs_handle_t *zhp, void *arg)
 {
 	snapspec_arg_t *ssa = arg;
-	char *shortsnapname;
+	const char *shortsnapname;
 	int err = 0;
 
 	if (ssa->ssa_seenlast)
 		return (0);
-	shortsnapname = zfs_strdup(zhp->zfs_hdl,
-	    strchr(zfs_get_name(zhp), '@') + 1);
 
+	shortsnapname = strchr(zfs_get_name(zhp), '@') + 1;
 	if (!ssa->ssa_seenfirst && strcmp(shortsnapname, ssa->ssa_first) == 0)
 		ssa->ssa_seenfirst = B_TRUE;
+	if (strcmp(shortsnapname, ssa->ssa_last) == 0)
+		ssa->ssa_seenlast = B_TRUE;
 
 	if (ssa->ssa_seenfirst) {
 		err = ssa->ssa_func(zhp, ssa->ssa_arg);
 	} else {
 		zfs_close(zhp);
 	}
-
-	if (strcmp(shortsnapname, ssa->ssa_last) == 0)
-		ssa->ssa_seenlast = B_TRUE;
-	free(shortsnapname);
 
 	return (err);
 }


### PR DESCRIPTION
Authored by: Marcel Telka <marcel@telka.sk>
Reviewed by: Yuri Pankov <yuri.pankov@gmail.com>
Reviewed by: Toomas Soome <tsoome@me.com>
Approved by: Matthew Ahrens <mahrens@delphix.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/7990
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/d8584ba