### PR TITLE
Issue 6065 - Adding ZVol as log device of seprate pool causes deadlock

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1188,12 +1188,36 @@ static int
 zvol_first_open(zvol_state_t *zv)
 {
 	objset_t *os;
-	int error;
+	int error, locked = 0;
+
+	/*
+	 * In all other cases the spa_namespace_lock is taken before the
+	 * bdev->bd_mutex lock.	 But in this case the Linux __blkdev_get()
+	 * function calls fops->open() with the bdev->bd_mutex lock held.
+	 * This deadlock can be easily observed with zvols used as vdevs.
+	 *
+	 * To avoid a potential lock inversion deadlock we preemptively
+	 * try to take the spa_namespace_lock().  Normally it will not
+	 * be contended and this is safe because spa_open_common() handles
+	 * the case where the caller already holds the spa_namespace_lock.
+	 *
+	 * When it is contended we risk a lock inversion if we were to
+	 * block waiting for the lock.	Luckily, the __blkdev_get()
+	 * function allows us to return -ERESTARTSYS which will result in
+	 * bdev->bd_mutex being dropped, reacquired, and fops->open() being
+	 * called again.  This process can be repeated safely until both
+	 * locks are acquired.
+	 */
+	if (!mutex_owned(&spa_namespace_lock)) {
+		locked = mutex_tryenter(&spa_namespace_lock);
+		if (!locked)
+			return (-SET_ERROR(ERESTARTSYS));
+	}
 
 	/* lie and say we're read-only */
 	error = dmu_objset_own(zv->zv_name, DMU_OST_ZVOL, 1, zv, &os);
 	if (error)
-		return (SET_ERROR(-error));
+		goto out_mutex;
 
 	zv->zv_objset = os;
 
@@ -1204,6 +1228,9 @@ zvol_first_open(zvol_state_t *zv)
 		zv->zv_objset = NULL;
 	}
 
+out_mutex:
+	if (locked)
+		mutex_exit(&spa_namespace_lock);
 	return (SET_ERROR(-error));
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Introduced zv_state_lock to protect internal state of zvol_state_t. 
Reverted commit 1ee159f423b5eb3c4646b0ba2dd0fb359503ba90
        Fix lock order inversion with zvol_open()... 

### Description
<!--- Describe your changes in detail -->
Introduced zv_state_lock to protect internal state of zvol_state_t and to avoid taking spa_namespace_lock (e.g. in dmu_objset_own() code path) while holding zvol_stat_lock. Refactore the code accordingly.

Reverted commit 1ee159f423b5eb3c4646b0ba2dd0fb359503ba90
        Fix lock order inversion with zvol_open()... 
as it did not account for use of zvols as vdevs. The latter use cases resulted in the lock order inversion deadlocks that involved spa_namespace_lock and bdev->bd_mutex.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is needed to allow use of zvols as vdevs (logs, caches, regular vdevs).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested use of zvols as regular vdevs, logs, and caches. Added and removed devices, exported, and re-imported pools. Performed basic I/O testing. Ran full suit of zfs-test (did not enable additional relevant test cases at this time).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
