### PR TITLE
Clean up correctly in zpool_scrub_004_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
@@ -46,12 +46,19 @@
 #	resilver does not complete before the scrub can be issued.  This
 #	can occur when testing with small pools or very fast hardware.
 
+function cleanup
+{
+	log_must zinject -c all
+}
+
 verify_runnable "global"
 
 # See issue: https://github.com/zfsonlinux/zfs/issues/5444
 if is_32bit; then
 	log_unsupported "Test case fails on 32-bit systems"
 fi
+
+log_onexit cleanup
 
 log_assert "Resilver prevent scrub from starting until the resilver completes"
 
@@ -66,5 +73,4 @@ while ! is_pool_resilvered $TESTPOOL; do
 	sleep 1
 done
 
-log_must zinject -c all
 log_pass "Resilver prevent scrub from starting until the resilver completes"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
If `zpool_scrub_004_pos` exits early, it never clears all the `zinject` records. This causes all subsequent tests to fail in the buildbot. Provide a cleanup function to ensure `zinject -c all` is run.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Ran `zpool_scrub_004_pos` on a VM after my change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
