### PR TITLE
OpenZFS 8072 - zfs-tests: several test cases incorrectly spell TESTPOOL

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_006_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_006_neg.ksh
@@ -53,7 +53,7 @@ snap=$TESTPOOL/$TESTFS@$TESTSNAP
 set -A args "" \
 	"$TESTPOOL/blah" \
 	"$TESTPOOL" "$TESTPOOL/$TESTFS" "$snap" \
-	"$TESTPOOL/$TESTVOL" "$TESTPOL $TESTPOOL/$TESTFS" \
+	"$TESTPOOL/$TESTVOL" "$TESTPOOL $TESTPOOL/$TESTFS" \
 	"$clone $TESTPOOL/$TESTFS" "- $clone" "-? $clone"
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/cli_user/misc/misc.cfg
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/misc.cfg
@@ -31,7 +31,7 @@
 if is_linux; then
 	# these are the set of setable ZFS properties
 	PROP_NAMES="\
-		aclinherit	acltype		atime		 \
+		acltype		atime		 \
 		checksum	compression			devices \
 		exec		mountpoint	quota		readonly \
 		recordsize	reservation	setuid		 \
@@ -41,17 +41,17 @@ if is_linux; then
 	# zfs get/set subcommands - ordered as per the list above so we
 	# can iterate over both sets in an array
 	PROP_VALS="\
-		secure		posixacl	on		 \
+		posixacl	on		 \
 		fletcher2	on				on \
 		on		legacy		none		on \
-		128k		none		on		 \
+		128K		none		on		 \
 		visible"
 
 	# these are an alternate set of property values
 	PROP_ALTVALS="\
-		noallow		noacl		off		 \
+		noacl		off		 \
 		fletcher4	lzjb				off \
-		off		/tmp/zfstest	100m		off \
+		off		/tmp/zfstest	100M		off \
 		512		10m		off		 \
 		hidden"
 else
@@ -67,17 +67,17 @@ else
 	# zfs get/set subcommands - ordered as per the list above so we
 	# can iterate over both sets in an array
 	PROP_VALS="\
-		secure		discard		on		 \
+		passthrough	discard		on		 \
 		fletcher2	on				on \
 		on		legacy		none		on \
-		128k		none		on		on \
+		128K		none		on		on \
 		visible"
 
 	# these are an alternate set of property values
 	PROP_ALTVALS="\
-		noallow		noacl		off		 \
+		passthrough-x	groupmask	off		 \
 		fletcher4	lzjb				off \
-		off		/tmp/zfstest	100m		off \
+		off		/tmp/zfstest	100M		off \
 		512		10m		off		off \
 		hidden"
 fi

--- a/tests/zfs-tests/tests/functional/cli_user/misc/zfs_get_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/zfs_get_001_neg.ksh
@@ -41,7 +41,6 @@
 # 1. Run zfs get with an array of different arguments
 # 2. Verify for each property, we get the value that's expected
 #
-#
 
 log_assert "zfs get works when run as a user"
 
@@ -50,16 +49,16 @@ typeset -i i=0
 set -A props $PROP_NAMES
 set -A prop_vals $PROP_VALS
 
-while [[ $i -lt ${#args[*]} ]]
+while [[ $i -lt ${#props[*]} ]]
 do
 	PROP=${props[$i]}
 	EXPECTED=${prop_vals[$i]}
-	ACTUAL=$( zfs get $PROP -o value -H snapdir $TESTPOOl/$TESTFS/prop )
+	ACTUAL=$(zfs get -H -o value $PROP $TESTPOOL/$TESTFS/prop)
 	if [ "$ACTUAL" != "$EXPECTED" ]
 	then
 		log_fail "Property $PROP value was $ACTUAL, expected $EXPECTED"
 	fi
-        i=$(( $i + 1 ))
+	i=$(( $i + 1 ))
 done
 
 log_pass "zfs get works when run as a user"

--- a/tests/zfs-tests/tests/functional/cli_user/misc/zfs_promote_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/zfs_promote_001_neg.ksh
@@ -50,7 +50,7 @@ log_mustnot zfs promote $TESTPOOL/$TESTFS/clone
 # Now verify that the above command didn't do anything
 if datasetexists $TESTPOOL/$TESTFS/clone@snap
 then
-	log_fail "Clone $TESTPOOl/$TESTFS/clone was actually promoted!"
+	log_fail "Clone $TESTPOOL/$TESTFS/clone was actually promoted!"
 fi
 
 log_pass "zfs promote returns an error when run as a user"

--- a/tests/zfs-tests/tests/functional/cli_user/misc/zfs_set_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/zfs_set_001_neg.ksh
@@ -41,7 +41,6 @@
 # 1. Attempt to set an array of properties on a dataset
 # 2. Verify that those properties were not set and retain their original values.
 #
-#
 
 log_assert "zfs set returns an error when run as a user"
 
@@ -51,7 +50,7 @@ set -A props $PROP_NAMES
 set -A prop_vals $PROP_VALS
 set -A prop_new $PROP_ALTVALS
 
-while [[ $i -lt ${#args[*]} ]]
+while [[ $i -lt ${#props[*]} ]]
 do
 	PROP=${props[$i]}
 	EXPECTED=${prop_vals[$i]}
@@ -59,12 +58,12 @@ do
 	log_mustnot zfs set $PROP=$NEW $TESTPOOL/$TESTFS/prop
 
 	# Now verify that the above command did nothing
-	ACTUAL=$(zfs get $PROP -o value -H snapdir $TESTPOOl/$TESTFS/prop )
+	ACTUAL=$(zfs get -H -o value $PROP $TESTPOOL/$TESTFS/prop)
 	if [ "$ACTUAL" != "$EXPECTED" ]
 	then
 		log_fail "Property $PROP was set to $ACTUAL, expected $EXPECTED"
 	fi
-        i=$(( $i + 1 ))
+	i=$(( $i + 1 ))
 done
 
 log_pass "zfs set returns an error when run as a user"


### PR DESCRIPTION
Authored by: Yuri Pankov <yuri.pankov@nexenta.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: John Kennedy <jwk404@gmail.com>
Approved by: Richard Lowe <richlowe@richlowe.net>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/8072
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/56e4733