### PR TITLE
Add additional sanity check when resuming a pool

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -307,7 +307,7 @@ get_usage(zpool_help_t idx)
 	case HELP_DETACH:
 		return (gettext("\tdetach <pool> <device>\n"));
 	case HELP_EXPORT:
-		return (gettext("\texport [-af] <pool> ...\n"));
+		return (gettext("\texport [-afF] <pool> ...\n"));
 	case HELP_HISTORY:
 		return (gettext("\thistory [-il] [<pool>] ...\n"));
 	case HELP_IMPORT:
@@ -1398,14 +1398,17 @@ zpool_export_one(zpool_handle_t *zhp, void *data)
 }
 
 /*
- * zpool export [-f] <pool> ...
+ * zpool export [-afF] <pool> ...
  *
  *	-a	Export all pools
  *	-f	Forcefully unmount datasets
+ *	-F	Don't update disk labels during export.  Can be used to
+ *		export a suspended pool all dirty data will be discard.
  *
  * Export the given pools.  By default, the command will attempt to cleanly
  * unmount any active datasets within the pool.  If the '-f' flag is specified,
- * then the datasets will be forcefully unmounted.
+ * then the datasets will be forcefully unmounted.  The '-F' flag can be added
+ * to export a suspended which cannot be resumed.
  */
 int
 zpool_do_export(int argc, char **argv)

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -567,7 +567,7 @@ extern enum zio_compress zio_compress_select(spa_t *spa,
     enum zio_compress child, enum zio_compress parent);
 
 extern void zio_suspend(spa_t *spa, zio_t *zio);
