### PR TITLE
Use errno.h instead of sys/errno.h

### DIFF
--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -28,7 +28,7 @@
 
 #include <sys/types.h>
 #include <sys/time.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/va_list.h>
 
 #if defined(_KERNEL) && !defined(_BOOT)

--- a/include/sys/u8_textprep.h
+++ b/include/sys/u8_textprep.h
@@ -30,7 +30,7 @@
 
 #include <sys/isa_defs.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <zlib.h>
 #include <libgen.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <sys/spa.h>
 #include <sys/stat.h>
 #include <sys/processor.h>

--- a/module/unicode/u8_textprep.c
+++ b/module/unicode/u8_textprep.c
@@ -49,7 +49,7 @@
 #include <strings.h>
 #endif	/* _KERNEL */
 #include <sys/byteorder.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/u8_textprep_data.h>
 
 

--- a/module/unicode/uconv.c
+++ b/module/unicode/uconv.c
@@ -46,7 +46,7 @@
 #include <sys/u8_textprep.h>
 #endif	/* _KERNEL */
 #include <sys/byteorder.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 
 /*

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -41,7 +41,7 @@
 #include <sys/sunddi.h>
 #include <sys/sa_impl.h>
 #include <sys/dnode.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/zfs_context.h>
 
 /*

--- a/module/zfs/zfs_acl.c
+++ b/module/zfs/zfs_acl.c
@@ -37,7 +37,7 @@
 #include <sys/stat.h>
 #include <sys/kmem.h>
 #include <sys/cmn_err.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/unistd.h>
 #include <sys/sdt.h>
 #include <sys/fs/zfs.h>

--- a/module/zfs/zfs_dir.c
+++ b/module/zfs/zfs_dir.c
@@ -39,7 +39,7 @@
 #include <sys/uio.h>
 #include <sys/pathname.h>
 #include <sys/cmn_err.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/stat.h>
 #include <sys/unistd.h>
 #include <sys/sunddi.h>

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -136,7 +136,7 @@
 
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/uio.h>
 #include <sys/buf.h>
 #include <sys/modctl.h>

--- a/module/zfs/zfs_onexit.c
+++ b/module/zfs/zfs_onexit.c
@@ -25,7 +25,7 @@
 
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/open.h>
 #include <sys/kmem.h>
 #include <sys/conf.h>

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -48,7 +48,7 @@
 #include <vm/pvn.h>
 #include <sys/pathname.h>
 #include <sys/cmn_err.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/unistd.h>
 #include <sys/zfs_dir.h>
 #include <sys/zfs_acl.h>

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -41,7 +41,7 @@
 #include <sys/vnode.h>
 #include <sys/file.h>
 #include <sys/kmem.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/unistd.h>
 #include <sys/mode.h>
 #include <sys/atomic.h>

--- a/tests/zfs-tests/cmd/file_trunc/file_trunc.c
+++ b/tests/zfs-tests/cmd/file_trunc/file_trunc.c
@@ -38,7 +38,7 @@
 #include <sys/fcntl.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/time.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>

--- a/tests/zfs-tests/cmd/mktree/mktree.c
+++ b/tests/zfs-tests/cmd/mktree/mktree.c
@@ -32,7 +32,7 @@
 #include <attr/xattr.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/param.h>
 
 #define	TYPE_D 'D'


### PR DESCRIPTION
musl's sys/errno.h is literally:

/#warning redirecting incorrect #include <sys/errno.h> to <errno.h>
/#include <errno.h>

Consequently, GCC becomes rather noisy when building ZoL against musl.
musl is also correct in pointing out that the correct header is errno.h:

http://pubs.opengroup.org/onlinepubs/7908799/xsh/errno.h.html

Lets change the files to use errno.h as per the Single UNIX
Specification.

Signed-off-by: Richard Yao <ryao@gentoo.org>

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
