### PR TITLE
Fixed zdb -e regression for active cacheless pools

### DIFF
--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1938,10 +1938,15 @@ zpool_find_import_impl(libzfs_handle_t *hdl, importargs_t *iarg)
 				 * exclusively. This will prune all underlying
 				 * multipath devices which otherwise could
 				 * result in the vdev appearing as UNAVAIL.
+				 *
+				 * Under zdb, this step isn't required and
+				 * would prevent a zdb -e of active pools with
+				 * no cachefile.
 				 */
 				fd = open(slice->rn_name, O_RDONLY | O_EXCL);
-				if (fd >= 0) {
-					close(fd);
+				if (fd >= 0 || iarg->can_be_active) {
+					if (fd >= 0)
+						close(fd);
 					add_config(hdl, &pools,
 					    slice->rn_name, slice->rn_order,
 					    slice->rn_num_labels, config);


### PR DESCRIPTION
Signed-off-by: Don Brady <don.brady@intel.com>

### Description

`zdb -e` for active cache-less pools fails:
```
-sh-4.2$ sudo zpool create -o cachefile=none basic mirror sdk sdl
-sh-4.2$ sudo zdb -e -b basic
zdb: can't open 'basic': No such file or directory
```

### Motivation and Context
this is a recent regression introduce by commit https://github.com/zfsonlinux/zfs/commit/c30d8ded0c8c64a9a144cf478502bb4e512ab9fa

### How Has This Been Tested?
tested using zdb to validate fix and ztest to exercise code path

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
