### PR TITLE
OpenZFS 8076 zfs-tests suite fails rootpool_002_neg

### DIFF
--- a/tests/zfs-tests/tests/functional/rootpool/rootpool_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/rootpool/rootpool_002_neg.ksh
@@ -27,6 +27,7 @@
 
 #
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+# Copyright 2014 Nexenta Systems, Inc.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -34,35 +35,35 @@
 #
 # DESCRIPTION:
 #
-# the zfs rootpool can not be destroyed
+# the zfs rootpool/rootfs can not be destroyed
 #
 # STRATEGY:
 # 1) check if the current system is installed as zfs root
 # 2) get the rootpool
-# 3) try to destroy the rootpool, which should fail.
-# 4) try to destroy the rootpool filesystem, which should fail.
+# 3) try to destroy the rootpool, which should fail
+# 4) try to destroy the rootpool filesystem, which should fail
 #
 
 verify_runnable "global"
-log_assert "zpool/zfs destory <rootpool> should return error"
+log_assert "zpool/zfs destroy <rootpool> should fail"
 
 typeset rootpool=$(get_rootpool)
 typeset tmpfile="/tmp/mounted-datasets.$$"
 
 # Collect the currently mounted ZFS filesystems, so that we can repair any
-# damage done by the attempted pool destroy. The destroy itself should fail, but
-# some filesystems can become unmounted in the process, and aren't automatically
-# remounted.
-mount -p | awk '{if ($4 == "zfs") print $1" "$3}' > $tmpfile
+# damage done by the attempted pool destroy. The destroy itself should fail,
+# but some filesystems can become unmounted in the process, and aren't
+# automatically remounted.
+mount -p | awk '{if ($4 == "zfs") print $1}' > $tmpfile
 
 log_mustnot zpool destroy $rootpool
 
 # Remount any filesystems that the destroy attempt unmounted.
-while read ds mntpt; do
-	mounted $ds || log_must mount -Fzfs $ds $mntpt
+while read ds; do
+	mounted $ds || log_must zfs mount $ds
 done < $tmpfile
 rm -f $tmpfile
 
 log_mustnot zfs destroy $rootpool
 
-log_pass "rootpool can not be destroyed"
+log_pass "rootpool/rootfs can not be destroyed"


### PR DESCRIPTION
Authored by: Yuri Pankov <yuri.pankov@nexenta.com>
Reviewed by: John Kennedy <jwk404@gmail.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>
Approved by: Richard Lowe <richlowe@richlowe.net>
Ported-by: bunder2015 <omfgbunder@gmail.com>

OpenZFS-issue: https://www.illumos.org/issues/8076
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/ab3407e

### Description
Porting some changes from the OpenZFS tracker

### Motivation and Context

### How Has This Been Tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
