### PR TITLE
Fix int overflow in zbookmark_is_before()

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3472,7 +3472,7 @@ zbookmark_is_before(const dnode_phys_t *dnp, const zbookmark_phys_t *zb1,
 
 	if (zb1->zb_object == DMU_META_DNODE_OBJECT) {
 		uint64_t nextobj = zb1nextL0 *
-		    (dnp->dn_datablkszsec << SPA_MINBLOCKSHIFT) >> DNODE_SHIFT;
+		    (dnp->dn_datablkszsec << (SPA_MINBLOCKSHIFT - DNODE_SHIFT));
 		return (nextobj <= zb2thisobj);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

We're seeing several reports (github, mailinglist, reddit) of pools migrated from FreeBSD that cannot be scrubbed with ZoL 0.6.5: the symptom is always scrubs completing **successfully** in mere minutes on multiple TB of used space.

The root cause seems to be an int overflow condition in `zbookmark_is_before()`, which is exacerbated by bumping the indirect block size to 128K (d7958b4, _OpenZFS 7104 - increase indirect block size_). A previous commit (fcff0f3, _Illumos 5960, 5925_) introduced new logic to the bookmark comparing code and fixes this, so the 0.7.0 releases are not affected.

It would be nice it we could backport this fix to 0.6.5.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/6038
Fix https://github.com/zfsonlinux/zfs/issues/6011

More info at hand

From the kernel debugger we clearly see the overflow in `zbookmark_is_before()` during the dnode traversal. The issue here is that we perform the multiplication before the right shift (this has been fixed in `zbookmark_compare()` with fcff0f3)

```
Breakpoint 2, zbookmark_is_before (dnp=0xffff88011543f800, zb1=0xffff8800d9d93b38, zb2=0xffff8800db9962e0) at /usr/src/zfs/module/zfs/zio.c:3476
3476			return (nextobj <= zb2thisobj);
(gdb) info locals
nextobj = 0
zb1nextL0 = 1125899906842624
zb2thisobj = 157
__FUNCTION__ = <error reading variable __FUNCTION__ (Cannot access memory at address 0x11d60)>
(gdb) bt
#0  zbookmark_is_before (dnp=0xffff88011543f800, zb1=0xffff8800d9d93b38, zb2=0xffff8800db9962e0) at /usr/src/zfs/module/zfs/zio.c:3476
#1  0xffffffffc08e7cc4 in dsl_scan_check_resume (zb=<optimized out>, dnp=<optimized out>, scn=<optimized out>) at /usr/src/zfs/module/zfs/dsl_scan.c:622
#2  dsl_scan_visitbp (bp=0xffff88011543f840, zb=0xffff8800d9d93b38, dnp=<optimized out>, ds=0xffff8800d3a83000, scn=0xffff8800db996200, ostype=<optimized out>, tx=0xffff88002aa9c600) at /usr/src/zfs/module/zfs/dsl_scan.c:792
#3  0xffffffffc08e84af in dsl_scan_visitdnode (tx=<optimized out>, object=<optimized out>, dnp=<optimized out>, ostype=<optimized out>, ds=<optimized out>, scn=<optimized out>) at /usr/src/zfs/module/zfs/dsl_scan.c:759
#4  dsl_scan_recurse (tx=<optimized out>, zb=<optimized out>, bp=<optimized out>, dnp=<optimized out>, ostype=<optimized out>, ds=<optimized out>, scn=<optimized out>) at /usr/src/zfs/module/zfs/dsl_scan.c:724
#5  dsl_scan_visitbp (bp=<optimized out>, zb=<optimized out>, dnp=<optimized out>, ds=0xffff8800d3a83000, scn=0xffff8800db996200, ostype=<optimized out>, tx=0xffff88002aa9c600) at /usr/src/zfs/module/zfs/dsl_scan.c:816
#6  0xffffffffc08e88aa in dsl_scan_visit_rootbp (scn=<optimized out>, ds=0xffff8800d9d93b38, bp=<optimized out>, tx=<optimized out>) at /usr/src/zfs/module/zfs/dsl_scan.c:851
#7  0xffffffffc08e89e7 in dsl_scan_visitds (scn=0xffff8800db996200, dsobj=259, tx=0xffff88002aa9c600) at /usr/src/zfs/module/zfs/dsl_scan.c:1082
#8  0xffffffffc08ea625 in dsl_scan_visit (tx=<optimized out>, scn=<optimized out>) at /usr/src/zfs/module/zfs/dsl_scan.c:1341
#9  dsl_scan_sync (dp=0xffff8800d93b8800, tx=0xffff88002aa9c600) at /usr/src/zfs/module/zfs/dsl_scan.c:1634
#10 0xffffffffc09014c8 in spa_sync (spa=0xffff8800d7c4a000, txg=1619) at /usr/src/zfs/module/zfs/spa.c:6256
#11 0xffffffffc0918836 in txg_sync_thread (dp=0xffff8800d93b8800) at /usr/src/zfs/module/zfs/txg.c:559
#12 0xffffffffc0215eae in thread_generic_wrapper ()
#13 0xffffffff8109ac4f in kthread ()
#14 0xffffffff815cc3f2 in ret_from_fork () at arch/x86/entry/entry_64.S:406
#15 0x0000000000000000 in ?? ()
(gdb) list
3471		    zb2->zb_blkid << (DNODE_BLOCK_SHIFT - DNODE_SHIFT);
3472	
3473		if (zb1->zb_object == DMU_META_DNODE_OBJECT) {
3474			uint64_t nextobj = zb1nextL0 *
3475			    (dnp->dn_datablkszsec << SPA_MINBLOCKSHIFT) >> DNODE_SHIFT;
3476			return (nextobj <= zb2thisobj);
3477		}
3478	
3479		if (zb1->zb_object < zb2thisobj)
3480			return (B_TRUE);
(gdb) p/x zb1nextL0
$4 = 0x4000000000000
(gdb) p/x dnp->dn_datablkszsec
$5 = 0x20
(gdb) p/x (dnp->dn_datablkszsec << 9)
$6 = 0x4000
(gdb) p/x zb1nextL0 * (dnp->dn_datablkszsec << 9)
$7 = 0x0
(gdb) p/x zb1nextL0 * (dnp->dn_datablkszsec << 9) >> 9
$8 = 0x0
(gdb) p/x zb1nextL0 * ((dnp->dn_datablkszsec << 9) >> 9)
$9 = 0x80000000000000
(gdb) p nextobj <= zb2thisobj
$10 = 1
(gdb) 
```

We can see this issue in action via systemtap tracing every `zbookmark_is_before()` call during a full scrub: excluding the MOS, everytime we try to resume the scan from the saved `zbookmark_phys_t` we conclude the dataset doesn't need scrubbing because the bookmark "is before" (return `1`), which means it has been already scanned.

```
root@linux:~# zpool list
NAME      SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
freenas  39.8G  3.24G  36.5G         -     0%     8%  1.00x  ONLINE  -
root@linux:~# zfs list
NAME                     USED  AVAIL  REFER  MOUNTPOINT
freenas                 1.61G  17.6G  32.9K  none
freenas/jails           1.61G  17.6G  40.3K  /mnt/jails
freenas/jails/debian-0   236M  17.6G   236M  /mnt/jails/debian-0
freenas/jails/debian-1   236M  17.6G   236M  /mnt/jails/debian-1
freenas/jails/debian-2   236M  17.6G   236M  /mnt/jails/debian-2
freenas/jails/debian-3   236M  17.6G   236M  /mnt/jails/debian-3
freenas/jails/debian-4   236M  17.6G   236M  /mnt/jails/debian-4
freenas/jails/debian-5   236M  17.6G   236M  /mnt/jails/debian-5
freenas/jails/debian-6   236M  17.6G   236M  /mnt/jails/debian-6
freenas/jails/debian-7  32.9K  17.6G  32.9K  /mnt/jails/debian-7
freenas/jails/debian-8  32.9K  17.6G  32.9K  /mnt/jails/debian-8
freenas/jails/debian-9  32.9K  17.6G  32.9K  /mnt/jails/debian-9
root@linux:~# echo 1 > /sys/module/zfs/parameters/zfs_dbgmsg_enable
root@linux:~# stap -v \
>    -e '
> probe begin { system("zpool scrub freenas") }
> probe
> module("zfs").function("zbookmark_is_before").return
> {
>    printf(" <- %s (zb1=%s, zb2=%s) %s\n", ppfunc(), $zb1$$, $zb2$$, $return$);
> }
> probe
> module("zfs").function("__zfs_dbgmsg").call
> {
>    printf("zfs_dbgmsg: %s\n", kernel_string($buf));
> }
> '
Pass 1: parsed user script and 113 library scripts using 94452virt/38756res/5040shr/34368data kb, in 310usr/30sys/337real ms.
Pass 2: analyzed script: 4 probes, 18 functions, 1 embed, 0 globals using 98372virt/44476res/6560shr/38288data kb, in 220usr/330sys/553real ms.
Pass 3: using cached /root/.systemtap/cache/5f/stap_5f82d7aa59375b4ddfa9cc7c90aa2f90_14214.c
Pass 4: using cached /root/.systemtap/cache/5f/stap_5f82d7aa59375b4ddfa9cc7c90aa2f90_14214.ko
Pass 5: starting run.
zfs_dbgmsg: txg=1894 quiesce_txg=1894 sync_txg=1894
zfs_dbgmsg: broadcasting sync more tx_synced=1893 waiting=1894 dp=ffff8801173b7800
zfs_dbgmsg: txg=1894 quiesce_txg=1895 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1894
zfs_dbgmsg: txg=1894 quiesce_txg=1895 sync_txg=1894
zfs_dbgmsg: os=ffff8801173b7000 obj=22 txg=1894 blocksize=512 ibs=14
zfs_dbgmsg: txg 1894 scan setup func=1 mintxg=0 maxtxg=1894
zfs_dbgmsg: doing scan sync txg 1894; ddt bm=0/0/0/0
zfs_dbgmsg: scanned 0 ddt entries with class_max = 1; pausing=0
zfs_dbgmsg: pausing at bookmark 0/0/0/19
zfs_dbgmsg: pausing at DDT bookmark 3/0/0/0
zfs_dbgmsg: visited 180 blocks in 1011ms
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: txg=1895 quiesce_txg=1896 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1895
zfs_dbgmsg: txg=1895 quiesce_txg=1896 sync_txg=1894
zfs_dbgmsg: doing scan sync txg 1895; bm=0/0/0/25
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=-1, .zb_blkid=0}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 0
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=1, .zb_blkid=0}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 0
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=0}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=1}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=2}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=3}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=4}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=5}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=6}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=7}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=8}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=9}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=10}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=11}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=12}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=13}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=14}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=15}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=16}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=17}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=18}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=19}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=20}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=21}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=22}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=23}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=24}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 1
 <- zbookmark_is_before (zb1={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}, zb2={.zb_objset=0, .zb_object=0, .zb_level=0, .zb_blkid=25}) 0
zfs_dbgmsg: resuming at 0/0/0/19
zfs_dbgmsg: scanned dataset 48 (freenas/$ORIGIN@$ORIGIN) with min=0 max=1894; pausing=0
zfs_dbgmsg: pausing at bookmark 109/245/0/0
zfs_dbgmsg: pausing at DDT bookmark 3/0/0/0
zfs_dbgmsg: scanned dataset 265 (freenas/jails/debian-4) with min=1 max=1894; pausing=1
zfs_dbgmsg: visited 451 blocks in 5280ms
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: txg=1896 quiesce_txg=1897 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1896
zfs_dbgmsg: txg=1896 quiesce_txg=1897 sync_txg=1894
zfs_dbgmsg: command: zpool scrub freenas
zfs_dbgmsg: doing scan sync txg 1896; bm=265/581/0/0
 <- zbookmark_is_before (zb1={.zb_objset=265, .zb_object=0, .zb_level=-1, .zb_blkid=0}, zb2={.zb_objset=265, .zb_object=581, .zb_level=0, .zb_blkid=0}) 0
 <- zbookmark_is_before (zb1={.zb_objset=265, .zb_object=0, .zb_level=5, .zb_blkid=0}, zb2={.zb_objset=265, .zb_object=581, .zb_level=0, .zb_blkid=0}) 1
 <- zbookmark_is_before (zb1={.zb_objset=265, .zb_object=0, .zb_level=5, .zb_blkid=1}, zb2={.zb_objset=265, .zb_object=581, .zb_level=0, .zb_blkid=0}) 1
 <- zbookmark_is_before (zb1={.zb_objset=265, .zb_object=0, .zb_level=5, .zb_blkid=2}, zb2={.zb_objset=265, .zb_object=581, .zb_level=0, .zb_blkid=0}) 1
zfs_dbgmsg: scanned dataset 265 (freenas/jails/debian-4) with min=1 max=1894; pausing=0
zfs_dbgmsg: pausing at bookmark 103/c2/0/0
zfs_dbgmsg: pausing at DDT bookmark 3/0/0/0
zfs_dbgmsg: scanned dataset 259 (freenas/jails/debian-0) with min=1 max=1894; pausing=1
zfs_dbgmsg: visited 277 blocks in 5375ms
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: os=ffff8801173b7000 obj=275, increase to 2
zfs_dbgmsg: txg=1897 quiesce_txg=1898 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1897
zfs_dbgmsg: txg=1897 quiesce_txg=1898 sync_txg=1894
zfs_dbgmsg: doing scan sync txg 1897; bm=259/194/0/0
 <- zbookmark_is_before (zb1={.zb_objset=259, .zb_object=0, .zb_level=-1, .zb_blkid=0}, zb2={.zb_objset=259, .zb_object=194, .zb_level=0, .zb_blkid=0}) 0
 <- zbookmark_is_before (zb1={.zb_objset=259, .zb_object=0, .zb_level=5, .zb_blkid=0}, zb2={.zb_objset=259, .zb_object=194, .zb_level=0, .zb_blkid=0}) 1
 <- zbookmark_is_before (zb1={.zb_objset=259, .zb_object=0, .zb_level=5, .zb_blkid=1}, zb2={.zb_objset=259, .zb_object=194, .zb_level=0, .zb_blkid=0}) 1
 <- zbookmark_is_before (zb1={.zb_objset=259, .zb_object=0, .zb_level=5, .zb_blkid=2}, zb2={.zb_objset=259, .zb_object=194, .zb_level=0, .zb_blkid=0}) 1
zfs_dbgmsg: scanned dataset 259 (freenas/jails/debian-0) with min=1 max=1894; pausing=0
zfs_dbgmsg: pausing at bookmark 183/27d/0/2
zfs_dbgmsg: pausing at DDT bookmark 3/0/0/0
zfs_dbgmsg: scanned dataset 387 (freenas/jails/debian-1) with min=1 max=1894; pausing=1
zfs_dbgmsg: visited 513 blocks in 5288ms
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: txg=1898 quiesce_txg=1899 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1898
zfs_dbgmsg: txg=1898 quiesce_txg=1899 sync_txg=1894
zfs_dbgmsg: doing scan sync txg 1898; bm=387/637/0/2
 <- zbookmark_is_before (zb1={.zb_objset=387, .zb_object=0, .zb_level=-1, .zb_blkid=0}, zb2={.zb_objset=387, .zb_object=637, .zb_level=0, .zb_blkid=2}) 0
 <- zbookmark_is_before (zb1={.zb_objset=387, .zb_object=0, .zb_level=5, .zb_blkid=0}, zb2={.zb_objset=387, .zb_object=637, .zb_level=0, .zb_blkid=2}) 1
 <- zbookmark_is_before (zb1={.zb_objset=387, .zb_object=0, .zb_level=5, .zb_blkid=1}, zb2={.zb_objset=387, .zb_object=637, .zb_level=0, .zb_blkid=2}) 1
 <- zbookmark_is_before (zb1={.zb_objset=387, .zb_object=0, .zb_level=5, .zb_blkid=2}, zb2={.zb_objset=387, .zb_object=637, .zb_level=0, .zb_blkid=2}) 1
zfs_dbgmsg: scanned dataset 387 (freenas/jails/debian-1) with min=1 max=1894; pausing=0
zfs_dbgmsg: pausing at bookmark 209/297/0/2
zfs_dbgmsg: pausing at DDT bookmark 3/0/0/0
zfs_dbgmsg: scanned dataset 521 (freenas/jails/debian-3) with min=1 max=1894; pausing=1
zfs_dbgmsg: visited 541 blocks in 5519ms
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: txg=1899 quiesce_txg=1900 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1899
zfs_dbgmsg: txg=1899 quiesce_txg=1900 sync_txg=1894
zfs_dbgmsg: doing scan sync txg 1899; bm=521/663/0/2
 <- zbookmark_is_before (zb1={.zb_objset=521, .zb_object=0, .zb_level=-1, .zb_blkid=0}, zb2={.zb_objset=521, .zb_object=663, .zb_level=0, .zb_blkid=2}) 0
 <- zbookmark_is_before (zb1={.zb_objset=521, .zb_object=0, .zb_level=5, .zb_blkid=0}, zb2={.zb_objset=521, .zb_object=663, .zb_level=0, .zb_blkid=2}) 1
 <- zbookmark_is_before (zb1={.zb_objset=521, .zb_object=0, .zb_level=5, .zb_blkid=1}, zb2={.zb_objset=521, .zb_object=663, .zb_level=0, .zb_blkid=2}) 1
 <- zbookmark_is_before (zb1={.zb_objset=521, .zb_object=0, .zb_level=5, .zb_blkid=2}, zb2={.zb_objset=521, .zb_object=663, .zb_level=0, .zb_blkid=2}) 1
zfs_dbgmsg: scanned dataset 521 (freenas/jails/debian-3) with min=1 max=1894; pausing=0
zfs_dbgmsg: pausing at bookmark 203/2bc/0/0
zfs_dbgmsg: pausing at DDT bookmark 3/0/0/0
zfs_dbgmsg: scanned dataset 515 (freenas/jails/debian-2) with min=1 max=1894; pausing=1
zfs_dbgmsg: visited 512 blocks in 5457ms
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: txg=1900 quiesce_txg=1901 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1900
zfs_dbgmsg: txg=1900 quiesce_txg=1901 sync_txg=1894
zfs_dbgmsg: doing scan sync txg 1900; bm=515/700/0/0
 <- zbookmark_is_before (zb1={.zb_objset=515, .zb_object=0, .zb_level=-1, .zb_blkid=0}, zb2={.zb_objset=515, .zb_object=700, .zb_level=0, .zb_blkid=0}) 0
 <- zbookmark_is_before (zb1={.zb_objset=515, .zb_object=0, .zb_level=5, .zb_blkid=0}, zb2={.zb_objset=515, .zb_object=700, .zb_level=0, .zb_blkid=0}) 1
 <- zbookmark_is_before (zb1={.zb_objset=515, .zb_object=0, .zb_level=5, .zb_blkid=1}, zb2={.zb_objset=515, .zb_object=700, .zb_level=0, .zb_blkid=0}) 1
 <- zbookmark_is_before (zb1={.zb_objset=515, .zb_object=0, .zb_level=5, .zb_blkid=2}, zb2={.zb_objset=515, .zb_object=700, .zb_level=0, .zb_blkid=0}) 1
zfs_dbgmsg: scanned dataset 515 (freenas/jails/debian-2) with min=1 max=1894; pausing=0
zfs_dbgmsg: scanned dataset 141 (freenas/jails) with min=1 max=1894; pausing=0
zfs_dbgmsg: pausing at bookmark 283/202/0/0
zfs_dbgmsg: pausing at DDT bookmark 3/0/0/0
zfs_dbgmsg: scanned dataset 643 (freenas/jails/debian-5) with min=1 max=1894; pausing=1
zfs_dbgmsg: visited 428 blocks in 5266ms
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: txg=1901 quiesce_txg=1902 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1901
zfs_dbgmsg: txg=1901 quiesce_txg=1902 sync_txg=1894
zfs_dbgmsg: doing scan sync txg 1901; bm=643/514/0/0
 <- zbookmark_is_before (zb1={.zb_objset=643, .zb_object=0, .zb_level=-1, .zb_blkid=0}, zb2={.zb_objset=643, .zb_object=514, .zb_level=0, .zb_blkid=0}) 0
 <- zbookmark_is_before (zb1={.zb_objset=643, .zb_object=0, .zb_level=5, .zb_blkid=0}, zb2={.zb_objset=643, .zb_object=514, .zb_level=0, .zb_blkid=0}) 1
 <- zbookmark_is_before (zb1={.zb_objset=643, .zb_object=0, .zb_level=5, .zb_blkid=1}, zb2={.zb_objset=643, .zb_object=514, .zb_level=0, .zb_blkid=0}) 1
 <- zbookmark_is_before (zb1={.zb_objset=643, .zb_object=0, .zb_level=5, .zb_blkid=2}, zb2={.zb_objset=643, .zb_object=514, .zb_level=0, .zb_blkid=0}) 1
zfs_dbgmsg: scanned dataset 643 (freenas/jails/debian-5) with min=1 max=1894; pausing=0
zfs_dbgmsg: scanned dataset 51 (freenas) with min=1 max=1894; pausing=0
zfs_dbgmsg: scanned dataset 527 (freenas/jails/debian-7) with min=1 max=1894; pausing=0
zfs_dbgmsg: scanned dataset 533 (freenas/jails/debian-8) with min=1 max=1894; pausing=0
zfs_dbgmsg: scanned dataset 539 (freenas/jails/debian-9) with min=1 max=1894; pausing=0
zfs_dbgmsg: pausing at bookmark 43/1b6/0/27
zfs_dbgmsg: pausing at DDT bookmark 3/0/0/0
zfs_dbgmsg: scanned dataset 67 (freenas/jails/debian-6) with min=1 max=1894; pausing=1
zfs_dbgmsg: visited 406 blocks in 5554ms
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: txg=1902 quiesce_txg=1903 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1902
zfs_dbgmsg: txg=1902 quiesce_txg=1903 sync_txg=1894
zfs_dbgmsg: doing scan sync txg 1902; bm=67/438/0/39
 <- zbookmark_is_before (zb1={.zb_objset=67, .zb_object=0, .zb_level=-1, .zb_blkid=0}, zb2={.zb_objset=67, .zb_object=438, .zb_level=0, .zb_blkid=39}) 0
 <- zbookmark_is_before (zb1={.zb_objset=67, .zb_object=0, .zb_level=5, .zb_blkid=0}, zb2={.zb_objset=67, .zb_object=438, .zb_level=0, .zb_blkid=39}) 1
 <- zbookmark_is_before (zb1={.zb_objset=67, .zb_object=0, .zb_level=5, .zb_blkid=1}, zb2={.zb_objset=67, .zb_object=438, .zb_level=0, .zb_blkid=39}) 1
 <- zbookmark_is_before (zb1={.zb_objset=67, .zb_object=0, .zb_level=5, .zb_blkid=2}, zb2={.zb_objset=67, .zb_object=438, .zb_level=0, .zb_blkid=39}) 1
zfs_dbgmsg: scanned dataset 67 (freenas/jails/debian-6) with min=1 max=1894; pausing=0
zfs_dbgmsg: scanned dataset 45 (freenas/$ORIGIN) with min=1 max=1894; pausing=0
zfs_dbgmsg: visited 3 blocks in 1ms
zfs_dbgmsg: txg 1902 traversal complete, waiting till txg 1903
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: txg=1903 quiesce_txg=1904 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1903
zfs_dbgmsg: txg=1903 quiesce_txg=1904 sync_txg=1894
zfs_dbgmsg: txg 1903 scan complete
zfs_dbgmsg: dn=ffff8800d62dcd78 txg=1903
zfs_dbgmsg: txg 1903 scan done complete=1
zfs_dbgmsg: spa=freenas async request task=8
zfs_dbgmsg: ds=          (null) obj=16 num=1
zfs_dbgmsg: ds=          (null) obj=29 num=1
zfs_dbgmsg: ds=          (null) obj=11 num=1
zfs_dbgmsg: ds=          (null) obj=12 num=1
zfs_dbgmsg: ds=          (null) obj=13 num=1
zfs_dbgmsg: ds=          (null) obj=14 num=1
zfs_dbgmsg: ds=          (null) obj=3d num=1
zfs_dbgmsg: waiting; tx_synced=1903 waiting=1894 dp=ffff8801173b7800
zfs_dbgmsg: txg=1904 quiesce_txg=1905 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1904
zfs_dbgmsg: txg=1904 quiesce_txg=1905 sync_txg=1894
zfs_dbgmsg: waiting; tx_synced=1904 waiting=1894 dp=ffff8801173b7800
zfs_dbgmsg: txg=1905 quiesce_txg=1906 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1905
zfs_dbgmsg: txg=1905 quiesce_txg=1906 sync_txg=1894
zfs_dbgmsg: waiting; tx_synced=1905 waiting=1894 dp=ffff8801173b7800
zfs_dbgmsg: txg=1906 quiesce_txg=1907 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1906
zfs_dbgmsg: txg=1906 quiesce_txg=1907 sync_txg=1894
zfs_dbgmsg: waiting; tx_synced=1906 waiting=1894 dp=ffff8801173b7800
zfs_dbgmsg: txg=1907 quiesce_txg=1908 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1907
zfs_dbgmsg: txg=1907 quiesce_txg=1908 sync_txg=1894
zfs_dbgmsg: waiting; tx_synced=1907 waiting=1894 dp=ffff8801173b7800
zfs_dbgmsg: txg=1908 quiesce_txg=1909 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1908
zfs_dbgmsg: txg=1908 quiesce_txg=1909 sync_txg=1894
zfs_dbgmsg: waiting; tx_synced=1908 waiting=1894 dp=ffff8801173b7800
zfs_dbgmsg: txg=1909 quiesce_txg=1910 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1909
zfs_dbgmsg: txg=1909 quiesce_txg=1910 sync_txg=1894
zfs_dbgmsg: waiting; tx_synced=1909 waiting=1894 dp=ffff8801173b7800
zfs_dbgmsg: txg=1910 quiesce_txg=1911 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1910
zfs_dbgmsg: txg=1910 quiesce_txg=1911 sync_txg=1894
zfs_dbgmsg: waiting; tx_synced=1910 waiting=1894 dp=ffff8801173b7800
zfs_dbgmsg: txg=1911 quiesce_txg=1912 sync_txg=1894
zfs_dbgmsg: quiesce done, handing off txg 1911
zfs_dbgmsg: txg=1911 quiesce_txg=1912 sync_txg=1894
zfs_dbgmsg: waiting; tx_synced=1911 waiting=1894 dp=ffff8801173b7800
^CPass 5: run completed in 0usr/170sys/121155real ms.
root@linux:~# 
```

To reproduce this just create a small pool with d7958b4 and try to scrub it on 0.6.5 without fcff0f3:

```
root@linux:~# zpool list
NAME         SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
issue-6038  9.94G   128M  9.81G         -     0%     1%  1.00x  ONLINE  -
root@linux:~# zfs list
NAME            USED  AVAIL  REFER  MOUNTPOINT
issue-6038      128M  9.50G  25.5K  /mnt/issue-6038
issue-6038/fs   128M  9.50G   128M  /mnt/issue-6038/fs
root@linux:~# ls -i /mnt/issue-6038/fs/zero.dat
2 /mnt/issue-6038/fs/zero.dat
root@linux:~# zdb -ddddddd issue-6038/fs 2 | tail
         7f60000   L0 0:9f80000:20000 20000L/20000P F=1 B=8/8
         7f80000   L0 0:9fa0000:20000 20000L/20000P F=1 B=8/8
         7fa0000   L0 0:9fc0000:20000 20000L/20000P F=1 B=8/8
         7fc0000   L0 0:9fe0000:20000 20000L/20000P F=1 B=8/8
         7fe0000   L0 0:a000000:20000 20000L/20000P F=1 B=8/8
         8000000  L1  0:c020000:400 0:84000000:400 20000L/400P F=1 B=8/8
         8000000   L0 0:c000000:20000 20000L/20000P F=1 B=8/8

		segment [0000000000000000, 0000000008020000) size  128M

root@linux:~# zdb issue-6038 -R 0:c000000:20000 | head
Found vdev type: mirror

0:c000000:20000
          0 1 2 3 4 5 6 7   8 9 a b c d e f  0123456789abcdef
000000:  4645454244414544  000000000000000a  DEADBEEF........
000010:  0000000000000000  0000000000000000  ................
000020:  0000000000000000  0000000000000000  ................
000030:  0000000000000000  0000000000000000  ................
000040:  0000000000000000  0000000000000000  ................
000050:  0000000000000000  0000000000000000  ................
000060:  0000000000000000  0000000000000000  ................
root@linux:~# xxd /mnt/issue-6038/fs/zero.dat | tail
7ffff70: 0000 0000 0000 0000 0000 0000 0000 0000  ................
7ffff80: 0000 0000 0000 0000 0000 0000 0000 0000  ................
7ffff90: 0000 0000 0000 0000 0000 0000 0000 0000  ................
7ffffa0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
7ffffb0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
7ffffc0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
7ffffd0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
7ffffe0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
7fffff0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
8000000: 4445 4144 4245 4546 0a                   DEADBEEF.
root@linux:~# 
```

Corrupt it:

```
root@linux:~# dd if=/dev/vda1 bs=1 skip=`printf '%d' $((0xc000000 + 0x400000))` count=8
DEADBEEF8+0 records in
8+0 records out
8 bytes (8 B) copied, 0.00143855 s, 5.6 kB/s
root@linux:~# echo 'FOOBARBAZ' | dd of=/dev/vda1 bs=1 seek=`printf '%d' $((0xc000000 + 0x400000))` 
10+0 records in
10+0 records out
10 bytes (10 B) copied, 0.000112565 s, 88.8 kB/s
root@linux:~# dd if=/dev/vda1 bs=1 skip=`printf '%d' $((0xc000000 + 0x400000))` count=8
FOOBARBA8+0 records in
8+0 records out
8 bytes (8 B) copied, 6.1197e-05 s, 131 kB/s
root@linux:~# 
```

Now scrub it: as you can see it doesn't detect the corruption becase the code is not scanning those indirect blocks.

```
root@linux:~# zpool status
  pool: issue-6038
 state: ONLINE
status: Some supported features are not enabled on the pool. The pool can
	still be used, but some features are unavailable.
action: Enable all features using 'zpool upgrade'. Once this is done,
	the pool may no longer be accessible by software that does not support
	the features. See zpool-features(5) for details.
  scan: scrub repaired 0 in 0h0m with 0 errors on Fri Jun 16 23:25:49 2017
config:

	NAME        STATE     READ WRITE CKSUM
	issue-6038  ONLINE       0     0     0
	  mirror-0  ONLINE       0     0     0
	    vda     ONLINE       0     0     0
	    vdb     ONLINE       0     0     0
```

We can quickly verify the fix by patching the running kernel module on the fly with systemtap and see if this times it detects corruption on that last indirect block.

```
root@linux:~# stap -v \
>    -g \
>    -e '
> probe begin { system("zpool scrub issue-6038") }
> probe
> module("zfs").statement("zbookmark_is_before@module/zfs/zio.c:3476")
> {
>    $nextobj = $zb1nextL0 * (($dnp->dn_datablkszsec << 9 ) >> 9);
> }
> ' -c 'zpool status issue-6038 1'
Pass 1: parsed user script and 113 library scripts using 94452virt/38724res/5008shr/34368data kb, in 300usr/50sys/963real ms.
Pass 2: analyzed script: 2 probes, 4 functions, 0 embeds, 0 globals using 99468virt/45444res/6632shr/39384data kb, in 160usr/1970sys/15702real ms.
Pass 3: translated to C into "/tmp/stapi60FTs/stap_1a9d7617cea66fe65ae7ea22c3821fed_3832_src.c" using 99468virt/45636res/6820shr/39384data kb, in 4170usr/730sys/5638real ms.
Pass 4: compiled C into "stap_1a9d7617cea66fe65ae7ea22c3821fed_3832.ko" in 2840usr/420sys/17003real ms.
Pass 5: starting run.
  pool: issue-6038
 state: ONLINE
status: Some supported features are not enabled on the pool. The pool can
	still be used, but some features are unavailable.
action: Enable all features using 'zpool upgrade'. Once this is done,
	the pool may no longer be accessible by software that does not support
	the features. See zpool-features(5) for details.
  scan: scrub repaired 0 in 0h0m with 0 errors on Fri Jun 16 23:32:10 2017
config:

	NAME        STATE     READ WRITE CKSUM
	issue-6038  ONLINE       0     0     0
	  mirror-0  ONLINE       0     0     0
	    vda     ONLINE       0     0     0
	    vdb     ONLINE       0     0     0

errors: No known data errors

  pool: issue-6038
 state: ONLINE
status: Some supported features are not enabled on the pool. The pool can
	still be used, but some features are unavailable.
action: Enable all features using 'zpool upgrade'. Once this is done,
	the pool may no longer be accessible by software that does not support
	the features. See zpool-features(5) for details.
  scan: scrub in progress since Fri Jun 16 23:33:35 2017
    113M scanned out of 128M at 5.39M/s, 0h0m to go
    0 repaired, 88.07% done
config:

	NAME        STATE     READ WRITE CKSUM
	issue-6038  ONLINE       0     0     0
	  mirror-0  ONLINE       0     0     0
	    vda     ONLINE       0     0     0
	    vdb     ONLINE       0     0     0

errors: No known data errors

  pool: issue-6038
 state: ONLINE
status: One or more devices has experienced an unrecoverable error.  An
	attempt was made to correct the error.  Applications are unaffected.
action: Determine if the device needs to be replaced, and clear the errors
	using 'zpool clear' or replace the device with 'zpool replace'.
   see: http://zfsonlinux.org/msg/ZFS-8000-9P
  scan: scrub repaired 128K in 0h0m with 0 errors on Fri Jun 16 23:33:48 2017
config:

	NAME        STATE     READ WRITE CKSUM
	issue-6038  ONLINE       0     0     0
	  mirror-0  ONLINE       0     0     0
	    vda     ONLINE       0     0     1
	    vdb     ONLINE       0     0     0
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Systemtap, GDB

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
