### PR TITLE
Fix 'zpool iostat -v' cache output

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3611,6 +3611,7 @@ children:
 		    !cb->cb_vdev_names) {
 			print_iostat_dashes(cb, 0, "logs");
 		}
+		printf("\n");
 
 		for (c = 0; c < children; c++) {
 			uint64_t islog = B_FALSE;
@@ -3645,6 +3646,7 @@ children:
 		    !cb->cb_vdev_names) {
 			print_iostat_dashes(cb, 0, "cache");
 		}
+		printf("\n");
 
 		for (c = 0; c < children; c++) {
 			vname = zpool_vdev_name(g_zfs, zhp, newchild[c],


### PR DESCRIPTION
### Description

Fixes formatting errors from commit d6418de057


### Motivation and Context

Without it, a pool with 2 caches looks like this:

<pre># zpool iostat -v
              capacity     operations     bandwidth 
pool        alloc   free   read  write   read  write
----------  -----  -----  -----  -----  -----  -----
atmaweapon  2.29T   450G      1     39  19.6K   698K
  mirror    2.29T   450G      1     39  19.6K   698K
    sdd         -      -      0     19  9.82K   349K
    sdc         -      -      0     19  9.74K   349K
cache           -      -      -      -      -      -  l2arc      347M  19.7G      0    240  2.66K  1.18M
  l2arc_2   1.84M  20.0G      1      8  39.3K   553K
----------  -----  -----  -----  -----  -----  -----
</pre>
With only 1 cache it still appears on the wrong line.

Similar output issue for log devices.

### How Has This Been Tested?
Tested manually on a pool with 0, 1 and 2 cache devices, and 0 and 1 log devices.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
