### PR TITLE
Add missing arc_free_cksum() to arc_release()

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5691,6 +5691,10 @@ arc_release(arc_buf_t *buf, void *tag)
 		arc_cksum_verify(buf);
 		arc_buf_unwatch(buf);
 
+		/* if this is the last uncompressed buf free the checksum */
+		if (!arc_hdr_has_uncompressed_buf(hdr))
+			arc_cksum_free(hdr);
+
 		mutex_exit(hash_lock);
 
 		/*


### PR DESCRIPTION
The arc layer tracks checksums of its data in the arc header
so that it can ensure that buffers haven't changed when they're
not supposed to. This checksum is only maintained while there
is an uncompressed buffer still attached to the header.
Unfortunately there is a missing call to arc_free_cksum() in
arc_release() that can trigger ASSERTs. This has not been a
common issue because the checksums are only maintained for
debug builds and triggering the bug requires writing a block
(and therefore calling arc_release()) while a compressed buffer
is still being used on a debug build. This simply corrects the
issue.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
See commit message

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This breaks #5769, but seems otherwise fairly benign.

### How Has This Been Tested?
The bug is actually very difficult to trigger on current master and I have not been able to reproduce it. It does come up fairly often simply by doing a raw send as implemented in #5769. That code already has this integrated.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly. (not needed)
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (not needed)
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
