### PR TITLE
Fix regression in zfs_ereport_start()

### DIFF
--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -269,7 +269,8 @@ zfs_ereport_start(nvlist_t **ereport_out, nvlist_t **detector_out,
 	fm_payload_set(ereport,
 	    FM_EREPORT_PAYLOAD_ZFS_POOL, DATA_TYPE_STRING, spa_name(spa),
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_GUID, DATA_TYPE_UINT64, spa_guid(spa),
-	    FM_EREPORT_PAYLOAD_ZFS_POOL_STATE, DATA_TYPE_UINT64, spa_state(spa),
+	    FM_EREPORT_PAYLOAD_ZFS_POOL_STATE, DATA_TYPE_UINT64,
+	    (uint64_t)spa_state(spa),
 	    FM_EREPORT_PAYLOAD_ZFS_POOL_CONTEXT, DATA_TYPE_INT32,
 	    spa_load_state(spa), NULL);
 


### PR DESCRIPTION
On 32-bit platforms spa_state is 32bits without cast, and thus cased a NULL pointer dereference when treated as 64bit in var arg.

Fixes zfsonlinux/zfs#5965

Signed-off-by: Nathaniel Clark <nathaniel.l.clark@intel.com>