### PR TITLE
Metadata classes wip no accounting

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -373,7 +373,7 @@ usage_prop_cb(int prop, void *cb)
 {
 	FILE *fp = cb;
 
-	(void) fprintf(fp, "\t%-15s ", zfs_prop_to_name(prop));
+	(void) fprintf(fp, "\t%-20s ", zfs_prop_to_name(prop));
 
 	if (zfs_prop_readonly(prop))
 		(void) fprintf(fp, " NO    ");
@@ -437,22 +437,22 @@ usage(boolean_t requested)
 		(void) fprintf(fp,
 		    gettext("\nThe following properties are supported:\n"));
 
-		(void) fprintf(fp, "\n\t%-14s %s  %s   %s\n\n",
+		(void) fprintf(fp, "\n\t%-19s %s  %s   %s\n\n",
 		    "PROPERTY", "EDIT", "INHERIT", "VALUES");
 
 		/* Iterate over all properties */
 		(void) zprop_iter(usage_prop_cb, fp, B_FALSE, B_TRUE,
 		    ZFS_TYPE_DATASET);
 
-		(void) fprintf(fp, "\t%-15s ", "userused@...");
+		(void) fprintf(fp, "\t%-20s ", "userused@...");
 		(void) fprintf(fp, " NO       NO   <size>\n");
-		(void) fprintf(fp, "\t%-15s ", "groupused@...");
+		(void) fprintf(fp, "\t%-20s ", "groupused@...");
 		(void) fprintf(fp, " NO       NO   <size>\n");
-		(void) fprintf(fp, "\t%-15s ", "userquota@...");
+		(void) fprintf(fp, "\t%-20s ", "userquota@...");
 		(void) fprintf(fp, "YES       NO   <size> | none\n");
-		(void) fprintf(fp, "\t%-15s ", "groupquota@...");
+		(void) fprintf(fp, "\t%-20s ", "groupquota@...");
 		(void) fprintf(fp, "YES       NO   <size> | none\n");
-		(void) fprintf(fp, "\t%-15s ", "written@<snap>");
+		(void) fprintf(fp, "\t%-20s ", "written@<snap>");
 		(void) fprintf(fp, " NO       NO   <size>\n");
 
 		(void) fprintf(fp, gettext("\nSizes are specified in bytes "

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -28,6 +28,7 @@
  * Copyright (c) 2013 by Prasad Joshi (sTec). All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>.
  * Copyright (c) 2017 Datto Inc.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <assert.h>
@@ -328,7 +329,7 @@ get_usage(zpool_help_t idx)
 	case HELP_LABELCLEAR:
 		return (gettext("\tlabelclear [-f] <vdev>\n"));
 	case HELP_LIST:
-		return (gettext("\tlist [-gHLpPv] [-o property[,...]] "
+		return (gettext("\tlist [-CgHLpPv] [-o property[,...]] "
 		    "[-T d|u] [pool] ... [interval [count]]\n"));
 	case HELP_OFFLINE:
 		return (gettext("\toffline [-f] [-t] <pool> <device> ...\n"));
@@ -380,7 +381,7 @@ print_prop_cb(int prop, void *cb)
 {
 	FILE *fp = cb;
 
-	(void) fprintf(fp, "\t%-15s  ", zpool_prop_to_name(prop));
+	(void) fprintf(fp, "\t%-19s  ", zpool_prop_to_name(prop));
 
 	if (zpool_prop_readonly(prop))
 		(void) fprintf(fp, "  NO   ");
@@ -432,14 +433,14 @@ usage(boolean_t requested)
 		(void) fprintf(fp,
 		    gettext("\nthe following properties are supported:\n"));
 
-		(void) fprintf(fp, "\n\t%-15s  %s   %s\n\n",
+		(void) fprintf(fp, "\n\t%-19s  %s   %s\n\n",
 		    "PROPERTY", "EDIT", "VALUES");
 
 		/* Iterate over all properties */
 		(void) zprop_iter(print_prop_cb, fp, B_FALSE, B_TRUE,
 		    ZFS_TYPE_POOL);
 
-		(void) fprintf(fp, "\t%-15s   ", "feature@...");
+		(void) fprintf(fp, "\t%-19s   ", "feature@...");
 		(void) fprintf(fp, "YES   disabled | enabled | active\n");
 
 		(void) fprintf(fp, gettext("\nThe feature@ properties must be "
@@ -457,7 +458,10 @@ usage(boolean_t requested)
 	exit(requested ? 0 : 2);
 }
 
-void
+/*
+ * print a pool vdev config for dry runs
+ */
+static void
 print_vdev_tree(zpool_handle_t *zhp, const char *name, nvlist_t *nv, int indent,
     boolean_t print_logs, int name_flags)
 {
@@ -722,8 +726,9 @@ zpool_do_add(int argc, char **argv)
 
 		/* print original main pool and new tree */
 		print_vdev_tree(zhp, poolname, poolnvroot, 0, B_FALSE,
-		    name_flags);
-		print_vdev_tree(zhp, NULL, nvroot, 0, B_FALSE, name_flags);
+		    name_flags | VDEV_NAME_TYPE_ID | VDEV_NAME_ALLOC_BIAS);
+		print_vdev_tree(zhp, NULL, nvroot, 0, B_FALSE,
+		    name_flags | VDEV_NAME_ALLOC_BIAS);
 
 		/* Do the same for the logs */
 		if (num_logs(poolnvroot) > 0) {
@@ -1232,7 +1237,9 @@ zpool_do_create(int argc, char **argv)
 		(void) printf(gettext("would create '%s' with the "
 		    "following layout:\n\n"), poolname);
 
-		print_vdev_tree(NULL, poolname, nvroot, 0, B_FALSE, 0);
+		print_vdev_tree(NULL, poolname, nvroot, 0, B_FALSE,
+		    VDEV_NAME_ALLOC_BIAS);
+
 		if (num_logs(nvroot) > 0)
 			print_vdev_tree(NULL, "logs", nvroot, 0, B_TRUE, 0);
 
@@ -1899,6 +1906,8 @@ print_logs(zpool_handle_t *zhp, status_cbdata_t *cb, nvlist_t *nv)
 {
 	uint_t c, children;
 	nvlist_t **child;
+
+	assert(zhp != NULL || !cb->cb_verbose);
 
 	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN, &child,
 	    &children) != 0)
@@ -3522,7 +3531,7 @@ print_iostat_default(vdev_stat_t *vs, iostat_cbdata_t *cb, double scale)
  *
  * Returns the number of stat lines printed.
  */
-unsigned int
+static unsigned int
 print_vdev_stats(zpool_handle_t *zhp, const char *name, nvlist_t *oldnv,
     nvlist_t *newnv, iostat_cbdata_t *cb, int depth)
 {
@@ -3656,7 +3665,7 @@ children:
 			continue;
 
 		vname = zpool_vdev_name(g_zfs, zhp, newchild[c],
-		    cb->cb_name_flags);
+		    cb->cb_name_flags | VDEV_NAME_ALLOC_BIAS);
 		ret += print_vdev_stats(zhp, vname, oldnv ? oldchild[c] : NULL,
 		    newchild[c], cb, depth + 2);
 		free(vname);
@@ -3811,7 +3820,7 @@ get_namewidth(zpool_handle_t *zhp, void *data)
 		else
 			cb->cb_namewidth = MAX(poolname_len,
 			    max_width(zhp, nvroot, 0, cb->cb_namewidth,
-			    cb->cb_name_flags));
+			    cb->cb_name_flags | VDEV_NAME_ALLOC_BIAS));
 	}
 	/*
 	 * The width must be at least 10, but may be as large as the
@@ -4607,7 +4616,11 @@ typedef struct list_cbdata {
 	boolean_t	cb_scripted;
 	zprop_list_t	*cb_proplist;
 	boolean_t	cb_literal;
+	boolean_t	cb_category;
 } list_cbdata_t;
+
+#define	CATEGORY_NAME_WIDTH	12
+
 
 /*
  * Given a list of columns to display, output appropriate headers for each one.
@@ -4621,6 +4634,20 @@ print_header(list_cbdata_t *cb)
 	boolean_t first = B_TRUE;
 	boolean_t right_justify;
 	size_t width = 0;
+
+	if (cb->cb_category) {
+		const char *line = "-----  -----  -----";
+		const char *column = "SPACE  ALLOC  USING";
+
+		(void) printf("\n%*s  %19s  %19s  %19s\n", CATEGORY_NAME_WIDTH,
+		    "", "Generic Blocks  ", "Small Blocks   ",
+		    "Metadata Blocks  ");
+		(void) printf("%-*s  %s  %s  %s\n", CATEGORY_NAME_WIDTH,
+		    "NAME", column, column, column);
+		(void) printf("%-*s  %s  %s  %s\n", CATEGORY_NAME_WIDTH,
+		    "------------", line, line, line);
+		return;
+	}
 
 	for (; pl != NULL; pl = pl->pl_next) {
 		width = pl->pl_width;
@@ -4663,7 +4690,7 @@ print_header(list_cbdata_t *cb)
 
 /*
  * Given a pool and a list of properties, print out all the properties according
- * to the described layout.
+ * to the described layout. Used by zpool_do_list().
  */
 static void
 print_pool(zpool_handle_t *zhp, list_cbdata_t *cb)
@@ -4758,12 +4785,14 @@ print_one_column(zpool_prop_t prop, uint64_t value, boolean_t scripted,
 		}
 		break;
 	case ZPOOL_PROP_CAPACITY:
+		/* by convention capacity value is 100x for more precision */
 		if (format == ZFS_NICENUM_RAW)
 			(void) snprintf(propval, sizeof (propval), "%llu",
-			    (unsigned long long)value);
+			    (unsigned long long)value / 100);
 		else
-			(void) snprintf(propval, sizeof (propval), "%llu%%",
-			    (unsigned long long)value);
+			(void) snprintf(propval, sizeof (propval),
+			    value < 1000 ? "%1.2f%%" : value < 10000 ?
+			    "%2.1f%%" : "%3.0f%%", value / 100.0);
 		break;
 	default:
 		zfs_nicenum_format(value, propval, sizeof (propval), format);
@@ -4778,6 +4807,10 @@ print_one_column(zpool_prop_t prop, uint64_t value, boolean_t scripted,
 		(void) printf("  %*s", (int)width, propval);
 }
 
+/*
+ * print static default line per vdev
+ * not compatible with '-o' <proplist> option
+ */
 void
 print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
     list_cbdata_t *cb, int depth)
@@ -4831,7 +4864,7 @@ print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		    (vs->vs_fragmentation != ZFS_FRAG_INVALID && toplevel),
 		    format);
 		cap = (vs->vs_space == 0) ? 0 :
-		    (vs->vs_alloc * 100 / vs->vs_space);
+		    (vs->vs_alloc * 10000 / vs->vs_space);
 		print_one_column(ZPOOL_PROP_CAPACITY, cap, scripted, toplevel,
 		    format);
 		(void) printf("\n");
@@ -4855,7 +4888,7 @@ print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		}
 
 		vname = zpool_vdev_name(g_zfs, zhp, child[c],
-		    cb->cb_name_flags);
+		    cb->cb_name_flags | VDEV_NAME_ALLOC_BIAS);
 		print_list_stats(zhp, vname, child[c], cb, depth + 2);
 		free(vname);
 	}
@@ -4899,7 +4932,6 @@ print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 	}
 }
 
-
 /*
  * Generic callback function to list a pool.
  */
@@ -4912,20 +4944,29 @@ list_callback(zpool_handle_t *zhp, void *data)
 
 	config = zpool_get_config(zhp, NULL);
 
-	print_pool(zhp, cbp);
-	if (!cbp->cb_verbose)
-		return (0);
+	if (cbp->cb_verbose || cbp->cb_category) {
+		config = zpool_get_config(zhp, NULL);
 
-	verify(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
-	    &nvroot) == 0);
-	print_list_stats(zhp, NULL, nvroot, cbp, 0);
+		verify(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
+		    &nvroot) == 0);
+	}
+
+	if (cbp->cb_verbose)
+		cbp->cb_namewidth = max_width(zhp, nvroot, 0, 0,
+		    cbp->cb_name_flags | VDEV_NAME_ALLOC_BIAS);
+
+	print_pool(zhp, cbp);
+
+	if (cbp->cb_verbose)
+		print_list_stats(zhp, NULL, nvroot, cbp, 0);
 
 	return (0);
 }
 
 /*
- * zpool list [-gHLpP] [-o prop[,prop]*] [-T d|u] [pool] ... [interval [count]]
+ * zpool list [-CgHLpP] [-o prop[,prop]*] [-T d|u] [pool] ... [interval [count]]
  *
+ *	-C	Diplay the list of block allocations by category
  *	-g	Display guid for individual vdev name.
  *	-H	Scripted mode.  Don't display headers, and separate properties
  *		by a single tab.
@@ -4949,6 +4990,7 @@ zpool_do_list(int argc, char **argv)
 	static char default_props[] =
 	    "name,size,allocated,free,expandsize,fragmentation,capacity,"
 	    "dedupratio,health,altroot";
+	static char category_props[] = "name,size,allocated";
 	char *props = default_props;
 	float interval = 0;
 	unsigned long count = 0;
@@ -4956,8 +4998,15 @@ zpool_do_list(int argc, char **argv)
 	boolean_t first = B_TRUE;
 
 	/* check options */
