### PR TITLE
Fix large dnode send stream flag conflict

### DIFF
--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -100,8 +100,9 @@ typedef enum drr_headertype {
 /* flag #18 is reserved for a Delphix feature */
 #define	DMU_BACKUP_FEATURE_LARGE_BLOCKS		(1 << 19)
 #define	DMU_BACKUP_FEATURE_RESUMING		(1 << 20)
-#define	DMU_BACKUP_FEATURE_LARGE_DNODE		(1 << 21)
+/* flag #21 is reserved for a Delphix feature */
 #define	DMU_BACKUP_FEATURE_COMPRESSED		(1 << 22)
+#define	DMU_BACKUP_FEATURE_LARGE_DNODE		(1 << 23)
 
 /*
  * Mask of all supported backup features


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

Bit 21 of the send stream flags was inadvertantly used for two
different features under concurrent development.  To avoid any
future compatibility problems the large dnode flag is being
switched to bit 23 which is unused.

The large dnode feature has only been present in prereleases of
ZoL and dnodesize defaults to legacy which is compatibile with
existing OpenZFS implementations.  Users with dnodesize=auto
needing to use zfs send/recv must update ZoL on both the
source and destination systems.

### Motivation and Context

Preserve send stream compatibility with OpenZFS implementations
once Delphix upstream their feature.

https://github.com/openzfs/openzfs/blob/master/usr/src/uts/common/fs/zfs/sys/zfs_ioctl.h#L94

### How Has This Been Tested?

ZFS Test Suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)