### PR TITLE
Use log_must_busy in destroy_pool

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1496,20 +1496,11 @@ function destroy_pool #pool
 		if poolexists "$pool" ; then
 			mtpt=$(get_prop mountpoint "$pool")
 
-			# At times, syseventd activity can cause attempts to
-			# destroy a pool to fail with EBUSY. We retry a few
+			# At times, syseventd/udev activity can cause attempts
+			# to destroy a pool to fail with EBUSY. We retry a few
 			# times allowing failures before requiring the destroy
 			# to succeed.
-			typeset -i wait_time=10 ret=1 count=0
-			must=""
-			while [[ $ret -ne 0 ]]; do
-				$must zpool destroy -f $pool
-				ret=$?
-				[[ $ret -eq 0 ]] && break
-				log_note "zpool destroy failed with $ret"
-				[[ count++ -ge 7 ]] && must=log_must
-				sleep $wait_time
-			done
+			log_must_busy zpool destroy -f $pool
 
 			[[ -d $mtpt ]] && \
 				log_must rm -rf $mtpt


### PR DESCRIPTION
### Description

The log function log_must_busy was added in commit e623aea2 for
this purpose.  Update destroy_pool to use it.

### Motivation and Context

A small bit of cleanup I happened to notice.

### How Has This Been Tested?

Used extensively by the test suite.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
