### PR TITLE
OpenZFS 6865 - want zfs-tests cases for zpool labelclear command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,6 +213,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/cli_root/zpool_get/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_history/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_import/Makefile
+	tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_offline/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_online/Makefile

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -286,6 +286,7 @@ extern int zpool_label_disk_wait(char *, int);
 extern int zpool_label_disk(libzfs_handle_t *, zpool_handle_t *, char *);
 
 int zfs_dev_is_dm(char *dev_name);
+int zfs_dev_is_whole_disk(char *dev_name);
 char *zfs_get_underlying_path(char *dev_name);
 char *zfs_get_enclosure_sysfs_path(char *dev_name);
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -308,6 +308,11 @@ tests = ['zpool_import_001_pos',
     'zpool_import_missing_002_pos', 'zpool_import_missing_003_pos',
     'zpool_import_rename_001_pos']
 
+[tests/functional/cli_root/zpool_labelclear]
+tests = ['zpool_labelclear_active', 'zpool_labelclear_exported']
+pre =
+post =
+
 [tests/functional/cli_root/zpool_offline]
 tests = ['zpool_offline_001_pos', 'zpool_offline_002_neg']
 

--- a/tests/zfs-tests/tests/functional/cli_root/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/Makefile.am
@@ -37,6 +37,7 @@ SUBDIRS = \
 	zpool_get \
 	zpool_history \
 	zpool_import \
+	zpool_labelclear \
 	zpool_offline \
 	zpool_online \
 	zpool_remove \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/add-o_ashift.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/add-o_ashift.ksh
@@ -100,7 +100,7 @@ do
 	log_mustnot zpool add -o ashift="$badval" $disk2
 	log_must zpool destroy $TESTPOOL
 	log_must zpool labelclear $disk1
-	log_must zpool labelclear $disk2
+	log_mustnot zpool labelclear $disk2
 done
 
 log_pass "zpool add -o ashift=<n>' works with different ashift values"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/Makefile.am