-	while ((c = getopt(argc, argv, ":gHLo:pPT:v")) != -1) {
+	while ((c = getopt(argc, argv, ":CgHLo:pPT:v")) != -1) {
 		switch (c) {
+		case 'C':
+			cb.cb_category = B_TRUE;
+			props = category_props;
+			cb.cb_name_flags |= VDEV_NAME_TYPE_ID;
+			cb.cb_namewidth = CATEGORY_NAME_WIDTH;
+			cb.cb_verbose = B_TRUE;
+			break;
 		case 'g':
 			cb.cb_name_flags |= VDEV_NAME_GUID;
 			break;
@@ -4981,6 +5030,7 @@ zpool_do_list(int argc, char **argv)
 			break;
 		case 'v':
 			cb.cb_verbose = B_TRUE;
+			cb.cb_namewidth = 8;	/* 8 until precalc is avail */
 			break;
 		case ':':
 			(void) fprintf(stderr, gettext("missing argument for "
@@ -6322,7 +6372,8 @@ status_callback(zpool_handle_t *zhp, void *data)
 		print_scan_status(ps);
 
 		cbp->cb_namewidth = max_width(zhp, nvroot, 0, 0,
-		    cbp->cb_name_flags | VDEV_NAME_TYPE_ID);
+		    cbp->cb_name_flags | VDEV_NAME_TYPE_ID |
+		    VDEV_NAME_ALLOC_BIAS);
 		if (cbp->cb_namewidth < 10)
 			cbp->cb_namewidth = 10;
 
@@ -6335,8 +6386,11 @@ status_callback(zpool_handle_t *zhp, void *data)
 			print_cmd_columns(cbp->vcdl, 0);
 
 		printf("\n");
+
+		cbp->cb_name_flags |= VDEV_NAME_ALLOC_BIAS;
 		print_status_config(zhp, cbp, zpool_get_name(zhp), nvroot, 0,
 		    B_FALSE);
+		cbp->cb_name_flags &= ~VDEV_NAME_ALLOC_BIAS;
 
 		if (num_logs(nvroot) > 0)
 			print_logs(zhp, cbp, nvroot);

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -1453,7 +1453,7 @@ is_grouping(const char *type, int *mindev, int *maxdev)
 	    strcmp(type, VDEV_ALLOC_BIAS_METADATA) == 0 ||
 	    strcmp(type, VDEV_ALLOC_BIAS_SMALLBLKS) == 0) {
 		if (mindev != NULL)
-			*mindev = 2;
+			*mindev = 1;
 		return (type);
 	}
 
@@ -1615,14 +1615,12 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 				is_log = is_dedup = is_metadata = B_FALSE;
 			}
 
-			if (is_log || is_dedup || is_metadata || is_smallblks) {
+			if (is_log) {
 				if (strcmp(type, VDEV_TYPE_MIRROR) != 0) {
 					(void) fprintf(stderr,
 					    gettext("invalid vdev "
-					    "specification: unsupported '%s' "
-					    "device: %s\n"), is_log ? "log" :
-					    is_dedup ? "dedup" : is_metadata ?
-					    "metadata" : "smallblks", type);
+					    "specification: unsupported 'log' "
+					    "device: %s\n"), type);
 					goto spec_out;
 				}
 				nlogs++;
@@ -1728,13 +1726,6 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 
 			if (is_log)
 				nlogs++;
-			if (is_dedup || is_metadata || is_smallblks) {
-				(void) fprintf(stderr,
-				    gettext("invalid vdev specification: '%s' "
-				    "expects mirror\n"), is_dedup ? "dedup" :
-				    is_metadata ? "metadata" : "smallblks");
-				goto spec_out;
-			}
 			argc--;
 			argv++;
 		}

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, 2015 by Delphix. All rights reserved.
- * Copyright (c) 2016 Intel Corporation.
+ * Copyright (c) 2017 Intel Corporation.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>.
  */
 
@@ -682,6 +682,9 @@ make_leaf_vdev(nvlist_t *props, const char *arg, uint64_t is_log)
 	verify(nvlist_add_string(vdev, ZPOOL_CONFIG_PATH, path) == 0);
 	verify(nvlist_add_string(vdev, ZPOOL_CONFIG_TYPE, type) == 0);
 	verify(nvlist_add_uint64(vdev, ZPOOL_CONFIG_IS_LOG, is_log) == 0);
+	if (is_log)
+		verify(nvlist_add_string(vdev, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    VDEV_ALLOC_BIAS_LOG) == 0);
 	if (strcmp(type, VDEV_TYPE_DISK) == 0)
 		verify(nvlist_add_uint64(vdev, ZPOOL_CONFIG_WHOLE_DISK,
 		    (uint64_t)wholedisk) == 0);
@@ -740,6 +743,9 @@ make_leaf_vdev(nvlist_t *props, const char *arg, uint64_t is_log)
  *
  * 	Otherwise, make sure that the current spec (if there is one) and the new
  * 	spec have consistent replication levels.
+ *
+ *	If there is no current spec (create), make sure new spec has at least
+ *	one general purpose vdev.
  */
 typedef struct replication_level {
 	char *zprl_type;
@@ -775,7 +781,7 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 	nvlist_t **child;
 	uint_t c, children;
 	nvlist_t *nv;
-	char *type;
+	char *type, *alloc_bias;
 	replication_level_t lastrep = {0};
 	replication_level_t rep;
 	replication_level_t *ret;
@@ -798,6 +804,9 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 		 */
 		(void) nvlist_lookup_uint64(nv, ZPOOL_CONFIG_IS_LOG, &is_log);
 		if (is_log)
+			continue;
+		if (nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &alloc_bias) == 0)
 			continue;
 
 		verify(nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE,
@@ -959,7 +968,7 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 		/*
 		 * At this point, we have the replication of the last toplevel
 		 * vdev in 'rep'.  Compare it to 'lastrep' to see if its
-		 * different.
+		 * different. Skip checks involving dedicated top-level vdevs.
 		 */
 		if (lastrep.zprl_type != NULL) {
 			if (is_raidz_mirror(&lastrep, &rep, &raidz, &mirror) ||
@@ -1443,6 +1452,14 @@ is_grouping(const char *type, int *mindev, int *maxdev)
 		return (VDEV_TYPE_LOG);
 	}
 
+	if (strcmp(type, VDEV_ALLOC_BIAS_DEDUP) == 0 ||
+	    strcmp(type, VDEV_ALLOC_BIAS_METADATA) == 0 ||
+	    strcmp(type, VDEV_ALLOC_BIAS_SMALLBLKS) == 0) {
+		if (mindev != NULL)
+			*mindev = 2;
+		return (type);
+	}
+
 	if (strcmp(type, "cache") == 0) {
 		if (mindev != NULL)
 			*mindev = 1;
@@ -1450,6 +1467,19 @@ is_grouping(const char *type, int *mindev, int *maxdev)
 	}
 
 	return (NULL);
+}
+
+static boolean_t
+segregate_prop_active(nvlist_t *props, zpool_prop_t prop)
+{
+	char *str;
+
+	if (props != NULL &&
+	    nvlist_lookup_string(props, zpool_prop_to_name(prop), &str) == 0 &&
+	    strcmp(str, "on") == 0) {
+		return (B_TRUE);
+	}
+	return (B_FALSE);
 }
 
 /*
@@ -1464,7 +1494,7 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 	nvlist_t *nvroot, *nv, **top, **spares, **l2cache;
 	int t, toplevels, mindev, maxdev, nspares, nlogs, nl2cache;
 	const char *type;
-	uint64_t is_log;
+	uint64_t is_log, is_dedup, is_metadata, is_smallblks;
 	boolean_t seen_logs;
 
 	top = NULL;
@@ -1474,7 +1504,7 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 	nspares = 0;
 	nlogs = 0;
 	nl2cache = 0;
-	is_log = B_FALSE;
+	is_log = is_dedup = is_metadata = is_smallblks = B_FALSE;
 	seen_logs = B_FALSE;
 	nvroot = NULL;
 
@@ -1497,7 +1527,8 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 					    "specified only once\n"));
 					goto spec_out;
 				}
-				is_log = B_FALSE;
+				is_log = is_dedup = B_FALSE;
+				is_metadata = is_smallblks = B_FALSE;
 			}
 
 			if (strcmp(type, VDEV_TYPE_LOG) == 0) {
@@ -1508,14 +1539,71 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 					    "specified only once\n"));
 					goto spec_out;
 				}
+				if (segregate_prop_active(props,
+				    ZPOOL_PROP_SEGREGATE_LOG)) {
+					(void) fprintf(stderr,
+					    gettext("invalid vdev specified: "
+					    "'%s' was already specified by "
+					    "'%s' property\n"),
+					    VDEV_TYPE_LOG, zpool_prop_to_name(
+					    ZPOOL_PROP_SEGREGATE_LOG));
+					goto spec_out;
+				}
 				seen_logs = B_TRUE;
 				is_log = B_TRUE;
+				is_dedup = is_metadata = is_smallblks = B_FALSE;
 				argc--;
 				argv++;
 				/*
 				 * A log is not a real grouping device.
 				 * We just set is_log and continue.
 				 */
+				continue;
+			}
+
+			if (strcmp(type, VDEV_ALLOC_BIAS_DEDUP) == 0) {
+				is_dedup = B_TRUE;
+				is_log = is_metadata = is_smallblks = B_FALSE;
+				argc--;
+				argv++;
+				continue;
+			}
+
+			if (strcmp(type, VDEV_ALLOC_BIAS_METADATA) == 0) {
+				if (segregate_prop_active(props,
+				    ZPOOL_PROP_SEGREGATE_METADATA)) {
+					(void) fprintf(stderr,
+					    gettext("invalid vdev specified: "
+					    "'%s' was already specified by "
+					    "'%s' property\n"),
+					    VDEV_ALLOC_BIAS_METADATA,
+					    zpool_prop_to_name(
+					    ZPOOL_PROP_SEGREGATE_METADATA));
+					goto spec_out;
+				}
+				is_metadata = B_TRUE;
+				is_log = is_dedup = is_smallblks = B_FALSE;
+				argc--;
+				argv++;
+				continue;
+			}
+
+			if (strcmp(type, VDEV_ALLOC_BIAS_SMALLBLKS) == 0) {
+				if (segregate_prop_active(props,
+				    ZPOOL_PROP_SEGREGATE_SMALLBLKS)) {
+					(void) fprintf(stderr,
+					    gettext("invalid vdev specified: "
+					    "'%s' was already specified by "
+					    "'%s' property\n"),
+					    VDEV_ALLOC_BIAS_SMALLBLKS,
+					    zpool_prop_to_name(
+					    ZPOOL_PROP_SEGREGATE_SMALLBLKS));
+					goto spec_out;
+				}
+				is_smallblks = B_TRUE;
+				is_log = is_metadata = is_dedup = B_FALSE;
+				argc--;
+				argv++;
 				continue;
 			}
 
@@ -1527,15 +1615,17 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 					    "specified only once\n"));
 					goto spec_out;
 				}
-				is_log = B_FALSE;
+				is_log = is_dedup = is_metadata = B_FALSE;
 			}
 
-			if (is_log) {
+			if (is_log || is_dedup || is_metadata || is_smallblks) {
 				if (strcmp(type, VDEV_TYPE_MIRROR) != 0) {
 					(void) fprintf(stderr,
 					    gettext("invalid vdev "
-					    "specification: unsupported 'log' "
-					    "device: %s\n"), type);
+					    "specification: unsupported '%s' "
+					    "device: %s\n"), is_log ? "log" :
+					    is_dedup ? "dedup" : is_metadata ?
+					    "metadata" : "smallblks", type);
 					goto spec_out;
 				}
 				nlogs++;
@@ -1598,6 +1688,25 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 				    type) == 0);
 				verify(nvlist_add_uint64(nv,
 				    ZPOOL_CONFIG_IS_LOG, is_log) == 0);
+				if (is_log)
+					verify(nvlist_add_string(nv,
+					    ZPOOL_CONFIG_ALLOCATION_BIAS,
+					    VDEV_ALLOC_BIAS_LOG) == 0);
+				if (is_dedup) {
+					verify(nvlist_add_string(nv,
+					    ZPOOL_CONFIG_ALLOCATION_BIAS,
+					    VDEV_ALLOC_BIAS_DEDUP) == 0);
+				}
+				if (is_metadata) {
+					verify(nvlist_add_string(nv,
+					    ZPOOL_CONFIG_ALLOCATION_BIAS,
+					    VDEV_ALLOC_BIAS_METADATA) == 0);
+				}
+				if (is_smallblks) {
+					verify(nvlist_add_string(nv,
+					    ZPOOL_CONFIG_ALLOCATION_BIAS,
+					    VDEV_ALLOC_BIAS_SMALLBLKS) == 0);
+				}
 				if (strcmp(type, VDEV_TYPE_RAIDZ) == 0) {
 					verify(nvlist_add_uint64(nv,
 					    ZPOOL_CONFIG_NPARITY,
@@ -1622,6 +1731,13 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 
 			if (is_log)
 				nlogs++;
+			if (is_dedup || is_metadata || is_smallblks) {
+				(void) fprintf(stderr,
+				    gettext("invalid vdev specification: '%s' "
+				    "expects mirror\n"), is_dedup ? "dedup" :
+				    is_metadata ? "metadata" : "smallblks");
+				goto spec_out;
+			}
 			argc--;
 			argv++;
 		}
@@ -1722,6 +1838,30 @@ split_mirror_vdev(zpool_handle_t *zhp, char *newname, nvlist_t *props,
 	return (newroot);
 }
 
+static int
+num_normal_vdevs(nvlist_t *nvroot)
+{
+	nvlist_t **top;
+	uint_t t, toplevels, normal = 0;
+
+	verify(nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
+	    &top, &toplevels) == 0);
+
+	for (t = 0; t < toplevels; t++) {
+		uint64_t log = B_FALSE;
+
+		(void) nvlist_lookup_uint64(top[t], ZPOOL_CONFIG_IS_LOG, &log);
+		if (log)
+			continue;
+		if (nvlist_exists(top[t], ZPOOL_CONFIG_ALLOCATION_BIAS))
+			continue;
+
+		normal++;
+	}
+
+	return (normal);
+}
+
 /*
  * Get and validate the contents of the given vdev specification.  This ensures
  * that the nvlist returned is well-formed, that all the devices exist, and that
@@ -1770,6 +1910,16 @@ make_root_vdev(zpool_handle_t *zhp, nvlist_t *props, int force, int check_rep,
 	 * catch changes against the existing replication level.
 	 */
 	if (check_rep && check_replication(poolconfig, newroot) != 0) {
+		nvlist_free(newroot);
+		return (NULL);
+	}
+
+	/*
+	 * On pool create the new vdev spec must have one normal vdev.
+	 */
+	if (poolconfig == NULL && num_normal_vdevs(newroot) == 0) {
+		vdev_error(gettext("at least one general top-level vdev must "
+		    "be specified\n"));
 		nvlist_free(newroot);
 		return (NULL);
 	}

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -781,7 +781,7 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 	nvlist_t **child;
 	uint_t c, children;
 	nvlist_t *nv;
-	char *type, *alloc_bias;
+	char *type;
 	replication_level_t lastrep = {0};
 	replication_level_t rep;
 	replication_level_t *ret;
@@ -804,9 +804,6 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 		 */
 		(void) nvlist_lookup_uint64(nv, ZPOOL_CONFIG_IS_LOG, &is_log);
 		if (is_log)
-			continue;
-		if (nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
-		    &alloc_bias) == 0)
 			continue;
 
 		verify(nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE,
@@ -968,7 +965,7 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 		/*
 		 * At this point, we have the replication of the last toplevel
 		 * vdev in 'rep'.  Compare it to 'lastrep' to see if its
-		 * different. Skip checks involving dedicated top-level vdevs.
+		 * different.
 		 */
 		if (lastrep.zprl_type != NULL) {
 			if (is_raidz_mirror(&lastrep, &rep, &raidz, &mirror) ||

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 /*
@@ -329,6 +330,7 @@ ztest_func_t ztest_dsl_dataset_promote_busy;
 ztest_func_t ztest_vdev_attach_detach;
 ztest_func_t ztest_vdev_LUN_growth;
 ztest_func_t ztest_vdev_add_remove;
+ztest_func_t ztest_vdev_class_add;
 ztest_func_t ztest_vdev_aux_add_remove;
 ztest_func_t ztest_split_pool;
 ztest_func_t ztest_reguid;
@@ -380,6 +382,7 @@ ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_vdev_attach_detach, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_vdev_LUN_growth, 1, &zopt_rarely),
 	ZTI_INIT(ztest_vdev_add_remove, 1, &ztest_opts.zo_vdevtime),
+	ZTI_INIT(ztest_vdev_class_add, 1, &ztest_opts.zo_vdevtime),
 	ZTI_INIT(ztest_vdev_aux_add_remove, 1, &ztest_opts.zo_vdevtime),
 	ZTI_INIT(ztest_fletcher, 1, &zopt_rarely),
 	ZTI_INIT(ztest_fletcher_incr, 1, &zopt_rarely),
@@ -978,12 +981,15 @@ make_vdev_mirror(char *path, char *aux, char *pool, size_t size,
 
 static nvlist_t *
 make_vdev_root(char *path, char *aux, char *pool, size_t size, uint64_t ashift,
-    int log, int r, int m, int t)
+    const char *classes, int r, int m, int t)
 {
 	nvlist_t *root, **child;
 	int c;
+	boolean_t log;
 
 	ASSERT(t > 0);
+
+	log = (classes != NULL && strcmp(classes, "log") == 0);
 
 	child = umem_alloc(t * sizeof (nvlist_t *), UMEM_NOFAIL);
 
@@ -992,6 +998,12 @@ make_vdev_root(char *path, char *aux, char *pool, size_t size, uint64_t ashift,
 		    r, m);
 		VERIFY(nvlist_add_uint64(child[c], ZPOOL_CONFIG_IS_LOG,
 		    log) == 0);
+
+		if (classes != NULL && classes[0] != '\0') {
+			ASSERT(m > 1 || log);   /* expecting a mirror */
+			VERIFY(nvlist_add_string(child[c],
+			    ZPOOL_CONFIG_ALLOCATION_BIAS, classes) == 0);
+		}
 	}
 
 	VERIFY(nvlist_alloc(&root, NV_UNIQUE_NAME, 0) == 0);
@@ -1031,6 +1043,8 @@ ztest_random_spa_version(uint64_t initial_version)
 static int
 ztest_random_blocksize(void)
 {
+	ASSERT(ztest_spa->spa_max_ashift != 0);
+
 	/*
 	 * Choose a block size >= the ashift.
 	 * If the SPA supports new MAXBLOCKSIZE, test up to 1MB blocks.
@@ -2628,7 +2642,7 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Attempt to create using a bad file.
 	 */
-	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, 0, 0, 0, 1);
+	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, NULL, 0, 0,  1);
 	VERIFY3U(ENOENT, ==,
 	    spa_create("ztest_bad_file", nvroot, NULL, NULL));
 	nvlist_free(nvroot);