-extern int zio_resume(spa_t *spa);
+extern int zio_resume(spa_t *spa, boolean_t discard);
 extern void zio_resume_wait(spa_t *spa);
 
 /*

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -64,7 +64,7 @@ zpool \- configures ZFS storage pools
 
 .LP
 .nf
-\fBzpool export\fR [\fB-a\fR] [\fB-f\fR] \fIpool\fR ...
+\fBzpool export\fR [\fB-a\fR] [\fB-f\fR] [\fB-F\fR] \fIpool\fR ...
 .fi
 
 .LP
@@ -1071,7 +1071,7 @@ Clear all previous events.
 .sp
 .ne 2
 .na
-\fB\fBzpool export\fR [\fB-a\fR] [\fB-f\fR] \fIpool\fR ...\fR
+\fB\fBzpool export\fR [\fB-a\fR] [\fB-f\fR] [\fB-F\fR] \fIpool\fR ...\fR
 .ad
 .sp .6
 .RS 4n
@@ -1098,6 +1098,21 @@ Exports all pools imported on the system.
 Forcefully unmount all datasets, using the "\fBunmount -f\fR" command.
 .sp
 This command will forcefully export the pool even if it has a shared spare that is currently being used. This may lead to potential data corruption.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-F\fR\fR
+.ad
+.RS 6n
+Forcefully export the pool without updating the ZFS disk labels.  Pools
+exported with this option will need to be force imported if they moved to
+a different system.
+.sp
+This option can be used to export a suspended pool which cannot be safely
+resumed with \fBzpool clear\fR.  When exporting a suspended pool all dirty
+in-core data will be discarded.  This may lead to potential data corruption.
 .RE
 
 .RE

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1439,12 +1439,15 @@ spa_freeze(spa_t *spa)
 {
 	uint64_t freeze_txg = 0;
 
-	spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
-	if (spa->spa_freeze_txg == UINT64_MAX) {
+	spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_WRITER);
+	if (spa_suspended(spa)) {
+		freeze_txg = spa->spa_last_ubsync_txg;
+		spa->spa_freeze_txg = freeze_txg;
+	} else if (spa->spa_freeze_txg == UINT64_MAX) {
 		freeze_txg = spa_last_synced_txg(spa) + TXG_SIZE;
 		spa->spa_freeze_txg = freeze_txg;
 	}
-	spa_config_exit(spa, SCL_ALL, FTAG);
+	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
 	if (freeze_txg != 0)
 		txg_wait_synced(spa_get_dsl(spa), freeze_txg);
 }

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -265,6 +265,8 @@ static int zfs_fill_zplprops_root(uint64_t, nvlist_t *, nvlist_t *,
     boolean_t *);
 int zfs_set_prop_nvlist(const char *, zprop_source_t, nvlist_t *, nvlist_t *);
 static int get_nvlist(uint64_t nvl, uint64_t size, int iflag, nvlist_t **nvp);
+static int pool_status_check(const char *, zfs_ioc_namecheck_t,
+    zfs_ioc_poolcheck_t);
 
 static void
 history_str_free(char *buf)
@@ -1577,12 +1579,25 @@ zfs_ioc_pool_import(zfs_cmd_t *zc)
 	return (error);
 }
 
+/*
+ * inputs:
+ * zc_name              name of the pool
+ * zc_zc_cookie         force flag
+ * zc->zc_guid          hardforce flag
+ */
 static int
 zfs_ioc_pool_export(zfs_cmd_t *zc)
 {
 	int error;
 	boolean_t force = (boolean_t)zc->zc_cookie;
 	boolean_t hardforce = (boolean_t)zc->zc_guid;
+
+	if (hardforce)
+		return (spa_export(zc->zc_name, NULL, force, hardforce));
+
+	error = pool_status_check(zc->zc_name, POOL_NAME, POOL_CHECK_SUSPENDED);
+	if (error)
+		return (error);
 
 	zfs_log_history(zc);
 	error = spa_export(zc->zc_name, NULL, force, hardforce);
@@ -4921,12 +4936,14 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 
 	vdev_clear(spa, vd);
 
-	(void) spa_vdev_state_exit(spa, spa->spa_root_vdev, 0);
+	(void) spa_vdev_state_exit(spa, spa_suspended(spa) ?
+	    NULL : spa->spa_root_vdev, 0);
 
 	/*
 	 * Resume any suspended I/Os.
 	 */
-	if (zio_resume(spa) != 0)
+	error = zio_resume(spa, B_FALSE);
+	if (error && error != EBUSY)
 		error = SET_ERROR(EIO);
 
 	spa_close(spa, FTAG);
@@ -6089,7 +6106,7 @@ zfs_ioctl_init(void)
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_DESTROY, zfs_ioc_pool_destroy,
 	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_SUSPENDED);
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_EXPORT, zfs_ioc_pool_export,
-	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_SUSPENDED);
+	    zfs_secpolicy_config, B_FALSE, POOL_CHECK_NONE);
 
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_STATS, zfs_ioc_pool_stats,
 	    zfs_secpolicy_read, B_FALSE, POOL_CHECK_NONE);
@@ -6182,7 +6199,7 @@ zfs_ioctl_init(void)
 	    zfs_secpolicy_config, NO_NAME, B_FALSE, POOL_CHECK_NONE);
 }
 
-int
+static int
 pool_status_check(const char *name, zfs_ioc_namecheck_t type,
     zfs_ioc_poolcheck_t check)
 {

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -200,7 +200,8 @@ tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
 tests = ['zpool_attach_001_neg', 'attach-o_ashift']
 
 [tests/functional/cli_root/zpool_clear]
-tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg']
+tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg',
+    'zpool_clear-resume']
 
 [tests/functional/cli_root/zpool_create]
 tests = ['zpool_create_001_pos', 'zpool_create_002_pos',

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2005,9 +2005,9 @@ function check_pool_status # pool token keyword
 	typeset token=$2
 	typeset keyword=$3
 
-	zpool status -v "$pool" 2>/dev/null | nawk -v token="$token:" '
-		($1==token) {print $0}' \
-	| grep -i "$keyword" > /dev/null 2>&1
+	zpool status -v "$pool" 2>&1 | \
+	    nawk -v token="$token:" '($1==token) {print $0}' | \
+	    grep -i "$keyword" > /dev/null 2>&1
 
 	return $?
 }