@@ -1,0 +1,5 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_labelclear
+dist_pkgdata_SCRIPTS = \
+	labelclear.cfg \
+	zpool_labelclear_active.ksh \
+	zpool_labelclear_exported.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
@@ -1,0 +1,26 @@
+#!/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+typeset LABELCLEAR="zpool labelclear"
+typeset LABELREAD="zdb -lq"
+
+typeset disks=(${DISKS[*]})
+typeset disk1=${disks[0]}
+typeset disk2=${disks[1]}
+typeset disk3=${disks[2]}

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_active.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_active.ksh
@@ -1,0 +1,68 @@
+#!/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+
+# DESCRIPTION:
+# Check that zpool labelclear will refuse to clear the label
+# (with or without -f) on any vdevs of the imported pool.
+#
+# STRATEGY:
+# 1. Create the pool with log device.
+# 2. Try clearing the label on data and log devices.
+# 3. Add auxilary (cache/spare) vdevs.
+# 4. Try clearing the label on auxilary vdevs.
+# 5. Check that zpool labelclear will return non-zero and
+#    labels are intact.
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+log_assert "zpool labelclear will fail on all vdevs of imported pool"
+
+# Create simple pool, skip any mounts
+log_must zpool create -O mountpoint=none -f $TESTPOOL $disk1 log $disk2
+
+# Check that labelclear [-f] will fail on ACTIVE pool vdevs
+log_mustnot $LABELCLEAR $disk1
+log_must $LABELREAD $disk1
+log_mustnot $LABELCLEAR -f $disk1
+log_must $LABELREAD $disk1
+log_mustnot $LABELCLEAR $disk2
+log_must $LABELREAD $disk2
+log_mustnot $LABELCLEAR -f $disk2
+log_must $LABELREAD $disk2
+
+# Add a cache/spare to the pool, check that labelclear [-f] will fail
+# on the vdev and will succeed once it's removed from pool config
+for vdevtype in "cache" "spare"; do
+	log_must zpool add $TESTPOOL $vdevtype $disk3
+	log_mustnot $LABELCLEAR $disk3
+	log_must $LABELREAD $disk3
+	log_mustnot $LABELCLEAR -f $disk3
+	log_must $LABELREAD $disk3
+	log_must zpool remove $TESTPOOL $disk3
+	log_must $LABELCLEAR $disk3
+	log_mustnot $LABELREAD $disk3
+done
+
+log_pass "zpool labelclear will fail on all vdevs of imported pool"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_exported.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_exported.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+
+# DESCRIPTION:
+# Check that zpool labelclear will refuse to clear the label
+# on ACTIVE vdevs of exported pool without -f, and will succeeded with -f.
+#
+# STRATEGY:
+# 1. Create a pool with log device.
+# 2. Export the pool.
+# 3. Check that zpool labelclear returns non-zero when trying to
+#    clear the label on ACTIVE vdevs, and succeeds with -f.
+# 4. Add auxilary vdevs (cache/spare).
+# 5. Check that zpool labelclear succeeds on auxilary vdevs of
+#    exported pool.
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+log_assert "zpool labelclear will fail on ACTIVE vdevs of exported pool and" \
+    "succeed with -f"
+
+for vdevtype in "" "cache" "spare"; do
+	# Create simple pool, skip any mounts
+	log_must zpool create -O mountpoint=none -f $TESTPOOL $disk1 log $disk2
+	# Add auxilary vdevs (cache/spare)
+	if [[ -n $vdevtype ]]; then
+		log_must zpool add $TESTPOOL $vdevtype $disk3
+	fi
+	# Export the pool
+	log_must zpool export $TESTPOOL
+
+	# Check that labelclear will fail without -f
+	log_mustnot $LABELCLEAR $disk1
+	log_must $LABELREAD $disk1
+	log_mustnot $LABELCLEAR $disk2
+	log_must $LABELREAD $disk2
+
+	# Check that labelclear will succeed with -f
+	log_must $LABELCLEAR -f $disk1
+	log_mustnot $LABELREAD $disk1
+	log_must $LABELCLEAR -f $disk2
+	log_mustnot $LABELREAD $disk2
+
+	# Check that labelclear on auxilary vdevs will succeed
+	if [[ -n $vdevtype ]]; then
+		log_must $LABELCLEAR $disk3
+		log_mustnot $LABELREAD $disk3
+	fi
+done
+
+log_pass "zpool labelclear will fail on ACTIVE vdevs of exported pool and" \
+    "succeed with -f"

--- a/tests/zfs-tests/tests/functional/fault/auto_online_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_online_001_pos.ksh
@@ -76,7 +76,7 @@ fi
 # Clear disk labels
 for i in {0..2}
 do
-	log_must zpool labelclear -f /dev/disk/by-id/"${devs_id[i]}"
+	zpool labelclear -f /dev/disk/by-id/"${devs_id[i]}"
 done
 
 if is_loop_device $DISK1; then

--- a/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
@@ -87,7 +87,7 @@ log_onexit cleanup
 # Clear disk labels
 for i in {0..2}
 do
-	log_must zpool labelclear -f /dev/disk/by-id/"${devs_id[i]}"
+	zpool labelclear -f /dev/disk/by-id/"${devs_id[i]}"
 done
 
 setup


### PR DESCRIPTION
Authored by: Yuri Pankov <yuri.pankov@nexenta.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: Brian Behlendorf <behlendorf1@llnl.gov>

Porting Notes:
- Updated 'zpool labelclear' and 'zdb -l' such that they attempt
  to find a vdev given solely its short name.  This behavior is
  consistent with the upstream OpenZFS code and the test cases
  depend on it.  The actual implementation differs slightly due
  to device naming conventions on Linux.

OpenZFS-issue: https://www.illumos.org/issues/6865
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/c95076c