### PR TITLE
zfs-tests - zfs_get_005_neg.ksh fix typos

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_005_neg.ksh
@@ -133,11 +133,11 @@ create_bookmark $TESTPOOL/$TESTVOL $TESTSNAP $TESTBKMARK
 
 log_note "Valid options + invalid properties, 'zfs get' should fail."
 test_options "$val_opts_str" "$inval_props_str"
-test_options_bookmark "$val_opts_str" "$inval_props_str"
+test_options_bookmarks "$val_opts_str" "$inval_props_str"
 
 log_note "Invalid options + valid properties, 'zfs get' should fail."
 test_options "$inval_opts_str" "$val_props_str"
-test_options_bookmark "$inval_opts_str" "$val_bookmark_props"
+test_options_bookmarks "$inval_opts_str" "$val_bookmark_props"
 
 log_note "Invalid options + invalid properties, 'zfs get' should fail."
 test_options "$inval_opts_str" "$inval_props_str"


### PR DESCRIPTION
'test_options_bookmark' function must have `s` at the end.

Signed-off-by: George Melikov <mail@gmelikov.ru>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
