### PR TITLE
add missing \n for "invalid optionusage" output

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -4149,7 +4149,7 @@ zfs_do_receive(int argc, char **argv)
 	if (abort_resumable) {
 		if (flags.isprefix || flags.istail || flags.dryrun ||
 		    flags.resumable || flags.nomount) {
-			(void) fprintf(stderr, gettext("invalid option"));
+			(void) fprintf(stderr, gettext("invalid option\n"));
 			usage(B_FALSE);
 		}
 


### PR DESCRIPTION
fixes this output:
```
# zfs recv -o foo=bar fishtank/foo
invalid optionusage:
```

Signed-off-by: Kash Pande <kash@tripleback.net>

<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixing a typo in help output

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
