### PR TITLE
OpenZFS 6392 - zdb: introduce -V for verbatim import

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -124,20 +124,21 @@ static void
 usage(void)
 {
 	(void) fprintf(stderr,
-	    "Usage:\t%s [-AbcdDFGhiLMPsvVX] [-e [-p <path> ...]] "
+	    "Usage:\t%s [-AbcdDFGhiLMPsvX] [-e [-V] [-p <path> ...]] "
 	    "[-I <inflight I/Os>]\n"
 	    "\t\t[-o <var>=<value>]... [-t <txg>] [-U <cache>] [-x <dumpdir>]\n"
 	    "\t\t[<poolname> [<object> ...]]\n"
-	    "\t%s [-AdiPv] [-e [-p <path> ...]] [-U <cache>] <dataset> "
+	    "\t%s [-AdiPv] [-e [-V] [-p <path> ...]] [-U <cache>] <dataset> "
 	    "[<object> ...]\n"
 	    "\t%s -C [-A] [-U <cache>]\n"
 	    "\t%s -l [-Aqu] <device>\n"
-	    "\t%s -m [-AFLPX] [-e [-p <path> ...]] [-t <txg>] [-U <cache>]\n"
-	    "\t\t<poolname> [<vdev> [<metaslab> ...]]\n"
+	    "\t%s -m [-AFLPX] [-e [-V] [-p <path> ...]] [-t <txg>] "
+	    "[-U <cache>]\n\t\t<poolname> [<vdev> [<metaslab> ...]]\n"
 	    "\t%s -O <dataset> <path>\n"
-	    "\t%s -R [-A] [-e [-p <path> ...]] [-U <cache>]\n"
+	    "\t%s -R [-A] [-e [-V] [-p <path> ...]] [-U <cache>]\n"
 	    "\t\t<poolname> <vdev>:<offset>:<size>[:<flags>]\n"
-	    "\t%s -S [-AP] [-e [-p <path> ...]] [-U <cache>] <poolname>\n\n",
+	    "\t%s -S [-AP] [-e [-V] [-p <path> ...]] [-U <cache>] "
+	    "<poolname>\n\n",
 	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname, cmdname,
 	    cmdname);
 
@@ -192,12 +193,11 @@ usage(void)
 	(void) fprintf(stderr, "        -u uberblock\n");
 	(void) fprintf(stderr, "        -U <cachefile_path> -- use alternate "
 	    "cachefile\n");
+	(void) fprintf(stderr, "        -V do verbatim import\n");
 	(void) fprintf(stderr, "        -x <dumpdir> -- "
 	    "dump all read blocks into specified directory\n");
 	(void) fprintf(stderr, "        -X attempt extreme rewind (does not "
 	    "work with dataset)\n");
-	(void) fprintf(stderr, "        -V verbatim import (as if it had been "
-	    "loaded at boot)\n\n");
 	(void) fprintf(stderr, "Specify an option more than once (e.g. -bb) "
 	    "to make only that option verbose\n");
 	(void) fprintf(stderr, "Default is to dump everything non-verbosely\n");
@@ -4289,7 +4289,7 @@ main(int argc, char **argv)
 			verbose++;
 			break;
 		case 'V':
-			flags |= ZFS_IMPORT_VERBATIM;
+			flags = ZFS_IMPORT_VERBATIM;
 			break;
 		case 'x':
 			vn_dumpdir = optarg;

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -23,8 +23,8 @@
 .Nd display zpool debugging and consistency information
 .Sh SYNOPSIS
 .Nm
-.Op Fl AbcdDFGhiLMPsvVX
-.Op Fl e Op Fl p Ar path ...
+.Op Fl AbcdDFGhiLMPsvX
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl I Ar inflight I/Os
 .Oo Fl o Ar var Ns = Ns Ar value Oc Ns ...
 .Op Fl t Ar txg
@@ -33,7 +33,7 @@
 .Op Ar poolname Op Ar object ...
 .Nm
 .Op Fl AdiPv
-.Op Fl e Op Fl p Ar path ...
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar dataset Op Ar object ...
 .Nm
@@ -46,9 +46,9 @@
 .Ar device
 .Nm
 .Fl m
-.Op Fl AFLPVX
+.Op Fl AFLPX
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl t Ar txg
-.Op Fl e Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar poolname Op Ar vdev Op Ar metaslab ...
 .Nm
@@ -57,13 +57,13 @@
 .Nm
 .Fl R
 .Op Fl A
-.Op Fl e Op Fl p Ar path ...
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar poolname vdev Ns : Ns Ar offset Ns : Ns Ar size Ns Op : Ns Ar flags
 .Nm
 .Fl S
 .Op Fl AP
-.Op Fl e Op Fl p Ar path ...
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar poolname
 .Sh DESCRIPTION
@@ -324,8 +324,10 @@ Use a cache file other than
 Enable verbosity.
 Specify multiple times for increased verbosity.
 .It Fl V
-Attempt a verbatim import. This mimics the behavior of the kernel when
-loading a pool from a cachefile.
+Attempt verbatim import.
+This mimics the behavior of the kernel when loading a pool from a cachefile.
+Only usable with
+.Fl e .
 .It Fl X
 Attempt
 .Qq extreme

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_001_neg.ksh
@@ -59,7 +59,7 @@ set -A args "create" "add" "destroy" "import fakepool" \
     "-a" "-f" "-g" "-h" "-j" "-k" "-m" "-n" "-o" "-p" \
     "-p /tmp" "-r" "-t" "-w" "-x" "-y" "-z" \
     "-D" "-E" "-G" "-H" "-I" "-J" "-K" "-M" \
-    "-N" "-Q" "-R" "-S" "-W" "-Y" "-Z"
+    "-N" "-Q" "-R" "-S" "-T" "-W" "-Y" "-Z"
 
 log_assert "Execute zdb using invalid parameters."
 


### PR DESCRIPTION
Authored by: Richard Yao <ryao@gentoo.org>
Approved by: Dan McDonald <danmcd@omniti.com>
Reviewed by: Yuri Pankov <yuri.pankov@gmail.com>
Reviewed by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed by: Matt Ahrens <mahrens@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

Porting Notes:
  This was already implemented in ZFS on Linux. This patch
  is to resolved the deltas present in our version.

OpenZFS-issue: https://www.illumos.org/issues/6392
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/9bb97de