### PR TITLE
Fix 'zfs inherit snapdev' device node behaviour

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -640,7 +640,8 @@ tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 
 [tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
-    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']
+    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos',
+    'zvol_misc_snapdev']
 
 [tests/functional/zvol/zvol_swap]
 tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/Makefile.am
@@ -7,4 +7,5 @@ dist_pkgdata_SCRIPTS = \
 	zvol_misc_003_neg.ksh \
 	zvol_misc_004_pos.ksh \
 	zvol_misc_005_neg.ksh \
-	zvol_misc_006_pos.ksh
+	zvol_misc_006_pos.ksh \
+	zvol_misc_snapdev.ksh

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_snapdev.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_snapdev.ksh
@@ -1,0 +1,159 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
+. $STF_SUITE/tests/functional/zvol/zvol_common.shlib
+
+#
+# DESCRIPTION:
+# Verify that ZFS volume property "snapdev" works as intended.
+#
+# STRATEGY:
+# 1. Verify "snapdev" property does not accept invalid values
+# 2. Verify "snapdev" adds and removes device nodes when updated
+# 3. Verify "snapdev" is inherited correctly
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	datasetexists $VOLFS && log_must zfs destroy -r $VOLFS
+	datasetexists $ZVOL && log_must zfs destroy -r $ZVOL
+	log_must zfs inherit snapdev $TESTPOOL
+	block_device_wait
+}
+
+#
+# Verify $device exists and is a block device
+#
+function blockdev_exists # device
+{
+	typeset device="$1"
+
+	if [[ ! -b "$device" ]]; then
+		log_fail "$device does not exist as a block device"
+	fi
+}
+
+#
+# Verify $device does not exist
+#
+function check_missing # device
+{
+	typeset device="$1"
+
+	if [[ -e "$device" ]]; then
+		log_fail "$device exists when not expected"
+	fi
+}
+
+#
+# Verify $property on $dataset is inherited by $parent and is set to $value
+#
+function verify_inherited # property value dataset parent
+{
+	typeset property="$1"
+	typeset value="$2"
+	typeset dataset="$3"
+	typeset parent="$4"
+
+	typeset val=$(get_prop "$property" "$dataset")
+	typeset src=$(get_source "$property" "$dataset")
+	if [[ "$val" != "$value" || "$src" != "inherited from $parent" ]]
+	then
+		log_fail "Dataset $dataset did not inherit $property properly:"\
+		    "expected=$value, value=$val, source=$src."
+	fi
+
+}
+
+log_assert "Verify that ZFS volume property 'snapdev' works as expected."
+log_onexit cleanup
+
+VOLFS="$TESTPOOL/volfs"
+ZVOL="$TESTPOOL/vol"
+SNAP="$ZVOL@snap"
+SNAPDEV="${ZVOL_DEVDIR}/$SNAP"
+SUBZVOL="$VOLFS/subvol"
+SUBSNAP="$SUBZVOL@snap"
+SUBSNAPDEV="${ZVOL_DEVDIR}/$SUBSNAP"
+
+log_must zfs create -o mountpoint=none $VOLFS
+log_must zfs create -V $VOLSIZE -s $ZVOL
+log_must zfs create -V $VOLSIZE -s $SUBZVOL
+
+# 1. Verify "snapdev" property does not accept invalid values
+typeset badvals=("off" "on" "1" "nope" "-")
+for badval in ${badvals[@]}
+do
+	log_mustnot zfs set snapdev="$badval" $ZVOL
+done
+
+# 2. Verify "snapdev" adds and removes device nodes when updated
+# 2.1 First create a snapshot then change snapdev property
+log_must zfs snapshot $SNAP
+log_must zfs set snapdev=visible $ZVOL
+block_device_wait
+blockdev_exists $SNAPDEV
+log_must zfs set snapdev=hidden $ZVOL
+block_device_wait
+check_missing $SNAPDEV
+log_must zfs destroy $SNAP
+# 2.2 First set snapdev property then create a snapshot
+log_must zfs set snapdev=visible $ZVOL
+log_must zfs snapshot $SNAP
+block_device_wait
+blockdev_exists $SNAPDEV
+log_must zfs destroy $SNAP
+block_device_wait
+check_missing $SNAPDEV
+
+# 3. Verify "snapdev" is inherited correctly
+# 3.1 Check snapdev=visible case
+log_must zfs snapshot $SNAP
+log_must zfs inherit snapdev $ZVOL
+log_must zfs set snapdev=visible $TESTPOOL
+verify_inherited 'snapdev' 'visible' $ZVOL $TESTPOOL
+block_device_wait
+blockdev_exists $SNAPDEV
+# 3.2 Check snapdev=hidden case
+log_must zfs set snapdev=hidden $TESTPOOL
+verify_inherited 'snapdev' 'hidden' $ZVOL $TESTPOOL
+block_device_wait
+check_missing $SNAPDEV
+# 3.3 Check inheritance on multiple levels
+log_must zfs snapshot $SUBSNAP
+log_must zfs inherit snapdev $SUBZVOL
+log_must zfs set snapdev=hidden $VOLFS
+log_must zfs set snapdev=visible $TESTPOOL
+verify_inherited 'snapdev' 'hidden' $SUBZVOL $VOLFS
+block_device_wait
+check_missing $SUBSNAPDEV
+blockdev_exists $SNAPDEV
+
+log_pass "ZFS volume property 'snapdev' works as expected"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
When inheriting the 'snapdev' property to "visible" we don't call `zfs_prop_set_special()`: this prevents device nodes from being created.

