### PR TITLE
Fix zinject probe error handling

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1055,7 +1055,6 @@ vdev_probe(vdev_t *vd, zio_t *zio)
 	spa_t *spa = vd->vdev_spa;
 	vdev_probe_stats_t *vps = NULL;
 	zio_t *pio;
-	int l;
 
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
 
@@ -1125,7 +1124,7 @@ vdev_probe(vdev_t *vd, zio_t *zio)
 		return (NULL);
 	}
 
-	for (l = 1; l < VDEV_LABELS; l++) {
+	for (int l = 0; l < VDEV_LABELS; l++) {
 		zio_nowait(zio_read_phys(pio, vd,
 		    vdev_label_offset(vd->vdev_psize, l,
 		    offsetof(vdev_label_t, vl_pad2)), VDEV_PAD_SIZE,

--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -261,9 +261,10 @@ zio_handle_device_injection(vdev_t *vd, zio_t *zio, int error)
 
 	/*
 	 * We skip over faults in the labels unless it's during
-	 * device open (i.e. zio == NULL).
+	 * device open (i.e. zio == NULL), or as a result of a probe
+	 * IO intended to assess the health of a device.
 	 */
-	if (zio != NULL) {
+	if ((zio != NULL) && !(zio->io_flags & ZIO_FLAG_PROBE)) {
 		uint64_t offset = zio->io_offset;
 
 		if (offset < VDEV_LABEL_START_SIZE ||


### PR DESCRIPTION
### Description

When using `zinject -d $DISK -e io -T write $POOL` to simulate IO
errors it is critical that probe IOs fail like normal IOs.  They
must not be excluded in zio_handle_device_injection().  Doing so
results in the vdev always being assessed as healthy and never
getting faulted.

Additionally, update vdev_probe() such that it reads all four
labels instead of just the last three.

### Motivation and Context

Issue #5970