@@ -2636,7 +2650,7 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Attempt to create using a bad mirror.
 	 */
-	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, 0, 0, 2, 1);
+	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, NULL, 0, 2, 1);
 	VERIFY3U(ENOENT, ==,
 	    spa_create("ztest_bad_mirror", nvroot, NULL, NULL));
 	nvlist_free(nvroot);
@@ -2646,7 +2660,7 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	 * what's in the nvroot; we should fail with EEXIST.
 	 */
 	(void) rw_rdlock(&ztest_name_lock);
-	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, 0, 0, 0, 1);
+	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, NULL, 0, 0, 1);
 	VERIFY3U(EEXIST, ==, spa_create(zo->zo_pool, nvroot, NULL, NULL));
 	nvlist_free(nvroot);
 	VERIFY3U(0, ==, spa_open(zo->zo_pool, &spa, FTAG));
@@ -2675,7 +2689,7 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 	(void) spa_destroy(name);
 
 	nvroot = make_vdev_root(NULL, NULL, name, ztest_opts.zo_vdev_size, 0,
-	    0, ztest_opts.zo_raidz, ztest_opts.zo_mirrors, 1);
+	    NULL, ztest_opts.zo_raidz, ztest_opts.zo_mirrors, 1);
 
 	/*
 	 * If we're configuring a RAIDZ device then make sure that the
@@ -2790,10 +2804,16 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 	 * If we have slogs then remove them 1/4 of the time.
 	 */
 	if (spa_has_slogs(spa) && ztest_random(4) == 0) {
+		metaslab_group_t *mg;
+
 		/*
-		 * Grab the guid from the head of the log class rotor.
+		 * find the first real slog in log allocation class
 		 */
-		guid = spa_log_class(spa)->mc_rotor->mg_vd->vdev_guid;
+		mg =  spa_log_class(spa)->mc_rotor;
+		while (!mg->mg_vd->vdev_islog)
+			mg = mg->mg_next;
+
+		guid = mg->mg_vd->vdev_guid;
 
 		spa_config_exit(spa, SCL_VDEV, FTAG);
 
@@ -2815,12 +2835,13 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 		spa_config_exit(spa, SCL_VDEV, FTAG);
 
 		/*
-		 * Make 1/4 of the devices be log devices.
+		 * Make 1/4 of the devices be log devices unless
+		 * segregated logs are requested for the pool.
 		 */
 		nvroot = make_vdev_root(NULL, NULL, NULL,
 		    ztest_opts.zo_vdev_size, 0,
-		    ztest_random(4) == 0, ztest_opts.zo_raidz,
-		    zs->zs_mirrors, 1);
+		    (ztest_random(4) == 0 && spa->spa_segregate_log == 0) ?
+		    "log" : NULL, ztest_opts.zo_raidz, zs->zs_mirrors, 1);
 
 		error = spa_vdev_add(spa, nvroot);
 		nvlist_free(nvroot);
@@ -2832,6 +2853,66 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 	}
 
 	mutex_exit(&ztest_vdev_lock);
+}
+
+static const char *vdev_alloc_classes[] = {
+	"dedup",
+	"metadata",
+	"smallblks"
+};
+
+/* ARGSUSED */
+void
+ztest_vdev_class_add(ztest_ds_t *zd, uint64_t id)
+{
+	ztest_shared_t *zs = ztest_shared;
+	spa_t *spa = ztest_spa;
+	const char *class;
+	uint64_t leaves;
+	nvlist_t *nvroot;
+	int error;
+
+	mutex_enter(&ztest_vdev_lock);
+
+	/* Only test with mirrors */
+	if (zs->zs_mirrors < 2) {
+		mutex_exit(&ztest_vdev_lock);
+		return;
+	}
+
+	/* requires feature@allocation_classes */
+	if (!spa_feature_is_enabled(spa, SPA_FEATURE_ALLOCATION_CLASSES)) {
+		mutex_exit(&ztest_vdev_lock);
+		return;
+	}
+
+	/* When pool is using segregated VDEVs only choice is dedup */
+	if (spa->spa_segregate_metadata || spa->spa_segregate_smallblks)
+		class = vdev_alloc_classes[0];
+	else
+		class = vdev_alloc_classes[ztest_random(3)];
+
+	leaves = MAX(zs->zs_mirrors + zs->zs_splits, 1) * ztest_opts.zo_raidz;
+
+	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
+	ztest_shared->zs_vdev_next_leaf = find_vdev_hole(spa) * leaves;
+	spa_config_exit(spa, SCL_VDEV, FTAG);
+
+	nvroot = make_vdev_root(NULL, NULL, NULL, ztest_opts.zo_vdev_size, 0,
+	    class, ztest_opts.zo_raidz, zs->zs_mirrors, 1);
+
+	error = spa_vdev_add(spa, nvroot);
+	nvlist_free(nvroot);
+
+	if (error == ENOSPC)
+		ztest_record_enospc("spa_vdev_add");
+	else if (error != 0)
+		fatal(0, "spa_vdev_add() = %d", error);
+
+	mutex_exit(&ztest_vdev_lock);
+
+	if (ztest_opts.zo_verbose >= 3)
+		(void) printf("Added a dedicated %s mirrored vdev\n", class);
 }
 
 /*
@@ -2897,7 +2978,7 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 		 * Add a new device.
 		 */
 		nvlist_t *nvroot = make_vdev_root(NULL, aux, NULL,
-		    (ztest_opts.zo_vdev_size * 5) / 4, 0, 0, 0, 0, 1);
+		    (ztest_opts.zo_vdev_size * 5) / 4, 0, NULL, 0, 0, 1);
 		error = spa_vdev_add(spa, nvroot);
 		if (error != 0)
 			fatal(0, "spa_vdev_add(%p) = %d", nvroot, error);
@@ -3069,11 +3150,15 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	 * Locate this vdev.
 	 */
 	oldvd = rvd->vdev_child[top];
+
+	/* pick a child from the mirror */
 	if (zs->zs_mirrors >= 1) {
 		ASSERT(oldvd->vdev_ops == &vdev_mirror_ops);
 		ASSERT(oldvd->vdev_children >= zs->zs_mirrors);
 		oldvd = oldvd->vdev_child[leaf / ztest_opts.zo_raidz];
 	}
+
+	/* pick a child out of the raidz group */
 	if (ztest_opts.zo_raidz > 1) {
 		ASSERT(oldvd->vdev_ops == &vdev_raidz_ops);
 		ASSERT(oldvd->vdev_children == ztest_opts.zo_raidz);
@@ -3170,7 +3255,7 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	 * Build the nvlist describing newpath.
 	 */
 	root = make_vdev_root(newpath, NULL, NULL, newvd == NULL ? newsize : 0,
-	    ashift, 0, 0, 0, 1);
+	    ashift, NULL, 0, 0, 1);
 
 	error = spa_vdev_attach(spa, oldguid, root, replacing);
 
@@ -3364,7 +3449,10 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 		return;
 	}
 	ASSERT(psize > 0);
-	newsize = psize + psize / 8;
+	if (vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE)
+		newsize = psize + MAX(psize / 4, SPA_MAXBLOCKSIZE);
+	else
+		newsize = psize + MAX(psize / 8, SPA_MAXBLOCKSIZE);
 	ASSERT3U(newsize, >, psize);
 
 	if (ztest_opts.zo_verbose >= 6) {
@@ -6553,12 +6641,28 @@ print_time(hrtime_t t, char *timebuf)
 		(void) sprintf(timebuf, "%llus", s);
 }
 
+#define	SEGREGATE_MINDEVSIZE	(256ULL << 20)		/* 256M minimum size */
+
 static nvlist_t *
 make_random_props(void)
 {
 	nvlist_t *props;
 
 	VERIFY(nvlist_alloc(&props, NV_UNIQUE_NAME, 0) == 0);
+
+	/* With mirror or raidz configs, use segregation 20% of the time */
+	if (ztest_opts.zo_vdev_size >= SEGREGATE_MINDEVSIZE &&
+	    (ztest_opts.zo_raidz > 1 || ztest_opts.zo_mirrors > 1) &&
+	    ztest_random(5) == 0) {
+		VERIFY(nvlist_add_uint64(props, "segregate_log", 1) == 0);
+		VERIFY(nvlist_add_uint64(props, "segregate_metadata", 1) == 0);
+		VERIFY(nvlist_add_uint64(props, "segregate_smallblks", 1) == 0);
+
+		if (ztest_opts.zo_verbose >= 3)
+			(void) printf("Adding segregate props to pool '%s'\n",
+			    ztest_opts.zo_pool);
+	}
+
 	if (ztest_random(2) == 0)
 		return (props);
 	VERIFY(nvlist_add_uint64(props, "autoreplace", 1) == 0);
@@ -6590,7 +6694,7 @@ ztest_init(ztest_shared_t *zs)
 	zs->zs_splits = 0;
 	zs->zs_mirrors = ztest_opts.zo_mirrors;
 	nvroot = make_vdev_root(NULL, NULL, NULL, ztest_opts.zo_vdev_size, 0,
-	    0, ztest_opts.zo_raidz, zs->zs_mirrors, 1);
+	    NULL, ztest_opts.zo_raidz, zs->zs_mirrors, 1);
 	props = make_random_props();
 	for (i = 0; i < SPA_FEATURES; i++) {
 		char *buf;
@@ -6599,6 +6703,7 @@ ztest_init(ztest_shared_t *zs)
 		VERIFY3U(0, ==, nvlist_add_uint64(props, buf, 0));
 		free(buf);
 	}
