### PR TITLE
Enable additional test cases

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -223,6 +223,7 @@ constrain_path() {
 
 	# Exceptions
 	ln -fs "$STF_PATH/awk" "$STF_PATH/nawk"
+	ln -fs /sbin/fsck.ext2 "$STF_PATH/fsck"
 	ln -fs /sbin/mkfs.ext2 "$STF_PATH/newfs"
 	ln -fs "$STF_PATH/gzip" "$STF_PATH/compress"
 	ln -fs "$STF_PATH/gunzip" "$STF_PATH/uncompress"

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -219,40 +219,26 @@ tests = ['zfs_upgrade_001_pos', 'zfs_upgrade_002_pos', 'zfs_upgrade_003_pos',
 [tests/functional/cli_root/zpool]
 tests = ['zpool_001_neg', 'zpool_002_pos', 'zpool_003_pos']
 
-# DISABLED:
-# zpool_add_004_pos - https://github.com/zfsonlinux/zfs/issues/3484
-# zpool_add_005_pos - no 'dumpadm' command.
-# zpool_add_006_pos - https://github.com/zfsonlinux/zfs/issues/3484
 [tests/functional/cli_root/zpool_add]
 tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
+    'zpool_add_004_pos', 'zpool_add_005_pos', 'zpool_add_006_pos',
     'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg',
     'add-o_ashift', 'add_prop_ashift']
 
 [tests/functional/cli_root/zpool_attach]
 tests = ['zpool_attach_001_neg', 'attach-o_ashift']
 
-# DISABLED:
-# zpool_clear_001_pos - https://github.com/zfsonlinux/zfs/issues/5634
 [tests/functional/cli_root/zpool_clear]
-tests = ['zpool_clear_002_neg', 'zpool_clear_003_neg']
+tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg']
 
-# DISABLED:
-# zpool_create_001_pos - needs investigation
-# zpool_create_002_pos - needs investigation
-# zpool_create_004_pos - needs investigation
-# zpool_create_006_pos - https://github.com/zfsonlinux/zfs/issues/3484
-# zpool_create_008_pos - uses VTOC labels (?) and 'overlapping slices'
-# zpool_create_011_neg - tries to access /etc/vfstab etc
-# zpool_create_012_neg - swap devices
-# zpool_create_014_neg - swap devices
-# zpool_create_015_neg - swap devices
-# zpool_create_016_pos - no dumadm command.
-# zpool_create_020_pos - needs investigation
 [tests/functional/cli_root/zpool_create]
-tests = [
-    'zpool_create_003_pos', 'zpool_create_005_pos', 'zpool_create_007_neg',
-    'zpool_create_009_neg', 'zpool_create_010_neg', 'zpool_create_017_neg',
-    'zpool_create_018_pos', 'zpool_create_019_pos',
+tests = ['zpool_create_001_pos', 'zpool_create_002_pos',
+    'zpool_create_003_pos', 'zpool_create_004_pos', 'zpool_create_005_pos',
+    'zpool_create_006_pos', 'zpool_create_007_neg', 'zpool_create_008_pos',
+    'zpool_create_009_neg', 'zpool_create_010_neg', 'zpool_create_011_neg',
+    'zpool_create_012_neg', 'zpool_create_014_neg',
+    'zpool_create_015_neg', 'zpool_create_016_pos', 'zpool_create_017_neg',
+    'zpool_create_018_pos', 'zpool_create_019_pos', 'zpool_create_020_pos',
     'zpool_create_021_pos', 'zpool_create_022_pos', 'zpool_create_023_neg',
     'zpool_create_024_pos',
     'zpool_create_features_001_pos', 'zpool_create_features_002_pos',
@@ -260,11 +246,8 @@ tests = [
     'zpool_create_features_005_pos',
     'create-o_ashift']
 
-# DISABLED:
-# zpool_destroy_001_pos - needs investigation
-# zpool_destroy_002_pos - busy mountpoint behavior
 [tests/functional/cli_root/zpool_destroy]
-tests = [
+tests = ['zpool_destroy_001_pos', 'zpool_destroy_002_pos',
     'zpool_destroy_003_neg']
 pre =
 post =
@@ -272,17 +255,13 @@ post =
 [tests/functional/cli_root/zpool_detach]
 tests = ['zpool_detach_001_neg']
 
-# DISABLED: Requires full FMA support in ZED
-# zpool_expand_001_pos - https://github.com/zfsonlinux/zfs/issues/2437
-# zpool_expand_003_pos - https://github.com/zfsonlinux/zfs/issues/2437
 [tests/functional/cli_root/zpool_expand]
-tests = ['zpool_expand_002_pos', 'zpool_expand_004_pos']
+tests = ['zpool_expand_001_pos', 'zpool_expand_002_pos',
+    'zpool_expand_003_neg', 'zpool_expand_004_pos']
 
-# DISABLED:
-# zpool_export_004_pos - https://github.com/zfsonlinux/zfs/issues/3484
 [tests/functional/cli_root/zpool_export]
 tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
-    'zpool_export_003_neg']
+    'zpool_export_003_neg', 'zpool_export_004_pos']
 
 [tests/functional/cli_root/zpool_get]
 tests = ['zpool_get_001_pos', 'zpool_get_002_pos', 'zpool_get_003_pos',
@@ -291,20 +270,16 @@ tests = ['zpool_get_001_pos', 'zpool_get_002_pos', 'zpool_get_003_pos',
 [tests/functional/cli_root/zpool_history]
 tests = ['zpool_history_001_neg', 'zpool_history_002_pos']
 
-# DISABLED:
-# zpool_import_002_pos - https://github.com/zfsonlinux/zfs/issues/5202
-# zpool_import_012_pos - sharenfs issue
-# zpool_import_all_001_pos - partition issue
 [tests/functional/cli_root/zpool_import]
-tests = ['zpool_import_001_pos',
+tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'zpool_import_003_pos', 'zpool_import_004_pos', 'zpool_import_005_pos',
     'zpool_import_006_pos', 'zpool_import_007_pos', 'zpool_import_008_pos',
     'zpool_import_009_neg', 'zpool_import_010_pos', 'zpool_import_011_neg',
-    'zpool_import_013_neg', 'zpool_import_014_pos',
+    'zpool_import_012_pos', 'zpool_import_013_neg', 'zpool_import_014_pos',
     'zpool_import_features_001_pos', 'zpool_import_features_002_neg',
     'zpool_import_features_003_pos','zpool_import_missing_001_pos',
     'zpool_import_missing_002_pos', 'zpool_import_missing_003_pos',
-    'zpool_import_rename_001_pos']
+    'zpool_import_rename_001_pos', 'zpool_import_all_001_pos']
 
 [tests/functional/cli_root/zpool_labelclear]
 tests = ['zpool_labelclear_active', 'zpool_labelclear_exported']
@@ -317,10 +292,9 @@ tests = ['zpool_offline_001_pos', 'zpool_offline_002_neg']
 [tests/functional/cli_root/zpool_online]
 tests = ['zpool_online_001_pos', 'zpool_online_002_neg']
 
-# DISABLED:
-# zpool_remove_003_pos - needs investigation
 [tests/functional/cli_root/zpool_remove]
-tests = ['zpool_remove_001_neg', 'zpool_remove_002_pos']
+tests = ['zpool_remove_001_neg', 'zpool_remove_002_pos',
+    'zpool_remove_003_pos']
 
 [tests/functional/cli_root/zpool_replace]
 tests = ['zpool_replace_001_neg', 'replace-o_ashift', 'replace_prop_ashift']
@@ -338,14 +312,11 @@ post =
 tests = ['zpool_status_001_pos', 'zpool_status_002_pos','zpool_status_003_pos']
 user =
 
-# DISABLED:
-# zpool_upgrade_002_pos - https://github.com/zfsonlinux/zfs/issues/4034
-# zpool_upgrade_004_pos - https://github.com/zfsonlinux/zfs/issues/4034
-# zpool_upgrade_007_pos - needs investigation
 [tests/functional/cli_root/zpool_upgrade]
-tests = ['zpool_upgrade_001_pos',
-    'zpool_upgrade_003_pos', 'zpool_upgrade_005_neg',
-    'zpool_upgrade_006_neg', 'zpool_upgrade_008_pos',
+tests = ['zpool_upgrade_001_pos', 'zpool_upgrade_002_pos',
+    'zpool_upgrade_003_pos', 'zpool_upgrade_004_pos',
+    'zpool_upgrade_005_neg', 'zpool_upgrade_006_neg',
+    'zpool_upgrade_007_pos', 'zpool_upgrade_008_pos',
     'zpool_upgrade_009_neg']
 
 # DISABLED:
@@ -667,15 +638,13 @@ tests = ['zvol_ENOSPC_001_pos']
 [tests/functional/zvol/zvol_cli]
 tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 
-# DISABLED: requires dumpadm
-#[tests/functional/zvol/zvol_misc]
-#tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
-#    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']
+[tests/functional/zvol/zvol_misc]
+tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
+    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']
 
-# DISABLED: requires updated for Linux
-#[tests/functional/zvol/zvol_swap]
-#tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',
-#    'zvol_swap_004_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos']
+[tests/functional/zvol/zvol_swap]
+tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',
+    'zvol_swap_004_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos']
 
 [tests/functional/libzfs]
 tests = ['many_fds']

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -65,6 +65,7 @@ export SYSTEM_FILES='arp
     md5sum
     mkdir
     mknod
+    mkswap
     mktemp
     modprobe
     mount
@@ -100,6 +101,7 @@ export SYSTEM_FILES='arp
     su
     sudo
     sum
+    swapoff
     swapon
     sync
     tail

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3302,3 +3302,59 @@ function zed_stop
 		log_must rmdir $ZEDLET_DIR
 	fi
 }
+
+#
+# Check is provided device is being active used as a swap device.
+#
+function is_swap_inuse
+{
+	typeset device=$1
+
+	if [[ -z $device ]] ; then
+		log_note "No device specified."
+		return 1
+	fi
+
+	if is_linux; then
+		swapon -s | grep -w $(readlink -f $device) > /dev/null 2>&1
+	else
+		swap -l | grep -w $device > /dev/null 2>&1
+	fi
+
+	return $?
+}
+
+#
+# Setup a swap device using the provided device.
+#
+function swap_setup
+{
+	typeset swapdev=$1
+
+	if is_linux; then
+		log_must mkswap $swapdev > /dev/null 2>&1
+		log_must swapon $swapdev
+	else
+	        log_must swap -a $swapdev
+	fi
+
+	return 0
+}
+
+#
+# Cleanup a swap device on the provided device.
+#
+function swap_cleanup
+{
+	typeset swapdev=$1
+
+	if is_swap_inuse $swapdev; then
+		if is_linux; then
+			log_must swapoff $swapdev
+		else
+			log_must swap -d $swapdev
+		fi
+	fi
+
+	return 0
+}

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_006_pos.ksh
@@ -50,7 +50,7 @@ verify_runnable "global"
 function cleanup
 {
 	if snapexists $SNAPFS1 ; then
-		log_must zfs destroy -Rf $SNAPFS1
+		log_must_busy zfs destroy -Rf $SNAPFS1
 	fi
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
@@ -161,7 +161,8 @@ function test_n_check
 	fi
 
 	# Invoke 'zfs destroy [-rRf] <dataset>'
-	log_must zfs destroy $opt $dtst
+	log_must_busy zfs destroy $opt $dtst
+	block_device_wait
 
 	# Kill any lingering instances of mkbusy, and clear the list.
 	if ! is_linux ; then

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
@@ -89,6 +89,7 @@ function setup_testenv #[dtst]
 		fi
 		if ! datasetexists $VOLCLONE && is_global_zone; then
 			log_must zfs clone $VOLSNAP $VOLCLONE
+			block_device_wait
 		fi
 	fi
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/receive-o-x_props_override.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/receive-o-x_props_override.ksh
@@ -181,7 +181,8 @@ log_must eval "zfs send $orig@snap1 > $streamfile_full"
 log_mustnot eval "zfs recv $dest -x volsize < $streamfile_full"
 log_mustnot eval "zfs recv $dest -o volsize=32K < $streamfile_full"
 # Cleanup
-log_must zfs destroy -r -f $orig
+block_device_wait
+log_must_busy zfs destroy -r -f $orig
 
 #
 # 3.2 Verify -o property=value works on streams without properties.

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/zfs_upgrade.kshlib
@@ -150,12 +150,12 @@ function default_check_zfs_upgrade #rootfs
 
 		if (( df_ret != 0 )); then
 			if (( spa_version != 0 )) && (( vp < spa_version )); then
-				log_mustnot eval 'zfs upgrade $opt -a > /dev/null 2>&1'
-				log_must eval 'zpool upgrade $pool > /dev/null 2>&1'
+				log_mustnot zfs upgrade $opt -a >/dev/null
+				log_must zpool upgrade $pool >/dev/null
 				vp=$(get_pool_prop version $pool)
 			fi
 
-			log_must eval 'zfs upgrade $opt -a > /dev/null 2>&1'
+			log_must zfs upgrade $opt -a
 
 			for fs in $(zfs list -rH -t filesystem -o name $rootfs) ; do
 				log_must check_fs_version $fs $newv

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.kshlib
@@ -36,11 +36,17 @@
 #
 function find_vfstab_dev
 {
-	typeset vfstab="/etc/vfstab"
-	typeset tmpfile="/tmp/vfstab.tmp"
 	typeset vfstabdev
 	typeset vfstabdevs=""
 	typeset line
+
+	if is_linux; then
+		vfstab="/etc/fstab"
+		tmpfile="/tmp/fstab.tmp"
+	else
+		vfstab="/etc/vfstab"
+		tmpfile="/tmp/vfstab.tmp"
+	fi
 
 	cat $vfstab | grep "^${DEV_DSKDIR}" >$tmpfile
 	while read -r line
@@ -59,11 +65,17 @@ function find_vfstab_dev
 #
 function find_mnttab_dev
 {
-	typeset mnttab="/etc/mnttab"
-	typeset tmpfile="/tmp/mnttab.tmp"
 	typeset mnttabdev
 	typeset mnttabdevs=""
 	typeset line
+
+	if is_linux; then
+		typeset mnttab="/etc/mtab"
+		typeset tmpfile="/tmp/mtab.tmp"
+	else
+		typeset mnttab="/etc/mnttab"
+		typeset tmpfile="/tmp/mnttab.tmp"
+	fi
 
 	cat $mnttab | grep "^${DEV_DSKDIR}" >$tmpfile
 	while read -r line
@@ -84,10 +96,14 @@ function save_dump_dev
 {
 
 	typeset dumpdev
-	typeset fnd="Dump device"
 
-	dumpdev=`dumpadm | grep "$fnd" | cut -f2 -d : | \
-		awk '{print $1}'`
+	if is_linux; then
+		dumpdev=""
+	else
+		typeset fnd="Dump device"
+		dumpdev=`dumpadm | grep "$fnd" | cut -f2 -d : | \
+			awk '{print $1}'`
+	fi
 	echo $dumpdev
 }
 
@@ -97,13 +113,13 @@ function save_dump_dev
 function partition_cleanup
 {
 
-        if [[ -n $DISK ]]; then
-                partition_disk $SIZE $DISK 7
-        else
-                typeset disk=""
-                for disk in $DISK0 $DISK1; do
-                        partition_disk $SIZE $disk 7
-                done
-        fi
+	if [[ -n $DISK ]]; then
+		partition_disk $SIZE $DISK 7
+	else
+		typeset disk=""
+		for disk in $DISK0 $DISK1; do
+			partition_disk $SIZE $disk 7
+		done
+	fi
 
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_004_pos.ksh
@@ -45,6 +45,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/6065
+if is_linux; then
+	log_unsupported "Creating a pool containing a zvol may deadlock"
+fi
+
 function cleanup
 {
 	poolexists $TESTPOOL && \
@@ -71,7 +76,7 @@ log_must poolexists "$TESTPOOL1"
 log_must zfs create -V $VOLSIZE $TESTPOOL1/$TESTVOL
 block_device_wait
 
-log_must zpool add "$TESTPOOL" /dev/zvol/dsk/$TESTPOOL1/$TESTVOL
+log_must zpool add "$TESTPOOL" $ZVOL_DEVDIR/$TESTPOOL1/$TESTVOL
 
 log_must vdevs_in_pool "$TESTPOOL" "$ZVOL_DEVDIR/$TESTPOOL1/$TESTVOL"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_005_pos.ksh
@@ -78,12 +78,14 @@ create_pool "$TESTPOOL1" "${disk}${SLICE_PREFIX}${SLICE1}"
 log_must poolexists "$TESTPOOL1"
 
 unset NOINUSE_CHECK
-log_mustnot zpool add -f "$TESTPOOL" ${disk}s${SLICE1}
+log_mustnot zpool add -f "$TESTPOOL" ${disk}${SLICE_PREFIX}${SLICE1}
 log_mustnot zpool add -f "$TESTPOOL" $mnttab_dev
 log_mustnot zpool add -f "$TESTPOOL" $vfstab_dev
 
-log_must echo "y" | newfs ${DEV_DSKDIR}/$dump_dev > /dev/null 2>&1
-log_must dumpadm -u -d ${DEV_DSKDIR}/$dump_dev > /dev/null
-log_mustnot zpool add -f "$TESTPOOL" $dump_dev
+if ! is_linux; then
+	log_must echo "y" | newfs ${DEV_DSKDIR}/$dump_dev > /dev/null 2>&1
+	log_must dumpadm -u -d ${DEV_DSKDIR}/$dump_dev > /dev/null
+	log_mustnot zpool add -f "$TESTPOOL" $dump_dev
+fi
 
 log_pass "'zpool add' should fail with inapplicable scenarios."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_006_pos.ksh
@@ -59,19 +59,18 @@ function cleanup
 log_assert "Adding a large number of file based vdevs to a zpool works."
 log_onexit cleanup
 
-create_pool $TESTPOOL ${DISKS%% *}
-log_must zfs create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS
-log_must mkfile $MINVDEVSIZE $TESTDIR/file.00
+log_must mkdir -p $TESTDIR
+log_must truncate -s $MINVDEVSIZE $TESTDIR/file.00
 create_pool "$TESTPOOL1" "$TESTDIR/file.00"
 
 vdevs_list=$(echo $TESTDIR/file.{01..16})
-log_must mkfile $MINVDEVSIZE $vdevs_list
+log_must truncate -s $MINVDEVSIZE $vdevs_list
 
 log_must zpool add -f "$TESTPOOL1" $vdevs_list
 log_must vdevs_in_pool "$TESTPOOL1" "$vdevs_list"
 
 # Attempt to add a file based vdev that's too small.
-log_must mkfile 32m $TESTDIR/broken_file
+log_must truncate -s 32m $TESTDIR/broken_file
 log_mustnot zpool add -f "$TESTPOOL1" ${TESTDIR}/broken_file
 log_mustnot vdevs_in_pool "$TESTPOOL1" "${TESTDIR}/broken_file"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
@@ -141,23 +141,17 @@ function do_testing #<clear type> <vdevs>
 	log_must zpool create -f $TESTPOOL1 $vdev
 	log_must zfs create $FS
 	#
-	# Fully fill up the zfs filesystem in order to make data block errors
-	# zfs filesystem
+	# Partially fill up the zfs filesystem in order to make data block
+	# errors.  It's not necessary to fill the entire filesystem.
 	#
-	typeset -i ret=0
-	typeset -i i=0
-	while true ; do
-		file_write -o create -f $file.$i -b $BLOCKSZ -c $NUM_WRITES
-		ret=$?
-		(( $ret != 0 )) && break
-		(( i = i + 1 ))
-	done
-	(( $ret != 28 )) && log_fail "file_write fails to fully fill up the $FS."
+	avail=$(get_prop available $FS)
+	fill_mb=$(((avail / 1024 / 1024) * 25 / 100))
+	log_must dd if=/dev/urandom of=$file.$i bs=$BLOCKSZ count=$fill_mb
 
 	#
-	#Make errors to the testing pool by overwrite the vdev device with
-	#/usr/bin/dd command. We donot want to have a full overwrite. That
-	#may cause the system panic. So, we should skip the vdev label space.
+	# Make errors to the testing pool by overwrite the vdev device with
+	# /usr/bin/dd command. We do not want to have a full overwrite. That
+	# may cause the system panic. So, we should skip the vdev label space.
 	#
 	(( i = $RANDOM % 3 ))
 	typeset -i wcount=0

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.shlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.shlib
@@ -79,7 +79,7 @@ function create_blockfile
 		log_fail "Create file system fail."
 
         log_must mount ${DEV_DSKDIR}/$disk $dir
-        log_must mkfile $size $file
+        log_must truncate -s $size $file
 }
 
 #
@@ -121,11 +121,17 @@ function clean_blockfile
 #
 function find_vfstab_dev
 {
-	typeset vfstab="/etc/vfstab"
-	typeset tmpfile="/tmp/vfstab.tmp"
 	typeset vfstabdev
 	typeset vfstabdevs=""
 	typeset line
+
+	if is_linux; then
+		vfstab="/etc/fstab"
+		tmpfile="/tmp/fstab.tmp"
+	else
+		vfstab="/etc/vfstab"
+		tmpfile="/tmp/vfstab.tmp"
+	fi
 
 	cat $vfstab | grep "^${DEV_DSKDIR}" >$tmpfile
 	while read -r line
@@ -144,11 +150,14 @@ function find_vfstab_dev
 #
 function save_dump_dev
 {
-
 	typeset dumpdev
-	typeset fnd="Dump device"
 
-	dumpdev=`dumpadm | grep "$fnd" | cut -f2 -d : | \
-		awk '{print $1}'`
+	if is_linux; then
+		dumpdev=""
+	else
+		typeset fnd="Dump device"
+		dumpdev=`dumpadm | grep "$fnd" | cut -f2 -d : | \
+			awk '{print $1}'`
+	fi
 	echo $dumpdev
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_002_pos.ksh
@@ -80,9 +80,9 @@ log_must echo "y" | newfs \
 	${DEV_RDSKDIR}/${disk}${SLICE_PREFIX}${SLICE1} >/dev/null 2>&1
 create_blockfile $FILESIZE $TESTDIR0/$FILEDISK0 ${disk}${SLICE_PREFIX}${SLICE4}
 create_blockfile $FILESIZE1 $TESTDIR1/$FILEDISK1 ${disk}${SLICE_PREFIX}${SLICE5}
-log_must mkfile $SIZE /var/tmp/$FILEDISK0
-log_must mkfile $SIZE /var/tmp/$FILEDISK1
-log_must mkfile $SIZE /var/tmp/$FILEDISK2
+log_must truncate -s $SIZE /var/tmp/$FILEDISK0
+log_must truncate -s $SIZE /var/tmp/$FILEDISK1
+log_must truncate -s $SIZE /var/tmp/$FILEDISK2
 
 unset NOINUSE_CHECK
 log_must zpool export $TESTPOOL

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_004_pos.ksh
@@ -62,7 +62,7 @@ create_pool $TESTPOOL $disk
 log_must zfs create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 
 vdevs_list=$(echo $TESTDIR/file.{01..16})
-log_must mkfile $MINVDEVSIZE $vdevs_list
+log_must truncate -s $MINVDEVSIZE $vdevs_list
 
 create_pool "$TESTPOOL1" $vdevs_list
 log_must vdevs_in_pool "$TESTPOOL1" "$vdevs_list"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_006_pos.ksh
@@ -87,7 +87,8 @@ set -A valid_args \
 		spare $vdev6" \
 	"raidz2 $vdev0 $vdev1 $vdev2 raidz2 $vdev3 $vdev4 $vdev5 \
 		raidz2 $vdev6 $vdev7 $vdev8 spare $vdev9" \
-	"raidz2 $vdev0 $vdev1 $vdev2 spare $vdev3 raidz2 $vdev4 $vdev5 $vdev6"
+	"raidz2 $vdev0 $vdev1 $vdev2 spare $vdev3 raidz2 $vdev4 $vdev5 $vdev6" \
+	"spare $vdev0 $vdev1 $vdev2 mirror $vdev3 $vdev4 raidz $vdev5 $vdev6"
 
 set -A forced_args \
 	"$vdev0 raidz $vdev1 $vdev2 raidz1 $vdev3 $vdev4 $vdev5" \
@@ -104,7 +105,8 @@ set -A forced_args \
 		raidz2 $vdev4 $vdev5 $vdev6 spare $vdev7" \
 	"mirror $vdev0 $vdev1 raidz $vdev2 $vdev3 \
 		spare $vdev4 raidz2 $vdev5 $vdev6 $vdev7" \
-	"spare $vdev0 $vdev1 $vdev2 mirror $vdev3 $vdev4 raidz $vdev5 $vdev6"
+	"spare $vdev0 $vdev1 $vdev2 mirror $vdev3 $vdev4 \
+		raidz2 $vdev5 $vdev6 $vdev7"
 
 i=0
 while ((i < ${#valid_args[@]})); do

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_008_pos.ksh
@@ -125,14 +125,16 @@ fi
 create_pool $TESTPOOL $disk
 destroy_pool $TESTPOOL
 
-# Make the disk is VTOC labeled since only VTOC label supports overlap
-log_must labelvtoc $disk
-log_must create_overlap_slice $disk
+if ! is_linux; then
+	# Make the disk is VTOC labeled since only VTOC label supports overlap
+	log_must labelvtoc $disk
+	log_must create_overlap_slice $disk
 
-unset NOINUSE_CHECK
-log_mustnot zpool create $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE0}
-log_must zpool create -f $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE0}
-destroy_pool $TESTPOOL
+	unset NOINUSE_CHECK
+	log_mustnot zpool create $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE0}
+	log_must zpool create -f $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE0}
+	destroy_pool $TESTPOOL
+fi
 
 # exported device to be as spare vdev need -f to create pool
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_011_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_011_neg.ksh
@@ -49,25 +49,25 @@ verify_runnable "global"
 
 function cleanup
 {
-        for pool in $TESTPOOL $TESTPOOL1
-        do
-                destroy_pool $pool
-        done
+	for pool in $TESTPOOL $TESTPOOL1
+	do
+		destroy_pool $pool
+	done
 
 	if [[ -n $saved_dump_dev ]]; then
 		log_must dumpadm -u -d $saved_dump_dev
 	fi
 
-        partition_disk $SIZE $disk 6
+	partition_disk $SIZE $disk 7
 }
 
 log_assert "'zpool create' should be failed with inapplicable scenarios."
 log_onexit cleanup
 
 if [[ -n $DISK ]]; then
-        disk=$DISK
+	disk=$DISK
 else
-        disk=$DISK0
+	disk=$DISK0
 fi
 pooldev1=${disk}${SLICE_PREFIX}${SLICE0}
 pooldev2=${disk}${SLICE_PREFIX}${SLICE1}
@@ -77,55 +77,64 @@ raidz1=$mirror1
 raidz2=$mirror2
 diff_size_dev="${disk}${SLICE_PREFIX}${SLICE6} ${disk}${SLICE_PREFIX}${SLICE7}"
 vfstab_dev=$(find_vfstab_dev)
-specified_dump_dev=${disk}${SLICE_PREFIX}${SLICE0}
-saved_dump_dev=$(save_dump_dev)
 
-cyl=$(get_endslice $disk $SLICE6)
-set_partition $SLICE7 "$cyl" $SIZE1 $disk
+if is_linux; then
+	partition_disk $SIZE $disk 7
+	cyl=$(get_endslice $disk $SLICE5)
+	set_partition $SLICE6 "$cyl" $SIZE1 $disk
+else
+	specified_dump_dev=${disk}${SLICE_PREFIX}${SLICE0}
+	saved_dump_dev=$(save_dump_dev)
+
+	cyl=$(get_endslice $disk $SLICE6)
+	set_partition $SLICE7 "$cyl" $SIZE1 $disk
+fi
 create_pool "$TESTPOOL" "$pooldev1"
 
 #
 # Set up the testing scenarios parameters
 #
 set -A arg "$TESTPOOL $pooldev2" \
-        "$TESTPOOL1 $pooldev1" \
-        "$TESTPOOL1 $TESTDIR0/$FILEDISK0" \
-        "$TESTPOOL1 mirror mirror $mirror1 mirror $mirror2" \
-        "$TESTPOOL1 raidz raidz $raidz1 raidz $raidz2" \
-        "$TESTPOOL1 raidz1 raidz1 $raidz1 raidz1 $raidz2" \
-        "$TESTPOOL1 mirror raidz $raidz1 raidz $raidz2" \
-        "$TESTPOOL1 mirror raidz1 $raidz1 raidz1 $raidz2" \
-        "$TESTPOOL1 raidz mirror $mirror1 mirror $mirror2" \
-        "$TESTPOOL1 raidz1 mirror $mirror1 mirror $mirror2" \
-        "$TESTPOOL1 mirror $diff_size_dev" \
-        "$TESTPOOL1 raidz $diff_size_dev" \
-        "$TESTPOOL1 raidz1 $diff_size_dev" \
+	"$TESTPOOL1 $pooldev1" \
+	"$TESTPOOL1 $TESTDIR0/$FILEDISK0" \
+	"$TESTPOOL1 mirror mirror $mirror1 mirror $mirror2" \
+	"$TESTPOOL1 raidz raidz $raidz1 raidz $raidz2" \
+	"$TESTPOOL1 raidz1 raidz1 $raidz1 raidz1 $raidz2" \
+	"$TESTPOOL1 mirror raidz $raidz1 raidz $raidz2" \
+	"$TESTPOOL1 mirror raidz1 $raidz1 raidz1 $raidz2" \
+	"$TESTPOOL1 raidz mirror $mirror1 mirror $mirror2" \
+	"$TESTPOOL1 raidz1 mirror $mirror1 mirror $mirror2" \
+	"$TESTPOOL1 mirror $diff_size_dev" \
+	"$TESTPOOL1 raidz $diff_size_dev" \
+	"$TESTPOOL1 raidz1 $diff_size_dev" \
 	"$TESTPOOL1 mirror $mirror1 spare $mirror2 spare $diff_size_dev" \
-        "$TESTPOOL1 $vfstab_dev" \
-        "$TESTPOOL1 ${disk}s10" \
+	"$TESTPOOL1 $vfstab_dev" \
+	"$TESTPOOL1 ${disk}s10" \
 	"$TESTPOOL1 spare $pooldev2"
 
 unset NOINUSE_CHECK
 typeset -i i=0
 while (( i < ${#arg[*]} )); do
-        log_mustnot zpool create ${arg[i]}
-        (( i = i+1 ))
+	log_mustnot zpool create ${arg[i]}
+	(( i = i+1 ))
 done
 
 # now destroy the pool to be polite
 log_must zpool destroy -f $TESTPOOL
 
-# create/destroy a pool as a simple way to set the partitioning
-# back to something normal so we can use this $disk as a dump device
-log_must zpool create -f $TESTPOOL3 $disk
-log_must zpool destroy -f $TESTPOOL3
+if ! is_linux; then
+	# create/destroy a pool as a simple way to set the partitioning
+	# back to something normal so we can use this $disk as a dump device
+	log_must zpool create -f $TESTPOOL3 $disk
+	log_must zpool destroy -f $TESTPOOL3
 
-log_must dumpadm -d ${DEV_DSKDIR}/$specified_dump_dev
-log_mustnot zpool create -f $TESTPOOL1 "$specified_dump_dev"
+	log_must dumpadm -d ${DEV_DSKDIR}/$specified_dump_dev
+	log_mustnot zpool create -f $TESTPOOL1 "$specified_dump_dev"
 
-# Also check to see that in-use checking prevents us from creating
-# a zpool from just the first slice on the disk.
-log_mustnot zpool create \
-	-f $TESTPOOL1 ${specified_dump_dev}${SLICE_PREFIX}${SLICE0}
+	# Also check to see that in-use checking prevents us from creating
+	# a zpool from just the first slice on the disk.
+	log_mustnot zpool create \
+		-f $TESTPOOL1 ${specified_dump_dev}${SLICE_PREFIX}${SLICE0}
+fi
 
 log_pass "'zpool create' is failed as expected with inapplicable scenarios."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_012_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_012_neg.ksh
@@ -50,10 +50,14 @@ function cleanup
 	if poolexists $TESTPOOL; then
 		destroy_pool $TESTPOOL
 	fi
-
 }
-typeset swap_disks=`swap -l | grep "c[0-9].*d[0-9].*s[0-9]" | \
-            awk '{print $1}'`
+
+if is_linux; then
+	typeset swap_disks=`swapon -s | grep "/dev" | awk '{print $1}'`
+else
+	typeset swap_disks=`swap -l | grep "c[0-9].*d[0-9].*s[0-9]" | \
+	    awk '{print $1}'`
+fi
 
 log_assert "'zpool create' should fail with disk slice in swap."
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
@@ -52,10 +52,7 @@ function cleanup
 {
 	# cleanup zfs pool and dataset
 	if datasetexists $vol_name; then
-		swap -l | grep ${ZVOL_DEVDIR}/$vol_name > /dev/null 2>&1
-		if [[ $? -eq 0 ]]; then
-			swap -d ${ZVOL_DEVDIR}/${vol_name}
-		fi
+		swap_cleanup ${ZVOL_DEVDIR}/${vol_name}
 	fi
 
 	for pool in $TESTPOOL1 $TESTPOOL; do
@@ -83,14 +80,16 @@ log_onexit cleanup
 #
 create_pool $TESTPOOL $pool_dev
 log_must zfs create -V 100m $vol_name
-log_must swap -a ${ZVOl_DEVDIR}/$vol_name
+block_device_wait
+swap_setup ${ZVOL_DEVDIR}/$vol_name
+
 for opt in "-n" "" "-f"; do
 	log_mustnot zpool create $opt $TESTPOOL1 ${ZVOL_DEVDIR}/${vol_name}
 done
 
 # cleanup
-log_must swap -d ${ZVOL_DEVDIR}/${vol_name}
-log_must zfs destroy $vol_name
+swap_cleanup ${ZVOL_DEVDIR}/${vol_name}
+log_must_busy zfs destroy $vol_name
 log_must zpool destroy $TESTPOOL
 
 log_pass "'zpool create' passed as expected with inapplicable scenario."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_016_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_016_pos.ksh
@@ -46,6 +46,10 @@
 
 verify_runnable "global"
 
+if is_linux; then
+	log_unsupported "Test case isn't useful under Linux."
+fi
+
 function cleanup
 {
 	if poolexists $TESTPOOL; then

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_020_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_020_pos.ksh
@@ -49,9 +49,9 @@ function cleanup
 	if poolexists $TESTPOOL ; then
                 destroy_pool $TESTPOOL
         fi
-	if [ -d ${TESTPOOL}.root ]
+	if [ -d /${TESTPOOL}.root ]
 	then
-		log_must rmdir ${TESTPOOL}.root
+		log_must rmdir /${TESTPOOL}.root
 	fi
 }
 
@@ -65,6 +65,7 @@ else
 	disk=$DISK0
 fi
 
+log_must rm -f /etc/zfs/zpool.cache
 log_must mkdir /${TESTPOOL}.root
 log_must zpool create -R /${TESTPOOL}.root $TESTPOOL $disk
 if [ ! -d /${TESTPOOL}.root ]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
@@ -29,6 +29,8 @@
 #
 
 export DISK=${DISKS%% *}
+export DISK_ARRAY_NUM=$(echo ${DISKS} | nawk '{print NF}')
+export DISKSARRAY=$DISKS
 
 if is_linux; then
 	set_device_dir

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh
@@ -72,9 +72,15 @@ log_onexit cleanup
 partition_disk $SLICE_SIZE $DISK 2
 
 create_pool "$TESTPOOL" "${DISK}${SLICE_PREFIX}${SLICE0}"
-create_pool "$TESTPOOL1" "${DISK}${SLICE_PREFIX}${SLICE1}"
-log_must zfs create -s -V $VOLSIZE $TESTPOOL1/$TESTVOL
-create_pool "$TESTPOOL2" "${ZVOL_DEVDIR}/$TESTPOOL1/$TESTVOL"
+
+if is_linux; then
+	# Layering a pool on a zvol can deadlock and isn't supported.
+	create_pool "$TESTPOOL2" "${DISK}${SLICE_PREFIX}${SLICE1}"
+else
+	create_pool "$TESTPOOL1" "${DISK}${SLICE_PREFIX}${SLICE1}"
+	log_must zfs create -s -V $VOLSIZE $TESTPOOL1/$TESTVOL
+	create_pool "$TESTPOOL2" "${ZVOL_DEVDIR}/$TESTPOOL1/$TESTVOL"
+fi
 
 typeset -i i=0
 while (( i < ${#datasets[*]} )); do

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
@@ -111,6 +111,11 @@ for dir in $TESTDIR /$TESTPOOL/$TESTCTR /$TESTPOOL/$TESTCTR/$TESTFS1 ; do
 	done
 done
 
+# 4. 'zpool destroy -f' the pool (unsupported behavior in Linux)
+if is_linux; then
+	log_must cd $cwd
+fi
+
 destroy_pool $TESTPOOL
 log_mustnot poolexists "$TESTPOOL"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
@@ -48,6 +48,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/6065
+if is_linux; then
+	log_unsupported "Creating a pool containing a zvol may deadlock"
+fi
+
 function cleanup
 {
 	if poolexists $TESTPOOL1; then

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_003_neg.ksh
@@ -48,6 +48,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/6065
+if is_linux; then
+	log_unsupported "Creating a pool containing a zvol may deadlock"
+fi
+
 function cleanup
 {
         if poolexists $TESTPOOL1; then

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_004_pos.ksh
@@ -52,8 +52,8 @@ verify_runnable "global"
 
 function cleanup
 {
-	mntpnt=$(get_prop mountpoint $TESTPOOL)
-        datasetexists $TESTPOOL1 || log_must zpool import -d $mntpnt $TESTPOOL1
+	mntpnt=$TESTDIR0
+	datasetexists $TESTPOOL1 || log_must zpool import -d $mntpnt $TESTPOOL1
 	datasetexists $TESTPOOL1 && destroy_pool $TESTPOOL1
 	datasetexists $TESTPOOL2 && destroy_pool $TESTPOOL2
 	typeset -i i=0
@@ -63,17 +63,21 @@ function cleanup
 		fi
 		((i += 1))
 	done
+	log_must rmdir $mntpnt
 }
 
 
 log_assert "Verify zpool export succeed or fail with spare."
 log_onexit cleanup
 
-mntpnt=$(get_prop mountpoint $TESTPOOL)
+mntpnt=$TESTDIR0
+log_must mkdir -p $mntpnt
+
+# mntpnt=$(get_prop mountpoint $TESTPOOL)
 
 typeset -i i=0
 while ((i < 5)); do
-	log_must mkfile $MINVDEVSIZE $mntpnt/vdev$i
+	log_must truncate -s $MINVDEVSIZE $mntpnt/vdev$i
 	eval vdev$i=$mntpnt/vdev$i
 	((i += 1))
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.cfg
@@ -43,6 +43,9 @@ case "${#disk_array[*]}" in
 1)
 	# We need to repartition the single disk to two slices.
 	if is_linux; then
+	        set_device_dir
+	        set_slice_prefix
+		PRIMARY_SLICE=1
 		DISK_COUNT=1
 		ZFS_DISK1=${disk_array[0]}
 		ZFS_DISK2=${disk_array[0]}
@@ -63,6 +66,7 @@ case "${#disk_array[*]}" in
 		fi
 	else
 		export DEV_DSKDIR="/dev"
+		PRIMARY_SLICE=2
 		DISK_COUNT=1
 		ZFS_DISK1=${disk_array[0]}
 		ZFSSIDE_DISK1=${ZFS_DISK1}s0
@@ -73,6 +77,9 @@ case "${#disk_array[*]}" in
 *)
 	# We need to repartition the single disk to two slices.
 	if is_linux; then
+	        set_device_dir
+	        set_slice_prefix
+		PRIMARY_SLICE=1
 		DISK_COUNT=2
 		ZFS_DISK1=${disk_array[0]}
 		if is_mpath_device $ZFS_DISK1; then
@@ -99,6 +106,7 @@ case "${#disk_array[*]}" in
 		fi
 	else
 		export DEV_DSKDIR="/dev"
+		PRIMARY_SLICE=2
 		DISK_COUNT=2
 		ZFS_DISK1=${disk_array[0]}
 		ZFSSIDE_DISK1=${ZFS_DISK1}s0

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_all_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_all_001_pos.ksh
@@ -123,7 +123,7 @@ function checksum_all #alter_root
 	typeset checksum2
 
 	while (( id < number )); do
-		if (( id == 2 )); then
+		if (( id == $PRIMARY_SLICE )); then
 			(( id = id + 1 ))
 			continue
 		fi
@@ -165,12 +165,12 @@ log_must zpool export ${TESTPOOL}-0
 #
 number=1
 while (( number <= $GROUP_NUM )); do
-	if (( number == 2)); then
+	if (( number == $PRIMARY_SLICE)); then
 		(( number = number + 1 ))
 		continue
 	fi
 
-	setup_single_disk "${ZFS_DISK1}s${number}" \
+	setup_single_disk "${ZFS_DISK1}${SLICE_PREFIX}${number}" \
 		"${TESTPOOL}-$number" \
 		"$TESTFS" \
 		"$TESTDIR.$number"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_007_pos.ksh
@@ -48,6 +48,9 @@
 
 verify_runnable "global"
 
+https://github.com/zfsonlinux/zfs/issues/6112
+log_unsupported "Known issue #6112"
+
 function cleanup
 {
 	destroy_upgraded_pool $config

--- a/tests/zfs-tests/tests/functional/write_dirs/write_dirs_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/write_dirs_001_pos.ksh
@@ -46,6 +46,10 @@
 
 verify_runnable "both"
 
+if is_32bit; then
+	log_unsupported "Test case occasionally fails on 32-bit systems"
+fi
+
 function cleanup
 {
 	for file in `find $TESTDIR -type f`; do

--- a/tests/zfs-tests/tests/functional/zvol/zvol_common.shlib
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_common.shlib
@@ -134,16 +134,3 @@ function is_zvol_dumpified
 	zdb -dddd $volume 2 | grep "dumpsize" > /dev/null 2>&1
 	return $?
 }
-
-function is_swap_inuse
-{
-	typeset device=$1
-
-	if [[ -z $device ]] ; then
-		log_note "No device specified."
-		return 1
-	fi
-
-	swap -l | grep -w $device > /dev/null 2>&1
-	return $?
-}

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/setup.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/setup.ksh
@@ -34,10 +34,6 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $DISKS) ; then
-	log_unsupported "This directory cannot be run on raw files."
-fi
-
 default_zvol_setup $DISK $VOLSIZE
 
 log_pass

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_001_neg.ksh
@@ -45,6 +45,10 @@
 
 verify_runnable "global"
 
+if ! $(is_physical_device $DISKS) ; then
+	log_unsupported "This directory cannot be run on raw files."
+fi
+
 volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
@@ -46,6 +46,10 @@
 
 verify_runnable "global"
 
+if ! $(is_physical_device $DISKS) ; then
+	log_unsupported "This directory cannot be run on raw files."
+fi
+
 volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_004_pos.ksh
@@ -45,6 +45,10 @@
 
 verify_runnable "global"
 
+if ! $(is_physical_device $DISKS) ; then
+	log_unsupported "This directory cannot be run on raw files."
+fi
+
 volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_005_neg.ksh
@@ -45,6 +45,10 @@
 
 verify_runnable "global"
 
+if ! $(is_physical_device $DISKS) ; then
+	log_unsupported "This directory cannot be run on raw files."
+fi
+
 volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_006_pos.ksh
@@ -45,6 +45,10 @@
 
 verify_runnable "global"
 
+if ! $(is_physical_device $DISKS) ; then
+	log_unsupported "This directory cannot be run on raw files."
+fi
+
 volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/cleanup.ksh
@@ -35,17 +35,22 @@
 
 verify_runnable "global"
 
-log_must swapadd
+if is_linux; then
+	log_must swapon -a
+else
+	log_must swapadd
+fi
+
 for swapdev in $SAVESWAPDEVS
 do
 	if ! is_swap_inuse $swapdev ; then
-		log_must swap -a $swapdev >/dev/null 2>&1
+		log_must swap_setup $swapdev >/dev/null 2>&1
 	fi
 done
 
 voldev=${ZVOL_DEVDIR}/$TESTPOOL/$TESTVOL
 if is_swap_inuse $voldev ; then
-	log_must swap -d $voldev
+	log_must swap_cleanup $voldev
 fi
 
 default_zvol_cleanup

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/setup.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/setup.ksh
@@ -36,8 +36,8 @@
 verify_runnable "global"
 
 for i in $SAVESWAPDEVS ; do
-	log_note "Executing: swap -d $i"
-	swap -d $i >/dev/null 2>&1
+	log_note "Executing: swap_cleanup $i"
+	swap_cleanup $i >/dev/null 2>&1
 	if [[ $? != 0 ]]; then
 		log_untested "Unable to delete swap device $i because of" \
 				"insufficient RAM"

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap.cfg
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap.cfg
@@ -33,7 +33,11 @@
 #
 # Remember swap devices
 #
-SAVESWAPDEVS=$(swap -l | nawk '(NR != 1) {print $1}')
+if is_linux; then
+	SAVESWAPDEVS=$(swapon -s | nawk '(NR != 1) {print $1}')
+else
+	SAVESWAPDEVS=$(swap -l | nawk '(NR != 1) {print $1}')
+fi
 
 export BLOCKSZ=$(( 1024 * 1024 ))
 export NUM_WRITES=40

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_001_pos.ksh
@@ -41,17 +41,17 @@
 # 1. Create a pool
 # 2. Create a zvol volume
 # 3. Use zvol as swap space
-# 4. Create a file under /tmp
+# 4. Create a file under /var/tmp
 #
 
 verify_runnable "global"
 
 function cleanup
 {
-	rm -rf /tmp/$TESTFILE
+	rm -rf $TEMPFILE
 
 	if is_swap_inuse $voldev ; then
-		log_must swap -d $voldev
+		log_must swap_cleanup $voldev
 	fi
 }
 
@@ -61,16 +61,15 @@ log_onexit cleanup
 
 voldev=${ZVOL_DEVDIR}/$TESTPOOL/$TESTVOL
 log_note "Add zvol volume as swap space"
-log_must swap -a $voldev
+log_must swap_setup $voldev
 
-log_note "Create a file under /tmp"
-log_must file_write -o create -f /tmp/$TESTFILE \
+log_note "Create a file under /var/tmp"
+log_must file_write -o create -f $TEMPFILE \
     -b $BLOCKSZ -c $NUM_WRITES -d $DATA
 
-[[ ! -f /tmp/$TESTFILE ]] &&
-    log_fail "Unable to create file under /tmp"
+[[ ! -f $TEMPFILE ]] && log_fail "Unable to create file under /var/tmp"
 
-filesize=`ls -l /tmp/$TESTFILE | awk '{print $5}'`
+filesize=`ls -l $TEMPFILE | awk '{print $5}'`
 tf_size=$(( BLOCKSZ * NUM_WRITES ))
 (( $tf_size != $filesize )) &&
     log_fail "testfile is ($filesize bytes), expected ($tf_size bytes)"

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_003_pos.ksh
@@ -46,6 +46,10 @@
 
 verify_runnable "global"
 
+if is_linux; then
+	log_unsupported "Modifies global non-ZFS system config"
+fi
+
 function cleanup
 {
 	[[ -f /tmp/$TESTFILE ]] && log_must rm -f /tmp/$TESTFILE
@@ -56,7 +60,7 @@ function cleanup
 
 	log_must swapadd $VFSTAB_FILE
 
-        if is_swap_inuse $voldev ; then
+	if is_swap_inuse $voldev ; then
 		log_must swap -d $voldev
 	fi
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/ksh -p
 #
 # CDDL HEADER START
 #
@@ -46,7 +46,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	is_swap_inuse $swapname && log_must swap -d $swapname
+	is_swap_inuse $swapname && log_must swap_cleanup $swapname
 	datasetexists $vol && log_must zfs destroy $vol
 }
 
@@ -55,20 +55,21 @@ log_assert "For an added swap zvol, (2G <= volsize <= 16G)"
 log_onexit cleanup
 
 for vbs in 8192 16384 32768 65536 131072; do
-	for multiplier in 1 32 16384 131072; do
+	for multiplier in 32 16384 131072; do
 		((volsize = vbs * multiplier))
 		vol="$TESTPOOL/vol_$volsize"
 		swapname="${ZVOL_DEVDIR}/$vol"
 
 		# Create a sparse volume to test larger sizes
 		log_must zfs create -s -b $vbs -V $volsize $vol
-		log_must swap -a $swapname
+		block_device_wait
+		log_must swap_setup $swapname
 
 		new_volsize=$(get_prop volsize $vol)
 		[[ $volsize -eq $new_volsize ]] || log_fail "$volsize $new_volsize"
 
-		log_must swap -d $swapname
-		log_must zfs destroy $vol
+		log_must swap_cleanup $swapname
+		log_must_busy zfs destroy $vol
 	done
 done
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_005_pos.ksh
@@ -44,6 +44,10 @@
 
 verify_runnable "global"
 
+if is_linux; then
+	log_unsupported "swaplow + swaplen unsupported Linux options"
+fi
+
 assertion="Verify the sum of swaplow and swaplen is less or equal to volsize"
 log_assert $assertion
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_006_pos.ksh
@@ -45,6 +45,10 @@
 
 verify_runnable "global"
 
+if is_linux; then
+	log_unsupported "swaplow + swaplen unsupported Linux options"
+fi
+
 function cleanup
 {
 	typeset -i i=0


### PR DESCRIPTION
Enable additional test cases, in most cases this required a few
minor modifications to the test scripts.  In a few cases a real
bug was uncovered and fixed.  And in a handful of cases where pools
are layered on pools the test case will be skipped until this is
supported.  Details below for each test case.
    
* zpool_add_004_pos - Skip test on Linux until adding zvols to pools
  is fully supported and deadlock free.
    
* zpool_add_005_pos.ksh - Skip dumpadm portion of the test which isn't
  relevant for Linux.  The find_vfstab_dev, find_mnttab_dev, and
  save_dump_dev functions were updated accordingly for Linux.
    
* zpool_add_006_pos - Update test case such that it doesn't depend
  on nested pools.  Switch to truncate from mkfile to reduce space
  requirements and speed up the test case.
    
* zpool_clear_001_pos - Speed up test case by filling filesystem to
  25% capacity.
    
* zpool_create_002_pos, zpool_create_004_pos - Use sparse files for
  file vdevs in order to avoid increasing the partition size.
    
* zpool_create_006_pos - 6ba1ce9 allows raidz+mirror configs with
   bug was uncovered and fixed.  And in a handful of cases where pools
   are layered on pools the test case will be skipped until this is
   supported.  Details below for each test case.
    
* zpool_add_004_pos - Skip test on Linux until adding zvols to pools
  is fully supported and deadlock free.
    
* zpool_add_005_pos.ksh - Skip dumpadm portion of the test which isn't
  relevant for Linux.  The find_vfstab_dev, find_mnttab_dev, and
  save_dump_dev functions were updated accordingly for Linux.
    
* zpool_add_006_pos - Update test case such that it doesn't depend
  on nested pools.  Switch to truncate from mkfile to reduce space
  requirements and speed up the test case.
    
* zpool_clear_001_pos - Speed up test case by filling filesystem to
  25% capacity.
    
* zpool_create_002_pos, zpool_create_004_pos - Use sparse files for
  file vdevs in order to avoid increasing the partition size.
    
* zpool_create_006_pos - 6ba1ce9 allows raidz+mirror configs with
  similar redundancy.  Updating the valid_args and forced_args cases.
    
* zpool_create_008_pos - Disable overlapping partition portion.
    
* zpool_create_011_neg - Fix to correctly create the extra partition.
  Modified zpool_vdev.c to use fstat64_blk() wrapper which includes
  the st_size even for block devices.
    
* zpool_create_012_neg - Updated to properly find swap devices.
    
* zpool_create_014_neg, zpool_create_015_neg - Updated to use
  swap_setup() and swap_cleanup() wrappers which do the right thing
  on Linux and Illumos.  Removed '-n' option which successed under
  Linux due to differences in the inuse checks.
    
* zpool_create_016_pos.ksh - Skipped test case isn't useful.
    
* zpool_create_020_pos - Added missing / to cleanup() function.
  Remove cache file prior to test to ensure a clean environment
  and avoid false positives.
    
* zpool_destroy_001_pos - Removed test case which creates a pool on
  a zvol.  This is more likely to deadlock under Linux and has never
  been completely supported on any platform.
    
* zpool_destroy_002_pos - 'zpool destroy -f' is unsupported on Linux.
  Mount point must not be busy in order to unmount them.
  
* zfs_destroy_001_pos - Handle EBUSY error which can occur with
  volumes when racing with udev.
    
* zpool_expand_001_pos, zpool_expand_003_neg - Skip test on Linux
  until adding zvols to pools is fully supported and deadlock free.
  The test could be modified to use loopback devices but it would
  be preerable to use the test case as is for improved coverage.
    
* zpool_export_004_pos - Updated test case to such that it doesn't
  depend on nested pools.  Normal file vdev under /var/tmp are fine.
    
* zpool_import_all_001_pos - Updated to skip partition 1, which is
  known as slice 2, on Illumos.  This prevents overwritting the
  default TESTPOOL which was causing the failure.
    
* zpool_import_002_pos, zpool_import_012_pos - No changes needed.
   
* zpool_remove_003_pos - No changes needed
    
* zpool_upgrade_002_pos, zpool_upgrade_004_pos - Root cause addressed
  by upstream OpenZFS commit 3b7f360.
    
* zpool_upgrade_007_pos - Disabled in test case due to known failure.
  Opened issue https://github.com/zfsonlinux/zfs/issues/6112
    
* zvol_misc_002_pos - Updated to to use ext2.
    
* zvol_misc_001_neg, zvol_misc_003_neg, zvol_misc_004_pos,
  zvol_misc_005_neg, zvol_misc_006_pos - Moved to skip list, thesei
  test case could be updated to use Linux's crash dump facility.
    
* zvol_swap_* - Updated to use swap_setup/swap_cleanup helpers.
  File creation switched from /tmp to /var/tmp.  Enabled minimal
  useful tests for Linux, skip test cases which aren't applicable.

__NOTE__: This ended up larger than I originally intended but I'd prefer to avoid to breaking this in to N individual patches.  Each fix here should still be relatively easy to review and comment on as they are mostly self contained in their respective test cases.  38 additional test cases have been enabled.