### PR TITLE
Fix man description of zfs_arc_dnode_limit

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -412,7 +412,7 @@ Default value: \fB2\fR.
 .RS 12n
 When the number of bytes consumed by dnodes in the ARC exceeds this number of
 bytes, try to unpin some of it in response to demand for non-metadata. This
-value acts as a floor to the amount of dnode metadata, and defaults to 0 which
+value acts as a ceiling to the amount of dnode metadata, and defaults to 0 which
 indicates that a percent which is based on \fBzfs_arc_dnode_limit_percent\fR of
 the ARC meta buffers that may be used for dnodes.
 


### PR DESCRIPTION
### Description
In arc_evict_state() we start pruning when arc_dnode_size > arc_dnode_limit, i.e. arc_dnode_limit is a  ceiling rather than a floor. Make the man page reflect this.

### Motivation and Context
Incorrect manuals can lead to bad choices.

### How Has This Been Tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