+
 	VERIFY3U(0, ==, spa_create(ztest_opts.zo_pool, nvroot, props, NULL));
 	nvlist_free(nvroot);
 	nvlist_free(props);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -425,6 +425,7 @@ typedef enum {
 	VDEV_NAME_GUID		= 1 << 1,
 	VDEV_NAME_FOLLOW_LINKS	= 1 << 2,
 	VDEV_NAME_TYPE_ID	= 1 << 3,
+	VDEV_NAME_ALLOC_BIAS	= 1 << 4	/* top-level only */
 } vdev_name_t;
 
 extern char *zpool_vdev_name(libzfs_handle_t *, zpool_handle_t *, nvlist_t *,

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -26,6 +26,7 @@
  * Copyright 2014 HybridCluster. All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -120,6 +121,12 @@ typedef enum dmu_object_byteswap {
 	((ot) & DMU_OT_METADATA) : \
 	dmu_ot[(int)(ot)].ot_metadata)
 
+#define	DMU_OT_IS_DDT(ot) \
+	((ot) == DMU_OT_DDT_ZAP || (ot) == DMU_OT_DDT_STATS)
+
+#define	DMU_OT_IS_ZIL(ot) \
+	((ot) == DMU_OT_INTENT_LOG)
+
 /*
  * These object types use bp_fill != 1 for their L0 bp's. Therefore they can't
  * have their data embedded (i.e. use a BP_IS_EMBEDDED() bp), because bp_fill
@@ -206,7 +213,7 @@ typedef enum dmu_object_type {
 	 * values.
 	 *
 	 * The DMU_OTN_* types do not have entries in the dmu_ot table,
-	 * use the DMU_OT_IS_METDATA() and DMU_OT_BYTESWAP() macros instead
+	 * use the DMU_OT_IS_METADATA() and DMU_OT_BYTESWAP() macros instead
 	 * of indexing into dmu_ot directly (this works for both DMU_OT_* types
 	 * and DMU_OTN_* types).
 	 */

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_METASLAB_H
@@ -64,6 +65,15 @@ uint64_t metaslab_block_maxsize(metaslab_t *);
 #define	METASLAB_ASYNC_ALLOC		0x8
 #define	METASLAB_DONT_THROTTLE		0x10
 #define	METASLAB_FASTWRITE		0x20
+
+typedef enum metaslab_block_category {
+	MS_CATEGORY_REGULAR,	/* regular file data */
+	MS_CATEGORY_LOG,	/* log data */
+	MS_CATEGORY_METADATA,	/* metadata */
+	MS_CATEGORY_DEDUP,	/* dedup block */
+	MS_CATEGORY_SMALL	/* small block */
+} metaslab_block_category_t;
+
 
 int metaslab_alloc(spa_t *, metaslab_class_t *, uint64_t,
     blkptr_t *, int, uint64_t, blkptr_t *, int, zio_alloc_list_t *, zio_t *);

--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_METASLAB_IMPL_H
@@ -160,6 +161,7 @@ struct metaslab_class {
 	 * updated the MOS config and the space has been added to the pool).
 	 */
 	uint64_t		mc_groups;
+	uint64_t		mc_partial_groups; /* from segregated vdevs */
 
 	/*
 	 * Toggle to enable/disable the allocation throttle.
@@ -198,6 +200,9 @@ struct metaslab_class {
  * space, fragmentation, or going offline. When this happens the allocator will
  * simply find the next metaslab group in the linked list and attempt
  * to allocate from that group instead.
+ *
+ * When vdev segregation is enabled (vdev_alloc_bias == VDEV_BIAS_SEGREGATE),
+ * a portion of the vdev's metaslabs will belong to another group.
  */
 struct metaslab_group {
 	kmutex_t		mg_lock;
@@ -221,6 +226,7 @@ struct metaslab_group {
 	taskq_t			*mg_taskq;
 	metaslab_group_t	*mg_prev;
 	metaslab_group_t	*mg_next;
+	uint64_t		mg_metaslab_cnt;	/* member metaslabs */
 
 	/*
 	 * Each metaslab group can handle mg_max_alloc_queue_depth allocations
@@ -367,6 +373,54 @@ struct metaslab {
 	avl_node_t	ms_group_node;	/* node in metaslab group tree	*/
 	txg_node_t	ms_txg_node;	/* per-txg dirty metaslab links	*/
 };
+
+/*
+ * With segregated top-level vdevs, a portion of the metaslabs are
+ * set aside for a specific allocation class. The following diagram
+ * shows the relationship between the vdev, its metaslabs, group and
+ * class when segregation is enabled.
+ *
+ *
+ *            +------------------------------------------+
+ *            |              TOP-LEVEL VDEV              |
+ *      +---->|                                          |<----+
+ *      |     |           ALLOC_BIAS=SEGREGATE           |     |
+ *      |     +------------------------------------------+     |
+ *      |         |        |                         |         |
+ *      |         |        |           vdev_custom_mg|         |mg_vd
+ *      |         |        |vdev_ms                  |         |
+ *      |         |        |                         V         |
+ * mg_vd|  vdev_mg|        |    ________   msg  +----------+   |
+ *      |         |        +-->|___00___|------>|          |---+
+ *      |         |            |___01___|------>|          |
+ *      |         |            |___02___|------>| MS_GROUP |<------+
+ *      |         V            |___03___|------>|          |       |
+ *      |   +----------+  msg  |___04___|------>|          |       |
+ *      +---|          |<------|___05___|       +----------+       |
+ *          |          |<------|___06___|            |             |
+ *          |          |<------|___07___|            |             |
+ *          |          |<------|___08___|            |             |
+ *          |          |<------|___09___|            |             |
+ *          |          |<------|___10___|            |             |
+ *          |          |<------|___11___|            |             |
+ *   +----->| MS_GROUP |<------|___12___|            |             |
+ *   |      |          |<------|___13___|            |             |
+ *   |      |          |<------|___14___|            |mg_class     |
+ *   |      |          |<------|___15___|            |             |
+ *   |      |          |<------|___16___|            |             |
+ *   |      |          |<------|___17___|            |             |
+ *   |      |          |<------|___18___|            |             |
+ *   |      |          |<------|___19___|            |             |
+ *   |      +----------+        METASLABS            |             |
+ *   |            |                                  |             |
+ *   |            |mg_class                          |             |
+ *   |            V                                  V             |
+ *   |   +------------------+               +------------------+   |
+ *   |   |                  |               |                  |   |
+ *   +---| SPA_NORMAL_CLASS |               | SPA_CUSTOM_CLASS |---+
+ * rotor |                  |               |                  | rotor
+ *       +------------------+               +------------------+
+ */
 
 #ifdef	__cplusplus
 }

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -24,6 +24,7 @@
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_SPA_H
@@ -815,6 +816,10 @@ extern uint64_t spa_version(spa_t *spa);
 extern boolean_t spa_deflate(spa_t *spa);
 extern metaslab_class_t *spa_normal_class(spa_t *spa);
 extern metaslab_class_t *spa_log_class(spa_t *spa);
+extern metaslab_class_t *spa_dedup_class(spa_t *spa);
+extern metaslab_class_t *spa_custom_class(spa_t *spa);
+extern metaslab_class_t *spa_preferred_class(spa_t *spa, uint64_t size,
+    int objtype, int level, uint64_t objset);
 extern void spa_evicting_os_register(spa_t *, objset_t *os);
 extern void spa_evicting_os_deregister(spa_t *, objset_t *os);
 extern void spa_evicting_os_wait(spa_t *spa);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -25,6 +25,7 @@
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2016 Actifio, Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_SPA_IMPL_H
@@ -147,6 +148,8 @@ struct spa {
 	boolean_t	spa_is_initializing;	/* true while opening pool */
 	metaslab_class_t *spa_normal_class;	/* normal data class */
 	metaslab_class_t *spa_log_class;	/* intent log data class */
+	metaslab_class_t *spa_dedup_class;	/* dedicated dedup data class */
+	metaslab_class_t *spa_custom_class;	/* custom allocation class */
 	uint64_t	spa_first_txg;		/* first txg after spa_open() */
 	uint64_t	spa_final_txg;		/* txg of export/destroy */
 	uint64_t	spa_freeze_txg;		/* freeze pool at this txg */
@@ -251,6 +254,9 @@ struct spa {
 	proc_t		*spa_proc;		/* "zpool-poolname" process */
 	uint64_t	spa_did;		/* if procp != p0, did of t1 */
 	boolean_t	spa_autoreplace;	/* autoreplace set in open */
+	boolean_t	spa_segregate_log;	/* segregate vdev log data */
+	boolean_t	spa_segregate_metadata;	/* segregate vdev metadata */
+	boolean_t	spa_segregate_smallblks; /* segregate vdev small blks */
 	int		spa_vdev_locks;		/* locks grabbed */
 	uint64_t	spa_creation_version;	/* version at pool creation */
 	uint64_t	spa_prev_software_version; /* See ub_software_version */

--- a/include/sys/space_map.h
+++ b/include/sys/space_map.h
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_SPACE_MAP_H
@@ -58,8 +59,13 @@ typedef struct space_map_phys {
 	uint64_t	smp_object;	/* on-disk space map object */
 	uint64_t	smp_objsize;	/* size of the object */
 	uint64_t	smp_alloc;	/* space allocated from the map */
-	uint64_t	smp_pad[5];	/* reserved */
 
+	/* More detailed allocation info */
+	struct sm_alloc_info {
+		uint64_t	alloc_bias;	/* metaslab's segregated bias */
+	} smp_alloc_info;
+
+	uint64_t	smp_pad[4];	/* reserved */
 	/*
 	 * The smp_histogram maintains a histogram of free regions. Each
 	 * bucket, smp_histogram[i], contains the number of free regions
@@ -133,6 +139,16 @@ typedef enum {
 	SM_FREE
 } maptype_t;
 
+/*
+ * Optional metaslab class allocation bias (segregated vdevs only)
+ */
+typedef enum {
+	SM_ALLOC_BIAS_DEFAULT =		0x0ULL,
+	SM_ALLOC_BIAS_METADATA =	0xa110cc1a55da7aULL,
+	SM_ALLOC_BIAS_LOG =		0xa110cc1a551065ULL,
+	SM_ALLOC_BIAS_SMALLBLKS =	0xa110cc1a55b10cULL
+} map_alloc_bias_t;
+
 int space_map_load(space_map_t *sm, range_tree_t *rt, maptype_t maptype);
 
 void space_map_histogram_clear(space_map_t *sm);
@@ -156,6 +172,9 @@ int space_map_open(space_map_t **smp, objset_t *os, uint64_t object,
 void space_map_close(space_map_t *sm);
 
 int64_t space_map_alloc_delta(space_map_t *sm);
+
+map_alloc_bias_t space_map_get_alloc_bias(space_map_t *sm);
+void space_map_set_alloc_bias(space_map_t *sm, map_alloc_bias_t bias);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_VDEV_H
@@ -97,6 +98,8 @@ extern void vdev_set_state(vdev_t *vd, boolean_t isopen, vdev_state_t state,
 
 extern void vdev_space_update(vdev_t *vd,
     int64_t alloc_delta, int64_t defer_delta, int64_t space_delta);
+
+extern int64_t vdev_deflated_space(vdev_t *vd, int64_t space);
 
 extern uint64_t vdev_psize_to_asize(vdev_t *vd, uint64_t psize);
 

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_VDEV_IMPL_H
@@ -130,6 +131,16 @@ struct vdev_queue {
 	uint64_t	vq_lastoffset;
 };
 
+typedef enum vdev_alloc_bias {
+	VDEV_BIAS_NONE,
+	VDEV_BIAS_LOG,		/* dedicated to ZIL data (SLOG) */
+	VDEV_BIAS_DEDUP,	/* dedicated to DDT data */
+	VDEV_BIAS_METADATA,	/* dedicated to metadata (DMU and MOS) */
+	VDEV_BIAS_SMALLBLKS,	/* dedicated to small blocks (<= 32K) */
+	VDEV_BIAS_SEGREGATE,	/* segregate metaslabs into multiple groups */
+} vdev_alloc_bias_t;
+
+
 /*
  * Virtual device descriptor
  */
@@ -171,7 +182,9 @@ struct vdev {
 	uint64_t	vdev_ms_array;	/* metaslab array object	*/
 	uint64_t	vdev_ms_shift;	/* metaslab size shift		*/
 	uint64_t	vdev_ms_count;	/* number of metaslabs		*/
-	metaslab_group_t *vdev_mg;	/* metaslab group		*/
+	metaslab_group_t *vdev_mg;	/* primary metaslab group	*/
+	metaslab_group_t *vdev_log_mg;	/* optional log group		*/
+	metaslab_group_t *vdev_custom_mg; /* optional metadata/smallblk	*/
 	metaslab_t	**vdev_ms;	/* metaslab array		*/
 	uint64_t	vdev_pending_fastwrite; /* allocated fastwrites */
 	txg_list_t	vdev_ms_list;	/* per-txg dirty metaslab lists	*/
@@ -187,6 +200,7 @@ struct vdev {
 	boolean_t	vdev_ishole;	/* is a hole in the namespace	*/
 	kmutex_t	vdev_queue_lock; /* protects vdev_queue_depth	*/
 	uint64_t	vdev_top_zap;
+	vdev_alloc_bias_t vdev_alloc_bias; /* metaslab allocation bias	*/
 
 	/*
 	 * The queue depth parameters determine how many async writes are
@@ -376,6 +390,11 @@ extern void vdev_set_min_asize(vdev_t *vd);
  */
 /* zdb uses this tunable, so it must be declared here to make lint happy. */
 extern int zfs_vdev_cache_size;
+
+/*
+ * Metaslab specific
+ */
+metaslab_group_t *vdev_get_mg(vdev_t *vd, metaslab_class_t *mc);
 
 #ifdef	__cplusplus
 }

--- a/include/zfeature_common.h
+++ b/include/zfeature_common.h
@@ -23,6 +23,7 @@
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _ZFEATURE_COMMON_H
@@ -57,6 +58,7 @@ typedef enum spa_feature {
 	SPA_FEATURE_SKEIN,
 	SPA_FEATURE_EDONR,
 	SPA_FEATURE_USEROBJ_ACCOUNTING,
+	SPA_FEATURE_ALLOCATION_CLASSES,
 	SPA_FEATURES
 } spa_feature_t;
 

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -504,7 +504,8 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			goto error;
 		}
 
-		if (zpool_prop_readonly(prop)) {
+		if (zpool_prop_readonly(prop) &&
+		    !(flags.create && zpool_prop_setonce(prop))) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "'%s' "
 			    "is readonly"), propname);
 			(void) zfs_error(hdl, EZFS_PROPREADONLY, errbuf);
@@ -3489,6 +3490,7 @@ zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
 	uint64_t value;
 	char buf[PATH_BUF_LEN];
 	char tmpbuf[PATH_BUF_LEN];
+	char altbuf[PATH_BUF_LEN];
 
 	env = getenv("ZPOOL_VDEV_NAME_PATH");
 	if (env && (strtoul(env, NULL, 0) > 0 ||
@@ -3597,6 +3599,19 @@ zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
 			(void) snprintf(buf, sizeof (buf), "%s%llu", path,
 			    (u_longlong_t)value);
 			path = buf;
+		}
+
+		/*
+		 * if requested add classes info for top-level vdevs
+		 */
+		if ((name_flags & VDEV_NAME_GUID) == 0 &&
+		    (name_flags & VDEV_NAME_ALLOC_BIAS) &&
+		    nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &type) == 0 &&
+		    strcmp(type, VDEV_ALLOC_BIAS_SEGREGATE) != 0) {
+			(void) snprintf(altbuf, sizeof (altbuf), "%s:%s",
+			    type, path);
+			path = altbuf;
 		}
 
 		/*

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -568,23 +568,6 @@ The space usage properties report actual physical space available to the storage
 
 .sp
 .LP
-The following property can be set at creation time:
-.sp
-.ne 2
-.na
-\fB\fBashift\fR=\fIashift\fR\fR
-.ad
-.sp .6
-.RS 4n
-Pool sector size exponent, to the power of 2 (internally referred to as "ashift"). Values from 9 to 13, inclusive, are valid; also, the special value 0 (the default) means to auto-detect using the kernel's block layer and a ZFS internal exception list. I/O operations will be aligned to the specified size boundaries. Additionally, the minimum (disk) write size will be set to the specified size, so this represents a space vs. performance trade-off. The typical case for setting this property is when performance is important and the underlying disks use 4KiB sectors but report 512B sectors to the OS (for compatibility reasons); in that case, set \fBashift=12\fR (which is 1<<12 = 4096).
-.LP
-For optimal performance, the pool sector size should be greater than or equal to the sector size of the underlying disks. Since the property cannot be changed after pool creation, if in a given pool, you \fIever\fR want to use drives that \fIreport\fR 4KiB sectors, you must set \fBashift=12\fR at pool creation time.
-.LP
-Keep in mind is that the \fBashift\fR is \fIvdev\fR specific and is not a \fIpool\fR global.  This means that when adding new vdevs to an existing pool you may need to specify the \fBashift\fR.
-.RE
-
-.sp
-.LP
 The following properties can be set at creation time:
 .ne 2
 .na

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -568,6 +568,44 @@ The space usage properties report actual physical space available to the storage
 
 .sp
 .LP
+The following property can be set at creation time:
+.sp
+.ne 2
+.na
+\fB\fBashift\fR=\fIashift\fR\fR
+.ad
+.sp .6
+.RS 4n
+Pool sector size exponent, to the power of 2 (internally referred to as "ashift"). Values from 9 to 13, inclusive, are valid; also, the special value 0 (the default) means to auto-detect using the kernel's block layer and a ZFS internal exception list. I/O operations will be aligned to the specified size boundaries. Additionally, the minimum (disk) write size will be set to the specified size, so this represents a space vs. performance trade-off. The typical case for setting this property is when performance is important and the underlying disks use 4KiB sectors but report 512B sectors to the OS (for compatibility reasons); in that case, set \fBashift=12\fR (which is 1<<12 = 4096).
+.LP
+For optimal performance, the pool sector size should be greater than or equal to the sector size of the underlying disks. Since the property cannot be changed after pool creation, if in a given pool, you \fIever\fR want to use drives that \fIreport\fR 4KiB sectors, you must set \fBashift=12\fR at pool creation time.
+.LP
+Keep in mind is that the \fBashift\fR is \fIvdev\fR specific and is not a \fIpool\fR global.  This means that when adding new vdevs to an existing pool you may need to specify the \fBashift\fR.
+.RE
+
+.sp
+.LP
+The following properties can be set at creation time:
+.ne 2
+.na
+.sp
+\fB\fBsegregate_log\fR=\fIon\fR\fR
+.sp
+\fB\fBsegregate_metadata\fR=\fIon\fR\fR
+.sp
+\fB\fBsegregate_smallblks\fR=\fIon\fR\fR
+.ad
+.sp .6
+.RS 4n
+The segregate properties direct the allocating vdevs in the pool
+to segregate a portion of their metaslabs to the allocation class
+indicated by the property's name. These properties require that
+\fIfeature@segregated_vdevs\fR be enabled and the feature becomes
+permanately active at pool create.
+.RE
+
+.sp
+.LP
 The following property can be set at creation time and import time:
 .sp
 .ne 2

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -51,6 +51,8 @@ zpool_prop_get_table(void)
 void
 zpool_prop_init(void)
 {
+	zprop_desc_t *prop_tbl = zpool_prop_get_table();
+
 	static zprop_index_t boolean_table[] = {
 		{ "off",	0},
 		{ "on",		1},
@@ -135,6 +137,20 @@ zpool_prop_init(void)
 	    PROP_ONETIME, ZFS_TYPE_POOL, "TNAME");
 	zprop_register_hidden(ZPOOL_PROP_MAXDNODESIZE, "maxdnodesize",
 	    PROP_TYPE_NUMBER, PROP_READONLY, ZFS_TYPE_POOL, "MAXDNODESIZE");
+
+	/* hidden boolean properties */
+	zprop_register_index(ZPOOL_PROP_SEGREGATE_LOG,
+	    "segregate_log", 0, PROP_ONETIME, ZFS_TYPE_POOL, "on",
+	    "SEGREGATE_LOG", boolean_table);
+	prop_tbl[ZPOOL_PROP_SEGREGATE_LOG].pd_visible = B_FALSE;
+	zprop_register_index(ZPOOL_PROP_SEGREGATE_METADATA,
+	    "segregate_metadata", 0, PROP_ONETIME, ZFS_TYPE_POOL, "on",
+	    "SEGREGATE_METADATA", boolean_table);
+	prop_tbl[ZPOOL_PROP_SEGREGATE_METADATA].pd_visible = B_FALSE;
+	zprop_register_index(ZPOOL_PROP_SEGREGATE_SMALLBLKS,
+	    "segregate_smallblks", 0, PROP_ONETIME, ZFS_TYPE_POOL, "on",
+	    "SEGREGATE_SMALLBLKS", boolean_table);
+	prop_tbl[ZPOOL_PROP_SEGREGATE_SMALLBLKS].pd_visible = B_FALSE;
 }
 
 /*
@@ -165,7 +181,18 @@ zpool_prop_get_type(zpool_prop_t prop)
 boolean_t
 zpool_prop_readonly(zpool_prop_t prop)
 {
-	return (zpool_prop_table[prop].pd_attr == PROP_READONLY);
+
+	return (zpool_prop_table[prop].pd_attr == PROP_READONLY ||
+	    zpool_prop_table[prop].pd_attr == PROP_ONETIME);
+}
+
+/*
+ * Returns TRUE if the property is only allowed to be set once.
+ */
+boolean_t
+zpool_prop_setonce(zfs_prop_t prop)
+{
+	return (zpool_prop_table[prop].pd_attr == PROP_ONETIME);
 }
 
 const char *

--- a/module/zfs/dsl_synctask.c
+++ b/module/zfs/dsl_synctask.c
@@ -21,14 +21,17 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <sys/dmu.h>
+#include <sys/dmu_objset.h>
 #include <sys/dmu_tx.h>
 #include <sys/dsl_pool.h>
 #include <sys/dsl_dir.h>
 #include <sys/dsl_synctask.h>
 #include <sys/metaslab.h>
+#include <sys/spa.h>
 
 #define	DST_AVG_BLKSHIFT 14
 
@@ -143,8 +146,12 @@ void
 dsl_sync_task_sync(dsl_sync_task_t *dst, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = dst->dst_pool;
+	metaslab_class_t *mc;
 
 	ASSERT0(dst->dst_error);
+
+	mc = spa_preferred_class(dp->dp_spa, dst->dst_space, DMU_OT_NONE, 0,
+	    DMU_META_OBJSET);
 
 	/*
 	 * Check for sufficient space.
@@ -162,7 +169,7 @@ dsl_sync_task_sync(dsl_sync_task_t *dst, dmu_tx_t *tx)
 	if (dst->dst_space_check != ZFS_SPACE_CHECK_NONE) {
 		uint64_t quota = dsl_pool_adjustedsize(dp,
 		    dst->dst_space_check == ZFS_SPACE_CHECK_RESERVED) -
-		    metaslab_class_get_deferred(spa_normal_class(dp->dp_spa));
+		    metaslab_class_get_deferred(mc);
 		uint64_t used = dsl_dir_phys(dp->dp_root_dir)->dd_used_bytes;
 		/* MOS space is triple-dittoed, so we multiply by 3. */
 		if (dst->dst_space > 0 && used + dst->dst_space * 3 > quota) {

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -29,6 +29,7 @@
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Toomas Soome <tsoome@me.com>
  * Copyright (c) 2016 Actifio, Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 /*
@@ -210,8 +211,25 @@ spa_prop_get_config(spa_t *spa, nvlist_t **nvp)
 	ASSERT(MUTEX_HELD(&spa->spa_props_lock));
 
 	if (rvd != NULL) {
-		alloc = metaslab_class_get_alloc(spa_normal_class(spa));
-		size = metaslab_class_get_space(spa_normal_class(spa));
+		metaslab_class_t *alt_mc;
+
+		alloc = metaslab_class_get_alloc(mc);
+		size = metaslab_class_get_space(mc);
+		/*
+		 * DJB - TBD does this need a fudge factor like for deflate?
+		 * like a compression factor or ditto copies?
+		 */
+		alt_mc = spa_dedup_class(spa);
+		if (alt_mc->mc_rotor != NULL) {
+			alloc += metaslab_class_get_alloc(alt_mc);
+			size += metaslab_class_get_space(alt_mc);
+		}
+		alt_mc = spa_custom_class(spa);
+		if (alt_mc->mc_rotor != NULL) {
+			alloc += metaslab_class_get_alloc(alt_mc);
+			size += metaslab_class_get_space(alt_mc);
+		}
+
 		spa_prop_add_list(*nvp, ZPOOL_PROP_NAME, spa_name(spa), 0, src);
 		spa_prop_add_list(*nvp, ZPOOL_PROP_SIZE, NULL, size, src);
 		spa_prop_add_list(*nvp, ZPOOL_PROP_ALLOCATED, NULL, alloc, src);
@@ -481,6 +499,15 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 		case ZPOOL_PROP_AUTOEXPAND:
 			error = nvpair_value_uint64(elem, &intval);
 			if (!error && intval > 1)
+				error = SET_ERROR(EINVAL);
+			break;
+
+		case ZPOOL_PROP_SEGREGATE_LOG:
+		case ZPOOL_PROP_SEGREGATE_METADATA:
+		case ZPOOL_PROP_SEGREGATE_SMALLBLKS:
+			/* set-once that can only be enabled */
+			error = nvpair_value_uint64(elem, &intval);
+			if (!error && intval != 1)
 				error = SET_ERROR(EINVAL);
 			break;
 
@@ -1093,6 +1120,8 @@ spa_activate(spa_t *spa, int mode)
 
 	spa->spa_normal_class = metaslab_class_create(spa, zfs_metaslab_ops);
 	spa->spa_log_class = metaslab_class_create(spa, zfs_metaslab_ops);
+	spa->spa_dedup_class = metaslab_class_create(spa, zfs_metaslab_ops);
+	spa->spa_custom_class = metaslab_class_create(spa, zfs_metaslab_ops);
 
 	/* Try to create a covering process */
 	mutex_enter(&spa->spa_proc_lock);
@@ -1218,6 +1247,12 @@ spa_deactivate(spa_t *spa)
 	metaslab_class_destroy(spa->spa_log_class);
 	spa->spa_log_class = NULL;
 
+	metaslab_class_destroy(spa->spa_dedup_class);
+	spa->spa_dedup_class = NULL;
+
+	metaslab_class_destroy(spa->spa_custom_class);
+	spa->spa_custom_class = NULL;
+
 	/*
 	 * If this was part of an import or the open otherwise failed, we may
 	 * still have errors left in the queues.  Empty them just in case.
@@ -1324,6 +1359,19 @@ spa_unload(spa_t *spa)
 	if (spa->spa_sync_on) {
 		txg_sync_stop(spa->spa_dsl_pool);
 		spa->spa_sync_on = B_FALSE;
+	}
+
+	/*
+	 * Even though vdev_free() also calls vdev_metaslab_fini, we need
+	 * to call it earlier, before we wait for async i/o to complete.
+	 * This ensures that there is no async metaslab prefetching, by
+	 * calling taskq_wait(mg_taskq).
+	 */
+	if (spa->spa_root_vdev != NULL) {
+		spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
+		for (c = 0; c < spa->spa_root_vdev->vdev_children; c++)
+			vdev_metaslab_fini(spa->spa_root_vdev->vdev_child[c]);
+		spa_config_exit(spa, SCL_ALL, FTAG);
 	}
 
 	/*
@@ -2316,6 +2364,39 @@ vdev_count_verify_zaps(vdev_t *vd)
 }
 #endif
 
+void
+spa_segregated_prop_get(spa_t *spa, nvlist_t *props)
+{
+	uint64_t segregate_log = 0;
+	uint64_t segregate_metadata = 0;
+	uint64_t segregate_smallblks = 0;
+
+	if (props != NULL) {
+		/* Create case is passed as a property */
+		(void) nvlist_lookup_uint64(props,
+		    zpool_prop_to_name(ZPOOL_PROP_SEGREGATE_LOG),
+		    &segregate_log);
+		(void) nvlist_lookup_uint64(props,
+		    zpool_prop_to_name(ZPOOL_PROP_SEGREGATE_METADATA),
+		    &segregate_metadata);
+		(void) nvlist_lookup_uint64(props,
+		    zpool_prop_to_name(ZPOOL_PROP_SEGREGATE_SMALLBLKS),
+		    &segregate_smallblks);
+	} else {
+		/* Import case comes from property zap */
+		spa_prop_find(spa, ZPOOL_PROP_SEGREGATE_LOG,
+		    &segregate_log);
+		spa_prop_find(spa, ZPOOL_PROP_SEGREGATE_METADATA,
+		    &segregate_metadata);
+		spa_prop_find(spa, ZPOOL_PROP_SEGREGATE_SMALLBLKS,
+		    &segregate_smallblks);
+	}
+
+	spa->spa_segregate_log = (segregate_log == 1);
+	spa->spa_segregate_metadata = (segregate_metadata == 1);
+	spa->spa_segregate_smallblks = (segregate_smallblks == 1);
+}
+
 /*
  * Load an existing storage pool, using the pool's builtin spa_config as a
  * source of configuration information.
@@ -2847,6 +2928,8 @@ spa_load_impl(spa_t *spa, uint64_t pool_guid, nvlist_t *config,
 		    &spa->spa_dedup_ditto);
 
 		spa->spa_autoreplace = (autoreplace != 0);
+
+		spa_segregated_prop_get(spa, NULL);
 	}
 
 	/*
@@ -3769,7 +3852,8 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	char *poolname;
 	nvlist_t *nvl;
 
-	if (nvlist_lookup_string(props, "tname", &poolname) != 0)
+	if (props == NULL ||
+	    nvlist_lookup_string(props, "tname", &poolname) != 0)
 		poolname = (char *)pool;
 
 	/*
@@ -3818,6 +3902,10 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	}
 	ASSERT(SPA_VERSION_IS_SUPPORTED(version));
 
+	/* examine segregation props before instantiating vdevs */
+	if (props != NULL)
+		spa_segregated_prop_get(spa, props);
+
 	spa->spa_first_txg = txg;
 	spa->spa_uberblock.ub_txg = txg - 1;
 	spa->spa_uberblock.ub_version = version;
@@ -3853,8 +3941,10 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	    (error = spa_validate_aux(spa, nvroot, txg,
 	    VDEV_ALLOC_ADD)) == 0) {
 		for (c = 0; c < rvd->vdev_children; c++) {
-			vdev_metaslab_set_size(rvd->vdev_child[c]);
-			vdev_expand(rvd->vdev_child[c], txg);
+			vdev_t *vd = rvd->vdev_child[c];
+
+			vdev_metaslab_set_size(vd);
+			vdev_expand(vd, txg);
 		}
 	}
 
@@ -3983,6 +4073,16 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	if (props != NULL) {
 		spa_configfile_set(spa, props, B_FALSE);
 		spa_sync_props(props, tx);
+	}
+
+	/*
+	 * Set-once segregate properties activate the segregated vdev feature
+	 */
+	if ((spa->spa_segregate_log ||
+	    spa->spa_segregate_metadata ||
+	    spa->spa_segregate_smallblks) &&
+	    spa_feature_is_enabled(spa, SPA_FEATURE_ALLOCATION_CLASSES)) {
+		spa_feature_incr(spa, SPA_FEATURE_ALLOCATION_CLASSES, tx);
 	}
 
 	dmu_tx_commit(tx);
@@ -4848,6 +4948,16 @@ spa_vdev_detach(spa_t *spa, uint64_t guid, uint64_t pguid, int replace_done)
 	ASSERT(pvd->vdev_children >= 2);
 
 	/*
+	 * If dedicated class, then it must remain mirrored
+	 */
+	if (pvd->vdev_alloc_bias == VDEV_BIAS_DEDUP ||
+	    pvd->vdev_alloc_bias == VDEV_BIAS_METADATA ||
+	    pvd->vdev_alloc_bias == VDEV_BIAS_SMALLBLKS) {
+		if (pvd->vdev_children <= 2 && 0) {
+			return (spa_vdev_exit(spa, NULL, txg, ENOTSUP));
+		}
+	}
+	/*
 	 * If we are detaching the second disk from a replacing vdev, then
 	 * check to see if we changed the original vdev's path to have "/old"
 	 * at the end in spa_vdev_attach().  If so, undo that change now.
@@ -5121,6 +5231,9 @@ spa_vdev_split_mirror(spa_t *spa, char *newname, nvlist_t *config,
 		    vml[c]->vdev_ishole ||
 		    vml[c]->vdev_isspare ||
 		    vml[c]->vdev_isl2cache ||
+		    vml[c]->vdev_alloc_bias == VDEV_BIAS_DEDUP ||
+		    vml[c]->vdev_alloc_bias == VDEV_BIAS_METADATA ||
+		    vml[c]->vdev_alloc_bias == VDEV_BIAS_SMALLBLKS ||
 		    !vdev_writeable(vml[c]) ||
 		    vml[c]->vdev_children != 0 ||
 		    vml[c]->vdev_state != VDEV_STATE_HEALTHY ||
@@ -5849,8 +5962,14 @@ spa_async_thread(spa_t *spa)
 
 		mutex_enter(&spa_namespace_lock);
 		old_space = metaslab_class_get_space(spa_normal_class(spa));
+		old_space += metaslab_class_get_space(spa_dedup_class(spa));
+		old_space += metaslab_class_get_space(spa_custom_class(spa));
+
 		spa_config_update(spa, SPA_CONFIG_UPDATE_POOL);
+
 		new_space = metaslab_class_get_space(spa_normal_class(spa));
+		new_space += metaslab_class_get_space(spa_dedup_class(spa));
+		new_space += metaslab_class_get_space(spa_custom_class(spa));
 		mutex_exit(&spa_namespace_lock);
 
 		/*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -4948,16 +4948,6 @@ spa_vdev_detach(spa_t *spa, uint64_t guid, uint64_t pguid, int replace_done)
 	ASSERT(pvd->vdev_children >= 2);
 
 	/*
-	 * If dedicated class, then it must remain mirrored
-	 */
-	if (pvd->vdev_alloc_bias == VDEV_BIAS_DEDUP ||
-	    pvd->vdev_alloc_bias == VDEV_BIAS_METADATA ||
-	    pvd->vdev_alloc_bias == VDEV_BIAS_SMALLBLKS) {
-		if (pvd->vdev_children <= 2 && 0) {
-			return (spa_vdev_exit(spa, NULL, txg, ENOTSUP));
-		}
-	}
-	/*
 	 * If we are detaching the second disk from a replacing vdev, then
 	 * check to see if we changed the original vdev's path to have "/old"
 	 * at the end in spa_vdev_attach().  If so, undo that change now.

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -24,6 +24,7 @@
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <sys/zfs_context.h>
@@ -1098,6 +1099,8 @@ spa_vdev_config_exit(spa_t *spa, vdev_t *vd, uint64_t txg, int error, char *tag)
 	 */
 	ASSERT(metaslab_class_validate(spa_normal_class(spa)) == 0);
 	ASSERT(metaslab_class_validate(spa_log_class(spa)) == 0);
+	ASSERT(metaslab_class_validate(spa_dedup_class(spa)) == 0);
+	ASSERT(metaslab_class_validate(spa_custom_class(spa)) == 0);
 
 	spa_config_exit(spa, SCL_ALL, spa);
 
@@ -1714,6 +1717,66 @@ spa_log_class(spa_t *spa)
 	return (spa->spa_log_class);
 }
 
+metaslab_class_t *
+spa_dedup_class(spa_t *spa)
+{
+	return (spa->spa_dedup_class);
+}
+
+metaslab_class_t *
+spa_custom_class(spa_t *spa)
+{
+	return (spa->spa_custom_class);
+}
+
+extern int zfs_class_smallblk_limit;
+
+/*
+ * Locate an appropriate allocation class
+ */
+metaslab_class_t *
+spa_preferred_class(spa_t *spa, uint64_t size, int objtype, int level,
+    uint64_t objset)
+{
+	if (DMU_OT_IS_DDT(objtype)) {
+		if (spa->spa_dedup_class->mc_rotor != NULL)
+			return (spa_dedup_class(spa));
+		else
+			return (spa_normal_class(spa));
+	}
+	if (DMU_OT_IS_ZIL(objtype)) {
+		if (spa->spa_log_class->mc_rotor != NULL)
+			return (spa_log_class(spa));
+		else
+			return (spa_normal_class(spa));
+	}
+	if (DMU_OT_IS_METADATA(objtype) || level > 0) {
+		if (spa->spa_custom_class->mc_rotor != NULL)
+			return (spa_custom_class(spa));
+	}
+	if (spa->spa_custom_class->mc_rotor != NULL) {
+		/*
+		 * Limit how many small blocks we place into the custom class.
+		 * Also allow large blocks to spill into the custom class when
+		 * the nomal class is full.
+		 */
+		if (size <= zfs_class_smallblk_limit) {
+			/*
+			 * For small blocks: try the custom (small block) class.
+			 */
+			return (spa_custom_class(spa));
+		} else {
+			/*
+			 * For this test, we do NOT spill into the
+			 * custom (small block) class when the big
+			 * class is full.
+			 */
+		}
+	}
+
+	return (spa_normal_class(spa));
+}
+
 void
 spa_evicting_os_register(spa_t *spa, objset_t *os)
 {
@@ -1927,12 +1990,15 @@ spa_fini(void)
 /*
  * Return whether this pool has slogs. No locking needed.
  * It's not a problem if the wrong answer is returned as it's only for
- * performance and not correctness
+ * performance and not correctness.
+ * Log groups from segregated vdevs don't count as a slog.
  */
 boolean_t
 spa_has_slogs(spa_t *spa)
 {
-	return (spa->spa_log_class->mc_rotor != NULL);
+	metaslab_class_t *mc = spa_log_class(spa);
+
+	return ((mc->mc_groups > 0) && (mc->mc_groups > mc->mc_partial_groups));
 }
 
 spa_log_state_t
@@ -2112,6 +2178,9 @@ EXPORT_SYMBOL(spa_update_dspace);
 EXPORT_SYMBOL(spa_deflate);
 EXPORT_SYMBOL(spa_normal_class);
 EXPORT_SYMBOL(spa_log_class);
+EXPORT_SYMBOL(spa_dedup_class);
+EXPORT_SYMBOL(spa_custom_class);
+EXPORT_SYMBOL(spa_preferred_class);
 EXPORT_SYMBOL(spa_max_replication);
 EXPORT_SYMBOL(spa_prev_software_version);
 EXPORT_SYMBOL(spa_get_failmode);

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -550,3 +550,27 @@ space_map_alloc_delta(space_map_t *sm)
 	ASSERT(sm->sm_dbuf != NULL);
 	return (sm->sm_phys->smp_alloc - space_map_allocated(sm));
 }
+
+map_alloc_bias_t
+space_map_get_alloc_bias(space_map_t *sm)
+{
+	if (sm == NULL)
+		return (SM_ALLOC_BIAS_DEFAULT);
+
+	ASSERT(sm->sm_dbuf != NULL);
+
+	return (sm->sm_phys->smp_alloc_info.alloc_bias);
+
+}
+
+void
+space_map_set_alloc_bias(space_map_t *sm, map_alloc_bias_t bias)
+{
+	ASSERT(sm != NULL && sm->sm_dbuf != NULL);
+	ASSERT(bias == SM_ALLOC_BIAS_DEFAULT ||
+	    bias == SM_ALLOC_BIAS_METADATA ||
+	    bias == SM_ALLOC_BIAS_LOG ||
+	    bias == SM_ALLOC_BIAS_SMALLBLKS);
+
+	sm->sm_phys->smp_alloc_info.alloc_bias = bias;
+}

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -25,6 +25,7 @@
  * Copyright 2017 Nexenta Systems, Inc.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Toomas Soome <tsoome@me.com>
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <sys/zfs_context.h>
@@ -85,6 +86,29 @@ vdev_getops(const char *type)
 			break;
 
 	return (ops);
+}
+
+/*
+ * Derive the enumerated alloction bias from string input.
+ * String origin is either the per-vdev zap or zpool(1M).
+ */
+static vdev_alloc_bias_t
+vdev_derive_alloc_bias(const char *bias)
+{
+	vdev_alloc_bias_t alloc_bias = VDEV_BIAS_NONE;
+
+	if (strcmp(bias, VDEV_ALLOC_BIAS_LOG) == 0)
+		alloc_bias = VDEV_BIAS_LOG;
+	else if (strcmp(bias, VDEV_ALLOC_BIAS_DEDUP) == 0)
+		alloc_bias = VDEV_BIAS_DEDUP;
+	else if (strcmp(bias, VDEV_ALLOC_BIAS_METADATA) == 0)
+		alloc_bias = VDEV_BIAS_METADATA;
+	else if (strcmp(bias, VDEV_ALLOC_BIAS_SMALLBLKS) == 0)
+		alloc_bias = VDEV_BIAS_SMALLBLKS;
+	else if (strcmp(bias, VDEV_ALLOC_BIAS_SEGREGATE) == 0)
+		alloc_bias = VDEV_BIAS_SEGREGATE;
+
+	return (alloc_bias);
 }
 
 /*
@@ -396,6 +420,8 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	vdev_t *vd;
 	char *tmp = NULL;
 	int rc;
+	vdev_alloc_bias_t alloc_bias = VDEV_BIAS_NONE;
+	boolean_t top_level = (parent && !parent->vdev_parent);
 
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
 
@@ -482,10 +508,57 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	}
 	ASSERT(nparity != -1ULL);
 
+	/*
+	 * If creating a top-level vdev, check for allocation classes input
+	 */
+	if (top_level && alloctype == VDEV_ALLOC_ADD) {
+		char *bias;
+
+		if (nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &bias) == 0) {
+			/* dedicated vdevs are expected to be mirrored */
+			if (ops != &vdev_mirror_ops && strcmp(bias,
+			    VDEV_ALLOC_BIAS_LOG) != 0) {
+				return (SET_ERROR(ENOTSUP));
+			}
+			alloc_bias = vdev_derive_alloc_bias(bias);
+
+			/* Disallow a dedicated bias if already segregating */
+			if ((alloc_bias == VDEV_BIAS_LOG &&
+			    spa->spa_segregate_log) ||
+			    (alloc_bias == VDEV_BIAS_METADATA &&
+			    spa->spa_segregate_metadata) ||
+			    (alloc_bias == VDEV_BIAS_SMALLBLKS &&
+			    spa->spa_segregate_smallblks)) {
+				return (SET_ERROR(EINVAL));
+			}
+			/* spa_vdev_add() expects feature to be enabled */
+			if (spa->spa_load_state != SPA_LOAD_CREATE &&
+			    !spa_feature_is_enabled(spa,
+			    SPA_FEATURE_ALLOCATION_CLASSES)) {
+				cmn_err(CE_WARN, "pool '%s' adding a %s class "
+				    "VDEV requires feature@allocation_classes",
+				    spa_name(spa), bias);
+				return (SET_ERROR(EINVAL));
+			}
+		}
+
+		if (alloc_bias == VDEV_BIAS_NONE && !islog) {
+			if (spa->spa_segregate_log ||
+			    spa->spa_segregate_metadata ||
+			    spa->spa_segregate_smallblks) {
+				alloc_bias = VDEV_BIAS_SEGREGATE;
+			}
+		}
+	}
+
 	vd = vdev_alloc_common(spa, id, guid, ops);
 
 	vd->vdev_islog = islog;
 	vd->vdev_nparity = nparity;
