### PR TITLE
Fixed small memory leak in ereport handling.

### DIFF
--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -210,17 +210,17 @@ zfs_ereport_start(nvlist_t **ereport_out, nvlist_t **detector_out,
 	    (vd->vdev_remove_wanted || vd->vdev_state == VDEV_STATE_REMOVED))
 		return;
 
+	if ((strcmp(subclass, FM_EREPORT_ZFS_DELAY) == 0) &&
+	    (zio != NULL) && (!zio->io_timestamp)) {
+		/* Ignore bogus delay events */
+		return;
+	}
+
 	if ((ereport = fm_nvlist_create(NULL)) == NULL)
 		return;
 
 	if ((detector = fm_nvlist_create(NULL)) == NULL) {
 		fm_nvlist_destroy(ereport, FM_NVA_FREE);
-		return;
-	}
-
-	if ((strcmp(subclass, FM_EREPORT_ZFS_DELAY) == 0) &&
-	    (zio != NULL) && (!zio->io_timestamp)) {
-		/* Ignore bogus delay events */
 		return;
 	}
 


### PR DESCRIPTION


Signed-off-by: Tom Caputi <tcaputi@datto.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description
One pre-check in zfs_ereport_start() was being called after
the nvlists were being allocated. This simply corrects that
issue.

### Motivation and Context
Fixes a memory leak that would occasionally trigger kmem leaks in buildbot.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