@@ -2019,6 +2019,7 @@ function check_pool_status # pool token keyword
 #	is_pool_scrubbing - to check if the pool is scrub in progress
 #	is_pool_scrubbed - to check if the pool is scrub completed
 #	is_pool_scrub_stopped - to check if the pool is scrub stopped
+#	is_pool_suspended - to check if the pool is suspended
 #
 function is_pool_resilvering #pool
 {
@@ -2047,6 +2048,12 @@ function is_pool_scrubbed #pool
 function is_pool_scrub_stopped #pool
 {
 	check_pool_status "$1" "scan" "scrub canceled"
+	return $?
+}
+
+function is_pool_suspended #pool
+{
+	check_pool_status "$1" "errors" "pool I/O is currently suspended"
 	return $?
 }
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/Makefile.am
@@ -5,4 +5,5 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	zpool_clear_001_pos.ksh \
 	zpool_clear_002_neg.ksh \
-	zpool_clear_003_neg.ksh
+	zpool_clear_003_neg.ksh \
+	zpool_clear-resume.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear-resume.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear-resume.ksh
@@ -1,0 +1,173 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2017 Lawrence Livermore National Security, LLC.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_clear/zpool_clear.cfg
+
+#
+# DESCRIPTION:
+#	Verify 'zpool clear' can safely resume a suspended pool.
+#
+# STRATEGY:
+#	1. Create a non-redundant pool with a small amount of data.
+#	2. Inject an IO fault in one of the pools vdevs.
+#	3. Force the pool to suspend itself by starting a scrub.
+#	4. Verify the pool immediately re-suspends until the vdev is repaired.
+#	5. Verify the pool will resume only after repairing the vdev.
+#	6. Verify the pool will not resume if it was modified while suspended.
+#	7. Verify the pool can only be exported using 'zpool export -F'.
+#	8. Verify the pool can be imported normally.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+        if poolexists $TESTPOOL1; then
+		log_must zinject -c all
+		log_must zpool export -F $TESTPOOL1
+		log_must zpool import -d $TESTDIR1 $TESTPOOL1
+		log_must zpool destroy -f $TESTPOOL1
+	fi
+
+	rm -f $VDEV1 $VDEV2 $VDEV3
+	rm -f $TESTDIR1/${TESTPOOL1}*
+	rmdir $TESTDIR1
+}
+
+
+log_assert "Verify 'zpool clear' can safely resume a suspended pool"
+log_onexit cleanup
+
+VDEV1=$TESTDIR1/vdev.0
+VDEV2=$TESTDIR1/vdev.1
+VDEV3=$TESTDIR1/vdev.2
+
+log_must mkdir -p $TESTDIR1
+log_must rm -f $TESTDIR1/${TESTPOOL1}*
+log_must truncate -s $MINVDEVSIZE $VDEV1 $VDEV2 $VDEV3
+
+# Start a scrub and make a random vdev return IO errors.
+function do_suspend # pool vdev
+{
+	typeset pool=$1
+	typeset vdev=$2
+
+	log_must zinject -a -d $vdev -e nxio $pool
+	log_must eval "zpool scrub $pool &"
+	log_must wait_suspend $pool
+}
+
+# Wait for pool to transition to a suspended state or timeout.
+function wait_suspend # pool [timeout]
+{
+	typeset pool=$1
+	typeset timeout=${2:-10}
+	typeset count=0
+
+	while ! is_pool_suspended $pool; do
+		if (( count == $timeout )); then
+			log_note "$pool did not suspend after ${timeout}s"
+			return 1
+		fi
+
+		((count = count + 1))
+		sleep 1
+	done
+
+	log_note "$pool successfully suspended"
+	return 0
+}
+
+# Wait for resilver to complete or timeout.
+function wait_resilver # pool [timeout]
+{
+	typeset pool=$1
+	typeset timeout=${2:-10}
+	typeset count=0
+
+	while ! is_pool_resilvered $pool; do
+		if (( count == $timeout )); then
+			log_note "$pool failed to resilver after ${timeout}s"
+			return 1
+		fi
+
+		((count = count + 1))
+		sleep 1
+	done
+
+	log_note "$pool successfully resilvered"
+	return 0
+}
+
+typeset file="/$TESTPOOL1/$TESTFS1/file"
+
+log_must zpool create -f $TESTPOOL1 $VDEV1 $VDEV2 $VDEV3
+log_must zfs create $TESTPOOL1/$TESTFS1
+
+# Partially fill up the zfs filesystem to give scrub something to read.
+avail=$(get_prop available $TESTPOOL1/$TESTFS1)
+fill_mb=$(((avail / 1024 / 1024) * 5 / 100))
+log_must dd if=/dev/urandom of=$file bs=$BLOCKSZ count=$fill_mb
+sync_pool $TESTPOOL1
+
+do_suspend $TESTPOOL1 $TESTDIR1/vdev.$(($RANDOM % 3))
+
+log_note "Verify the pool immediately re-suspends until the vdev is repaired."
+log_must zpool clear $TESTPOOL1
+log_must wait_suspend $TESTPOOL1
+
+log_note "Verify the pool will resume only after repairing the vdev."
+log_must zinject -c all
+log_must zpool clear $TESTPOOL1
+log_mustnot wait_suspend $TESTPOOL1 3
+if is_pool_suspended $TESTPOOL1; then
+	log_fail "'zpool clear' failed to resume repaired pool"
+fi
+
+log_must wait_resilver $TESTPOOL1
+log_must check_state $TESTPOOL1 "" ONLINE
+log_must check_state $TESTPOOL1 $TESTDIR1/vdev.$i ONLINE
+
+log_note "Verify the pool will not resume if it was modified while suspended."
+do_suspend $TESTPOOL1 $TESTDIR1/vdev.$(($RANDOM % 3))
+log_must zinject -c all
+ztest -E -f $TESTDIR1 -p $TESTPOOL1 -T1 2>&1 >/dev/null
+log_mustnot zpool clear $TESTPOOL1
+
+log_note "Verify the pool can only be exported using 'zpool export -F'."
+log_mustnot zpool export $TESTPOOL1
+log_mustnot zpool export -f $TESTPOOL1
+log_must zpool export -F $TESTPOOL1
+
+log_note "Verify the pool can be imported normally."
+log_must zpool import -d $TESTDIR1 $TESTPOOL1
+log_must zpool destroy $TESTPOOL1
+
+log_pass "'zpool clear' safely resumed a suspended pool."


