### PR TITLE
Add MS_MANDLOCK mount failure message

### DIFF
--- a/cmd/mount_zfs/mount_zfs.c
+++ b/cmd/mount_zfs/mount_zfs.c
@@ -607,10 +607,23 @@ main(int argc, char **argv)
 				    "failed for unknown reason.\n"), dataset);
 			}
 			return (MOUNT_SYSERR);
+#ifdef MS_MANDLOCK
+		case EPERM:
+			if (mntflags & MS_MANDLOCK) {
+				(void) fprintf(stderr, gettext("filesystem "
+				    "'%s' has the 'nbmand=on' property set, "
+				    "this mount\noption may be disabled in "
+				    "your kernel.  Use 'zfs set nbmand=off'\n"
+				    "to disable this option and try to "
+				    "mount the filesystem again.\n"), dataset);
+				return (MOUNT_SYSERR);
+			}
+			/* fallthru */
+#endif
 		default:
 			(void) fprintf(stderr, gettext("filesystem "
-			    "'%s' can not be mounted due to error "
-			    "%d\n"), dataset, errno);
+			    "'%s' can not be mounted: %s\n"), dataset,
+			    strerror(errno));
 			return (MOUNT_USAGE);
 		}
 	}


### PR DESCRIPTION
### Description

Commit torvalds/linux@9e8925b6 allowed for kernels to be built
without support for mandatory locking (MS_MANDLOCK).  This will
result in 'zfs mount' failing when the nbmand=on property is set
and the kernel is build without CONFIG_MANDATORY_FILE_LOCKING.

Unfortunately we can't detect prior to the mount(2) system call
if the kernel was built with this support.  The best we can do
is check if the mount failed with EPERM and if we passed 'mand'
as a mount option and print a more useful error message.  e.g.

  filesystem 'tank' has the 'nbmand=on' property set, this mount
  option may be disabled in your kernel.  Use 'zfs set nbmand=off'
  to disable this option and try to mount the filesystem again.

Additionally, switch the default error message case to use
strerror() to produce a more human readable message.

### Motivation and Context

Issue #4729

### How Has This Been Tested?

Locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
