### PR TITLE
Fix a shellcheck warning in the 'lsblk' pre-baked script

### DIFF
--- a/cmd/zpool/zpool.d/lsblk
+++ b/cmd/zpool/zpool.d/lsblk
@@ -68,7 +68,7 @@ for i in $list ; do
 	# Special case: Looking up the size of a file-based vdev can't
 	# be done with lsblk.
 	if [ "$i" = "size" ] && [ -f "$VDEV_UPATH" ] ; then
-		size="$(du -h --apparent-size $VDEV_UPATH | cut -f 1)"
+		size=$(du -h --apparent-size "$VDEV_UPATH" | cut -f 1)
 		echo "size=$size"
 		continue
 	fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Fix a shellcheck warning in the `lsblk` pre-baked script:

```
cmd/zpool/zpool.d/label:71:33: note: Double quote to prevent globbing and word splitting. [SC2086]
cmd/zpool/zpool.d/lsblk:71:33: note: Double quote to prevent globbing and word splitting. [SC2086]
cmd/zpool/zpool.d/model:71:33: note: Double quote to prevent globbing and word splitting. [SC2086]
cmd/zpool/zpool.d/serial:71:33: note: Double quote to prevent globbing and word splitting. [SC2086]
cmd/zpool/zpool.d/size:71:33: note: Double quote to prevent globbing and word splitting. [SC2086]
cmd/zpool/zpool.d/vendor:71:33: note: Double quote to prevent globbing and word splitting. [SC2086]
Makefile:1316: recipe for target 'shellcheck' failed
make: *** [shellcheck] Error 1
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
