### PR TITLE
Skip rate limiting events in zfs_ereport_post

### DIFF
--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -778,13 +778,13 @@ zfs_ereport_post(const char *subclass, spa_t *spa, vdev_t *vd, zio_t *zio,
 	nvlist_t *ereport = NULL;
 	nvlist_t *detector = NULL;
 
+	if (zfs_is_ratelimiting_event(subclass, vd))
+		return;
+
 	zfs_ereport_start(&ereport, &detector,
 	    subclass, spa, vd, zio, stateoroffset, size);
 
 	if (ereport == NULL)
-		return;
-
-	if (zfs_is_ratelimiting_event(subclass, vd))
 		return;
 
 	/* Cleanup is handled by the callback function */


### PR DESCRIPTION
### Description
The Kmemleak TEST builder occasionally reports a memory leak relating to zfs_ereport_post. Looking at the code, there appears to be an ordering problem when handling rate limiting events. Simply return immediately in those cases and skip all the event processing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
