### PR TITLE
OpenZFS 2932 - support crash dumps to raidz, etc. pools

### DIFF
--- a/include/zfeature_common.h
+++ b/include/zfeature_common.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  */
 
 #ifndef _ZFEATURE_COMMON_H
@@ -42,6 +43,7 @@ typedef enum spa_feature {
 	SPA_FEATURE_ASYNC_DESTROY,
 	SPA_FEATURE_EMPTY_BPOBJ,
 	SPA_FEATURE_LZ4_COMPRESS,
+	SPA_FEATURE_MULTI_VDEV_CRASH_DUMP,
 	SPA_FEATURE_SPACEMAP_HISTOGRAM,
 	SPA_FEATURE_ENABLED_TXG,
 	SPA_FEATURE_HOLE_BIRTH,

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -279,6 +279,34 @@ an existing space map is upgraded to the new format. Once the feature is
 .sp
 .ne 2
 .na
+\fB\fBmulti_vdev_crash_dump\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID    com.joyent:multi_vdev_crash_dump
+READ\-ONLY COMPATIBLE   no
+DEPENDENCIES    none
+.TE
+
+This feature allows a dump device to be configured with a pool comprised
+of multiple vdevs.  Those vdevs may be arranged in any mirrored or raidz
+configuration.
+
+When the \fBmulti_vdev_crash_dump\fR feature is set to \fBenabled\fR,
+the administrator can use the \fBdumpadm\fR(1M) command to configure a
+dump device on a pool comprised of multiple vdevs.
+
+NOTE: This feature is registered for compatibility reasons under Linux.
+A pool with this feature \fBenabled\fR or \fB\fBactive\fR can be read, but
+it is not required to support crash dumps under Linux. Also, this should
+not cause problems with grub since the feature will not be added to the
+\fBfeatures_for_read:\fR list unless it is active.
+.RE
+
+.sp
+.ne 2
+.na
 \fB\fBextensible_dataset\fR\fR
 .ad
 .RS 4n

--- a/module/zfs/zfeature_common.c
+++ b/module/zfs/zfeature_common.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2014, Nexenta Systems, Inc. All rights reserved.
  */
 
@@ -191,6 +192,11 @@ zpool_feature_init(void)
 	    "org.illumos:lz4_compress", "lz4_compress",
 	    "LZ4 compression algorithm support.",
 	    ZFEATURE_FLAG_ACTIVATE_ON_ENABLE, NULL);
+
+	zfeature_register(SPA_FEATURE_MULTI_VDEV_CRASH_DUMP,
+	    "com.joyent:multi_vdev_crash_dump", "multi_vdev_crash_dump",
+	    "Crash dumps to multiple vdev pools.",
+	    0, NULL);
 
 	zfeature_register(SPA_FEATURE_SPACEMAP_HISTOGRAM,
 	    "com.delphix:spacemap_histogram", "spacemap_histogram",

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -39,7 +39,7 @@ typeset -a properties=("size" "capacity" "altroot" "health" "guid" "version"
     "feature@spacemap_histogram" "feature@enabled_txg" "feature@hole_birth"
     "feature@extensible_dataset" "feature@bookmarks" "feature@embedded_data"
     "feature@sha512" "feature@skein" "feature@edonr"
-    "feature@userobj_accounting")
+    "feature@userobj_accounting" "feature@multi_vdev_crash_dump")
 else
 typeset -a properties=("size" "capacity" "altroot" "health" "guid" "version"
     "bootfs" ""leaked" delegation" "autoreplace" "cachefile" "dedupditto" "dedupratio"


### PR DESCRIPTION
Authored by: Bill Pijewski <wdp@joyent.com>
Reviewed by: Jerry Jelinek <jerry.jelinek@joyent.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Approved by: Dan McDonald <danmcd@nexenta.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/2932
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/810e43b
Closes #5216