### PR TITLE
Update rsend_014_pos and send-c_volume test cases

### DIFF
--- a/tests/zfs-tests/tests/functional/rsend/rsend_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_014_pos.ksh
@@ -33,8 +33,8 @@ verify_runnable "both"
 log_assert "zfs send will work on filesystems and volumes in a read-only pool."
 log_onexit cleanup_pool $POOL2
 
-log_must eval "zpool export $POOL"
-log_must eval "zpool import -o readonly=on $POOL"
+log_must zpool export $POOL
+log_must zpool import -o readonly=on $POOL
 log_must eval "zfs send -R $POOL@final > $BACKDIR/pool-final-R"
 log_must eval "zfs receive -d -F $POOL2 < $BACKDIR/pool-final-R"
 
@@ -46,9 +46,8 @@ log_must cleanup_pool $POOL2
 
 log_must eval "zfs send -R $POOL/$FS@final > $BACKDIR/fs-final-R"
 log_must eval "zfs receive -d $POOL2 < $BACKDIR/fs-final-R"
-block_device_wait
-log_must eval "zpool export $POOL"
-log_must eval "zpool import $POOL"
+log_must_busy zpool export $POOL
+log_must zpool import $POOL
 
 dstds=$(get_dst_ds $POOL/$FS $POOL2)
 log_must cmp_ds_subs $POOL/$FS $dstds

--- a/tests/zfs-tests/tests/functional/rsend/send-c_volume.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_volume.ksh
@@ -35,6 +35,11 @@ function cleanup
 
 verify_runnable "both"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/6087
+if is_32bit; then
+	log_unsupported "Test case occasionally fails on 32-bit systems"
+fi
+
 log_assert "Verify compressed send works with volumes"
 log_onexit cleanup
 


### PR DESCRIPTION
The following three test cases occasionally fail the automated
testing.  For the moment disable these test cases until the
underlying issues can be fully investigated and resolved.

zfs_destroy_010_pos - zfsonlinux/zfs#5893
rsend_020_pos       - zfsonlinux/zfs#6086 (32-bit only)
send-c_volume       - zfsonlinux/zfs#6087 (32-bit only)

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #5893
Issue #6086
Issue #6087