### PR DESCRIPTION
### Description

A pool may only be resumed when the txg in the "best" uberblock
found on-disk matches the in-core last synced txg.  This is done
to verify that the pool was not modified by another node or process
while it was suspended.  If this were to happen the result would
be a corrupted pool.

Since a suspended pool may no longer always be resumable it was
necessary to extend the 'zpool export -F` command to allow a
suspended pool to be exported.  This was accomplished by leveraging
the existing spa freeze functionality.  During export if '-F' is
given and the pool is suspended the pool will be frozen at the last
synced txg and all in-core dirty data will be discarded.  This
allows for the pool to be safely exported without having to reboot
the system.

In order to test this functionality the broken 'ztest -E' option,
which allows for ztest to use an existing pool, was fixed.  The
code needed for this was copied over from zdb.  ztest is used to
modify the test pool from user space while the kernel has the pool
imported and suspended.

This commit partially addresses issues #4003, #2023, #2878, #3256
by allowing a suspended pool to be exported, 'zpool export -F'.
There may still be cases where a reference on the pool, such as
a filesystem which cannot be unmounted, will prevent the pool
from being exported.

### Motivation and Context

Related to multi-modifier protection, PR #6073.

### How Has This Been Tested?

Added test case `zpool_clear-resume.ksh`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.