### PR TITLE
Additional Information for Zedlets

### DIFF
--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -628,6 +628,16 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 	case DATA_TYPE_INT32:
 		(void) nvpair_value_int32(nvp, (int32_t *)&i32);
 		_zed_event_add_var(eid, zsp, prefix, name, "%d", i32);
+		/*
+		 * shadow readable strings for pool state
+		 */
+		if (strcmp(name, FM_EREPORT_PAYLOAD_ZFS_POOL_STATE) == 0) {
+			char alt[32];
+
+			(void) snprintf(alt, sizeof (alt), "%s_str", name);
+			_zed_event_add_var(eid, zsp, prefix, alt, "%s",
+			    zpool_pool_state_to_name(i32));
+		}
 		break;
 	case DATA_TYPE_UINT32:
 		(void) nvpair_value_uint32(nvp, &i32);

--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -628,16 +628,6 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 	case DATA_TYPE_INT32:
 		(void) nvpair_value_int32(nvp, (int32_t *)&i32);
 		_zed_event_add_var(eid, zsp, prefix, name, "%d", i32);
-		/*
-		 * shadow readable strings for pool state
-		 */
-		if (strcmp(name, FM_EREPORT_PAYLOAD_ZFS_POOL_STATE) == 0) {
-			char alt[32];
-
-			(void) snprintf(alt, sizeof (alt), "%s_str", name);
-			_zed_event_add_var(eid, zsp, prefix, alt, "%s",
-			    zpool_pool_state_to_name(i32));
-		}
 		break;
 	case DATA_TYPE_UINT32:
 		(void) nvpair_value_uint32(nvp, &i32);
@@ -663,6 +653,16 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 			(void) snprintf(alt, sizeof (alt), "%s_str", name);
 			_zed_event_add_var(eid, zsp, prefix, alt, "%s",
 			    zpool_state_to_name(i64, VDEV_AUX_NONE));
+		} else
+		/*
+		 * shadow readable strings for pool state
+		 */
+		if (strcmp(name, FM_EREPORT_PAYLOAD_ZFS_POOL_STATE) == 0) {
+			char alt[32];
+
+			(void) snprintf(alt, sizeof (alt), "%s_str", name);
+			_zed_event_add_var(eid, zsp, prefix, alt, "%s",
+			    zpool_pool_state_to_name(i32));
 		}
 		break;
 	case DATA_TYPE_DOUBLE:

--- a/include/sys/fm/fs/zfs.h
+++ b/include/sys/fm/fs/zfs.h
@@ -54,6 +54,7 @@ extern "C" {
 #define	FM_EREPORT_PAYLOAD_ZFS_POOL_FAILMODE	"pool_failmode"
 #define	FM_EREPORT_PAYLOAD_ZFS_POOL_GUID	"pool_guid"
 #define	FM_EREPORT_PAYLOAD_ZFS_POOL_CONTEXT	"pool_context"
+#define	FM_EREPORT_PAYLOAD_ZFS_POOL_STATE	"pool_state"
 #define	FM_EREPORT_PAYLOAD_ZFS_VDEV_GUID	"vdev_guid"
 #define	FM_EREPORT_PAYLOAD_ZFS_VDEV_TYPE	"vdev_type"
 #define	FM_EREPORT_PAYLOAD_ZFS_VDEV_PATH	"vdev_path"

--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -269,7 +269,7 @@ zfs_ereport_start(nvlist_t **ereport_out, nvlist_t **detector_out,
 	fm_payload_set(ereport,
 	    FM_EREPORT_PAYLOAD_ZFS_POOL, DATA_TYPE_STRING, spa_name(spa),
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_GUID, DATA_TYPE_UINT64, spa_guid(spa),
-	    FM_EREPORT_PAYLOAD_ZFS_POOL_STATE, DATA_TYPE_INT32, spa_state(spa),
+	    FM_EREPORT_PAYLOAD_ZFS_POOL_STATE, DATA_TYPE_UINT64, spa_state(spa),
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_CONTEXT, DATA_TYPE_INT32,
 	    spa_load_state(spa), NULL);
 
@@ -916,7 +916,7 @@ zfs_post_common(spa_t *spa, vdev_t *vd, const char *type, const char *name,
 	    FM_EREPORT_PAYLOAD_ZFS_POOL, spa_name(spa)));
 	VERIFY0(nvlist_add_uint64(resource,
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_GUID, spa_guid(spa)));
-	VERIFY0(nvlist_add_int32(resource,
+	VERIFY0(nvlist_add_uint64(resource,
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_STATE, spa_state(spa)));
 	VERIFY0(nvlist_add_int32(resource,
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_CONTEXT, spa_load_state(spa)));

--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -912,6 +912,8 @@ zfs_post_common(spa_t *spa, vdev_t *vd, const char *type, const char *name,
 	    ZFS_ERROR_CLASS, name);
 	VERIFY0(nvlist_add_uint8(resource, FM_VERSION, FM_RSRC_VERSION));
 	VERIFY0(nvlist_add_string(resource, FM_CLASS, class));
+	VERIFY0(nvlist_add_string(resource,
+	    FM_EREPORT_PAYLOAD_ZFS_POOL, spa_name(spa)));
 	VERIFY0(nvlist_add_uint64(resource,
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_GUID, spa_guid(spa)));
 	VERIFY0(nvlist_add_int32(resource,

--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -266,9 +266,10 @@ zfs_ereport_start(nvlist_t **ereport_out, nvlist_t **detector_out,
 	/*
 	 * Generic payload members common to all ereports.
 	 */
-	fm_payload_set(ereport, FM_EREPORT_PAYLOAD_ZFS_POOL,
-	    DATA_TYPE_STRING, spa_name(spa), FM_EREPORT_PAYLOAD_ZFS_POOL_GUID,
-	    DATA_TYPE_UINT64, spa_guid(spa),
+	fm_payload_set(ereport,
+	    FM_EREPORT_PAYLOAD_ZFS_POOL, DATA_TYPE_STRING, spa_name(spa),
+	    FM_EREPORT_PAYLOAD_ZFS_POOL_GUID, DATA_TYPE_UINT64, spa_guid(spa),
+	    FM_EREPORT_PAYLOAD_ZFS_POOL_STATE, DATA_TYPE_INT32, spa_state(spa),
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_CONTEXT, DATA_TYPE_INT32,
 	    spa_load_state(spa), NULL);
 
@@ -913,6 +914,8 @@ zfs_post_common(spa_t *spa, vdev_t *vd, const char *type, const char *name,
 	VERIFY0(nvlist_add_string(resource, FM_CLASS, class));
 	VERIFY0(nvlist_add_uint64(resource,
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_GUID, spa_guid(spa)));
+	VERIFY0(nvlist_add_int32(resource,
+	    FM_EREPORT_PAYLOAD_ZFS_POOL_STATE, spa_state(spa)));
 	VERIFY0(nvlist_add_int32(resource,
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_CONTEXT, spa_load_state(spa)));
 


### PR DESCRIPTION
Provide more information for ZEDLETs to work with, including POOL NAME (this seems to be an oversight more than anything else), and POOL STATE (to differentiate exports and destroys).

### Description
Ensure pool name is exported to ZED along with pool guid.
Export pool state to differentiate export and destroy.

### Motivation and Context
Adding this info simplifies and enables custom ZEDLETs to properly handle events.

### How Has This Been Tested?
This has been tested on el7.3 via import/export/destroy of zpool, and monitoring ZED 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Change has been approved by a ZFS on Linux member.
