### PR TITLE
WIP: Ensure zpool import testcases cleanup correctly

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_all_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_all_001_pos.ksh
@@ -49,7 +49,7 @@ verify_runnable "global"
 set -A options "" "-R $ALTER_ROOT"
 
 typeset -i number=0
-typeset -i id=0
+typeset -i id=1
 typeset -i i=0
 typeset checksum1
 typeset unwantedpool
@@ -62,9 +62,7 @@ function setup_single_disk #disk #pool #fs #mtpt
 	typeset mtpt=$4
 
 	setup_filesystem "$disk" "$pool" "$fs" "$mtpt"
-
 	log_must cp $MYTESTFILE $mtpt/$TESTFILE0
-
 	log_must zpool export $pool
 
 	[[ -d $mtpt ]] && \
@@ -73,7 +71,7 @@ function setup_single_disk #disk #pool #fs #mtpt
 
 function cleanup_all
 {
-	typeset -i id=0
+	typeset -i id=1
 
 	#
 	# Try import individually if 'import -a' failed.
@@ -87,27 +85,10 @@ function cleanup_all
 	done
 
 	while (( id < number )); do
-		if ! poolexists ${TESTPOOL}-$id ; then
-			(( id = id + 1 ))
-			continue
-		fi
-
-		if (( id == 0 )); then
-			log_must zpool export ${TESTPOOL}-$id
-
-			[[ -d /${TESTPOOL}-$id ]] && \
-				log_must rm -rf /${TESTPOOL}-$id
-
-			log_must zpool import -f ${TESTPOOL}-$id $TESTPOOL
-
-			[[ -e $TESTDIR/$TESTFILE0 ]] && \
-				log_must rm -rf $TESTDIR/$TESTFILE0
-		else
+		if poolexists ${TESTPOOL}-$id ; then
 			cleanup_filesystem "${TESTPOOL}-$id" $TESTFS
-
 			destroy_pool ${TESTPOOL}-$id
 		fi
-
 		(( id = id + 1 ))
         done
 
@@ -118,21 +99,12 @@ function cleanup_all
 function checksum_all #alter_root
 {
 	typeset alter_root=$1
-	typeset -i id=0
+	typeset -i id=1
 	typeset file
 	typeset checksum2
 
 	while (( id < number )); do
-		if (( id == $PRIMARY_SLICE )); then
-			(( id = id + 1 ))
-			continue
-		fi
-
-		if (( id == 0 )); then
-			file=${alter_root}/$TESTDIR/$TESTFILE0
-		else
-			file=${alter_root}/$TESTDIR.$id/$TESTFILE0
-		fi
+		file=${alter_root}/$TESTDIR.$id/$TESTFILE0
 		[[ ! -e $file ]] && \
 			log_fail "$file missing after import."
 
@@ -148,35 +120,10 @@ function checksum_all #alter_root
 
 
 log_assert "Verify that 'zpool import -a' succeeds as root."
-
 log_onexit cleanup_all
 
 checksum1=$(sum $MYTESTFILE | awk '{print $1}')
-
-log_must zpool export $TESTPOOL
-log_must zpool import $TESTPOOL ${TESTPOOL}-0
-log_must cp $MYTESTFILE $TESTDIR/$TESTFILE0
-log_must zpool export ${TESTPOOL}-0
-[[ -d /${TESTPOOL}-0 ]] && \
-	log_must rm -rf /${TESTPOOL}-0
-
-#
-# setup exported pools on normal devices
-#
 number=1
-while (( number <= $GROUP_NUM )); do
-	if (( number == $PRIMARY_SLICE)); then
-		(( number = number + 1 ))
-		continue
-	fi
-
-	setup_single_disk "${ZFS_DISK1}${SLICE_PREFIX}${number}" \
-		"${TESTPOOL}-$number" \
-		"$TESTFS" \
-		"$TESTDIR.$number"
-
-	(( number = number + 1 ))
-done
 
 #
 # setup exported pools on raw files
@@ -194,7 +141,7 @@ done
 
 while (( i < ${#options[*]} )); do
 
-	log_must zpool import -d ${DEV_DSKDIR} -d $DEVICE_DIR ${options[i]} -a -f
+	log_must zpool import -d $DEVICE_DIR ${options[i]} -a -f
 
 	# destroy unintentional imported pools
 	typeset exclude=`eval echo \"'(${KEEP})'\"`
@@ -209,7 +156,7 @@ while (( i < ${#options[*]} )); do
 		checksum_all
 	fi
 
-	id=0
+	id=1
 	while (( id < number )); do
 		if poolexists ${TESTPOOL}-$id ; then
 			log_must zpool export ${TESTPOOL}-$id


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Not all zpool import test cases cleanup correctly. Ensure
that all files used as devices for testpool1 are removed
and recreated in each test case.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Intermittent failure of the CentOS 7.X builder on the buildbot.

This PR is a test PR. If this solves the intermittent failure of the CentOS 7.X builder, then
I'll submit a cleaner/better patch. Most notably, `truncate` should be used instead of `mkfile`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Will be tested via buildbot.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
