### PR TITLE
Skip zpool_create_024_pos and zvol_misc_002_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_024_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_024_pos.ksh
@@ -39,6 +39,10 @@
 
 verify_runnable "global"
 
+if is_32bit; then
+	log_unsupported "Test case runs slowly on 32 bit"
+fi
+
 function cleanup
 {
 	if [[ -n "$child_pids" ]]; then

--- a/tests/zfs-tests/tests/functional/write_dirs/write_dirs_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/write_dirs_002_pos.ksh
@@ -46,6 +46,10 @@
 
 verify_runnable "both"
 
+if is_32bit; then
+	log_unsupported "Test case runs slowly on 32 bit"
+fi
+
 function cleanup
 {
 	for file in `find $TESTDIR -type f`; do

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
@@ -44,6 +44,10 @@
 
 verify_runnable "global"
 
+if is_32bit; then
+	log_unsupported "Test case runs slowly on 32 bit"
+fi
+
 volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
 
 function cleanup
@@ -88,7 +92,7 @@ done
 
 if is_linux; then
 	EXIT_STATUS=4
-	sync
+	log_must sync
 else
 	EXIT_STATUS=39
 	log_must lockfs -f $TESTDIR


### PR DESCRIPTION
zpool_create_024_pos and zvol_misc_002_pos are slow
on the buildbot 32-bit builder. Skip the test cases
for now on 32-bit builders.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.