+	if (top_level && alloc_bias != VDEV_BIAS_NONE)
+		vd->vdev_alloc_bias = alloc_bias;
+
 
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &vd->vdev_path) == 0)
 		vd->vdev_path = spa_strdup(vd->vdev_path);
@@ -544,7 +617,7 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	/*
 	 * If we're a top-level vdev, try to load the allocation parameters.
 	 */
-	if (parent && !parent->vdev_parent &&
+	if (top_level &&
 	    (alloctype == VDEV_ALLOC_LOAD || alloctype == VDEV_ALLOC_SPLIT)) {
 		(void) nvlist_lookup_uint64(nv, ZPOOL_CONFIG_METASLAB_ARRAY,
 		    &vd->vdev_ms_array);
@@ -560,13 +633,12 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 		ASSERT0(vd->vdev_top_zap);
 	}
 
-	if (parent && !parent->vdev_parent && alloctype != VDEV_ALLOC_ATTACH) {
+	if (top_level && alloctype != VDEV_ALLOC_ATTACH) {
 		ASSERT(alloctype == VDEV_ALLOC_LOAD ||
 		    alloctype == VDEV_ALLOC_ADD ||
 		    alloctype == VDEV_ALLOC_SPLIT ||
 		    alloctype == VDEV_ALLOC_ROOTPOOL);
-		vd->vdev_mg = metaslab_group_create(islog ?
-		    spa_log_class(spa) : spa_normal_class(spa), vd);
+		/* Note: metaslab_group_create() is now deferred */
 	}
 
 	if (vd->vdev_ops->vdev_op_leaf &&
@@ -677,6 +749,10 @@ vdev_free(vdev_t *vd)
 	if (vd->vdev_mg != NULL) {
 		vdev_metaslab_fini(vd);
 		metaslab_group_destroy(vd->vdev_mg);
+		if (vd->vdev_log_mg != NULL)
+			metaslab_group_destroy(vd->vdev_log_mg);
+		if (vd->vdev_custom_mg != NULL)
+			metaslab_group_destroy(vd->vdev_custom_mg);
 	}
 
 	ASSERT0(vd->vdev_stat.vs_space);
@@ -705,7 +781,6 @@ vdev_free(vdev_t *vd)
 
 	if (vd->vdev_enc_sysfs_path)
 		spa_strfree(vd->vdev_enc_sysfs_path);
-
 	if (vd->vdev_fru)
 		spa_strfree(vd->vdev_fru);
 
@@ -766,13 +841,24 @@ vdev_top_transfer(vdev_t *svd, vdev_t *tvd)
 	if (tvd->vdev_mg)
 		ASSERT3P(tvd->vdev_mg, ==, svd->vdev_mg);
 	tvd->vdev_mg = svd->vdev_mg;
+	tvd->vdev_log_mg = svd->vdev_log_mg;
+	tvd->vdev_custom_mg = svd->vdev_custom_mg;
 	tvd->vdev_ms = svd->vdev_ms;
 
 	svd->vdev_mg = NULL;
+	svd->vdev_log_mg = NULL;
+	svd->vdev_custom_mg = NULL;
 	svd->vdev_ms = NULL;
 
 	if (tvd->vdev_mg != NULL)
 		tvd->vdev_mg->mg_vd = tvd;
+	if (tvd->vdev_log_mg != NULL)
+		tvd->vdev_log_mg->mg_vd = tvd;
+	if (tvd->vdev_custom_mg != NULL)
+		tvd->vdev_custom_mg->mg_vd = tvd;
+
+	tvd->vdev_alloc_bias = svd->vdev_alloc_bias;
+	svd->vdev_alloc_bias = VDEV_BIAS_NONE;
 
 	tvd->vdev_stat.vs_alloc = svd->vdev_stat.vs_alloc;
 	tvd->vdev_stat.vs_space = svd->vdev_stat.vs_space;
@@ -909,6 +995,68 @@ vdev_remove_parent(vdev_t *cvd)
 	vdev_free(mvd);
 }
 
+static void
+vdev_metaslab_group_create(vdev_t *vd)
+{
+	spa_t *spa = vd->vdev_spa;
+
+	/*
+	 * metaslab_group_create was delayed until allocation bias was available
+	 */
+	if (vd->vdev_mg == NULL) {
+		metaslab_class_t *mc;
+
+		if (vd->vdev_islog && vd->vdev_alloc_bias == VDEV_BIAS_NONE)
+			vd->vdev_alloc_bias = VDEV_BIAS_LOG;
+
+		ASSERT3U(vd->vdev_islog, ==,
+		    (vd->vdev_alloc_bias == VDEV_BIAS_LOG));
+
+		switch (vd->vdev_alloc_bias) {
+		case VDEV_BIAS_LOG:
+			mc = spa_log_class(spa);
+			break;
+		case VDEV_BIAS_DEDUP:
+			mc = spa_dedup_class(spa);
+			break;
+		case VDEV_BIAS_METADATA:
+		case VDEV_BIAS_SMALLBLKS:
+			mc = spa_custom_class(spa);
+			break;
+		case VDEV_BIAS_SEGREGATE:
+			/* Segregate allocations into multiple groups */
+			if (spa->spa_segregate_log) {
+				vd->vdev_log_mg = metaslab_group_create(
+				    spa_log_class(spa), vd);
+			}
+			if (spa->spa_segregate_metadata ||
+			    spa->spa_segregate_smallblks) {
+				vd->vdev_custom_mg = metaslab_group_create(
+				    spa_custom_class(spa), vd);
+			}
+			mc = spa_normal_class(spa);
+			break;
+		default:
+			mc = spa_normal_class(spa);
+		}
+
+		vd->vdev_mg = metaslab_group_create(mc, vd);
+
+		/*
+		 * The spa ashift values currently only reflect the
+		 * general vdev classes. Class destination is late
+		 * binding so ashift checking had to wait until now
+		 */
+		if (vd->vdev_top == vd && vd->vdev_ashift != 0 &&
+		    mc == spa_normal_class(spa) && vd->vdev_aux == NULL) {
+			if (vd->vdev_ashift > spa->spa_max_ashift)
+				spa->spa_max_ashift = vd->vdev_ashift;
+			if (vd->vdev_ashift < spa->spa_min_ashift)
+				spa->spa_min_ashift = vd->vdev_ashift;
+		}
+	}
+}
+
 int
 vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 {
@@ -919,6 +1067,7 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 	uint64_t newc = vd->vdev_asize >> vd->vdev_ms_shift;
 	metaslab_t **mspp;
 	int error;
+	boolean_t expanding = (oldc != 0);
 
 	ASSERT(txg == 0 || spa_config_held(spa, SCL_ALLOC, RW_WRITER));
 
@@ -943,7 +1092,7 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 
 	mspp = vmem_zalloc(newc * sizeof (*mspp), KM_SLEEP);
 
-	if (oldc != 0) {
+	if (expanding) {
 		bcopy(vd->vdev_ms, mspp, oldc * sizeof (*mspp));
 		vmem_free(vd->vdev_ms, oldc * sizeof (*mspp));
 	}
@@ -953,6 +1102,7 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 
 	for (m = oldc; m < newc; m++) {
 		uint64_t object = 0;
+		metaslab_group_t *mg = vd->vdev_mg;
 
 		if (txg == 0) {
 			error = dmu_read(mos, vd->vdev_ms_array,
@@ -960,12 +1110,35 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 			    DMU_READ_PREFETCH);
 			if (error)
 				return (error);
+
+			/*
+			 * Segregated vdevs only instantiate active metaslabs
+			 * in the first pass over the metaslab array.
+			 */
+			if (vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE &&
+			    !expanding && object == 0)
+				continue;
 		}
 
-		error = metaslab_init(vd->vdev_mg, m, object, txg,
-		    &(vd->vdev_ms[m]));
+		error = metaslab_init(mg, m, object, txg, &(vd->vdev_ms[m]));
 		if (error)
 			return (error);
+	}
+
+	/*
+	 * Segregated vdevs take a second pass which now has activation context
+	 */
+	if (vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE && !expanding) {
+		for (m = oldc; m < newc; m++) {
+			metaslab_group_t *mg = vd->vdev_mg;
+
+			if (vd->vdev_ms[m] != NULL)
+				continue;
+
+			error = metaslab_init(mg, m, 0, txg, &(vd->vdev_ms[m]));
+			if (error)
+				return (error);
+		}
 	}
 
 	if (txg == 0)
@@ -976,8 +1149,13 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 	 * the metaslabs since we want to ensure that no new
 	 * allocations are performed on this device.
 	 */
-	if (oldc == 0 && !vd->vdev_removing)
+	if (!expanding && !vd->vdev_removing) {
 		metaslab_group_activate(vd->vdev_mg);
+		if (vd->vdev_log_mg)
+			metaslab_group_activate(vd->vdev_log_mg);
+		if (vd->vdev_custom_mg)
+			metaslab_group_activate(vd->vdev_custom_mg);
+	}
 
 	if (txg == 0)
 		spa_config_exit(spa, SCL_ALLOC, FTAG);
@@ -993,6 +1171,11 @@ vdev_metaslab_fini(vdev_t *vd)
 
 	if (vd->vdev_ms != NULL) {
 		metaslab_group_passivate(vd->vdev_mg);
+		if (vd->vdev_log_mg != NULL)
+			metaslab_group_passivate(vd->vdev_log_mg);
+		if (vd->vdev_custom_mg != NULL)
+			metaslab_group_passivate(vd->vdev_custom_mg);
+
 		for (m = 0; m < count; m++) {
 			metaslab_t *msp = vd->vdev_ms[m];
 
@@ -1435,9 +1618,14 @@ vdev_open(vdev_t *vd)
 
 	/*
 	 * Track the min and max ashift values for normal data devices.
+	 *
+	 * DJB - TBD these should perhaps be tracked per allocation class
+	 * (e.g. spa_min_ashift is used to round up post compression buffers)
 	 */
 	if (vd->vdev_top == vd && vd->vdev_ashift != 0 &&
-	    !vd->vdev_islog && vd->vdev_aux == NULL) {
+	    (vd->vdev_alloc_bias == VDEV_BIAS_NONE ||
+	    vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE) &&
+	    vd->vdev_aux == NULL) {
 		if (vd->vdev_ashift > spa->spa_max_ashift)
 			spa->spa_max_ashift = vd->vdev_ashift;
 		if (vd->vdev_ashift < spa->spa_min_ashift)
@@ -1717,14 +1905,34 @@ vdev_create(vdev_t *vd, uint64_t txg, boolean_t isreplacing)
 	return (0);
 }
 
+#define	VDEV_SMALL_ASIZE	(100ULL << 30ULL)	/* 100GB */
+#define	METASLABS_MIN_GOAL	(50)
+
 void
 vdev_metaslab_set_size(vdev_t *vd)
 {
+	int metaslab_goal = metaslabs_per_vdev;
+
+	/*
+	 * Now that ZFS supports large blocks, with smaller vdevs,
+	 * we should consider going for fewer, but larger metaslabs.
+	 *
+	 * Aim for 256MB minimum size each (i.e. space for 16 16MB blocks)
+	 * but no less than a target goal of 50 metaslabs.
+	 */
+	if (vd->vdev_asize < VDEV_SMALL_ASIZE) {
+		uint64_t min_goal = MIN(metaslabs_per_vdev, METASLABS_MIN_GOAL);
+		uint64_t metaslab_size = SPA_MAXBLOCKSIZE << 4;  /* 16MB x 16 */
+
+		metaslab_goal = MAX(vd->vdev_asize / metaslab_size, min_goal);
+	}
+
 	/*
 	 * Aim for roughly metaslabs_per_vdev (default 200) metaslabs per vdev.
 	 */
-	vd->vdev_ms_shift = highbit64(vd->vdev_asize / metaslabs_per_vdev);
+	vd->vdev_ms_shift = highbit64(vd->vdev_asize / metaslab_goal);
 	vd->vdev_ms_shift = MAX(vd->vdev_ms_shift, SPA_MAXBLOCKSHIFT);
+
 }
 
 void
@@ -2086,6 +2294,35 @@ vdev_dtl_load(vdev_t *vd)
 	return (error);
 }
 
+static void
+vdev_zap_allocation_data(vdev_t *vd, dmu_tx_t *tx)
+{
+	spa_t *spa = vd->vdev_spa;
+	objset_t *mos = spa->spa_meta_objset;
+	vdev_alloc_bias_t alloc_bias = vd->vdev_alloc_bias;
+	const char *string;
+
+	ASSERT(alloc_bias != VDEV_BIAS_NONE);
+
+	string =
+	    (alloc_bias == VDEV_BIAS_LOG) ? VDEV_ALLOC_BIAS_LOG :
+	    (alloc_bias == VDEV_BIAS_DEDUP) ? VDEV_ALLOC_BIAS_DEDUP :
+	    (alloc_bias == VDEV_BIAS_METADATA) ? VDEV_ALLOC_BIAS_METADATA :
+	    (alloc_bias == VDEV_BIAS_SMALLBLKS) ? VDEV_ALLOC_BIAS_SMALLBLKS :
+	    (alloc_bias == VDEV_BIAS_SEGREGATE) ? VDEV_ALLOC_BIAS_SEGREGATE :
+	    NULL;
+
+	ASSERT(string != NULL);
+	VERIFY0(zap_add(mos, vd->vdev_top_zap, VDEV_TOP_ZAP_ALLOCATION_BIAS,
+	    1, strlen(string) + 1, string, tx));
+
+	if (alloc_bias != VDEV_BIAS_LOG) {
+		ASSERT(spa_feature_is_enabled(spa,
+		    SPA_FEATURE_ALLOCATION_CLASSES));
+		spa_feature_incr(spa, SPA_FEATURE_ALLOCATION_CLASSES, tx);
+	}
+}
+
 void
 vdev_destroy_unlink_zap(vdev_t *vd, uint64_t zapobj, dmu_tx_t *tx)
 {
@@ -2124,8 +2361,11 @@ vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx)
 		}
 		if (vd == vd->vdev_top && vd->vdev_top_zap == 0) {
 			vd->vdev_top_zap = vdev_create_link_zap(vd, tx);
+			if (vd->vdev_alloc_bias != VDEV_BIAS_NONE)
+				vdev_zap_allocation_data(vd, tx);
 		}
 	}
+
 	for (i = 0; i < vd->vdev_children; i++) {
 		vdev_construct_zaps(vd->vdev_child[i], tx);
 	}
@@ -2306,11 +2546,29 @@ vdev_load(vdev_t *vd)
 	/*
 	 * If this is a top-level vdev, initialize its metaslabs.
 	 */
-	if (vd == vd->vdev_top && !vd->vdev_ishole &&
-	    (vd->vdev_ashift == 0 || vd->vdev_asize == 0 ||
-	    vdev_metaslab_init(vd, 0) != 0))
-		vdev_set_state(vd, B_FALSE, VDEV_STATE_CANT_OPEN,
-		    VDEV_AUX_CORRUPT_DATA);
+	if (vd == vd->vdev_top && !vd->vdev_ishole) {
+		char bias_str[64];
+
+		/*
+		 * On spa_load path, grab the allocation bias from our zap
+		 */
+		if (vd->vdev_top_zap != 0 &&
+		    zap_lookup(vd->vdev_spa->spa_meta_objset, vd->vdev_top_zap,
+		    VDEV_TOP_ZAP_ALLOCATION_BIAS, 1, sizeof (bias_str),
+		    bias_str) == 0) {
+			ASSERT(vd->vdev_alloc_bias == VDEV_BIAS_NONE);
+			vd->vdev_alloc_bias = vdev_derive_alloc_bias(bias_str);
+		}
+
+		vdev_metaslab_group_create(vd);
+
+		if (vd->vdev_ashift == 0 || vd->vdev_asize == 0 ||
+		    vdev_metaslab_init(vd, 0) != 0) {
+			vdev_set_state(vd, B_FALSE, VDEV_STATE_CANT_OPEN,
+			    VDEV_AUX_CORRUPT_DATA);
+		}
+	}
+
 	/*
 	 * If this is a leaf vdev, load its DTL.
 	 */
@@ -2361,6 +2619,24 @@ vdev_validate_aux(vdev_t *vd)
 	return (0);
 }
 
+static void
+vdev_metaslab_histogram_verify(vdev_t *vd)
+{
+	metaslab_group_t *mg = vd->vdev_mg;
+
+	metaslab_group_histogram_verify(mg);
+	metaslab_class_histogram_verify(mg->mg_class);
+
+	if ((mg = vd->vdev_log_mg) != NULL) {
+		metaslab_group_histogram_verify(mg);
+		metaslab_class_histogram_verify(mg->mg_class);
+	}
+	if ((mg = vd->vdev_custom_mg) != NULL) {
+		metaslab_group_histogram_verify(mg);
+		metaslab_class_histogram_verify(mg->mg_class);
+	}
+}
+
 void
 vdev_remove(vdev_t *vd, uint64_t txg)
 {
@@ -2374,10 +2650,7 @@ vdev_remove(vdev_t *vd, uint64_t txg)
 	ASSERT3U(txg, ==, spa_syncing_txg(spa));
 
 	if (vd->vdev_ms != NULL) {
-		metaslab_group_t *mg = vd->vdev_mg;
-
-		metaslab_group_histogram_verify(mg);
-		metaslab_class_histogram_verify(mg->mg_class);
+		vdev_metaslab_histogram_verify(vd);
 
 		for (m = 0; m < vd->vdev_ms_count; m++) {
 			metaslab_t *msp = vd->vdev_ms[m];
@@ -2393,7 +2666,7 @@ vdev_remove(vdev_t *vd, uint64_t txg)
 			 * here so that we ensure that the metaslab group
 			 * and metaslab class are up-to-date.
 			 */
-			metaslab_group_histogram_remove(mg, msp);
+			metaslab_group_histogram_remove(msp->ms_group, msp);
 
 			VERIFY0(space_map_allocated(msp->ms_sm));
 			space_map_free(msp->ms_sm, tx);
@@ -2402,11 +2675,15 @@ vdev_remove(vdev_t *vd, uint64_t txg)
 			mutex_exit(&msp->ms_lock);
 		}
 
-		metaslab_group_histogram_verify(mg);
-		metaslab_class_histogram_verify(mg->mg_class);
-		for (i = 0; i < RANGE_TREE_HISTOGRAM_SIZE; i++)
-			ASSERT0(mg->mg_histogram[i]);
+		vdev_metaslab_histogram_verify(vd);
 
+		for (i = 0; i < RANGE_TREE_HISTOGRAM_SIZE; i++) {
+			ASSERT0(vd->vdev_mg->mg_histogram[i]);
+			if (vd->vdev_log_mg != NULL)
+				ASSERT0(vd->vdev_log_mg->mg_histogram[i]);
+			if (vd->vdev_custom_mg != NULL)
+				ASSERT0(vd->vdev_custom_mg->mg_histogram[i]);
+		}
 	}
 
 	if (vd->vdev_ms_array) {
@@ -2425,15 +2702,29 @@ void
 vdev_sync_done(vdev_t *vd, uint64_t txg)
 {
 	metaslab_t *msp;
-	boolean_t reassess = !txg_list_empty(&vd->vdev_ms_list, TXG_CLEAN(txg));
+	boolean_t dirty_primary = B_FALSE;
+	boolean_t dirty_log = B_FALSE;
+	boolean_t dirty_meta = B_FALSE;
 
 	ASSERT(!vd->vdev_ishole);
 
-	while ((msp = txg_list_remove(&vd->vdev_ms_list, TXG_CLEAN(txg))))
+	while ((msp = txg_list_remove(&vd->vdev_ms_list, TXG_CLEAN(txg)))) {
 		metaslab_sync_done(msp, txg);
 
-	if (reassess)
+		if (msp->ms_group == vd->vdev_mg)
+			dirty_primary = B_TRUE;
+		else if (msp->ms_group == vd->vdev_log_mg)
+			dirty_log = B_TRUE;
+		else if (msp->ms_group == vd->vdev_custom_mg)
+			dirty_meta = B_TRUE;
+	}
+
+	if (dirty_primary)
 		metaslab_sync_reassess(vd->vdev_mg);
+	if (dirty_log)
+		metaslab_sync_reassess(vd->vdev_log_mg);
+	if (dirty_meta)
+		metaslab_sync_reassess(vd->vdev_custom_mg);
 }
 
 void
@@ -2865,6 +3156,12 @@ boolean_t
 vdev_allocatable(vdev_t *vd)
 {
 	uint64_t state = vd->vdev_state;
+	boolean_t mg_initialized = vd->vdev_mg->mg_initialized;
+
+	if ((vd->vdev_log_mg && !vd->vdev_log_mg->mg_initialized) ||
+	    (vd->vdev_custom_mg && !vd->vdev_custom_mg->mg_initialized)) {
+		mg_initialized = B_FALSE;
+	}
 
 	/*
 	 * We currently allow allocations from vdevs which may be in the
@@ -2876,7 +3173,7 @@ vdev_allocatable(vdev_t *vd)
 	 */
 	return (!(state < VDEV_STATE_DEGRADED && state != VDEV_STATE_CLOSED) &&
 	    !vd->vdev_cant_write && !vd->vdev_ishole &&
-	    vd->vdev_mg->mg_initialized);
+	    mg_initialized);
 }
 
 boolean_t
@@ -2894,6 +3191,24 @@ vdev_accessible(vdev_t *vd, zio_t *zio)
 		return (!vd->vdev_cant_write);
 
 	return (B_TRUE);
+}
+
+metaslab_group_t *
+vdev_get_mg(vdev_t *vd, metaslab_class_t *mc)
+{
+	spa_t *spa = vd->vdev_spa;
+	metaslab_group_t *mg = vd->vdev_mg;
+
+	if (vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE) {
+		if (mc == spa_log_class(spa) && vd->vdev_log_mg != NULL) {
+			mg = vd->vdev_log_mg;
+		} else if (mc == spa_custom_class(spa) &&
+		    vd->vdev_custom_mg != NULL) {
+			mg = vd->vdev_custom_mg;
+		}
+	}
+
+	return (mg);
 }
 
 static void
@@ -3019,7 +3334,8 @@ vdev_get_stats_ex(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 		vs->vs_esize = vd->vdev_max_asize - vd->vdev_asize;
 		if (vd->vdev_aux == NULL && vd == vd->vdev_top &&
 		    !vd->vdev_ishole) {
-			vs->vs_fragmentation = vd->vdev_mg->mg_fragmentation;
+			vs->vs_fragmentation = (vd->vdev_mg != NULL) ?
+			    vd->vdev_mg->mg_fragmentation : 0;
 		}
 	}
 
@@ -3224,6 +3540,15 @@ vdev_stat_update(zio_t *zio, uint64_t psize)
 	}
 }
 
