### PR TITLE
Fix dmu throttle on zvols

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -2378,6 +2378,7 @@ out_free:
 out_taskq:
 	taskq_destroy(zvol_taskq);
 out:
+	ida_destroy(&zvol_ida);
 	mutex_destroy(&zvol_state_lock);
 	list_destroy(&zvol_state_list);
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -747,8 +747,8 @@ zvol_op_hold(zvol_op_t *zvop)
 void
 zvol_op_release(zvol_op_t *zvop)
 {
-	rw_exit(&zvop->op_zv->zv_suspend_lock);
 	if (atomic_add_64_nv(&zvop->op_refcount, -1) == 0) {
+		rw_exit(&zvop->op_zv->zv_suspend_lock);
 		kmem_cache_free(zvol_op_cache, zvop);
 	}
 }

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -747,10 +747,10 @@ zvol_op_hold(zvol_op_t *zvop)
 void
 zvol_op_release(zvol_op_t *zvop)
 {
+	rw_exit(&zvop->op_zv->zv_suspend_lock);
 	if (atomic_add_64_nv(&zvop->op_refcount, -1) == 0) {
 		kmem_cache_free(zvol_op_cache, zvop);
 	}
-	rw_exit(&zvop->op_zv->zv_suspend_lock);
 }
 
 static void

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -748,7 +748,6 @@ void
 zvol_op_release(zvol_op_t *zvop)
 {
 	if (atomic_add_64_nv(&zvop->op_refcount, -1) == 0) {
-		rw_exit(&zvop->op_zv->zv_suspend_lock);
 		kmem_cache_free(zvol_op_cache, zvop);
 	}
 }
@@ -2397,6 +2396,8 @@ zvol_op_dtor(void *buf, void *args)
 
 	if (zvop->op_sync)
 		zil_commit(zv->zv_zilog, ZVOL_OBJ);
+
+	rw_exit(&zvop->op_zv->zv_suspend_lock);
 
 	generic_end_io_acct(bio_data_dir(bio),
 	    &zv->zv_disk->part0, zvop->op_start);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The idea here is to open the transaction before passing to a worker thread. That allows the DMU throttle to work its magic. This was inspired by my original idea to try to have this operate asynchronously via the DMU. That turned out to cause potential IO amplification, so I scrapped it in favor of this simpler approach. I had reverted @tuxoko's work, but by the time I had finished, I had something that looked very similar to what he had done.

I also found a small bug in the zvol_init() handling. The patch to fix it is broken out into a discrete patch, but included in the PR.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is intended to improve zvol IOPS performance. Actual mileage will vary. This is meant to address #6127.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
This actually slowed average IOPS down at work when placed on top of the ZIL commit changes. It was not tested independently and the testing was done on a backport to the 0.6.5.x branch. The theory is sound, so I am putting it out there for comments and review. Maybe it will help other people's workloads.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
