### PR TITLE
Implemented zpool sync command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,6 +223,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/cli_root/zpool_scrub/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_set/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_status/Makefile
+	tests/zfs-tests/tests/functional/cli_root/zpool_sync/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/Makefile
 	tests/zfs-tests/tests/functional/cli_user/Makefile
 	tests/zfs-tests/tests/functional/cli_user/misc/Makefile

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -26,6 +26,7 @@
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2016, Intel Corporation.
  * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright (c) 2017 Datto Inc.
  */
 
 #ifndef	_LIBZFS_H
@@ -263,6 +264,8 @@ extern int zpool_scan(zpool_handle_t *, pool_scan_func_t);
 extern int zpool_clear(zpool_handle_t *, const char *, nvlist_t *);
 extern int zpool_reguid(zpool_handle_t *);
 extern int zpool_reopen(zpool_handle_t *);
+
+extern int zpool_sync_one(zpool_handle_t *, void *);
 
 extern int zpool_vdev_online(zpool_handle_t *, const char *, int,
     vdev_state_t *);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2017 Datto Inc.
  */
 
 #ifndef	_LIBZFS_CORE_H
@@ -88,6 +89,8 @@ int lzc_receive_with_cmdprops(const char *, nvlist_t *, nvlist_t *,
 boolean_t lzc_exists(const char *);
 
 int lzc_rollback(const char *, char *, int);
+
+int lzc_sync(const char *, nvlist_t *, nvlist_t **);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -24,6 +24,7 @@
  * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017 Datto Inc.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -1019,6 +1020,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_GET_BOOKMARKS,
 	ZFS_IOC_DESTROY_BOOKMARKS,
 	ZFS_IOC_RECV_NEW,
+	ZFS_IOC_POOL_SYNC,
 
 	/*
 	 * Linux - 3/64 numbers reserved.

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -3,6 +3,7 @@
 .\" Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
 .\" Copyright (c) 2013 by Delphix. All rights reserved.
 .\" Copyright (c) 2012 Cyril Plisko. All Rights Reserved.
+.\" Copyright (c) 2017 Datto Inc.
 .\" The contents of this file are subject to the terms of the Common Development
 .\" and Distribution License (the "License"). You may not use this file except
 .\" in compliance with the License. You can obtain a copy of the license at
@@ -15,7 +16,7 @@
 .\" CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
-.TH zpool 8 "May 11, 2016" "ZFS pool 28, filesystem 5" "System Administration Commands"
+.TH zpool 8 "April 12, 2017" "ZFS pool 28, filesystem 5" "System Administration Commands"
 .SH NAME
 zpool \- configures ZFS storage pools
 .SH SYNOPSIS
@@ -160,6 +161,11 @@ zpool \- configures ZFS storage pools
 .LP
 .nf
 \fBzpool status\fR [\fB-c\fR \fBSCRIPT\fR] [\fB-gLPvxD\fR] [\fB-T\fR d | u] [\fIpool\fR] ... [\fIinterval\fR [\fIcount\fR]]
+.fi
+
+.LP
+.nf
+\fBzpool sync\fR [\fBpool\fR] ...
 .fi
 
 .LP
@@ -2230,6 +2236,20 @@ Display a time stamp.
 Specify \fBu\fR for a printed representation of the internal representation of time. See \fBtime\fR(2). Specify \fBd\fR for standard date format. See \fBdate\fR(1).
 .RE
 
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBzpool sync\fR\fR [\fBpool\fR] ...
+.ad
+.sp .6
+.RS 4n
+This command forces all in-core dirty data to be written to the primary pool
+storage and not the ZIL. It will also update administrative information
+including quota reporting.
+Without arguments, \fBzpool sync\fR will sync all pools on the system.
+Otherwise, it will sync only the specified pool(s).
 .RE
 
 .sp

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -34,6 +34,7 @@
  * Copyright 2016 Toomas Soome <tsoome@me.com>
  * Copyright (c) 2016 Actifio, Inc. All rights reserved.
  * Copyright (c) 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+ * Copyright (c) 2017 Datto Inc.
  */
 
 /*
@@ -5464,6 +5465,7 @@ zfs_ioc_hold(const char *pool, nvlist_t *args, nvlist_t *errlist)
 static int
 zfs_ioc_get_holds(const char *snapname, nvlist_t *args, nvlist_t *outnvl)
 {
+	ASSERT3P(args, ==, NULL);
 	return (dsl_dataset_get_holds(snapname, outnvl));
 }
 
@@ -5821,6 +5823,44 @@ out:
 	return (error);
 }
 
+/*
+ * Sync the currently open TXG to disk for the specified pool.
+ * This is somewhat similar to 'zfs_sync()'.
+ * For cases that do not result in error this ioctl will wait for
+ * the currently open TXG to commit before returning back to the caller.
+ *
+ * innvl: {
+ *  "force" -> when true, force uberblock update even if there is no dirty data.
+ *             In addition this will cause the vdev configuration to be written
+ *             out including updating the zpool cache file. (boolean_t)
+ * }
+ *
+ * onvl is unused
+ */
+/* ARGSUSED */
+static int
+zfs_ioc_pool_sync(const char *pool, nvlist_t *innvl, nvlist_t *onvl)
+{
+	int err;
+	boolean_t force;
+	spa_t *spa;
+
+	if ((err = spa_open(pool, &spa, FTAG)) != 0)
+		return (err);
+
+	force = fnvlist_lookup_boolean_value(innvl, "force");
+	if (force) {
+		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_WRITER);
+		vdev_config_dirty(spa->spa_root_vdev);
+		spa_config_exit(spa, SCL_CONFIG, FTAG);
+	}
+	txg_wait_synced(spa_get_dsl(spa), 0);
+
+	spa_close(spa, FTAG);
+
+	return (err);
+}
+
 static zfs_ioc_vec_t zfs_ioc_vec[ZFS_IOC_LAST - ZFS_IOC_FIRST];
 
 static void
