### PR TITLE
ZED: Auto-sparing should handle multiple faults

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2859,7 +2859,7 @@ zpool_vdev_attach(zpool_handle_t *zhp,
 	case EBUSY:
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "%s is busy"),
 		    new_disk);
-		(void) zfs_error(hdl, EZFS_BADDEV, msg);
+		(void) zfs_error(hdl, EZFS_BUSY, msg);
 		break;
 
 	case EOVERFLOW:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When zed detects faults and tries to spare a drive it will fail if a
rebuild/resilver is in process. Zed now detects that the failure is because a
rebuild/resilver is in progress and saves the request off to later so it can be
attempted again when we recive notification of the rebuild/resilver being
finished.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
The zed retire-agent has been modified to save off spare requests that fail due to the pool being busy and replay them when resilvering/rebuilding is complete.
<!--- Describe your changes in detail -->

### Motivation and Context
Multiple faults would have their sparing requests dropped on the floor. This saves them and replays them later.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
Created a pool with 3 drives and faulted 3 drives so zed would spare them out and waited for them to spare in each drive after rebuilds. Demoed live in front of Brian B.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
