### PR TITLE
Add kpreempt_disable/enable around CPU_SEQID uses to fix kernel BUG warnings

### DIFF
--- a/module/icp/core/kcf_sched.c
+++ b/module/icp/core/kcf_sched.c
@@ -1306,8 +1306,11 @@ kcf_reqid_insert(kcf_areq_node_t *areq)
 	int indx;
 	crypto_req_id_t id;
 	kcf_areq_node_t *headp;
-	kcf_reqid_table_t *rt =
-	    kcf_reqid_table[CPU_SEQID & REQID_TABLE_MASK];
+	kcf_reqid_table_t *rt;
+
+	kpreempt_disable();
+	rt = kcf_reqid_table[CPU_SEQID & REQID_TABLE_MASK];
+	kpreempt_enable();
 
 	mutex_enter(&rt->rt_lock);
 

--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -59,9 +59,13 @@ dmu_object_alloc_dnsize(objset_t *os, dmu_object_type_t ot, int blocksize,
 	dnode_t *dn = NULL;
 	int dn_slots = dnodesize >> DNODE_SHIFT;
 	boolean_t restarted = B_FALSE;
-	uint64_t *cpuobj = &os->os_obj_next_percpu[CPU_SEQID %
-	    os->os_obj_next_percpu_len];
+	uint64_t *cpuobj = NULL;
 	int dnodes_per_chunk = 1 << dmu_object_alloc_chunk_shift;
+
+	kpreempt_disable();
+	cpuobj = &os->os_obj_next_percpu[CPU_SEQID %
+	    os->os_obj_next_percpu_len];
+	kpreempt_enable();
 
 	if (dn_slots == 0) {
 		dn_slots = DNODE_MIN_SLOTS;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description

In `zfs/dmu_object` and `icp/core/kcf_sched`, the `CPU_SEQID` macro should be surrounded by `kpreempt_disable` and `kpreempt_enable` calls to avoid a Linux kernel BUG warning.

### Motivation and Context

Remediating frequent (but mostly harmless) Linux kernel BUG warnings during use of the ZFS 0.7 release candidate (see #6232)

### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Compiled and installed the module. The system affected by #6232 no longer gets these BUG warnings in its dmesg.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
