### PR TITLE
Fix RHEL 7.4 bio_set_op_attrs build error

### DIFF
--- a/config/kernel-bio-op.m4
+++ b/config/kernel-bio-op.m4
@@ -69,7 +69,7 @@ AC_DEFUN([ZFS_AC_KERNEL_BIO_BI_OPF], [
 AC_DEFUN([ZFS_AC_KERNEL_HAVE_BIO_SET_OP_ATTRS], [
 	AC_MSG_CHECKING([whether bio_set_op_attrs is available])
 	ZFS_LINUX_TRY_COMPILE([
-		#include <linux/blk_types.h>
+		#include <linux/bio.h>
 	],[
 		struct bio *bio __attribute__ ((unused)) = NULL;
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
On RHEL 7.4, `include/linux/bio.h` now includes a macro for
`bio_set_op_attrs` that conflicts with the ifndef in ZFS's
`include/linux/blkdev_compat.h`.  This patch fixes the build.

Signed-off-by: Tony Hutter <hutter2@llnl.gov>
### Motivation and Context
Fix build error (https://github.com/zfsonlinux/zfs/issues/6234)

### How Has This Been Tested?
Fixes build on RHEL server 7.4 beta.  Test loaded module.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
