### PR TITLE
Retire send space estimation via ZFS_IOC_SEND

### DIFF
--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -590,6 +590,8 @@ lzc_send_space(const char *snapname, const char *from,
 		fnvlist_add_boolean(args, "embedok");
 	if (flags & LZC_SEND_FLAG_COMPRESS)
 		fnvlist_add_boolean(args, "compressok");
+	if (flags & LZC_SEND_FLAG_RAW)
+		fnvlist_add_boolean(args, "rawok");
 	err = lzc_ioctl(ZFS_IOC_SEND_SPACE, snapname, args, &result);
 	nvlist_free(args);
 	if (err == 0)

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4758,6 +4758,9 @@ zfs_ioc_recv_new(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl)
  *
  * outputs:
  * zc_objset_type	estimated size, if zc_guid is set
+ *
+ * NOTE: This is no longer the preferred interface, any new functionality
+ *	  should be added to zfs_ioc_send_new() instead.
  */
 static int
 zfs_ioc_send(zfs_cmd_t *zc)
@@ -5876,6 +5879,8 @@ zfs_ioc_send_new(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
  *         presence indicates DRR_WRITE_EMBEDDED records are permitted
  *     (optional) "compressok" -> (value ignored)
  *         presence indicates compressed DRR_WRITE records are permitted
+ *	(optional) "rawok" -> (value ignored)
+ *         presence indicates raw encrypted records should be used.
  * }
  *
  * outnvl: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Add a small wrapper around `lzc_send_space()` (libzfs_core) so that every legacy consumer of `estimate_ioctl()` (libzfs) can leverage the new interface to request send space estimation.

This is just laying the groundwork to implement send estimates for bookmarks in userland (https://github.com/zfsonlinux/zfs/issues/3666): i'm trying to follow more carefully the CONTRIBUTING guidelines and limit my pull requests to a single commit which resolves one specific issue. This is just going to be code cleanup.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

More context and history:

 - "zfs send" stream size estimation was implemented in Illumos 1646: this adds `estimate_ioctl()` to libzfs (https://github.com/zfsonlinux/zfs/commit/330d06f90d143b41b276796526a66a1c1fff046d)
 - libzfs_core was integrated in Illumos 2882: this adds `zfs_ioc_send_space()` and its userland counterpart `lzc_send_space()` (https://github.com/zfsonlinux/zfs/commit/6f1ffb06655008c9b519108ed29fbf03acd6e5de)
 - bookmarks implementation landed later in Illumos 4369 (https://github.com/zfsonlinux/zfs/commit/da536844d55b2f3aaefdaebd36fb97bb867494aa)
 - "zfs send" stream size estimation for bookmarks came with Illumos 5765 (https://github.com/zfsonlinux/zfs/commit/5dc8b7365ff1932bfd969bc71cd49db9b3a6dc87)

Right now we have every codepath that still use `estimate_ioctl()`. The only exception is `zfs_do_send -> zfs_send_resume()` which already leverage `lzc_send_space()` for space estimation.

This PR retires space estimation via ZFS_IOC_SEND (and its userland counterpart `estimate_ioctl()`) so that we have a single interface to do this: since `lzc_send_space()` already supports bookmarks it is, hopefully, going be easier to expose this functionality when the user request it (`zfs send -vn bookmark`).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Manually tested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Breaking code cleanup (breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
