### PR TITLE
list -o props should be alloc,free not used,avail

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1877,7 +1877,7 @@ Specify \fBu\fR for a printed representation of the internal representation of t
 \fB\fB-o\fR \fIprops\fR\fR
 .ad
 .RS 12n
-Comma-separated list of properties to display. See the "Properties" section for a list of valid properties. The default list is "name, size, used, available, fragmentation, expandsize, capacity, dedupratio, health, altroot"
+Comma-separated list of properties to display. See the "Properties" section for a list of valid properties. The default list is "name, size, alloc, free, fragmentation, expandsize, capacity, dedupratio, health, altroot"
 .RE
 
 .sp

--- a/tests/zfs-tests/tests/functional/cli_user/zpool_list/zpool_list_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/zpool_list/zpool_list_001_pos.ksh
@@ -50,8 +50,8 @@ fi
 set -A args "list $TESTPOOL" "list -H $TESTPOOL" "list" "list -H" \
     "list -H -o name $TESTPOOL" "list -o name $TESTPOOL" \
     "list -o name,size,capacity,health,altroot $TESTPOOL" \
-    "list -H -o name,size,capacity,health,altroot $TESTPOOL"
-
+    "list -H -o name,size,capacity,health,altroot $TESTPOOL" \
+    "list -o alloc,free $TESTPOOL"
 log_assert "zpool list [-H] [-o filed[,filed]*] [<pool_name> ...]"
 
 typeset -i i=0


### PR DESCRIPTION
**Description**
This commit fixes the zpool manpage to reflect the correct list options; 'alloc' and 'free', instead of the invalid ones 'used','avail'.

**Motivation and Context**
zpool manpage was incorrect.

**How Has This Been Tested?**
A modification to the unit tests for zpool have been made to cover these properties.

**Types of changes**
[ ] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Performance enhancement (non-breaking change which improves efficiency)
[x] Code cleanup (non-breaking change which makes code smaller or more readable)
[ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
 [x] My code follows the ZFS on Linux code style requirements.
 [x] I have updated the documentation accordingly.
 [x] I have read the CONTRIBUTING document.
 [x] I have added tests to cover my changes.
 [x] All new and existing tests passed.
 [ ] Change has been approved by a ZFS on Linux member.
