### PR TITLE
Fix zfs .deb package warning in prerm script

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -257,7 +257,7 @@ exit 0
 %if 0%{?_systemd}
 %systemd_preun %{systemd_svcs}
 %else
-if [ $1 -eq 0 ] && [ -x /sbin/chkconfig ]; then
+if [ "$1" = "0" ] && [ -x /sbin/chkconfig ]; then
     /sbin/chkconfig --del zfs-import
     /sbin/chkconfig --del zfs-mount
     /sbin/chkconfig --del zfs-share


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Small change in the "prerm" shell script to avoid a warning.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Debian zfs package generated by alien doesn't call the prerm script (rpm's %preun) with an integer as first parameter, which results in a warning:

```
root@debian-8-zfs:/usr/src/zfs# dpkg -r zfs
(Reading database ... 88773 files and directories currently installed.)
Removing zfs (0.7.0-0) ...
/var/lib/dpkg/info/zfs.prerm: line 2: [: remove: integer expression expected
Processing triggers for man-db (2.7.0.2-5) ...
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Manually tested

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
