### PR TITLE
Add zfs_nicebytes() to print human-readable sizes

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -3077,7 +3077,7 @@ zdb_blkptr_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 		int sec_remaining =
 		    (zcb->zcb_totalasize - bytes) / 1024 / kb_per_sec;
 
-		zfs_nicenum(bytes, buf, sizeof (buf));
+		zfs_nicebytes(bytes, buf, sizeof (buf));
 		(void) fprintf(stderr,
 		    "\r%5s completed (%4dMB/s) "
 		    "estimated time remaining: %uhr %02umin %02usec        ",

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -2656,15 +2656,15 @@ print_us_node(boolean_t scripted, boolean_t parsable, int *fields, int types,
 				if (parsable) {
 					(void) sprintf(valstr, "%llu",
 					    (u_longlong_t)val64);
+					strval = valstr;
+				} else if (field == USFIELD_QUOTA &&
+				    val64 == 0) {
+					strval = "none";
 				} else {
 					zfs_nicebytes(val64, valstr,
 					    sizeof (valstr));
-				}
-				if (field == USFIELD_QUOTA &&
-				    strcmp(valstr, "0") == 0)
-					strval = "none";
-				else
 					strval = valstr;
+				}
 			}
 			break;
 		case USFIELD_OBJUSED:
@@ -2673,15 +2673,15 @@ print_us_node(boolean_t scripted, boolean_t parsable, int *fields, int types,
 				if (parsable) {
 					(void) sprintf(valstr, "%llu",
 					    (u_longlong_t)val64);
+					strval = valstr;
+				} else if (field == USFIELD_OBJQUOTA &&
+				    val64 == 0) {
+					strval = "none";
 				} else {
 					zfs_nicenum(val64, valstr,
 					    sizeof (valstr));
-				}
-				if (field == USFIELD_OBJQUOTA &&
-				    strcmp(valstr, "0") == 0)
-					strval = "none";
-				else
 					strval = valstr;
+				}
 			}
 			break;
 		}

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -5730,7 +5730,7 @@ print_scan_status(pool_scan_stat_t *ps)
 
 	start = ps->pss_start_time;
 	end = ps->pss_end_time;
-	zfs_nicenum(ps->pss_processed, processed_buf, sizeof (processed_buf));
+	zfs_nicebytes(ps->pss_processed, processed_buf, sizeof (processed_buf));
 
 	assert(ps->pss_func == POOL_SCAN_SCRUB ||
 	    ps->pss_func == POOL_SCAN_RESILVER);
@@ -5792,9 +5792,9 @@ print_scan_status(pool_scan_stat_t *ps)
 	mins_left = ((total - examined) / rate) / 60;
 	hours_left = mins_left / 60;
 
-	zfs_nicenum(examined, examined_buf, sizeof (examined_buf));
-	zfs_nicenum(total, total_buf, sizeof (total_buf));
-	zfs_nicenum(rate, rate_buf, sizeof (rate_buf));
+	zfs_nicebytes(examined, examined_buf, sizeof (examined_buf));
+	zfs_nicebytes(total, total_buf, sizeof (total_buf));
+	zfs_nicebytes(rate, rate_buf, sizeof (rate_buf));
 
 	/*
 	 * do not print estimated time if hours_left is more than 30 days
@@ -5897,6 +5897,7 @@ print_dedup_stats(nvlist_t *config)
 	ddt_stat_t *dds;
 	ddt_object_t *ddo;
 	uint_t c;
+	char dspace[6], mspace[6];
 
 	/*
 	 * If the pool was faulted then we may not have been able to
@@ -5914,10 +5915,12 @@ print_dedup_stats(nvlist_t *config)
 		return;
 	}
 
-	(void) printf("DDT entries %llu, size %llu on disk, %llu in core\n",
+	zfs_nicebytes(ddo->ddo_dspace, dspace, sizeof (dspace));
+	zfs_nicebytes(ddo->ddo_mspace, mspace, sizeof (mspace));
+	(void) printf("DDT entries %llu, size %s on disk, %s in core\n",
 	    (u_longlong_t)ddo->ddo_count,
-	    (u_longlong_t)ddo->ddo_dspace,
-	    (u_longlong_t)ddo->ddo_mspace);
+	    dspace,
+	    mspace);
 
 	verify(nvlist_lookup_uint64_array(config, ZPOOL_CONFIG_DDT_STATS,
 	    (uint64_t **)&dds, &c) == 0);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -773,8 +773,9 @@ extern int zfs_deleg_share_nfs(libzfs_handle_t *, char *, char *, char *,
 
 enum zfs_nicenum_format {
 	ZFS_NICENUM_1024 = 0,
-	ZFS_NICENUM_TIME = 1,
-	ZFS_NICENUM_RAW = 2
+	ZFS_NICENUM_BYTES = 1,
+	ZFS_NICENUM_TIME = 2,
+	ZFS_NICENUM_RAW = 3
 };
 
 /*
@@ -786,6 +787,7 @@ extern void zfs_nicenum_format(uint64_t num, char *buf, size_t buflen,
 
 
 extern void zfs_nicetime(uint64_t, char *, size_t);
+extern void zfs_nicebytes(uint64_t, char *, size_t);
 extern int zfs_nicestrtonum(libzfs_handle_t *, const char *, uint64_t *);
 
 /*

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1173,7 +1173,7 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 			 */
 			if (intval < SPA_MINBLOCKSIZE ||
 			    intval > maxbs || !ISP2(intval)) {
-				zfs_nicenum(maxbs, buf, sizeof (buf));
+				zfs_nicebytes(maxbs, buf, sizeof (buf));
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "'%s' must be power of 2 from 512B "
 				    "to %s"), propname, buf);
