### PR TITLE
Correct Coverity Scan Issue 161264

### DIFF
--- a/cmd/zed/zed_event.c
+++ b/cmd/zed/zed_event.c
@@ -662,7 +662,7 @@ _zed_event_add_nvpair(uint64_t eid, zed_strings_t *zsp, nvpair_t *nvp)
 
 			(void) snprintf(alt, sizeof (alt), "%s_str", name);
 			_zed_event_add_var(eid, zsp, prefix, alt, "%s",
-			    zpool_pool_state_to_name(i32));
+			    zpool_pool_state_to_name(i64));
 		}
 		break;
 	case DATA_TYPE_DOUBLE:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
In _zed_event_add_nvpair, when handling DATA_TYPE_UINT64,
we should be using i64 throughout the entire case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
