### PR TITLE
Fix typo in zfs-module-parameters man page

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -136,7 +136,7 @@ Use \fB1\fR for yes and \fB0\fR for no (default).
 \fBl2arc_write_boost\fR (ulong)
 .ad
 .RS 12n
-Cold L2ARC devices will have \fBl2arc_write_nax\fR increased by this amount
+Cold L2ARC devices will have \fBl2arc_write_max\fR increased by this amount
 while they remain cold.
 .sp
 Default value: \fB8,388,608\fR.


### PR DESCRIPTION
### Description
Fix typo in zfs-module-parameters man page

### Motivation and Context
Makes my eyes not bleed

### How Has This Been Tested?
None should be necessary as it's a man page.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
