### PR TITLE
Update documentation for zfs_vdev_queue_depth_pct

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1151,8 +1151,14 @@ Default value: \fB10\fR.
 \fBzfs_vdev_queue_depth_pct\fR (int)
 .ad
 .RS 12n
-The queue depth percentage for each top-level virtual device.
-Used in conjunction with zfs_vdev_async_max_active.
+Maximum number of queued allocations per top-level vdev expressed as
+a percentage of \fBzfs_vdev_async_write_max_active\fR which allows the
+system to detect devices that are more capable of handling allocations
+and to allocate more blocks to those devices.  It allows for dynamic
+allocation distribution when devices are imbalanced as fuller devices
+will tend to be slower than dempty devices.
+
+See also \fBzio_dva_throttle_enabled\fR.
 .sp
 Default value: \fB1000\fR.
 .RE
@@ -1940,6 +1946,8 @@ Default value: \fB30,000\fR.
 .RS 12n
 Throttle block allocations in the ZIO pipeline. This allows for
 dynamic allocation distribution when devices are imbalanced.
+When enabled, the maximum number of pending allocations per top-level vdev
+is limited by \fBzfs_vdev_queue_depth_pct\fR.
 .sp
 Default value: \fB1\fR.
 .RE


### PR DESCRIPTION
It was documented as being related to zfs_vdev_async_max_active when it
is actually related to zfs_vdev_async_write_max_active.  Also, expand the
documentation to describe the allocation throttle which was introduced
as part of OpenZFS 7090 in 3dfb57a.

<!--- Provide a general summary of your changes in the Title above -->

### Description
See summary above.

### Motivation and Context
Correct documentation of new parameters.

### How Has This Been Tested?
Run nroff against new documentation file and examine the output.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
