### PR TITLE
Call cv_signal() with mutex held.

### DIFF
--- a/module/zfs/bqueue.c
+++ b/module/zfs/bqueue.c
@@ -97,8 +97,8 @@ bqueue_dequeue(bqueue_t *q)
 	ASSERT3P(ret, !=, NULL);
 	item_size = obj2node(q, ret)->bqn_size;
 	q->bq_size -= item_size;
-	mutex_exit(&q->bq_lock);
 	cv_signal(&q->bq_add_cv);
+	mutex_exit(&q->bq_lock);
 	return (ret);
 }
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -482,10 +482,9 @@ tests = ['reservation_001_pos', 'reservation_002_pos', 'reservation_003_pos',
 tests = ['rootpool_002_neg', 'rootpool_003_neg', 'rootpool_007_pos']
 
 # rsend_008_pos - https://github.com/zfsonlinux/zfs/issues/6066
-# rsend_009_pos - https://github.com/zfsonlinux/zfs/issues/5887
 [tests/functional/rsend]
 tests = ['rsend_001_pos', 'rsend_002_pos', 'rsend_003_pos', 'rsend_004_pos',
-    'rsend_005_pos', 'rsend_006_pos', 'rsend_007_pos',
+    'rsend_005_pos', 'rsend_006_pos', 'rsend_007_pos', 'rsend_009_pos',
     'rsend_010_pos', 'rsend_011_pos', 'rsend_012_pos',
     'rsend_013_pos', 'rsend_014_pos',
     'rsend_019_pos', 'rsend_020_pos',


### PR DESCRIPTION
In bqueue_dequeue(), call cv_signal() with bq_lock held.

Signed-off-by: Boris Protopopov <boris.protopopov@actifio.com>

<!--- Provide a general summary of your changes in the Title above -->
While testing unrelated code changes, I ran into an intermittent hang in the `dmu_recv_stream()` code that was blocked in `bqueue_enqueue()`. After reviewing the code, I came to a conclusion that the `bqueue_dequeue()` function might not be delivering the signal properly.
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
In `bqueue_dequeue()`, call `cv_signal()` with bq_lock held.  
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is to attempt to address the intermittent hang in the `dmu_recv_stream()` code blocked in `bqueue_enqueue()`.
<!--- If it fixes an open issue, please link to the issue here. -->
#5887 includes the same backtrace of the hang.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Re-enabled rsend_009_pos to see if this change addresses the hang. However, my local environment does not reproduce the failure easily.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