@@ -5992,6 +6032,10 @@ zfs_ioctl_init(void)
 	zfs_ioctl_register("receive", ZFS_IOC_RECV_NEW,
 	    zfs_ioc_recv_new, zfs_secpolicy_recv_new, DATASET_NAME,
 	    POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY, B_TRUE, B_TRUE);
+
+	zfs_ioctl_register("sync", ZFS_IOC_POOL_SYNC,
+	    zfs_ioc_pool_sync, zfs_secpolicy_none, POOL_NAME,
+	    POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY, B_FALSE, B_FALSE);
 
 	/* IOCTLS that use the legacy function signature */
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -348,6 +348,9 @@ tests = ['zpool_upgrade_001_pos',
     'zpool_upgrade_006_neg', 'zpool_upgrade_008_pos',
     'zpool_upgrade_009_neg']
 
+[tests/functional/cli_root/zpool_sync]
+tests = ['zpool_sync_001_pos', 'zpool_sync_002_neg']
+
 # DISABLED:
 # zfs_share_001_neg - requires additional dependencies
 # zfs_unshare_001_neg - requires additional dependencies

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -26,6 +26,7 @@
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 # Copyright 2016 Nexenta Systems, Inc.
 # Copyright (c) 2017 Lawrence Livermore National Security, LLC.
+# Copyright (c) 2017 Datto Inc.
 #
 
 . ${STF_TOOLS}/include/logapi.shlib
@@ -3203,29 +3204,23 @@ function get_objnum
 }
 
 #
-# Synchronize all the data in pool
+# Sync data to the pool
 #
 # $1 pool name
+# $2 boolean to force uberblock (and config including zpool cache file) update
 #
-function sync_pool #pool
+function sync_pool #pool <force>
 {
 	typeset pool=${1:-$TESTPOOL}
+	typeset force=${2:-false}
 
-	log_must $SYNC
-	log_must sleep 2
-	# Flush all the pool data.
-	typeset -i ret
-	zpool scrub $pool >/dev/null 2>&1
-	ret=$?
-	(( $ret != 0 )) && \
-	log_fail "zpool scrub $pool failed."
+	if [[ $force == true ]]; then
+		log_must zpool sync -f $pool
+	else
+		log_must zpool sync $pool
+	fi
 
-	while ! is_pool_scrubbed $pool; do
-		if is_pool_resilvered $pool ; then
-			log_fail "$pool should not be resilver completed."
-		fi
-		log_must sleep 2
-	done
+	return 0
 }
 
 #