+int64_t
+vdev_deflated_space(vdev_t *vd, int64_t space)
+{
+	ASSERT((space & (SPA_MINBLOCKSIZE-1)) == 0);
+	ASSERT(vd->vdev_deflate_ratio != 0 || vd->vdev_isl2cache);
+
+	return ((space >> SPA_MINBLOCKSHIFT) * vd->vdev_deflate_ratio);
+}
+
 /*
  * Update the in-core space usage stats for this vdev, its metaslab class,
  * and the root vdev.
@@ -3232,11 +3557,9 @@ void
 vdev_space_update(vdev_t *vd, int64_t alloc_delta, int64_t defer_delta,
     int64_t space_delta)
 {
-	int64_t dspace_delta = space_delta;
+	int64_t dspace_delta;
 	spa_t *spa = vd->vdev_spa;
 	vdev_t *rvd = spa->spa_root_vdev;
-	metaslab_group_t *mg = vd->vdev_mg;
-	metaslab_class_t *mc = mg ? mg->mg_class : NULL;
 
 	ASSERT(vd == vd->vdev_top);
 
@@ -3246,10 +3569,7 @@ vdev_space_update(vdev_t *vd, int64_t alloc_delta, int64_t defer_delta,
 	 * because the root vdev's psize-to-asize is simply the max of its
 	 * childrens', thus not accurate enough for us.
 	 */
