### PR TITLE
zfstest - dircmp is replaced by diff

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_009_pos.ksh
@@ -90,9 +90,11 @@ for i in 1 2 3; do
 done
 log_note "verify snapshot contents"
 for ds in $datasets; do
-	status=$(dircmp /$ds /$ds/.zfs/snapshot/snap | grep "different")
-	[[ -z $status ]] || log_fail "snapshot contents are different from" \
-	    "the filesystem"
+	diff -q -r /$ds /$ds/.zfs/snapshot/snap > /dev/null 2>&1
+	if [[ $? -eq 1 ]]; then
+		log_fail "snapshot contents are different from" \
+		    "the filesystem"
+	fi
 done
 
 # We subtract 3 + 7 + 7 + 1 = 18 for three slashes (/), strlen("TESTFSA") == 7,

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_002_pos.ksh
@@ -125,9 +125,8 @@ log_must tar xf $TESTDIR/tarball.snapshot.tar
 
 cd $CWD || log_fail "Could not cd $CWD"
 
-dircmp $TESTDIR/original $TESTDIR/snapshot > /tmp/zfs_snapshot2.$$
-grep different /tmp/zfs_snapshot2.$$ >/dev/null 2>&1
-if [[ $? -ne 1 ]]; then
+diff -q -r $TESTDIR/original $TESTDIR/snapshot > /dev/null 2>&1
+if [[ $? -eq 1 ]]; then
 	log_fail "Directory structures differ."
 fi
 

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_006_pos.ksh
@@ -123,9 +123,8 @@ log_must tar xf $TESTDIR1/tarball.snapshot.tar
 
 cd $CWD || log_fail "Could not cd $CWD"
 
-dircmp $TESTDIR1/original $TESTDIR1/snapshot > /tmp/zfs_snapshot2.$$
-grep different /tmp/zfs_snapshot2.$$ >/dev/null 2>&1
-if [[ $? -ne 1 ]]; then
+diff -q -r $TESTDIR1/original $TESTDIR1/snapshot > /dev/null 2>&1
+if [[ $? -eq 1 ]]; then
 	log_fail "Directory structures differ."
 fi
 


### PR DESCRIPTION
`dircmp` doesn't exists in Linux.
`diff` is already in zfstests on all platforms.

Error example: `/usr/share/zfs/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_009_pos.ksh: line 93: dircmp: not found`

We can backport it to OpenZFS too.

Signed-off-by: George Melikov <mail@gmelikov.ru>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)