### PR TITLE
Print fail messages before callbacks in test suite

### DIFF
--- a/tests/test-runner/include/logapi.shlib
+++ b/tests/test-runner/include/logapi.shlib
@@ -418,7 +418,11 @@ function _endlog
 	typeset logfile="/tmp/log.$$"
 	_recursive_output $logfile
 
-	if [[ $1 == $STF_FAIL ]] ; then
+	typeset exitcode=$1
+	shift
+	(( ${#@} > 0 )) && _printline "$@"
+
+	if [[ $exitcode == $STF_FAIL ]] ; then
 		_execute_testfail_callbacks
 	fi
 
@@ -428,9 +432,7 @@ function _endlog
 		log_note "Performing local cleanup via log_onexit ($cleanup)"
 		$cleanup
 	fi
-	typeset exitcode=$1
-	shift
-	(( ${#@} > 0 )) && _printline "$@"
+
 	exit $exitcode
 }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
When a test fails, print out the message provided to `log_fail` before executing test failure callbacks.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Useful information is printed with `log_fail` regarding exactly why a test failed. Problem is, you have to hunt for the `log_fail` message because it is printed after the test failure callbacks.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Ran the test suite in a VM to verify test log output looks sane.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
