### PR TITLE
SEEK_HOLE should not block on txg_wait_synced()

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1430,6 +1430,20 @@ Use \fB1\fR for yes (default) and \fB0\fR to disable.
 .sp
 .ne 2
 .na
+\fBzfs_dmu_offset_next_sync\fR (int)
+.ad
+.RS 12n
+Enable forcing txg sync to find holes. When enabled forces ZFS to act
+like prior versions when SEEK_HOLE or SEEK_DATA flags are used, which
+when a dnode is dirty causes txg's to be synced so that this data can be
+found.
+.sp
+Use \fB1\fR for yes and \fB0\fR to disable (default).
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_pd_bytes_max\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1989,32 +1989,44 @@ dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp,
 	zp->zp_nopwrite = nopwrite;
 }
 
+/*
+ * This fn is only called from zfs_holey_common for zpl_llseek
+ * Previously, this required flushing of all the TXG's associated with this
+ * file in order to scan the dnode for holes. This caused extremely poor
+ * performance for dirty files, for example log files. As a compromise, if a
+ * dnode is clean, then we can provide hole data. However if a dnode is dirty,
+ * simply fall back to what we would have done if we did not support seeking
+ * holes in this vfsop at all, which is a valid thing to do.
+ */
 int
 dmu_offset_next(objset_t *os, uint64_t object, boolean_t hole, uint64_t *off)
 {
 	dnode_t *dn;
 	int i, err;
+	boolean_t clean = B_TRUE;
 
 	err = dnode_hold(os, object, FTAG, &dn);
 	if (err)
 		return (err);
+
 	/*
-	 * Sync any current changes before
-	 * we go trundling through the block pointers.
+	 * Check if dnode is dirty
 	 */
-	for (i = 0; i < TXG_SIZE; i++) {
-		if (list_link_active(&dn->dn_dirty_link[i]))
-			break;
-	}
-	if (i != TXG_SIZE) {
-		dnode_rele(dn, FTAG);
-		txg_wait_synced(dmu_objset_pool(os), 0);
-		err = dnode_hold(os, object, FTAG, &dn);
-		if (err)
-			return (err);
+	if (dn->dn_dirtyctx != DN_UNDIRTIED) {
+		for (i = 0; i < TXG_SIZE; i++) {
+			if (!list_is_empty(&dn->dn_dirty_records[i])) {
+				clean = B_FALSE;
+				break;
+			}
+		}
 	}
 
-	err = dnode_next_offset(dn, (hole ? DNODE_FIND_HOLE : 0), off, 1, 1, 0);
+	if (clean)
+		err = dnode_next_offset(dn,
+		    (hole ? DNODE_FIND_HOLE : 0), off, 1, 1, 0);
+	else
+		err = SET_ERROR(EBUSY);
+
 	dnode_rele(dn, FTAG);
 
 	return (err);

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -278,6 +278,10 @@ zfs_holey_common(struct inode *ip, int cmd, loff_t *off)
 	if (error == ESRCH)
 		return (SET_ERROR(ENXIO));
 
+	/* file was dirty, so fall back to using file_sz logic */
+	if (error == EBUSY)
+		error = 0;
+
 	/*
 	 * We could find a hole that begins after the logical end-of-file,
 	 * because dmu_offset_next() only works on whole blocks.  If the


### PR DESCRIPTION
Force flushing of txg's can be painfully slow when competing for disk io,
since this is a process meant to execute asyncronously. Optimize this path
via allowing data/hole seeking if the file is clean, but if dirty fall back
to old logic. This is a compromise to disabling the feature entirely.

Signed-off-by: Debabrata Banerjee <dbanerje@akamai.com>

### Motivation and Context
https://github.com/zfsonlinux/zfs/issues/4306

### How Has This Been Tested?
Create bar.log > 32kB via appending
Create diskio's with any tool of at least queue depth of 1 on all pool members. I used 1 outstanding random io per disk.
Test speed of "touch bar.log; time strace grep foo bar.log". When TXG's must be synced, takes seconds to minutes, being hung up at "lseek(3, 32768, SEEK_HOLE)". With the fix it takes a few milliseconds (normal time to grep).
Fix should not break correctness, however it falls back to not providing hole data when the file is dirty. This should satisfy everyone's use cases.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
