### PR TITLE
zfs_receive_010_pos: change dd arguments

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
@@ -53,9 +53,9 @@ function make_object
 	if [[ $type == "file" ]]; then
 		dd if=/dev/urandom of=${mntpnt}/f$objnum bs=512 count=16
 	elif [[ $type == "hole1" ]]; then
-		dd if=/dev/urandom of=${mntpnt}/fh$objnum bs=512 count=5 stride=4
+		dd if=/dev/zero of=${mntpnt}/fh$objnum bs=512 count=5 seek=4 conv=notrunc
 	elif [[ $type == "hole2" ]]; then
-		dd if=/dev/urandom of=${mntpnt}/fh$objnum bs=512 count=4 stride=5
+		dd if=/dev/zero of=${mntpnt}/fh$objnum bs=512 count=4 seek=5 conv=notrunc
 	elif [[ $type == "directory" ]]; then
 		mkdir ${mntpnt}/d$objnum
 	elif [[ $type == "missing" ]]; then


### PR DESCRIPTION
`dd` didn't make holes in such scenario
and it doesn't have `stride` argument,
instead `seek` and  `conv=notrunc`
are the right arguments.

Signed-off-by: George Melikov <mail@gmelikov.ru>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
