### PR TITLE
[WIP] report txg and timestamp in output of zpool import

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1869,6 +1869,8 @@ show_import(nvlist_t *config)
 	uint_t vsc;
 	char *comment;
 	status_cbdata_t cb = { 0 };
+	uint64_t timestamp;
+	uint64_t txg;
 
 	verify(nvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME,
 	    &name) == 0);
@@ -1878,6 +1880,10 @@ show_import(nvlist_t *config)
 	    &pool_state) == 0);
 	verify(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
 	    &nvroot) == 0);
+	verify(nvlist_lookup_uint64(config, ZPOOL_CONFIG_TIMESTAMP,
+	    &timestamp) == 0);
+	verify(nvlist_lookup_uint64(config, ZPOOL_CONFIG_FOUND_TXG,
+	    &txg) == 0);
 
 	verify(nvlist_lookup_uint64_array(nvroot, ZPOOL_CONFIG_VDEV_STATS,
 	    (uint64_t **)&vs, &vsc) == 0);
@@ -1887,7 +1893,11 @@ show_import(nvlist_t *config)
 
 	(void) printf(gettext("   pool: %s\n"), name);
 	(void) printf(gettext("     id: %llu\n"), (u_longlong_t)guid);
-	(void) printf(gettext("  state: %s"), health);
+	(void) printf(gettext("  state: %s\n"), health);
+	(void) printf(gettext("    txg: %llu\n"), (u_longlong_t)txg);
+	(void) printf(gettext("updated: %s"), asctime(localtime(
+	    (time_t *)&timestamp)));
+
 	if (pool_state == POOL_STATE_DESTROYED)
 		(void) printf(gettext(" (DESTROYED)"));
 	(void) printf("\n");

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -628,6 +628,7 @@ typedef struct zpool_rewind_policy {
 #define	ZPOOL_CONFIG_COMMENT		"comment"
 #define	ZPOOL_CONFIG_SUSPENDED		"suspended"	/* not stored on disk */
 #define	ZPOOL_CONFIG_TIMESTAMP		"timestamp"	/* not stored on disk */
+#define	ZPOOL_CONFIG_FOUND_TXG		"found_txg"	/* not stored on disk */
 #define	ZPOOL_CONFIG_BOOTFS		"bootfs"	/* not stored on disk */
 #define	ZPOOL_CONFIG_MISSING_DEVICES	"missing_vdevs"	/* not stored on disk */
 #define	ZPOOL_CONFIG_LOAD_INFO		"load_info"	/* not stored on disk */

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -4243,6 +4243,8 @@ spa_tryimport(nvlist_t *tryconfig)
 		    state) == 0);
 		VERIFY(nvlist_add_uint64(config, ZPOOL_CONFIG_TIMESTAMP,
 		    spa->spa_uberblock.ub_timestamp) == 0);
+		VERIFY(nvlist_add_uint64(config, ZPOOL_CONFIG_FOUND_TXG,
+		    spa->spa_uberblock.ub_txg) == 0);
 		VERIFY(nvlist_add_nvlist(config, ZPOOL_CONFIG_LOAD_INFO,
 		    spa->spa_load_info) == 0);
 		VERIFY(nvlist_add_uint64(config, ZPOOL_CONFIG_ERRATA,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
spa_tryimport() records the txg, from the uberblock spa_load() chose, in the config passed back to user space.  show_config() then displays that txg as well as the timestamp from the same uberblock.

As a result, the txg and timestamp are displayed, from the uberblock which will be used for import, when one lists the available pools via ```zpool import```.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This provides the basis for the simplified MMP (see separate PR for the design) as well as providing information useful for troubleshooting.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Brief manual testing, and several iterations of zloop.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
