### PR TITLE
Print dashes for zero latency values in zpool iostat -p

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3460,7 +3460,7 @@ print_iostat_latency(iostat_cbdata_t *cb, nvlist_t *oldnv,
 	nva = calc_and_alloc_stats_ex(names, ARRAY_SIZE(names), oldnv, newnv);
 
 	if (cb->cb_literal)
-		format = ZFS_NICENUM_RAW;
+		format = ZFS_NICENUM_RAWTIME;
 	else
 		format = ZFS_NICENUM_TIME;
 

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -775,11 +775,21 @@ extern int zfs_unshareall(zfs_handle_t *);
 extern int zfs_deleg_share_nfs(libzfs_handle_t *, char *, char *, char *,
     void *, void *, int, zfs_share_op_t);
 
+/*
+ * Formats for iostat numbers.  Examples: "12K", "30ms", "4B", "2321234", "-".
+ *
+ * ZFS_NICENUM_1024:	Print kilo, mega, tera, peta, exa..
+ * ZFS_NICENUM_BYTES:	Print single bytes ("13B"), kilo, mega, tera...
+ * ZFS_NICENUM_TIME:	Print nanosecs, microsecs, millisecs, seconds...
+ * ZFS_NICENUM_RAW:	Print the raw number without any formatting
+ * ZFS_NICENUM_RAWTIME:	Same as RAW, but print dashes ('-') for zero.
+ */
 enum zfs_nicenum_format {
 	ZFS_NICENUM_1024 = 0,
 	ZFS_NICENUM_BYTES = 1,
 	ZFS_NICENUM_TIME = 2,
-	ZFS_NICENUM_RAW = 3
+	ZFS_NICENUM_RAW = 3,
+	ZFS_NICENUM_RAWTIME = 4
 };
 
 /*

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -623,8 +623,13 @@ zfs_nicenum_format(uint64_t num, char *buf, size_t buflen,
 	if (format == ZFS_NICENUM_RAW) {
 		snprintf(buf, buflen, "%llu", (u_longlong_t)num);
 		return;
+	} else if (format == ZFS_NICENUM_RAWTIME && num > 0) {
+		snprintf(buf, buflen, "%llu", (u_longlong_t)num);
+		return;
+	} else if (format == ZFS_NICENUM_RAWTIME && num == 0) {
+		snprintf(buf, buflen, "%s", "-");
+		return;
 	}
-
 
 	while (n >= k_unit[format] && index < units_len[format]) {
 		n /= k_unit[format];
@@ -633,7 +638,7 @@ zfs_nicenum_format(uint64_t num, char *buf, size_t buflen,
 
 	u = units[format][index];
 
-	/* Don't print 0ns times */
+	/* Don't print zero latencies since they're invalid */
 	if ((format == ZFS_NICENUM_TIME) && (num == 0)) {
 		(void) snprintf(buf, buflen, "-");
 	} else if ((index == 0) || ((num %


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description
This prints dashes instead of zeros for zero latency values in
`zpool iostat -p`.  You'll get zero latencies reported when the
disk is idle, but technically a zero latency is invalid, since you
can't measure the latency of doing nothing.

Signed-off-by: Tony Hutter <hutter2@llnl.gov>

### Motivation and Context
This change was requested on the zfs-devel mailing list.

### How Has This Been Tested?
Verified `zpool iostat -p` printed `-` instead of `0`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
