### PR TITLE
Memory reclaim and cache interaction

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -702,6 +702,24 @@ Default value: \fB5\fR.
 .sp
 .ne 2
 .na
+\fBzfs_arc_pc_percent\fR (uint)
+.ad
+.RS 12n
+Percent of pagecache to reclaim arc to
+
+This tunable allows ZFS arc to play more nicely with the kernel's LRU
+pagecache. It can guarantee that the arc size won't collapse under scanning
+pressure on the pagecache, yet still allows arc to be reclaimed down to
+zfs_arc_min if necessary. This value is specified as percent of pagecache
+size (as measured by NR_FILE_PAGES) where that percent may exceed 100. This
+only operates during memory pressure/reclaim.
+.sp
+Default value: \fB0\fR (disabled).
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_arc_sys_free\fR (ulong)
 .ad
 .RS 12n

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4389,7 +4389,7 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 	/* Reclaim in progress */
 	if (mutex_tryenter(&arc_reclaim_lock) == 0) {
 		ARCSTAT_INCR(arcstat_need_free, ptob(sc->nr_to_scan));
-		return (SHRINK_STOP);
+		return (0);
 	}
 
 	mutex_exit(&arc_reclaim_lock);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4407,15 +4407,15 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 #else
 		pages = btop(arc_evictable_memory());
 #endif
+		/*
+		 * We've shrunk what we can, wake up threads.
+		 */
+		cv_broadcast(&arc_reclaim_waiters_cv);
+
 	} else {
 		arc_kmem_reap_now();
 		pages = SHRINK_STOP;
 	}
-
-	/*
-	 * We've reaped what we can, wake up threads.
-	 */
-	cv_broadcast(&arc_reclaim_waiters_cv);
 
 	/*
 	 * When direct reclaim is observed it usually indicates a rapid

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4403,7 +4403,8 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 		if (current_is_kswapd())
 			arc_kmem_reap_now();
 #ifdef HAVE_SPLIT_SHRINKER_CALLBACK
-		pages = MAX(pages - btop(arc_evictable_memory()), 0);
+		pages = MAX((int64_t)pages -
+		    (int64_t)btop(arc_evictable_memory()), 0);
 #else
 		pages = btop(arc_evictable_memory());
 #endif
@@ -4411,7 +4412,6 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 		 * We've shrunk what we can, wake up threads.
 		 */
 		cv_broadcast(&arc_reclaim_waiters_cv);
-
 	} else
 		pages = SHRINK_STOP;
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4387,8 +4387,10 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 		return (SHRINK_STOP);
 
 	/* Reclaim in progress */
-	if (mutex_tryenter(&arc_reclaim_lock) == 0)
+	if (mutex_tryenter(&arc_reclaim_lock) == 0) {
+		ARCSTAT_INCR(arcstat_need_free, ptob(sc->nr_to_scan));
 		return (SHRINK_STOP);
+	}
 
 	mutex_exit(&arc_reclaim_lock);
 
