### PR TITLE
Linux 4.9 compat: fix zfs_ctldir xattr handling

### DIFF
--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -492,6 +492,9 @@ zfsctl_inode_alloc(zfsvfs_t *zfsvfs, uint64_t id,
 	ip->i_ctime = now;
 	ip->i_fop = fops;
 	ip->i_op = ops;
+#if defined(IOP_XATTR)
+	ip->i_opflags &= ~IOP_XATTR;
+#endif
 
 	if (insert_inode_locked(ip)) {
 		unlock_new_inode(ip);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Since torvalds/linux@d0a5b99 `IOP_XATTR` is used to indicate the inode has xattr support: we should clear it for the ctldir inodes to avoid IO errors.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On Linux 4.9+ `ls -la` on the ".zfs" directory produces IO errors:

```
root@linux:~# uname -r
4.9.0
root@linux:~# POOLNAME='testpool'
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:~# zpool destroy $POOLNAME
root@linux:~# rm -f $TMPDIR/zpool.dat
root@linux:~# fallocate -l 128m $TMPDIR/zpool.dat
root@linux:~# zpool create -O mountpoint=/tmp/$POOLNAME $POOLNAME $TMPDIR/zpool.dat
root@linux:~# zfs create $POOLNAME/fs1
root@linux:~# zfs snap $POOLNAME@snap1
root@linux:~# ls -lah /tmp/$POOLNAME/.zfs/
ls: /tmp/testpool/.zfs/: Input/output error
ls: /tmp/testpool/.zfs/.: Input/output error
ls: /tmp/testpool/.zfs/snapshot: Input/output error
ls: /tmp/testpool/.zfs/shares: Input/output error
total 512
drwxrwxrwx 1 root root 0 Jun  3 11:56 .
drwxr-xr-x 3 root root 3 Jun  3 11:56 ..
drwxrwxrwx 2 root root 2 Jun  3 11:56 shares
drwxrwxrwx 2 root root 2 Jun  3 11:56 snapshot
root@linux:~# strace -e trace=lgetxattr ls -lah /tmp/$POOLNAME/.zfs/
lgetxattr("/tmp/testpool/.zfs/", "security.selinux", 0x249dd90, 255) = -1 EIO (Input/output error)
ls: /tmp/testpool/.zfs/: Input/output error
lgetxattr("/tmp/testpool/.zfs/.", "security.selinux", 0x24a8aa0, 255) = -1 EIO (Input/output error)
ls: /tmp/testpool/.zfs/.: Input/output error
lgetxattr("/tmp/testpool/.zfs/..", "security.selinux", 0x24a8ae0, 255) = -1 ENODATA (No data available)
lgetxattr("/tmp/testpool/.zfs/snapshot", "security.selinux", 0x24a8b00, 255) = -1 EIO (Input/output error)
ls: /tmp/testpool/.zfs/snapshot: Input/output error
lgetxattr("/tmp/testpool/.zfs/shares", "security.selinux", 0x24a8b20, 255) = -1 EIO (Input/output error)
ls: /tmp/testpool/.zfs/shares: Input/output error
total 512
drwxrwxrwx 1 root root 0 Jun  3 11:56 .
drwxr-xr-x 3 root root 3 Jun  3 11:56 ..
drwxrwxrwx 2 root root 2 Jun  3 11:56 shares
drwxrwxrwx 2 root root 2 Jun  3 11:56 snapshot
+++ exited with 0 +++
root@linux:~# 
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Manual testing. We could also add a new test to the ZTS in "functional/xattr".

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
