### PR TITLE
Fix memory leak in zvol_set_volsize()

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -419,11 +419,12 @@ zvol_set_volsize(const char *name, uint64_t volsize)
 		goto out;
 
 	error = zvol_update_volsize(volsize, os);
-	kmem_free(doi, sizeof (dmu_object_info_t));
 
 	if (error == 0 && zv != NULL)
 		error = zvol_update_live_volsize(zv, volsize);
 out:
+	kmem_free(doi, sizeof (dmu_object_info_t));
+
 	if (owned) {
 		dmu_objset_disown(os, FTAG);
 		if (zv != NULL)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
~~Make `dmu_object_info_t doi` a local variable: this change increase the stack size but at the same time decrease the code difference with the other OpenZFS platforms: https://github.com/openzfs/openzfs/blob/master/usr/src/uts/common/fs/zfs/zvol.c#L827~~

EDIT: to keep stack usage to a minimum we keep `dmu_object_info_t doi` off the stack and move `kmem_free()` after the `out:` label.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If we bypass the userland (libzfs) validation on `volsize` we exercise an error path that does not free `dmu_object_info_t doi` in `zvol_set_volsize()`:

```
root@debian-8-zfs:~# POOLNAME='testpool'
root@debian-8-zfs:~# TMPDIR='/var/tmp'
root@debian-8-zfs:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@debian-8-zfs:~# zpool destroy $POOLNAME
root@debian-8-zfs:~# rm -f $TMPDIR/zpool.dat
root@debian-8-zfs:~# fallocate -l 128m $TMPDIR/zpool.dat
root@debian-8-zfs:~# zpool create -O mountpoint=none $POOLNAME $TMPDIR/zpool.dat
root@debian-8-zfs:~# zfs create -V 1M $POOLNAME/zvol1
root@debian-8-zfs:~# #
root@debian-8-zfs:~# echo clear > /sys/kernel/debug/kmemleak
root@debian-8-zfs:~# zfs set volsize=0 $POOLNAME/zvol1 # patched libzfs to allow volsize=0
internal error: Invalid argument
Aborted
root@debian-8-zfs:~# echo scan > /sys/kernel/debug/kmemleak
root@debian-8-zfs:~# cat /sys/kernel/debug/kmemleak
unreferenced object 0xffff880035ad7a40 (size 64):
  comm "zfs", pid 3113, jiffies 4295041407 (age 7.684s)
  hex dump (first 32 bytes):
    00 20 00 00 00 00 02 00 17 00 00 00 00 00 00 00  . ..............
    00 00 00 00 00 00 00 00 01 00 00 03 00 00 ad de  ................
  backtrace:
    [<ffffffff81809fee>] kmemleak_alloc+0x4e/0xb0
    [<ffffffff811e5f5d>] kmem_cache_alloc_node_trace+0xfd/0x4f0
    [<ffffffff811e6541>] __kmalloc_node+0x31/0x40
    [<ffffffffc0058070>] spl_kmem_alloc+0xe0/0x1c0 [spl]
    [<ffffffffc0333312>] zvol_set_volsize+0x362/0x570 [zfs]
    [<ffffffffc02f0918>] zfs_prop_set_special+0x148/0x560 [zfs]
    [<ffffffffc02f1546>] zfs_set_prop_nvlist+0x1a6/0x3d0 [zfs]
    [<ffffffffc02f31de>] zfs_ioc_set_prop+0x10e/0x140 [zfs]
    [<ffffffffc02f4285>] zfsdev_ioctl+0x635/0x750 [zfs]
    [<ffffffff8121ac4d>] do_vfs_ioctl+0x9d/0x5b0
    [<ffffffff8121b1d9>] SyS_ioctl+0x79/0x90
    [<ffffffff81814376>] system_call_fast_compare_end+0xc/0x96
    [<ffffffffffffffff>] 0xffffffffffffffff
root@debian-8-zfs:~# gdb -q -batch -ex 'set listsize 25' -ex 'list *(zvol_set_volsize+0x362)' -ex 'p sizeof(dmu_object_info_t)' /lib/modules/4.6.4/extra/zfs/zfs.ko
0x11a342 is in zvol_set_volsize (/usr/src/zfs/module/zfs/zvol.c:417).
405				return (SET_ERROR(error));
406			}
407			owned = B_TRUE;
408			if (zv != NULL)
409				zv->zv_objset = os;
410		} else {
411			rw_enter(&zv->zv_suspend_lock, RW_READER);
412			os = zv->zv_objset;
413		}
414	
415		doi = kmem_alloc(sizeof (dmu_object_info_t), KM_SLEEP);
416	
417		if ((error = dmu_object_info(os, ZVOL_OBJ, doi)) ||
418		    (error = zvol_check_volsize(volsize, doi->doi_data_block_size)))
419			goto out;
420	
421		error = zvol_update_volsize(volsize, os);
422		kmem_free(doi, sizeof (dmu_object_info_t));
423	
424		if (error == 0 && zv != NULL)
425			error = zvol_update_live_volsize(zv, volsize);
426	out:
427		if (owned) {
428			dmu_objset_disown(os, FTAG);
429			if (zv != NULL)
$1 = 64
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Patched libzfs to allow `zfs set volsize=<invalid value> pool/zvol`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
