### PR TITLE
Prevent commitcheck.sh from running twice

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,7 +55,7 @@ shellcheck:
 		shellcheck --exclude=SC1090 --format gcc scripts/paxcheck.sh \
 			scripts/zloop.sh \
 			scripts/zfs-tests.sh \
-			scripts/zfs.sh; \
+			scripts/zfs.sh \
 			scripts/commitcheck.sh; \
 		(find cmd/zed/zed.d/*.sh -type f) | \
 		 grep -v 'zfs-script-config' | \

--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -11,12 +11,14 @@ function test_url()
         echo "\"$url\" is unreachable"
         return 1
     fi
+
+    return 0
 }
 
 # check for a tagged line
 function check_tagged_line()
 {
-    regex='^\s*'"$1"':\s+\S+\s+\<\S+\>'
+    regex='^\s*'"$1"':\s[[:print:]]+\s<[[:graph:]]+>$'
     foundline=$(git log -n 1 "$REF" | egrep -m 1 "$regex")
     if [ -z "$foundline" ]; then
         echo "error: missing \"$1\""
@@ -29,7 +31,7 @@ function check_tagged_line()
 # check for a tagged line and check that the link is valid
 function check_tagged_line_with_url ()
 {
-    regex='^\s*'"$1"':\s+\K(\S+)'
+    regex='^\s*'"$1"':\s\K([[:graph:]]+)$'
     foundline=$(git log -n 1 "$REF" | grep -Po "$regex")
     if [ -z "$foundline" ]; then
         echo "error: missing \"$1\""


### PR DESCRIPTION
### Description
`commitcheck.sh` runs twice when running a `make checkstyle`. A stray semicolon in the `shellcheck` make target is causing the problem.

### How Has This Been Tested?
On a CentOS 7 VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.