### PR TITLE
OpenZFS 8071 zfs-tests: 7290 missed some cases

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -41,6 +41,7 @@ export SYSTEM_FILES='arp
     file
     find
     fio
+    fsck
     getconf
     getent
     getfacl

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
@@ -52,9 +52,7 @@ function cleanup
 	[[ -n $cwd ]] && log_must cd $cwd
 
 	if [[ -d $TESTDIR ]]; then
-		ismounted $TESTDIR
-		((  $? == 0 )) && \
-			log_must $UNMOUNT $TESTDIR
+		ismounted $TESTDIR && log_must umount $TESTDIR
 		log_must rm -rf $TESTDIR
 	fi
 

--- a/tests/zfs-tests/tests/functional/xattr/xattr_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_009_neg.ksh
@@ -58,9 +58,9 @@ log_must touch $TESTDIR/myfile.$$
 create_xattr $TESTDIR/myfile.$$ passwd /etc/passwd
 
 # Try to create a soft link from the xattr namespace to the default namespace
-log_mustnot runat $TESTDIR/myfile.$$ $LN -s /etc/passwd foo
+log_mustnot runat $TESTDIR/myfile.$$ ln -s /etc/passwd foo
 
 # Try to create a hard link from the xattr namespace to the default namespace
-log_mustnot runat $TESTDIR/myfile.$$ $LN /etc/passwd foo
+log_mustnot runat $TESTDIR/myfile.$$ ln /etc/passwd foo
 
 log_pass "links between xattr and normal file namespace fail"

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
@@ -83,7 +83,6 @@ while (( 1 )); do
         if (( $retval != 0 )); then
                 break
         fi
-
         (( fn = fn + 1 ))
 done
 


### PR DESCRIPTION
Authored by: Yuri Pankov <yuri.pankov@nexenta.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: John Kennedy <jwk404@gmail.com>
Approved by: Richard Lowe <richlowe@richlowe.net>
Ported-by: bunder2015 <omfgbunder@gmail.com>

OpenZFS-issue: https://www.illumos.org/issues/8071
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/e84991e

### Description
Porting some changes from the OpenZFS tracker

### Motivation and Context

### How Has This Been Tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