@@ -4426,7 +4428,6 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 		ARCSTAT_BUMP(arcstat_memory_indirect_count);
 	} else {
 		arc_no_grow = B_TRUE;
-		ARCSTAT_INCR(arcstat_need_free, ptob(sc->nr_to_scan));
 		ARCSTAT_BUMP(arcstat_memory_direct_count);
 	}
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4193,7 +4193,7 @@ arc_reclaim_thread(void)
 	while (!arc_reclaim_thread_exit) {
 		int64_t to_free;
 		uint64_t evicted = 0;
-
+		uint64_t need_free = arc_need_free;
 		arc_tuning_update();
 
 		/*
@@ -4243,7 +4243,7 @@ arc_reclaim_thread(void)
 			to_free = (arc_c >> arc_shrink_shift) - free_memory;
 			if (to_free > 0) {
 #ifdef _KERNEL
-				to_free = MAX(to_free, arc_need_free);
+				to_free = MAX(to_free, need_free);
 #endif
 				arc_shrink(to_free);
 			}
@@ -4268,11 +4268,12 @@ arc_reclaim_thread(void)
 			/*
 			 * We're either no longer overflowing, or we
 			 * can't evict anything more, so we should wake
-			 * up any threads before we go to sleep and clear
-			 * arc_need_free since nothing more can be done.
+			 * up any threads before we go to sleep and remove
+			 * the bytes we were working on from arc_need_free
+			 * since nothing more will be done here.
 			 */
 			cv_broadcast(&arc_reclaim_waiters_cv);
-			arc_need_free = 0;
+			ARCSTAT_INCR(arcstat_need_free, -need_free);
 
 			/*
 			 * Block until signaled, or after one second (we
@@ -4425,7 +4426,7 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 		ARCSTAT_BUMP(arcstat_memory_indirect_count);
 	} else {
 		arc_no_grow = B_TRUE;
-		arc_need_free = ptob(sc->nr_to_scan);
+		ARCSTAT_INCR(arcstat_need_free, ptob(sc->nr_to_scan));
 		ARCSTAT_BUMP(arcstat_memory_direct_count);
 	}
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -319,6 +319,11 @@ static int		arc_p_min_shift = 4;
 /* log2(fraction of arc to reclaim) */
 static int		arc_shrink_shift = 7;
 
+/* percent of pagecache to reclaim arc to */
+#ifdef _KERNEL
+static uint_t		zfs_arc_pc_percent = 0;
+#endif
+
 /*
  * log2(fraction of ARC which must be free to allow growing).
  * I.e. If there is less than arc_c >> arc_no_grow_shift free memory,
@@ -4350,10 +4355,18 @@ arc_evictable_memory(void)
 	    refcount_count(&arc_mfu->arcs_esize[ARC_BUFC_METADATA]);
 	uint64_t arc_dirty = MAX((int64_t)arc_size - (int64_t)arc_clean, 0);
 
-	if (arc_dirty >= arc_c_min)
+	/*
+	 * Scale reported evictable memory in proportion to page cache, cap
+	 * at specified min/max.
+	 */
+	uint64_t min = (ptob(global_page_state(NR_FILE_PAGES)) / 100) *
+	    zfs_arc_pc_percent;
+	min = MAX(arc_c_min, MIN(arc_c_max, min));
+
+	if (arc_dirty >= min)
 		return (arc_clean);
 
-	return (MAX((int64_t)arc_size - (int64_t)arc_c_min, 0));
+	return (MAX((int64_t)arc_size - (int64_t)min, 0));
 }
 
 /*
@@ -7724,6 +7737,10 @@ MODULE_PARM_DESC(zfs_arc_p_dampener_disable, "disable arc_p adapt dampener");
 
 module_param(zfs_arc_shrink_shift, int, 0644);
 MODULE_PARM_DESC(zfs_arc_shrink_shift, "log2(fraction of arc to reclaim)");
+
+module_param(zfs_arc_pc_percent, uint, 0644);
+MODULE_PARM_DESC(zfs_arc_pc_percent,
+	"Percent of pagecache to reclaim arc to");
 
 module_param(zfs_arc_p_min_shift, int, 0644);
 MODULE_PARM_DESC(zfs_arc_p_min_shift, "arc_c shift to calc min/max arc_p");

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4347,17 +4347,12 @@ arc_evictable_memory(void)
 	    refcount_count(&arc_mru->arcs_esize[ARC_BUFC_METADATA]) +
 	    refcount_count(&arc_mfu->arcs_esize[ARC_BUFC_DATA]) +
 	    refcount_count(&arc_mfu->arcs_esize[ARC_BUFC_METADATA]);
-	uint64_t ghost_clean =
-	    refcount_count(&arc_mru_ghost->arcs_esize[ARC_BUFC_DATA]) +
-	    refcount_count(&arc_mru_ghost->arcs_esize[ARC_BUFC_METADATA]) +
-	    refcount_count(&arc_mfu_ghost->arcs_esize[ARC_BUFC_DATA]) +
-	    refcount_count(&arc_mfu_ghost->arcs_esize[ARC_BUFC_METADATA]);
 	uint64_t arc_dirty = MAX((int64_t)arc_size - (int64_t)arc_clean, 0);
 
 	if (arc_dirty >= arc_c_min)
-		return (ghost_clean + arc_clean);
+		return (arc_clean);
 
-	return (ghost_clean + MAX((int64_t)arc_size - (int64_t)arc_c_min, 0));
+	return (MAX((int64_t)arc_size - (int64_t)arc_c_min, 0));
 }
 
 /*


### PR DESCRIPTION
### Description
Fix memory reclaim behavior and add scaling factor to balance multiple caches (default disabled)

### Motivation and Context
We deployed ZFS to several thousand machines and immediately started noticing some bad performance characteristics. Our machines still have traditional filesystems utilizing pagecache which compete with zfs. I identified one of the main problems was the arc cache would collapse to minimum, regardless of several GB of memory being free/used by pagecache and other reclaimable objects. This set of patches corrects the reclaim behavior, and also adds an option that allows balancing of multiple caches via scaling factor, which only activates on reclaim. This means under memory pressure a user-defined scaling factor will balance pagecache and arc cache, and when not under pressure will work normally. This is disabled by default. In addition this patchset means the zfs_arc_sys_free algorithm is no longer necessary. Although some user may want to set this for other reasons but the zfs module does neither get the appropriate watermarks from the kernel, nor does it need to as the feedback mechanism is the reclaim callback, which is based on the true watermarks. Performance should be improved by disabling this by default, I can add a patch later for this.

Other fixes:
1. Reclaim behavior was fixed in regards to drop_caches, previously with a significant cache size it would take many calls of drop_caches to actually reclaim all memory, only a single run should do it now. This was problematic for several reasons, for example trying to free memory before huge page allocation.
2. zfs routines now take significantly less CPU on the kswapd stack for multiple reasons.

### How Has This Been Tested?
Test with production traffic on 100 machines. Verified arc cache does not collapse to minimum size, and we do not incur performance hit from heavy MFU cache misses. Expanding to 100k+ machines over several weeks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
