### PR TITLE
Invalidate cache during a zpool labelclear

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -865,6 +865,10 @@ zpool_do_labelclear(int argc, char **argv)
 		return (1);
 	}
 
+	if (ioctl(fd, BLKFLSBUF) != 0)
+		(void) printf("failed to invalidate cache for %s: %s\n",
+		    vdev, strerror(errno));
+
 	if (zpool_read_label(fd, &config, NULL) != 0 || config == NULL) {
 		(void) fprintf(stderr,
 		    gettext("failed to check state for %s\n"), vdev);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
`zpool labelclear` is succeeding when it shouldn't be on some of the buildbot slaves. Looking at `zpool labelclear` in `zpool_main.c`, it appears the cache is not invalidated prior to reading the vdev's label. There are still cases where the cache may be stale, so we should invalidate it to be safe.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Going to run this through buildbot and see if the `zpool_labelclear_active` test begins passing reliably.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
