### PR TITLE
Skip xfstests on Amazon Linux

### DIFF
--- a/TEST
+++ b/TEST
@@ -71,6 +71,8 @@ TEST_ZCONFIG_OPTIONS="-c -s10"
 #
 case "$BB_NAME" in
 Amazon*)
+    # ZFS enabled xfstests fails to build
+    TEST_XFSTESTS_SKIP="yes"
     ;;
 CentOS-7*)
     # ZFS enabled xfstests fails to build


### PR DESCRIPTION
### Description

The ZFS enabled versions of xfstests fails to build cleanly on
Amazon Linux.  This issue should be resolved by rebasing the ZFS
patches against the latest xfstests and pushing those patches
upstream.  This would allow us to use an unmodified xfstests.

### Motivation and Context

Issue #5481 