### PR TITLE
Change U16 to U32 due to atomic_inc_32_nv

### DIFF
--- a/module/zfs/qat_compress.c
+++ b/module/zfs/qat_compress.c
@@ -104,8 +104,8 @@ static kstat_t *qat_ksp;
 static CpaInstanceHandle dc_inst_handles[MAX_INSTANCES];
 static CpaDcSessionHandle session_handles[MAX_INSTANCES];
 static CpaBufferList **buffer_array[MAX_INSTANCES];
-static Cpa16U num_inst = 0;
-static Cpa16U inst_num = 0;
+static Cpa32U num_inst = 0;
+static Cpa32U inst_num = 0;
 static boolean_t qat_init_done = B_FALSE;
 int zfs_qat_disable = 0;
 


### PR DESCRIPTION
After run a long time with QAT compression, the variable "inst_num"
is overflow by "atomic_inc_32_nv", which causes its neighbor
variable overwritten. Change its definition from U16 to U32.

Signed-off-by: Weigang Li <weigang.li@intel.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Change "inst_num" from U16 to U32 in qat_compress.c
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
