### PR TITLE
zfstests cli_user/misc/setup.ksh space missed

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_user/misc/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/setup.ksh
@@ -95,7 +95,7 @@ done
 log_must zfs create $TESTPOOL/$TESTFS/renameme
 
 
-if is_global_zone && !is_linux
+if is_global_zone && ! is_linux
 then
 	# create a filesystem we can share
 	log_must zfs create $TESTPOOL/$TESTFS/unshared


### PR DESCRIPTION
Ksh syntax requires a space after `!` in `if` statement.

Error example - `/usr/share/zfs/zfs-tests/tests/functional/cli_user/misc/setup.ksh[98]: !is_linux: not found [No such file or directory]`

Signed-off-by: George Melikov <mail@gmelikov.ru>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
