### PR TITLE
Inject zinject(8) a percentage amount of device errors

### DIFF
--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -22,6 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
  * Copyright 2016 RackTop Systems.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef	_SYS_ZFS_IOCTL_H
@@ -337,6 +338,10 @@ typedef struct zinject_record {
 
 #define	ZEVENT_SEEK_START	0
 #define	ZEVENT_SEEK_END		UINT64_MAX
+
+/* scaled frequency ranges */
+#define	ZI_PERCENTAGE_MIN	4294UL
+#define	ZI_PERCENTAGE_MAX	UINT32_MAX
 
 typedef enum zinject_type {
 	ZINJECT_UNINITIALIZED,

--- a/man/man8/zinject.8
+++ b/man/man8/zinject.8
@@ -76,7 +76,7 @@ create 3 lanes on the device; one lane with a latency
 of 10 ms and two lanes with a 25 ms latency.
 
 .TP
-.B "zinject \-d \fIvdev\fB [\-e \fIdevice_error\fB] [\-L \fIlabel_error\fB] [\-T \fIfailure\fB] [\-F] \fIpool\fB"
+.B "zinject \-d \fIvdev\fB [\-e \fIdevice_error\fB] [\-L \fIlabel_error\fB] [\-T \fIfailure\fB] [\-f \fIfrequency\fB] [\-F] \fIpool\fB"
 Force a vdev error.
 .TP
 .B "zinject \-I [\-s \fIseconds\fB | \-g \fItxgs\fB] \fIpool\fB"
@@ -113,8 +113,8 @@ Specify
 .BR "nxio" " for an ENXIO error where reopening the device will fail."
 .TP
 .BI "\-f" " frequency"
-Only inject errors a fraction of the time. Expressed as an integer
-percentage between 1 and 100.
+Only inject errors a fraction of the time. Expressed as a real number
+percentage between 0.0001 and 100.
 .TP
 .BI "\-F"
 Fail faster. Do fewer checks.


### PR DESCRIPTION
Inject zinject(8) a percentage amount of device errors

### Description
In the original form of device error injection, it was an all or nothing situation.  To help simulate intermittent error conditions, you can now specify a real number percentage value. The value has a range between 0.0001 and 100.0 that limits device error injection to that percentage of the I/Os. Note that this change extends the higher resolution for '-f' for other use cases but that it remains backwards compatible with previous integer-only values.

### Motivation and Context
This feature is very useful for our ZFS fault diagnosis engine testing and for injecting intermittent errors during load testing.

### How Has This Been Tested?
Tested using live pools with same workload with and without a percentage value in the command.

### Example Session
(note: ZED was not running in this session)
```
-sh-4.2$ sudo zpool import aurora
-sh-4.2$ sudo zpool status aurora
  pool: aurora
 state: ONLINE
  scan: none requested
config:

        NAME                        STATE     READ WRITE CKSUM
        aurora                      ONLINE       0     0     0
          mirror-0                  ONLINE       0     0     0
            wwn-0x55cd2e404c033dab  ONLINE       0     0     0
            wwn-0x55cd2e404c033d2e  ONLINE       0     0     0
          mirror-1                  ONLINE       0     0     0
            wwn-0x55cd2e404c033fac  ONLINE       0     0     0
            wwn-0x55cd2e404c033da3  ONLINE       0     0     0

errors: No known data errors
-sh-4.2$ sudo zpool events -c
cleared 5 events

-sh-4.2$ sudo zinject -d wwn-0x55cd2e404c033dab -e io -T read aurora
Added handler 5 with the following properties:
  pool: aurora
  vdev: cc07a3708a5fdb2d
-sh-4.2$ sudo cp -r /aurora/src /tmp/src
-sh-4.2$ sudo zpool status aurora
  pool: aurora
 state: ONLINE
status: One or more devices has experienced an unrecoverable error.  An
        attempt was made to correct the error.  Applications are unaffected.
action: Determine if the device needs to be replaced, and clear the errors
        using 'zpool clear' or replace the device with 'zpool replace'.
   see: http://zfsonlinux.org/msg/ZFS-8000-9P
  scan: none requested
config:

        NAME                        STATE     READ WRITE CKSUM
        aurora                      ONLINE       0     0     0
          mirror-0                  ONLINE       0     0     0
            wwn-0x55cd2e404c033dab  ONLINE   1.71K     0     0
            wwn-0x55cd2e404c033d2e  ONLINE       0     0     0
          mirror-1                  ONLINE       0     0     0
            wwn-0x55cd2e404c033fac  ONLINE       0     0     0
            wwn-0x55cd2e404c033da3  ONLINE       0     0     0

errors: No known data errors
-sh-4.2$ sudo zpool events | grep "ereport.fs.zfs.io" | wc -l
2145

-sh-4.2$ sudo zinject -c all
removed all registered handlers
-sh-4.2$ sudo zpool export aurora
-sh-4.2$ sudo zpool import aurora
-sh-4.2$ sudo zpool events -c
cleared 2150 events
-sh-4.2$ sudo zinject -d wwn-0x55cd2e404c033dab -e io -T read -f 0.5 aurora
Added handler 6 with the following properties:
  pool: aurora
  vdev: cc07a3708a5fdb2d
-sh-4.2$ sudo cp -r /aurora/src /tmp/src
-sh-4.2$ sudo zpool status aurora
  pool: aurora
 state: ONLINE
status: One or more devices has experienced an unrecoverable error.  An
        attempt was made to correct the error.  Applications are unaffected.
action: Determine if the device needs to be replaced, and clear the errors
        using 'zpool clear' or replace the device with 'zpool replace'.
   see: http://zfsonlinux.org/msg/ZFS-8000-9P
  scan: none requested
config:

        NAME                        STATE     READ WRITE CKSUM
        aurora                      ONLINE       0     0     0
          mirror-0                  ONLINE       0     0     0
            wwn-0x55cd2e404c033dab  ONLINE      11     0     0
            wwn-0x55cd2e404c033d2e  ONLINE       0     0     0
          mirror-1                  ONLINE       0     0     0
            wwn-0x55cd2e404c033fac  ONLINE       0     0     0
            wwn-0x55cd2e404c033da3  ONLINE       0     0     0

errors: No known data errors
-sh-4.2$ sudo zpool events | grep "ereport.fs.zfs.io" | wc -l
16
-sh-4.2$
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