-	ASSERT((dspace_delta & (SPA_MINBLOCKSIZE-1)) == 0);
-	ASSERT(vd->vdev_deflate_ratio != 0 || vd->vdev_isl2cache);
-	dspace_delta = (dspace_delta >> SPA_MINBLOCKSHIFT) *
-	    vd->vdev_deflate_ratio;
+	dspace_delta = vdev_deflated_space(vd, space_delta);
 
 	mutex_enter(&vd->vdev_stat_lock);
 	vd->vdev_stat.vs_alloc += alloc_delta;
@@ -3257,21 +3577,15 @@ vdev_space_update(vdev_t *vd, int64_t alloc_delta, int64_t defer_delta,
 	vd->vdev_stat.vs_dspace += dspace_delta;
 	mutex_exit(&vd->vdev_stat_lock);
 
-	if (mc == spa_normal_class(spa)) {
+	/* every class but log contributes to root space stats */
+	if (vd->vdev_mg != NULL && !vd->vdev_islog) {
 		mutex_enter(&rvd->vdev_stat_lock);
 		rvd->vdev_stat.vs_alloc += alloc_delta;
 		rvd->vdev_stat.vs_space += space_delta;
 		rvd->vdev_stat.vs_dspace += dspace_delta;
 		mutex_exit(&rvd->vdev_stat_lock);
 	}
-
-	if (mc != NULL) {
-		ASSERT(rvd == vd->vdev_parent);
-		ASSERT(vd->vdev_ms_count != 0);
-
-		metaslab_class_space_update(mc,
-		    alloc_delta, defer_delta, space_delta, dspace_delta);
-	}
+	/* Note: metaslab_class_space_update moved to metaslab_space_update */
 }
 
 /*
@@ -3700,6 +4014,7 @@ vdev_expand(vdev_t *vd, uint64_t txg)
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER) == SCL_ALL);
 
 	if ((vd->vdev_asize >> vd->vdev_ms_shift) > vd->vdev_ms_count) {
+		vdev_metaslab_group_create(vd);
 		VERIFY(vdev_metaslab_init(vd, txg) == 0);
 		vdev_config_dirty(vd);
 	}

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 /*
@@ -428,6 +429,34 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 		if (vd->vdev_removing)
 			fnvlist_add_uint64(nv, ZPOOL_CONFIG_REMOVING,
 			    vd->vdev_removing);
+
+		/* zpool command expects alloc class data */
+		if (getstats && vd->vdev_alloc_bias != VDEV_BIAS_NONE) {
+			const char *bias = NULL;
+
+			switch (vd->vdev_alloc_bias) {
+			case VDEV_BIAS_LOG:
+				bias = VDEV_ALLOC_BIAS_LOG;
+				break;
+			case VDEV_BIAS_DEDUP:
+				bias = VDEV_ALLOC_BIAS_DEDUP;
+				break;
+			case VDEV_BIAS_METADATA:
+				bias = VDEV_ALLOC_BIAS_METADATA;
+				break;
+			case VDEV_BIAS_SMALLBLKS:
+				bias = VDEV_ALLOC_BIAS_SMALLBLKS;
+				break;
+			case VDEV_BIAS_SEGREGATE:
+				bias = VDEV_ALLOC_BIAS_SEGREGATE;
+				break;
+			default:
+				ASSERT3U(vd->vdev_alloc_bias, ==,
+				    VDEV_BIAS_NONE);
+			}
+			fnvlist_add_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+			    bias);
+		}
 	}
 
 	if (vd->vdev_dtl_sm != NULL) {

--- a/module/zfs/zfeature_common.c
+++ b/module/zfs/zfeature_common.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2014, Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifdef _KERNEL
@@ -318,4 +319,10 @@ zpool_feature_init(void)
 	    ZFEATURE_FLAG_READONLY_COMPAT | ZFEATURE_FLAG_PER_DATASET,
 	    userobj_accounting_deps);
 	}
