### PR TITLE
zfs_receive_010_pos.ksh local => typeset change

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
@@ -47,9 +47,9 @@ rfs=$TESTPOOL/$TESTFS/base/rfs
 
 function make_object
 {
-	local objnum=$1
-	local mntpnt=$2
-	local type=$3
+	typeset objnum=$1
+	typeset mntpnt=$2
+	typeset type=$3
 	if [[ $type == "file" ]]; then
 		dd if=/dev/urandom of=${mntpnt}/f$objnum bs=512 count=16
 	elif [[ $type == "hole1" ]]; then
@@ -65,11 +65,11 @@ function make_object
 
 function create_pair
 {
-	local objnum=$1
-	local mntpnt1=$2
-	local mntpnt2=$3
-	local type1=$4
-	local type2=$5
+	typeset objnum=$1
+	typeset mntpnt1=$2
+	typeset mntpnt2=$3
+	typeset type1=$4
+	typeset type2=$5
 	make_object $objnum $mntpnt1 $type1
 	make_object $objnum $mntpnt2 $type2
 }


### PR DESCRIPTION
Ksh uses `typeset`, `local` is a Bash analog.

Error example: `/usr/share/zfs/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh[102]: create_pair[68]: local: not found [No such file or directory]`

Signed-off-by: George Melikov <mail@gmelikov.ru>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)