@@ -1428,7 +1428,7 @@ badlabel:
 
 			case ZFS_PROP_VOLSIZE:
 				if (intval % blocksize != 0) {
-					zfs_nicenum(blocksize, buf,
+					zfs_nicebytes(blocksize, buf,
 					    sizeof (buf));
 					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 					    "'%s' must be a multiple of "
@@ -2569,7 +2569,7 @@ zfs_prop_get(zfs_handle_t *zhp, zfs_prop_t prop, char *propbuf, size_t proplen,
 				(void) snprintf(propbuf, proplen, "%llu",
 				    (u_longlong_t)val);
 			else
-				zfs_nicenum(val, propbuf, proplen);
+				zfs_nicebytes(val, propbuf, proplen);
 		}
 		break;
 
@@ -2703,6 +2703,22 @@ zfs_prop_get(zfs_handle_t *zhp, zfs_prop_t prop, char *propbuf, size_t proplen,
 		if (get_numeric_property(zhp, prop, src, &source, &val) != 0)
 			return (-1);
 		(void) snprintf(propbuf, proplen, "%llu", (u_longlong_t)val);
+		break;
+
+	case ZFS_PROP_REFERENCED:
+	case ZFS_PROP_AVAILABLE:
+	case ZFS_PROP_USED:
+	case ZFS_PROP_USEDSNAP:
+	case ZFS_PROP_USEDDS:
+	case ZFS_PROP_USEDREFRESERV:
+	case ZFS_PROP_USEDCHILD:
+		if (get_numeric_property(zhp, prop, src, &source, &val) != 0)
+			return (-1);
+		if (literal)
+			(void) snprintf(propbuf, proplen, "%llu",
+			    (u_longlong_t)val);
+		else
+			zfs_nicebytes(val, propbuf, proplen);
 		break;
 
 	default:
@@ -3001,6 +3017,9 @@ zfs_prop_get_userquota(zfs_handle_t *zhp, const char *propname,
 	    (type == ZFS_PROP_USERQUOTA || type == ZFS_PROP_GROUPQUOTA ||
 	    type == ZFS_PROP_USEROBJQUOTA || type == ZFS_PROP_GROUPOBJQUOTA)) {
 		(void) strlcpy(propbuf, "none", proplen);
+	} else if (type == ZFS_PROP_USERQUOTA || type == ZFS_PROP_GROUPQUOTA ||
+	    type == ZFS_PROP_USERUSED || type == ZFS_PROP_GROUPUSED) {
+		zfs_nicebytes(propvalue, propbuf, proplen);
 	} else {
 		zfs_nicenum(propvalue, propbuf, proplen);
 	}
@@ -3057,7 +3076,7 @@ zfs_prop_get_written(zfs_handle_t *zhp, const char *propname,
 		(void) snprintf(propbuf, proplen, "%llu",
 		    (u_longlong_t)propvalue);
 	} else {
-		zfs_nicenum(propvalue, propbuf, proplen);
+		zfs_nicebytes(propvalue, propbuf, proplen);
 	}
 
 	return (0);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -322,7 +322,7 @@ zpool_get_prop(zpool_handle_t *zhp, zpool_prop_t prop, char *buf,
 				(void) snprintf(buf, len, "%llu",
 				    (u_longlong_t)intval);
 			} else {
-				(void) zfs_nicenum(intval, buf, len);
+				(void) zfs_nicebytes(intval, buf, len);
 			}
 			break;
 
@@ -1253,7 +1253,8 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 			{
 				char buf[64];
 
-				zfs_nicenum(SPA_MINDEVSIZE, buf, sizeof (buf));
+				zfs_nicebytes(SPA_MINDEVSIZE, buf,
+				    sizeof (buf));
 
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "one or more devices is less than the "
@@ -1390,7 +1391,8 @@ zpool_add(zpool_handle_t *zhp, nvlist_t *nvroot)
 			{
 				char buf[64];
 
-				zfs_nicenum(SPA_MINDEVSIZE, buf, sizeof (buf));
+				zfs_nicebytes(SPA_MINDEVSIZE, buf,
+				    sizeof (buf));
 
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "device is less than the minimum "

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -1166,7 +1166,7 @@ send_progress_thread(void *arg)
 			    tm->tm_hour, tm->tm_min, tm->tm_sec,
 			    bytes, zhp->zfs_name);
 		} else {
-			zfs_nicenum(bytes, buf, sizeof (buf));
+			zfs_nicebytes(bytes, buf, sizeof (buf));
 			(void) fprintf(stderr, "%02d:%02d:%02d   %5s   %s\n",
 			    tm->tm_hour, tm->tm_min, tm->tm_sec,
 			    buf, zhp->zfs_name);
@@ -1211,7 +1211,7 @@ send_print_verbose(FILE *fout, const char *tosnap, const char *fromsnap,
 			    (longlong_t)size);
 		} else {
 			char buf[16];
-			zfs_nicenum(size, buf, sizeof (buf));
+			zfs_nicebytes(size, buf, sizeof (buf));
 			(void) fprintf(fout, dgettext(TEXT_DOMAIN,
 			    " estimated size is %s"), buf);
 		}
@@ -1959,7 +1959,7 @@ zfs_send(zfs_handle_t *zhp, const char *fromsnap, const char *tosnap,
 				    (longlong_t)sdd.size);
 			} else {
 				char buf[16];
-				zfs_nicenum(sdd.size, buf, sizeof (buf));
+				zfs_nicebytes(sdd.size, buf, sizeof (buf));
 				(void) fprintf(fout, dgettext(TEXT_DOMAIN,
 				    "total estimated size is %s\n"), buf);
 			}
@@ -3645,10 +3645,10 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		time_t delta = time(NULL) - begin_time;
 		if (delta == 0)
 			delta = 1;
-		zfs_nicenum(bytes, buf1, sizeof (buf1));
-		zfs_nicenum(bytes/delta, buf2, sizeof (buf1));
+		zfs_nicebytes(bytes, buf1, sizeof (buf1));
+		zfs_nicebytes(bytes/delta, buf2, sizeof (buf1));
 
-		(void) printf("received %sB stream in %lu seconds (%sB/sec)\n",
+		(void) printf("received %s stream in %lu seconds (%s/sec)\n",
 		    buf1, delta, buf2);
 	}
 

--- a/lib/libzfs/libzfs_status.c
+++ b/lib/libzfs/libzfs_status.c
@@ -412,13 +412,13 @@ dump_ddt_stat(const ddt_stat_t *dds, int h)
 		zfs_nicenum(1ULL << h, refcnt, sizeof (refcnt));
 
 	zfs_nicenum(dds->dds_blocks, blocks, sizeof (blocks));
-	zfs_nicenum(dds->dds_lsize, lsize, sizeof (lsize));
-	zfs_nicenum(dds->dds_psize, psize, sizeof (psize));
-	zfs_nicenum(dds->dds_dsize, dsize, sizeof (dsize));
+	zfs_nicebytes(dds->dds_lsize, lsize, sizeof (lsize));
+	zfs_nicebytes(dds->dds_psize, psize, sizeof (psize));
+	zfs_nicebytes(dds->dds_dsize, dsize, sizeof (dsize));
 	zfs_nicenum(dds->dds_ref_blocks, ref_blocks, sizeof (ref_blocks));
-	zfs_nicenum(dds->dds_ref_lsize, ref_lsize, sizeof (ref_lsize));
-	zfs_nicenum(dds->dds_ref_psize, ref_psize, sizeof (ref_psize));
-	zfs_nicenum(dds->dds_ref_dsize, ref_dsize, sizeof (ref_dsize));
+	zfs_nicebytes(dds->dds_ref_lsize, ref_lsize, sizeof (ref_lsize));
+	zfs_nicebytes(dds->dds_ref_psize, ref_psize, sizeof (ref_psize));
+	zfs_nicebytes(dds->dds_ref_dsize, ref_dsize, sizeof (ref_dsize));
 
 	(void) printf("%6s   %6s   %5s   %5s   %5s   %6s   %5s   %5s   %5s\n",
 	    refcnt,

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -606,13 +606,16 @@ zfs_nicenum_format(uint64_t num, char *buf, size_t buflen,
 	const char *u;
 	const char *units[3][7] = {
 	    [ZFS_NICENUM_1024] = {"", "K", "M", "G", "T", "P", "E"},
+	    [ZFS_NICENUM_BYTES] = {"B", "K", "M", "G", "T", "P", "E"},
 	    [ZFS_NICENUM_TIME] = {"ns", "us", "ms", "s", "?", "?", "?"}
 	};
 
 	const int units_len[] = {[ZFS_NICENUM_1024] = 6,
+	    [ZFS_NICENUM_BYTES] = 6,
 	    [ZFS_NICENUM_TIME] = 4};
 
 	const int k_unit[] = {	[ZFS_NICENUM_1024] = 1024,
+	    [ZFS_NICENUM_BYTES] = 1024,
 	    [ZFS_NICENUM_TIME] = 1000};
 
 	double val;
@@ -706,7 +709,14 @@ zfs_niceraw(uint64_t num, char *buf, size_t buflen)
 	zfs_nicenum_format(num, buf, buflen, ZFS_NICENUM_RAW);
 }
 
-
+/*
+ * Convert a number of bytes to an appropriately human-readable output.
+ */
+void
+zfs_nicebytes(uint64_t num, char *buf, size_t buflen)
+{
+	zfs_nicenum_format(num, buf, buflen, ZFS_NICENUM_BYTES);
+}
 
 void
 libzfs_print_on_error(libzfs_handle_t *hdl, boolean_t printerr)

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
@@ -58,11 +58,7 @@ function get_used_prop
 	typeset ds=$1
 	typeset used
 
-	used=`zfs list -H -o used $ds`
-	used=${used%[m|M]}
-	if [[ $used == *K ]]; then
-		used=0
-	fi
+	used=`zfs list -H -p -o used $ds`
 	echo $used
 }
 
@@ -79,7 +75,7 @@ function check_used
 	typeset -i cfactor
 	typeset -i fsize=${FILESIZE%[m|M]}
 
-	((used = ${charged_spc%[m|M]}))
+	((used = $charged_spc / 1024 / 1024))
 	((cfactor = used / fsize))
 	if ((cfactor != expected_cfactor)); then
 		log_fail "The space is not charged correctly while setting" \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies_002_pos.ksh
@@ -88,20 +88,22 @@ else
 fi
 for val in 1 2 3; do
 	blks=`ls -ls /$TESTPOOL/fs_$val/$FILE | awk '{print $1}'`
-	(( used = blks * $blksize / (1024 * 1024) ))
+	(( used = blks * $blksize )) # bytes
 	check_used $used $val
 done
 
 log_note "Verify df(1M) can corectly display the space charged."
 for val in 1 2 3; do
-	used=`df -F zfs -h /$TESTPOOL/fs_$val/$FILE | grep $TESTPOOL/fs_$val \
+	used=`df -F zfs -k /$TESTPOOL/fs_$val/$FILE | grep $TESTPOOL/fs_$val \
 		| awk '{print $3}'`
+	(( used = used * 1024 )) # kb -> bytes
 	check_used $used $val
 done
 
 log_note "Verify du(1) can correctly display the space charged."
 for val in 1 2 3; do
-	used=`du -h /$TESTPOOL/fs_$val/$FILE | awk '{print $1}'`
+	used=`du -k /$TESTPOOL/fs_$val/$FILE | awk '{print $1}'`
+	(( used = used * 1024 )) # kb -> bytes
 	check_used $used $val
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/properties.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/properties.kshlib
@@ -28,9 +28,9 @@
 # Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
-set -A RW_FS_PROP "quota=512M" \
-		  "reservation=512M" \
-		  "recordsize=256K" \
+set -A RW_FS_PROP "quota=536870912" \
+		  "reservation=536870912" \
+		  "recordsize=262144" \
 		  "mountpoint=/tmp/mnt$$" \
 		  "checksum=fletcher2" \
 		  "compression=lzjb" \
@@ -43,7 +43,7 @@ set -A RW_FS_PROP "quota=512M" \
 		  "canmount=off" \
 		  "local:department=123"
 
-set -A RW_VOL_PROP "volblocksize=16K" \
+set -A RW_VOL_PROP "volblocksize=16384" \
 		   "checksum=fletcher2" \
 		   "compression=lzjb" \
 		   "readonly=on" \
@@ -54,8 +54,8 @@ set -A RW_VOL_CLONE_PROP "checksum=fletcher2" \
 		   "readonly=on" \
 		   "local:department=123"
 
-set -A FS_ONLY_PROP "quota=512M" \
-                    "recordsize=64K" \
+set -A FS_ONLY_PROP "quota=536870912" \
+                    "recordsize=65536" \
                     "mountpoint=/tmp/mnt$$" \
                     "atime=off" \
                     "devices=off" \
@@ -66,4 +66,4 @@ set -A FS_ONLY_PROP "quota=512M" \
 		    "canmount=off" \
 		    "version=1"
 
-set -A VOL_ONLY_PROP "volblocksize=16K" "volsize=512M"
+set -A VOL_ONLY_PROP "volblocksize=16384" "volsize=536870912"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_common.kshlib
@@ -43,7 +43,7 @@ function propertycheck
 
 	typeset prop=$(echo $propstr | awk -F= '{print $1}')
 	typeset expect_value=$(echo $propstr | awk -F= '{print $2}')
-	typeset value=$(zfs get -H -o value $prop $dtst)
+	typeset value=$(zfs get -H -p -o value $prop $dtst)
 
 
 	if [[ "$expect_value" == "$value" ]]; then

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_021_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_021_pos.ksh
@@ -56,9 +56,9 @@ log_onexit cleanup
 log_assert "'zpool create -O property=value pool' can successfully create a pool \
 		with correct filesystem property set."
 
-set -A RW_FS_PROP "quota=512M" \
-		  "reservation=512M" \
-		  "recordsize=64K" \
+set -A RW_FS_PROP "quota=536870912" \
+		  "reservation=536870912" \
+		  "recordsize=262144" \
 		  "mountpoint=/tmp/mnt$$" \
 		  "checksum=fletcher2" \
 		  "compression=lzjb" \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_022_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_022_pos.ksh
@@ -56,9 +56,9 @@ log_onexit cleanup
 log_assert "'zpool create -O property=value pool' can successfully create a pool \
 		with multiple filesystem properties set."
 
-set -A RW_FS_PROP "quota=512M" \
-		  "reservation=512M" \
-		  "recordsize=64K" \
+set -A RW_FS_PROP "quota=536870912" \
+		  "reservation=536870912" \
+		  "recordsize=262144" \
 		  "mountpoint=/tmp/mnt$$" \
 		  "checksum=fletcher2" \
 		  "compression=lzjb" \

--- a/tests/zfs-tests/tests/functional/userquota/userquota_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userquota_004_pos.ksh
@@ -53,6 +53,7 @@ log_assert "Check the basic function of {user|group} used"
 sync_pool
 typeset user_used=$(get_value "userused@$QUSER1" $QFS)
 typeset group_used=$(get_value "groupused@$QGROUP" $QFS)
+typeset file_size='100m'
 
 if [[ $user_used != 0 ]]; then
 	log_fail "FAIL: userused is $user_used, should be 0"
@@ -62,15 +63,17 @@ if [[ $group_used != 0 ]]; then
 fi
 
 mkmount_writable $QFS
-log_must user_run $QUSER1 mkfile 100m $QFILE
+log_must user_run $QUSER1 mkfile $file_size $QFILE
 sync_pool
 
 user_used=$(get_value "userused@$QUSER1" $QFS)
 group_used=$(get_value "groupused@$QGROUP" $QFS)
 
-if [[ $user_used != "100M" ]]; then
+# get_value() reads the exact byte value which is slightly more than 100m
+if [[ "$(($user_used/1024/1024))m" != "$file_size" ]]; then
 	log_note "user $QUSER1 used is $user_used"
-	log_fail "userused for user $QUSER1 expected to be 50.0M, not $user_used"
+	log_fail "userused for user $QUSER1 expected to be $file_size, " \
+	    "not $user_used"
 fi
 
 if [[ $user_used != $group_used ]]; then

--- a/tests/zfs-tests/tests/functional/userquota/userquota_common.kshlib
+++ b/tests/zfs-tests/tests/functional/userquota/userquota_common.kshlib
@@ -111,7 +111,7 @@ function get_value # property dataset
         typeset prop=$1
         typeset dataset=$2
 
-        prop_val=$(zfs get -H -o value $prop $dataset 2>/dev/null)
+        prop_val=$(zfs get -H -p -o value $prop $dataset 2>/dev/null)
         if [[ $? -ne 0 ]]; then
                 log_note "Unable to get $prop property for dataset " \
                 "$dataset"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Some `zfs`, `zpool` and `zdb` output strings can be confusing to the user when no units are specified. This add a new `zfs_nicenum_format` "ZFS_NICENUM_BYTES" used to print bytes in their human-readable form.

**EDIT**: To be honest some of these changes feel strange to me, maybe i'm too accustomed to seeing "M" instead of "MB" (or "MiB").

**EDIT2**: The more i look at the new ouput of `zfs list` the less i like it, maybe this wasn't such a good idea. I'm open to suggestions.
```
root@debian-8-zfs:/usr/src/zfs# ./cmd/zfs/zfs list
NAME                     USED  AVAIL  REFER  MOUNTPOINT
testpool                129KB  880MB   23KB  /testpool
testpool/newname         46KB  880MB   23KB  /testpool/newname
testpool/newname/child   23KB  880MB   23KB  /testpool/newname/child
root@debian-8-zfs:/usr/src/zfs# df -t zfs -h
Filesystem              Size  Used Avail Use% Mounted on
testpool                880M  128K  880M   1% /testpool
testpool/newname        880M  128K  880M   1% /testpool/newname
testpool/newname/child  880M  128K  880M   1% /testpool/newname/child
```

**EDIT3**: This PR now only adds "B" when the value is < 1024, other values are still reported as "K", "M", "G" and so on. I've also added a commit that fixes an issue with `zfs userspace -p`: i've kept this separate so we can `git blame` these changes later.

```
root@debian-8-zfs:~# zfs get reservation
NAME        PROPERTY     VALUE   SOURCE
testpool    reservation  none    default
testpool/a  reservation  none    local
testpool/b  reservation  512B    local
testpool/c  reservation  1K      local
testpool/d  reservation  1M      local
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/3185
Fix https://github.com/zfsonlinux/zfs/issues/3594
Fix https://github.com/zfsonlinux/zfs/issues/2414

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Manually tested (see size of repaired data and scrub bandwidth)

before
```
root@debian-8-zfs:~# zpool status 
  pool: testpool
 state: ONLINE
status: One or more devices has experienced an unrecoverable error.  An
	attempt was made to correct the error.  Applications are unaffected.
action: Determine if the device needs to be replaced, and clear the errors
	using 'zpool clear' or replace the device with 'zpool replace'.
   see: http://zfsonlinux.org/msg/ZFS-8000-9P
  scan: scrub repaired 512 in 0h0m with 0 errors on Thu Apr 20 23:21:27 2017
config:

	NAME                     STATE     READ WRITE CKSUM
	testpool                 ONLINE       0     0     0
	  mirror-0               ONLINE       0     0     0
	    /var/tmp/zpool.dat   ONLINE       0     0     1
	    /var/tmp/zpool2.dat  ONLINE       0     0     0

errors: No known data errors
```

after:

```
root@debian-8-zfs:~# zpool status -v 
  pool: testpool
 state: ONLINE
status: One or more devices has experienced an unrecoverable error.  An
	attempt was made to correct the error.  Applications are unaffected.
action: Determine if the device needs to be replaced, and clear the errors
	using 'zpool clear' or replace the device with 'zpool replace'.
   see: http://zfsonlinux.org/msg/ZFS-8000-9P
  scan: scrub in progress since Thu Apr 20 23:35:17 2017
	688M scanned out of 866M at 1B/s, (scan is slow, no estimated time)
	512B repaired, 79.45% done
config:

	NAME                     STATE     READ WRITE CKSUM
	testpool                 ONLINE       0     0     0
	  mirror-0               ONLINE       0     0     0
	    /var/tmp/zpool.dat   ONLINE       0     0     1  (repairing)
	    /var/tmp/zpool2.dat  ONLINE       0     0     0

errors: No known data errors
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