+
+	/* DJB TBD if ZFEATURE_FLAG_MOS applies to per-vdev zap data */
+	zfeature_register(SPA_FEATURE_ALLOCATION_CLASSES,
+	    "com.intel:allocation_classes", "allocation_classes",
+	    "Support for separate allocation classes.",
+	    ZFEATURE_FLAG_READONLY_COMPAT, NULL);
 }

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <sys/sysmacros.h>
@@ -57,7 +58,11 @@ const char *zio_type_name[ZIO_TYPES] = {
 	"z_null", "z_rd", "z_wr", "z_fr", "z_cl", "z_ioctl"
 };
 
+#ifdef ZPOOL_CONFIG_ALLOCATION_BIAS
+int zio_dva_throttle_enabled = B_FALSE;  /* not compatible with alloc classes */
+#else
 int zio_dva_throttle_enabled = B_TRUE;
+#endif
 
 /*
  * ==========================================================================
@@ -2287,7 +2292,7 @@ static int
 zio_write_gang_block(zio_t *pio)
 {
 	spa_t *spa = pio->io_spa;
-	metaslab_class_t *mc = spa_normal_class(spa);
+	metaslab_class_t *mc;
 	blkptr_t *bp = pio->io_bp;
 	zio_t *gio = pio->io_gang_leader;
 	zio_t *zio;
@@ -2301,8 +2306,11 @@ zio_write_gang_block(zio_t *pio)
 	int gbh_copies = MIN(copies + 1, spa_max_replication(spa));
 	zio_prop_t zp;
 	int g, error;
-
 	int flags = METASLAB_HINTBP_FAVOR | METASLAB_GANG_HEADER;
+
+	mc = spa_preferred_class(spa, SPA_GANGBLOCKSIZE, BP_GET_TYPE(bp), 0,
+	    gio->io_bookmark.zb_objset);
+
 	if (pio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 		ASSERT(pio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
 		ASSERT(!(pio->io_flags & ZIO_FLAG_NODATA));
@@ -3009,7 +3017,7 @@ static int
 zio_dva_allocate(zio_t *zio)
 {
 	spa_t *spa = zio->io_spa;
-	metaslab_class_t *mc = spa_normal_class(spa);
+	metaslab_class_t *mc;
 	blkptr_t *bp = zio->io_bp;
 	int error;
 	int flags = 0;
@@ -3033,9 +3041,24 @@ zio_dva_allocate(zio_t *zio)
 	if (zio->io_priority == ZIO_PRIORITY_ASYNC_WRITE)
 		flags |= METASLAB_ASYNC_ALLOC;
 
+	/* locate an appropriate allocation class */
+	mc = spa_preferred_class(spa, zio->io_size, zio->io_prop.zp_type,
+	    zio->io_prop.zp_level, zio->io_prop.zp_copies == 3 ?
+	    DMU_META_OBJSET : zio->io_bookmark.zb_objset);
+
 	error = metaslab_alloc(spa, mc, zio->io_size, bp,
 	    zio->io_prop.zp_copies, zio->io_txg, NULL, flags,
 	    &zio->io_alloc_list, zio);
+
+	/*
+	 * Fallback to spa_normal_class when a dedicated class is full
+	 */
+	if (error == ENOSPC && mc != spa_normal_class(spa)) {
+		mc = spa_normal_class(spa);
+		error = metaslab_alloc(spa, mc, zio->io_size, bp,
+		    zio->io_prop.zp_copies, zio->io_txg, NULL, flags,
+		    &zio->io_alloc_list, zio);
+	}
 
 	if (error != 0) {
 		spa_dbgmsg(spa, "%s: metaslab allocation failure: zio %p, "
@@ -3106,6 +3129,14 @@ zio_alloc_zil(spa_t *spa, uint64_t txg, blkptr_t *new_bp, uint64_t size,
 	ASSERT(txg > spa_syncing_txg(spa));
 
 	metaslab_trace_init(&io_alloc_list);
+
+	/*
+	 * Block pointer fields are useful to metaslabs for stats and debugging.
+	 * Fill in the obvious ones before calling into metaslab_alloc().
+	 */
+	BP_SET_TYPE(new_bp, DMU_OT_INTENT_LOG);
+	BP_SET_PSIZE(new_bp, size);
+	BP_SET_LEVEL(new_bp, 0);
 
 	if (use_slog) {
 		error = metaslab_alloc(spa, spa_log_class(spa), size,

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -77,5 +77,6 @@ if is_linux; then
 	    "ashift"
 	    "feature@large_dnode"
 	    "feature@userobj_accounting"
+	    "feature@allocation_classes"
 	)
 fi


### PR DESCRIPTION
Please ignore this PR.
I just want to see how the metadata allocation classes behave if the special accounting is removed.  (Which would allow the small-block-size limit to be changed after creation more easily.)
