### PR TITLE
Enable all zfs_destroy test cases

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -99,15 +99,13 @@ tests = ['zfs_create_001_pos', 'zfs_create_002_pos', 'zfs_create_003_pos',
     'zfs_create_010_neg', 'zfs_create_011_pos', 'zfs_create_012_pos',
     'zfs_create_013_pos', 'zfs_create_014_pos']
 
-# DISABLED:
-# zfs_destroy_005_neg - busy mountpoint behavior
-# zfs_destroy_001_pos - https://github.com/zfsonlinux/zfs/issues/5635
 [tests/functional/cli_root/zfs_destroy]
-tests = ['zfs_destroy_002_pos', 'zfs_destroy_003_pos',
-    'zfs_destroy_004_pos','zfs_destroy_006_neg', 'zfs_destroy_007_neg',
-    'zfs_destroy_008_pos','zfs_destroy_009_pos', 'zfs_destroy_010_pos',
-    'zfs_destroy_011_pos','zfs_destroy_012_pos', 'zfs_destroy_013_neg',
-    'zfs_destroy_014_pos','zfs_destroy_015_pos', 'zfs_destroy_016_pos']
+tests = ['zfs_destroy_001_pos', 'zfs_destroy_002_pos', 'zfs_destroy_003_pos',
+    'zfs_destroy_004_pos', 'zfs_destroy_005_neg', 'zfs_destroy_006_neg',
+    'zfs_destroy_007_neg', 'zfs_destroy_008_pos', 'zfs_destroy_009_pos',
+    'zfs_destroy_010_pos', 'zfs_destroy_011_pos', 'zfs_destroy_012_pos',
+    'zfs_destroy_013_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
+    'zfs_destroy_016_pos']
 
 # DISABLED:
 # zfs_get_004_pos - https://github.com/zfsonlinux/zfs/issues/3484

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_010_pos.ksh
@@ -54,7 +54,7 @@ function test_clone_run
     clone=$(eval echo \$${dstype}CLONE)
     log_must zfs destroy -d $snap
     log_must datasetexists $snap
-    log_must zfs destroy -R $clone
+    log_must_busy zfs destroy -R $clone
     log_mustnot datasetexists $snap
     log_mustnot datasetexists $clone
 }


### PR DESCRIPTION
* zfs_destroy_001_pos - Unable to reproduce the failures locally.
  Re-enabled to determine observed buildbot failure rate.

* zfs_destroy_005_neg - Updated for expected Linux behavior.
  Busy mount points, even snapshots, are expected to fail.

* zfs_destroy_010_pos - Resolved transient EBUSY with retry.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Issue #5635
Issue #5893