### PR TITLE
Compatibilty with glibc-2.23

### DIFF
--- a/lib/libspl/getmntany.c
+++ b/lib/libspl/getmntany.c
@@ -34,6 +34,7 @@
 #include <sys/mnttab.h>
 
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <unistd.h>
 


### PR DESCRIPTION
In glibc-2.23 <sys/sysmacros.h> isn't automatically included in
<sys/types.h> [1], so we need ot explicitely include it.

1)
https://sourceware.org/ml/libc-alpha/2015-11/msg00253.html

Signed-off-by: Justin Lecher <jlec@gentoo.org>