### PR TITLE
WIP: DDT ZAP operations should rely on dnode holds

### DIFF
--- a/include/sys/ddt.h
+++ b/include/sys/ddt.h
@@ -132,6 +132,7 @@ struct ddt {
 	objset_t	*ddt_os;
 	uint64_t	ddt_stat_object;
 	uint64_t	ddt_object[DDT_TYPES][DDT_CLASSES];
+	dnode_t		*ddt_dn[DDT_TYPES][DDT_CLASSES];
 	ddt_histogram_t	ddt_histogram[DDT_TYPES][DDT_CLASSES];
 	ddt_histogram_t	ddt_histogram_cache[DDT_TYPES][DDT_CLASSES];
 	ddt_object_t	ddt_object_stats[DDT_TYPES][DDT_CLASSES];
@@ -156,16 +157,12 @@ typedef struct ddt_ops {
 	int (*ddt_op_create)(objset_t *os, uint64_t *object, dmu_tx_t *tx,
 	    boolean_t prehash);
 	int (*ddt_op_destroy)(objset_t *os, uint64_t object, dmu_tx_t *tx);
-	int (*ddt_op_lookup)(objset_t *os, uint64_t object, ddt_entry_t *dde);
-	void (*ddt_op_prefetch)(objset_t *os, uint64_t object,
-	    ddt_entry_t *dde);
-	int (*ddt_op_update)(objset_t *os, uint64_t object, ddt_entry_t *dde,
-	    dmu_tx_t *tx);
-	int (*ddt_op_remove)(objset_t *os, uint64_t object, ddt_entry_t *dde,
-	    dmu_tx_t *tx);
-	int (*ddt_op_walk)(objset_t *os, uint64_t object, ddt_entry_t *dde,
-	    uint64_t *walk);
-	int (*ddt_op_count)(objset_t *os, uint64_t object, uint64_t *count);
+	int (*ddt_op_lookup)(dnode_t *dn, ddt_entry_t *dde);
+	void (*ddt_op_prefetch)(dnode_t *dn, ddt_entry_t *dde);
+	int (*ddt_op_update)(dnode_t *dn, ddt_entry_t *dde, dmu_tx_t *tx);
+	int (*ddt_op_remove)(dnode_t *dn, ddt_entry_t *dde, dmu_tx_t *tx);
+	int (*ddt_op_walk)(dnode_t *dn, ddt_entry_t *dde, uint64_t *walk);
+	int (*ddt_op_count)(dnode_t *dn, uint64_t *count);
 } ddt_ops_t;
 
 #define	DDT_NAMELEN	80


### PR DESCRIPTION
I have observed at work that DDT operations seem to suffer from excessive objset lookup / dnode_hold operations. This is an experimental change intended to correct that. I am pushing it for feedback from the upstream buildbot in parallel with performance evaluation at work.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
