### PR TITLE
Fix various standards conformance issues in includes shown by building against musl

### DIFF
--- a/cmd/zed/zed_log.c
+++ b/cmd/zed/zed_log.c
@@ -18,7 +18,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <syslog.h>
+#include <unistd.h>
 #include "zed_log.h"
 
 #define	ZED_LOG_MAX_LOG_LEN	1024

--- a/lib/libspl/include/sys/Makefile.am
+++ b/lib/libspl/include/sys/Makefile.am
@@ -13,6 +13,7 @@ libspl_HEADERS = \
 	$(top_srcdir)/lib/libspl/include/sys/debug.h \
 	$(top_srcdir)/lib/libspl/include/sys/dkio.h \
 	$(top_srcdir)/lib/libspl/include/sys/dklabel.h \
+	$(top_srcdir)/lib/libspl/include/sys/errno.h \
 	$(top_srcdir)/lib/libspl/include/sys/feature_tests.h \
 	$(top_srcdir)/lib/libspl/include/sys/file.h \
 	$(top_srcdir)/lib/libspl/include/sys/frame.h \
@@ -31,8 +32,10 @@ libspl_HEADERS = \
 	$(top_srcdir)/lib/libspl/include/sys/note.h \
 	$(top_srcdir)/lib/libspl/include/sys/param.h \
 	$(top_srcdir)/lib/libspl/include/sys/policy.h \
+	$(top_srcdir)/lib/libspl/include/sys/poll.h \
 	$(top_srcdir)/lib/libspl/include/sys/priv.h \
 	$(top_srcdir)/lib/libspl/include/sys/processor.h \
+	$(top_srcdir)/lib/libspl/include/sys/signal.h \
 	$(top_srcdir)/lib/libspl/include/sys/stack.h \
 	$(top_srcdir)/lib/libspl/include/sys/stat.h \
 	$(top_srcdir)/lib/libspl/include/sys/stropts.h \

--- a/lib/libspl/include/sys/errno.h
+++ b/lib/libspl/include/sys/errno.h
@@ -1,0 +1,35 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2017 Zettabyte Software, LLC.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+/*
+ * Compiling against musl correctly points out that including sys/errno.h is
+ * disallowed by the Single UNIX Specification when building in userspace, so
+ * we implement a dummy header to redirect the include to the proper header.
+ */
+#ifndef _LIBSPL_SYS_ERRNO_H
+#define	_LIBSPL_SYS_ERRNO_H
+#include <errno.h>
+#endif /* _LIBSPL_SYS_ERRNO_H */

--- a/lib/libspl/include/sys/poll.h
+++ b/lib/libspl/include/sys/poll.h
@@ -1,0 +1,41 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2017 Zettabyte Software, LLC.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+/*
+ * Compiling against musl correctly points out that including sys/poll.h is
+ * disallowed by the Single UNIX Specification when building in userspace. We
+ * implement a dummy header to redirect the include to the proper header.
+ * However, glibc, klibc and uclibc break this shim by including sys/poll.h
+ * from poll.h, so we add explicit exceptions for them.
+ */
+#ifndef _LIBSPL_SYS_POLL_H
+#define	_LIBSPL_SYS_POLL_H
+#if defined(__GLIBC__) || defined(__KLIBC__) || defined(__UCLIBC__)
+#include_next <sys/poll.h>
+#else
+#include <poll.h>
+#endif
+#endif /* _LIBSPL_SYS_POLL_H */

--- a/lib/libspl/include/sys/signal.h
+++ b/lib/libspl/include/sys/signal.h
@@ -1,0 +1,35 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2017 Zettabyte Software, LLC.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+/*
+ * Compiling against musl correctly points out that including sys/signal.h is
+ * disallowed by the Single UNIX Specification when building in userspace, so
+ * we implement a dummy header to redirect the include to the proper header.
+ */
+#ifndef _LIBSPL_SYS_SIGNAL_H
+#define	_LIBSPL_SYS_SIGNAL_H
+#include <signal.h>
+#endif /* _LIBSPL_SYS_SIGNAL_H */

--- a/lib/libspl/timestamp.c
+++ b/lib/libspl/timestamp.c
@@ -29,8 +29,12 @@
 #include "statcommon.h"
 
 #ifndef _DATE_FMT
+#ifdef D_T_FMT
+#define	_DATE_FMT D_T_FMT
+#else /* D_T_FMT */
 #define	_DATE_FMT "%+"
-#endif
+#endif /* !D_T_FMT */
+#endif /* _DATE_FMT */
 
 /*
  * Print timestamp as decimal reprentation of time_t value (-T u was specified)

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -44,7 +44,7 @@
 #include <sys/mnttab.h>
 #include <sys/mntent.h>
 #include <sys/types.h>
-#include <wait.h>
+#include <sys/wait.h>
 
 #include <libzfs.h>
 #include <libzfs_core.h>

--- a/tests/zfs-tests/cmd/file_trunc/file_trunc.c
+++ b/tests/zfs-tests/cmd/file_trunc/file_trunc.c
@@ -35,10 +35,8 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/types.h>
-#include <sys/fcntl.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
-#include <sys/errno.h>
 #include <sys/time.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>

--- a/tests/zfs-tests/cmd/mktree/mktree.c
+++ b/tests/zfs-tests/cmd/mktree/mktree.c
@@ -24,6 +24,7 @@
  * Use is subject to license terms.
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -32,7 +33,6 @@
 #include <attr/xattr.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/errno.h>
 #include <sys/param.h>
 
 #define	TYPE_D 'D'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Fixed includes to use errno.h, poll.h and signal.h instead of their sys/* versions for UNIX System V compliance. Added includes for sys/types.h and unistd.h to cmd/zed/zed_log.c to fix implicit function declarations.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Building with GCC 4.9.4 against musl on Gentoo was noisy due to a mix of preprocessor warnings and compiler warnings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

After witnessing the problem, I patched the files, ran `make clean; make` and observed that the problem with noisy includes was gone.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
