### PR TITLE
OpenZFS 8026 - retire zfs_throttle_delay and zfs_throttle_resolution

### DIFF
--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -129,9 +129,6 @@ int zfs_delay_min_dirty_percent = 60;
  */
 unsigned long zfs_delay_scale = 1000 * 1000 * 1000 / 2000;
 
-hrtime_t zfs_throttle_delay = MSEC2NSEC(10);
-hrtime_t zfs_throttle_resolution = MSEC2NSEC(10);
-
 /*
  * This determines the number of threads used by the dp_sync_taskq.
  */


### PR DESCRIPTION
Authored by: Andriy Gapon <avg@FreeBSD.org>
Approved by: Richard Lowe <richlowe@richlowe.net>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>
Closes #330
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/8026
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/9b33e07