Because 'snapdev' is the only "special" property that is also inheritable we need to call `zfs_prop_set_special()` even when we're not reverting to the received value (`zfs inherit -S`).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I discovered this while porting FreeBSD "volmode" to ZoL: i was trying to test all the corner cases and found that inheriting snapdev was not triggering zvol_*_minor functions.

I'm kind of two minds about this: this is increasing the code difference between us and the other ZFS implementations, but on the other hand the 'snapdev' property is specific to ZoL so it's kind of inevitable to diverge until 'snapdev' is ported to other platforms.

```
root@debian-8-zfs:~# function block_device_wait() {
>    udevadm trigger
>    udevadm settle
> }
root@debian-8-zfs:~# #
root@debian-8-zfs:~# POOLNAME='testpool'
root@debian-8-zfs:~# TMPDIR='/var/tmp'
root@debian-8-zfs:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@debian-8-zfs:~# zpool destroy $POOLNAME
root@debian-8-zfs:~# rm -f $TMPDIR/zpool.dat
root@debian-8-zfs:~# fallocate -l 128m $TMPDIR/zpool.dat
root@debian-8-zfs:~# zpool create -O mountpoint=none $POOLNAME $TMPDIR/zpool.dat
root@debian-8-zfs:~# #
root@debian-8-zfs:~# zfs set snapdev=visible $POOLNAME
root@debian-8-zfs:~# zfs create -V 1M -o snapdev=hidden $POOLNAME/zvol1
root@debian-8-zfs:~# zfs snap $POOLNAME/zvol1@snap1
root@debian-8-zfs:~# block_device_wait
root@debian-8-zfs:~# ls -l /dev/zvol/$POOLNAME/
total 0
lrwxrwxrwx 1 root root 9 May 13 21:49 zvol1 -> ../../zd0
root@debian-8-zfs:~# # inherit 'snapdev'
root@debian-8-zfs:~# zfs inherit snapdev $POOLNAME/zvol1
root@debian-8-zfs:~# block_device_wait
root@debian-8-zfs:~# zfs get -o all snapdev $POOLNAME/zvol1
NAME            PROPERTY  VALUE    RECEIVED  SOURCE
testpool/zvol1  snapdev   visible  -         inherited from testpool
root@debian-8-zfs:~# # snapdev=visible, we should have 2 dev nodes
root@debian-8-zfs:~# ls -l /dev/zvol/$POOLNAME/
total 0
lrwxrwxrwx 1 root root 9 May 13 21:49 zvol1 -> ../../zd0
root@debian-8-zfs:~# # set snapdev=visible, dev node is created
root@debian-8-zfs:~# zfs set snapdev=visible $POOLNAME/zvol1
root@debian-8-zfs:~# zfs get -o all snapdev $POOLNAME/zvol1
NAME            PROPERTY  VALUE    RECEIVED  SOURCE
testpool/zvol1  snapdev   visible  -         local
root@debian-8-zfs:~# ls -l /dev/zvol/$POOLNAME/
total 0
lrwxrwxrwx 1 root root  9 May 13 21:49 zvol1 -> ../../zd0
lrwxrwxrwx 1 root root 10 May 13 21:49 zvol1@snap1 -> ../../zd16
root@debian-8-zfs:~# 
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Test case added to zvol_misc

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
