### PR TITLE
zfstest: add dmesg command to $PATH

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -30,6 +30,7 @@ export SYSTEM_FILES='arp
     df
     diff
     dirname
+    dmesg
     du
     echo
     egrep


### PR DESCRIPTION
Error example in `zfs_list_007_pos`:
`sudo: dmesg: command not found`

Signed-off-by: George Melikov <mail@gmelikov.ru>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