--- a/tests/zfs-tests/tests/functional/clean_mirror/clean_mirror_common.kshlib
+++ b/tests/zfs-tests/tests/functional/clean_mirror/clean_mirror_common.kshlib
@@ -26,8 +26,10 @@
 
 #
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2017 Datto Inc.
 #
 
+. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/clean_mirror/default.cfg
 
 # Most of the code related to the clearing of mirrors is duplicated in all
@@ -35,32 +37,6 @@
 # involving the device to be affected and the 'object' to use to mangle
 # the contents of the mirror.
 # This code is sourced into each of these test cases.
-
-#
-# Synchronize all the data in pool
-#
-# $1 pool name
-#
-function sync_pool #pool
-{
-	typeset pool=$1
-
-	log_must sync
-	log_must sleep 2
-	# Flush all the pool data.
-	typeset -i ret
-	zpool scrub $pool >/dev/null 2>&1
-	ret=$?
-	(( $ret != 0 )) && \
-		log_fail "zpool scrub $pool failed."
-
-	while ! is_pool_scrubbed $pool; do
-		if is_pool_resilvered $pool ; then
-			log_fail "$pool should not be resilver completed."
-		fi
-		log_must sleep 2
-	done
-}
 
 function overwrite_verify_mirror
 {

--- a/tests/zfs-tests/tests/functional/cli_root/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/Makefile.am
@@ -45,4 +45,5 @@ SUBDIRS = \
 	zpool_scrub \
 	zpool_set \
 	zpool_status \
+	zpool_sync \
 	zpool_upgrade

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_sync/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_sync/Makefile.am
@@ -1,0 +1,6 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_sync
+dist_pkgdata_SCRIPTS = \
+	cleanup.ksh \
+	setup.ksh \
+	zpool_sync_001_pos.ksh \
+	zpool_sync_002_neg.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_sync/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_sync/cleanup.ksh
@@ -1,0 +1,32 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_sync/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_sync/setup.ksh
@@ -1,0 +1,34 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+DISK=${DISKS%% *}
+
+default_setup $DISK

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_sync/zpool_sync_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_sync/zpool_sync_001_pos.ksh
@@ -1,0 +1,88 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2017 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify 'zpool sync' can sync txgs to the pool(s) main vdevs.
+#
+# STRATEGY:
+# 1. Create a pool
+# 2. Use zdb to obtain current txg
+# 3. Create a file in the pool if we're not using force sync
+# 4. Use zpool sync to sync pool
+# 5. Verify the new txg is now bigger than the saved one
+#
+
+verify_runnable "global"
+
+function get_txg {
+	typeset -i txg=$(zdb -u $1 | sed -n 's/^.*txg = \(.*\)$/\1/p')
+	echo $txg
+}
+
+set -A args "sync $TESTPOOL" "sync -f $TESTPOOL" "sync" "sync -f"
+
+log_assert "Verify 'zpool sync' can sync a pool"
+
+typeset -i i=0
+typeset -i orig_txg=0
+typeset -i new_txg=0
+while [[ $i -lt ${#args[*]} ]]; do
+	orig_txg=$(get_txg $TESTPOOL)
+	if ! [[ "${args[i]}" =~ "-f" ]]; then
+		log_must touch /$TESTPOOL/$i
+	fi
+	log_must zpool ${args[i]}
+	new_txg=$(get_txg $TESTPOOL)
+	if [[ $orig_txg -ge $new_txg ]]; then
+		log_fail "'zpool ${args[i]}' failed: txg $orig_txg >= $new_txg"
+	fi
+	((i = i + 1))
+done
+
+# sync_pool is implemented using 'zpool sync' so let's test it as well
+
+# make sure we can use sync_pool with force sync explicitly not used
+orig_txg=$(get_txg $TESTPOOL)
+log_must touch /$TESTPOOL/$i
+log_must sync_pool $TESTPOOL false
+new_txg=$(get_txg $TESTPOOL)
+if [[ $orig_txg -ge $new_txg ]]; then
+	log_fail "'sync_pool $TESTPOOL false' failed: txg $orig_txg >= $new_txg"
+fi
+
+# make sure we can use sync_pool with force sync explicitly enabled
+orig_txg=$(get_txg $TESTPOOL)
+log_must sync_pool $TESTPOOL true
+new_txg=$(get_txg $TESTPOOL)
+if [[ $orig_txg -ge $new_txg ]]; then
+	log_fail "'sync_pool $TESTPOOL true' failed: txg $orig_txg >= $new_txg"
+fi
+
+# make sure we can use sync_pool with force sync implicitly not used
+orig_txg=$(get_txg $TESTPOOL)
+log_must touch /$TESTPOOL/$i
+log_must sync_pool $TESTPOOL
+new_txg=$(get_txg $TESTPOOL)
+if [[ $orig_txg -ge $new_txg ]]; then
+	log_fail "'sync_pool $TESTPOOL' failed: txg $orig_txg >= $new_txg"
+fi
+
+log_pass "'zpool sync' syncs pool as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_sync/zpool_sync_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_sync/zpool_sync_002_neg.ksh
@@ -1,0 +1,44 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2017 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# A badly formed parameter passed to 'zpool sync' should
+# return an error.
+#
+# STRATEGY:
+# 1. Create an array containing bad 'zpool sync' parameters.
+# 2. For each element, execute the sub-command.
+# 3. Verify it returns an error.
+#
+
+verify_runnable "global"
+
+set -A args "1" "-a" "-?" "--%" "-123456" "0.5" "-o" "-b" "-b no" "-z 2"
+
+log_assert "Execute 'zpool sync' using invalid parameters."
+
+typeset -i i=0
+while [[ $i -lt ${#args[*]} ]]; do
+	log_mustnot zpool sync ${args[i]}
+	((i = i + 1))
+done
+
+log_pass "Invalid parameters to 'zpool sync' fail as expected."

--- a/tests/zfs-tests/tests/functional/upgrade/upgrade_userobj_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/upgrade/upgrade_userobj_001_pos.ksh
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2013 by Jinshan Xiong. No rights reserved.
+# Copyright (c) 2017 Datto Inc.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -71,7 +72,7 @@ zfs userspace -o objused -H $TESTPOOL | head -n 1 | grep -q "-" ||
 
 # Create a file in fs1 should trigger dataset upgrade
 log_must mkfile 1m $TESTDIR/fs1/tf
-sync_pool
+log_must sleep 1 # upgrade done in the background so let's give it a sec
 
 # Make sure userobj accounting is working for fs1
 zfs userspace -o objused -H $TESTPOOL/fs1 | head -n 1 | grep -q "-" &&
@@ -79,7 +80,7 @@ zfs userspace -o objused -H $TESTPOOL/fs1 | head -n 1 | grep -q "-" &&
 
 # Mount a dataset should trigger upgrade
 log_must zfs mount $TESTPOOL/fs2
-sync_pool
+log_must sleep 1 # upgrade done in the background so let's give it a sec
 
 # Make sure userobj accounting is working for fs2
 zfs userspace -o objused -H $TESTPOOL/fs2 | head -n 1 | grep -q "-" &&
@@ -91,6 +92,7 @@ zfs userspace -o objused -H $TESTPOOL | head -n 1 | grep -q "-" ||
 	log_fail "userobj accounting should be disabled for $TESTPOOL"
 
 # Manual upgrade root dataset
+# uses an ioctl which will wait for the upgrade to be done before returning
 log_must zfs set version=current $TESTPOOL
 zfs userspace -o objused -H $TESTPOOL | head -n 1 | grep -q "-" &&
 	log_fail "userobj accounting should be enabled for $TESTPOOL"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implemented 'zpool sync' command. This command is similar to the sync command expect it returns after data has hit the main pool instead of just the ZIL as can be the case with 'sync'.

### Description
<!--- Describe your changes in detail -->
This patch adds a new zpool cmd - zpool sync. This command will wait until the currently open TXG has
been committed to the main pool before returning. It can be ran on all pools or just the specified pools.  Manpage was updated as well as tests added to zfs-tests. Most of the functionality was already there so this patch added an IOCTL and a bit of libzfscore code.
Note I've modified lzc_ioctl() to be able to deal with a NULL ioctl name and source nvl.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is something we decided to implemented at Datto to facilitate ZIL flushing.
Because of the way ZIL is implemented flushing ZIL contents is useful when you have an encrypted dataset (note ZIL is still encrypted, see #5769 for details) that has absorbed "sensitive" sync write(s).
zpool sync could also be useful in the rare cases of replacing a failing SLOG to make sure all data has been flushed out.
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
unit testing
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.