### PR TITLE
[WIP] Design for simplified MMP

### DIFF
--- a/doc/poor_mans_mmp_design.txt
+++ b/doc/poor_mans_mmp_design.txt
@@ -1,0 +1,70 @@
+MMP (Multi-Modifier Protection) attempts to prevent a user from
+importing a pool on more than one node at a time.
+
+See
+	https://github.com/zfsonlinux/zfs/issues/745
+and
+	https://github.com/zfsonlinux/zfs/pull/5821
+for more background.
+
+This design is for a very simple subset of MMP that can be coded,
+tested, and reviewed quickly.
+
+It attempts to detect and prevent the case of importing a pool via "zpool
+import -f", while it is already imported on another node.
+
+On-disk changes:
+
+The last uberblock slot in each ring is used only for MMP; uberblocks
+written by the sync thread always go into the first (N-1) slots.  The
+slot used for MMP is used to hold an uberblock which is exactly the
+same as the last written uberblock, except that its ub_timestamp is
+frequently updated, and its embedded checksum is different
+accordingly.
+
+This is used to provide the "heartbeat" without overwriting good
+uberblocks.
+
+During Import:
+
+zpool_do_import() (user space)
+1. Examine the hostid.  If it is 0,
+   skip the steps below and perform the import as normal.
+2. Issue the ZFS_IOC_POOL_TRYIMPORT ioctl
+3. Extract the txg and timestamp from the returned config nvlist and
+   save them.
+4. Sleep 1 second.
+5. Issue the ZFS_IOC_POOL_TRYIMPORT ioctl again and compare the returned txg
+   and timestamp.  If they changed, the import fails.
+6. Repeat steps 4,5 until 5 seconds have passed.
+7. Import the pool normally via the ZFS_IOC_POOL_IMPORT ioctl
+
+spa_tryimport() (kernel space)
+1. Add an additional key to the config nvlist, with the value from
+   spa->spa_uberblock.ub_txg after spa_load() succeeds.  ub_timestamp is
+   already recorded in the config nvlist.
+
+spa_import() (kernel space)
+1. Start an mmp thread in a manner similar to the sync thread
+
+While the pool is open:
+mmp_thread() (kernel space)
+1. Sleep 1 second.
+2. Choose a random leaf vdev.
+3. Copy the last synced uberblock from spa_ubsync to a buffer and update ub_timestamp.
+4. Write the buffer to the MMP uberblock slot in all 4 labels
+5. Go to step 1
+
+Limitations:
+
+Once a node has the pool imported, it does not detect other nodes which
+have the pool imported or alter the pool's devices.
+
+It does not detect and prevent two nodes importing the pool at the
+same time.
+
+It does not detect changes to one or more individual devices by some outside
+process, e.g. "zpool labelclear -f" or "zpool add -f".
+
+Every import pays the 5 second delay cost, even if the pool was cleanly
+exported and there are no competing imports.

--- a/doc/poor_mans_mmp_design.txt
+++ b/doc/poor_mans_mmp_design.txt
@@ -28,16 +28,19 @@ uberblocks.
 During Import:
 
 zpool_do_import() (user space)
-1. Examine the hostid.  If it is 0,
+1. Examine the system's hostid.  If it is 0,
    skip the steps below and perform the import as normal.
 2. Issue the ZFS_IOC_POOL_TRYIMPORT ioctl
-3. Extract the txg and timestamp from the returned config nvlist and
+3. Extract the hostid, txg and timestamp from the returned config nvlist and
    save them.
-4. Sleep 1 second.
-5. Issue the ZFS_IOC_POOL_TRYIMPORT ioctl again and compare the returned txg
+4. If the ZPOOL_CONFIG_HOSTID matches the system hostid, skip the steps below
+   and perform the import as normal.
+5. If the user did not use "--force" option, the import fails.
+6. Sleep 1 second.  Print something like "verifying pool is not in use".
+7. Issue the ZFS_IOC_POOL_TRYIMPORT ioctl again and compare the returned txg
    and timestamp.  If they changed, the import fails.
-6. Repeat steps 4,5 until 5 seconds have passed.
-7. Import the pool normally via the ZFS_IOC_POOL_IMPORT ioctl
+8. Repeat steps 6,7 until 10 seconds have passed.
+9. Import the pool normally via the ZFS_IOC_POOL_IMPORT ioctl
 
 spa_tryimport() (kernel space)
 1. Add an additional key to the config nvlist, with the value from
@@ -50,21 +53,31 @@ spa_import() (kernel space)
 While the pool is open:
 mmp_thread() (kernel space)
 1. Sleep 1 second.
-2. Choose a random leaf vdev.
-3. Copy the last synced uberblock from spa_ubsync to a buffer and update ub_timestamp.
-4. Write the buffer to the MMP uberblock slot in all 4 labels
-5. Go to step 1
+2. If (now - spa->ubsync.ub_timestamp) < 1 second, go to step 1
+3. Choose a random leaf vdev.
+4. Copy the last synced uberblock from spa_ubsync to a buffer and update ub_timestamp.
+5. Write the buffer to the MMP uberblock slot in all 4 labels
+6. Go to step 1
+
+When a user attempts to resume a suspended pool via 'zpool clear':
+zio_resume() (kernel space)
+1. spa->spa_suspended = B_FALSE
+2. Obtain the latest txg on disk using vdev_uberblock_load()
+3. If the following is true, resume the pool as normal:
+	 txg_on_disk <= spa->spa_ubsync.ub_txg &&
+	 txg_on_disk >= (spa->spa_ubsync.ub_txg - TXG_DEFER_SIZE)
+Otherwise:
+4. spa->spa_suspended = B_TRUE and return failure.  This propogates back to
+user space and the 'zpool clear' fails, the pool remains suspended.
 
 Limitations:
 
 Once a node has the pool imported, it does not detect other nodes which
-have the pool imported or alter the pool's devices.
+have the pool imported or alter the pool's devices, except when resuming
+after the pool was suspended.
 
 It does not detect and prevent two nodes importing the pool at the
 same time.
 
 It does not detect changes to one or more individual devices by some outside
 process, e.g. "zpool labelclear -f" or "zpool add -f".
-
-Every import pays the 5 second delay cost, even if the pool was cleanly
-exported and there are no competing imports.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This is a design for Multi-Modifier Protection that is simple and does not
attempt to cover all cases, but can be implemented and tested quickly.

It is here for discussion.  

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This attempts to help prevent a user from importing a pool via "zpool import -f" when it is already imported on another node.

For more detail on the problem it is trying to solve, see Issue #745.  For a design that attempts to provide a complete solution, see PR #5821.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
