### PR TITLE
Fix coverity defects: CID 161638

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -4117,8 +4117,11 @@ print_zpool_script_help(char *name, char *path)
 
 	rc = libzfs_run_process_get_stdout_nopath(path, argv, NULL, &lines,
 	    &lines_cnt);
-	if (rc != 0 || lines == NULL || lines_cnt <= 0)
+	if (rc != 0 || lines == NULL || lines_cnt <= 0) {
+		if (lines != NULL)
+			libzfs_free_str_array(lines, lines_cnt);
 		return;
+	}
 
 	for (int i = 0; i < lines_cnt; i++)
 		if (!is_blank_str(lines[i]))


### PR DESCRIPTION
CID 161638: Resource leak (RESOURCE_LEAK)

Ensure the string array in print_zpool_script_help
is freed in cases when there is an error.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
