### PR TITLE
Don't dirty bpobj if it has no entries

### DIFF
--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2017 Datto Inc.
  */
 
 #include <sys/bpobj.h>
@@ -210,6 +211,9 @@ bpobj_iterate_impl(bpobj_t *bpo, bpobj_itor_t func, void *arg, dmu_tx_t *tx,
 	dmu_buf_t *dbuf = NULL;
 
 	mutex_enter(&bpo->bpo_lock);
+
+	if (!bpobj_hasentries(bpo))
+		goto out;
 
 	if (free)
 		dmu_buf_will_dirty(bpo->bpo_dbuf, tx);


### PR DESCRIPTION
We shouldn't dirty bpobj if it has no entries to prevent unneeded writes.

### Description
In certain cases (dsl_scan_sync() is one), we may end up calling
bpobj_iterate() on an empty bpobj. Even though we don't end up
modifying the bpobj it still gets dirtied, causing unneeded writes
to the pool.

This patch adds an early bail from bpobj_iterate_impl() if bpobj
is empty to prevent unneeded writes.

### Motivation and Context
During development of scrub pause, I noticed that there was write activity even when the scrub was paused. The investigation of this phenomenon lead me to this issue.
This happened because of these calls dsl_scan_sync() -> bpobj_iterate() -> dmu_buf_will_dirty() even when there was nothing to free in the dp_free_bpobj

### How Has This Been Tested?
Making sure with a paused scrub the write load went away.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
