### PR TITLE
Convert man zfs.8 to mdoc (OpenZFS sync)

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1,4 +1,3 @@
-'\" t
 .\"
 .\" CDDL HEADER START
 .\"
@@ -23,3237 +22,3465 @@
 .\" Copyright (c) 2009 Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright 2011 Joshua M. Clulow <josh@sysmgr.org>
 .\" Copyright (c) 2011, 2016 by Delphix. All rights reserved.
-.\" Copyright (c) 2014, Joyent, Inc. All rights reserved.
-.\" Copyright 2012 Nexenta Systems, Inc. All Rights Reserved.
 .\" Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
+.\" Copyright (c) 2014, Joyent, Inc. All rights reserved.
+.\" Copyright (c) 2014 by Adam Stevko. All rights reserved.
+.\" Copyright (c) 2014 Integros [integros.com]
+.\" Copyright 2016 Nexenta Systems, Inc.
 .\" Copyright 2016 Richard Laager. All rights reserved.
 .\"
-.TH zfs 8 "May 11, 2016" "ZFS pool 28, filesystem 5" "System Administration Commands"
-.SH NAME
-zfs \- configures ZFS file systems
-.SH SYNOPSIS
-.LP
-.nf
-\fBzfs\fR [\fB-?\fR]
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBcreate\fR [\fB-p\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... \fIfilesystem\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBcreate\fR [\fB-ps\fR] [\fB-b\fR \fIblocksize\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... \fB-V\fR \fIsize\fR \fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBdestroy\fR [\fB-fnpRrv\fR] \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBdestroy\fR [\fB-dnpRrv\fR] \fIfilesystem\fR|\fIvolume\fR@\fIsnap\fR[%\fIsnap\fR][,...]
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBdestroy\fR \fIfilesystem\fR|\fIvolume\fR#\fIbookmark\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBsnapshot | snap\fR [\fB-r\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ...
-      \fIfilesystem@snapname\fR|\fIvolume@snapname\fR ...
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBrollback\fR [\fB-rRf\fR] \fIsnapshot\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBclone\fR [\fB-p\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... \fIsnapshot\fR \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBpromote\fR \fIclone-filesystem\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBrename\fR [\fB-f\fR] \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR
-     \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBrename\fR [\fB-fp\fR] \fIfilesystem\fR|\fIvolume\fR \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBrename\fR \fB-r\fR \fIsnapshot\fR \fIsnapshot\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBlist\fR [\fB-r\fR|\fB-d\fR \fIdepth\fR][\fB-Hp\fR][\fB-o\fR \fIproperty\fR[,\fIproperty\fR]...] [\fB-t\fR \fItype\fR[,\fItype\fR]..]
-     [\fB-s\fR \fIproperty\fR] ... [\fB-S\fR \fIproperty\fR] ... [\fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR|\fImountpoint\fR] ...
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBset\fR \fIproperty\fR=\fIvalue\fR... \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR...
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBget\fR [\fB-r\fR|\fB-d\fR \fIdepth\fR][\fB-Hp\fR][\fB-o\fR \fIfield\fR[,...]] [\fB-t\fR \fItype\fR[,...]]
-    [\fB-s\fR \fIsource\fR[,...]] "\fIall\fR" | \fIproperty\fR[,...] \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR|\fImountpoint\fR ...
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBinherit\fR [\fB-rS\fR] \fIproperty\fR \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR ...
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBupgrade\fR [\fB-v\fR]
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBupgrade\fR [\fB-r\fR] [\fB-V\fR \fIversion\fR] \fB-a\fR | \fIfilesystem\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBuserspace\fR [\fB-Hinp\fR] [\fB-o\fR \fIfield\fR[,...]] [\fB-s\fR \fIfield\fR] ...
-    [\fB-S\fR \fIfield\fR] ... [\fB-t\fR \fItype\fR[,...]] \fIfilesystem\fR|\fIsnapshot\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBgroupspace\fR [\fB-Hinp\fR] [\fB-o\fR \fIfield\fR[,...]] [\fB-s\fR \fIfield\fR] ...
-    [\fB-S\fR \fIfield\fR] ... [\fB-t\fR \fItype\fR[,...]] \fIfilesystem\fR|\fIsnapshot\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBmount\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBmount\fR [\fB-vO\fR] [\fB-o \fIoptions\fR\fR] \fB-a\fR | \fIfilesystem\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBunmount | umount\fR [\fB-f\fR] \fB-a\fR | \fIfilesystem\fR|\fImountpoint\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBshare\fR [\fBnfs\fR|\fBsmb\fR] \fB-a\fR | \fIfilesystem\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBunshare\fR [\fBnfs\fR|\fBsmb\fR] \fB-a\fR | \fIfilesystem\fR|\fImountpoint\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBbookmark\fR \fIsnapshot\fR \fIbookmark\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBsend\fR [\fB-DnPpRveLc\fR] [\fB-\fR[\fBi\fR|\fBI\fR] \fIsnapshot\fR] \fIsnapshot\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBsend\fR [\fB-Lec\fR] [\fB-i \fIsnapshot\fR|\fIbookmark\fR]\fR \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBsend\fR [\fB-Penv\fR] \fB-t\fR \fIreceive_resume_token\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBreceive\fR [\fB-Fnsuv\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... [\fB-x\fR \fIproperty\fR] ...
-     \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBreceive\fR [\fB-Fnsuv\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... [\fB-x\fR \fIproperty\fR] ...
-     [\fB-d\fR|\fB-e\fR] \fIfilesystem\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBreceive\fR \fB-A\fR \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBallow\fR \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBallow\fR [\fB-ldug\fR] "\fIeveryone\fR"|\fIuser\fR|\fIgroup\fR[,...] \fIperm\fR|\fI@setname\fR[,...]
-     \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBallow\fR [\fB-ld\fR] \fB-e\fR \fIperm\fR|@\fIsetname\fR[,...] \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBallow\fR \fB-c\fR \fIperm\fR|@\fIsetname\fR[,...] \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBallow\fR \fB-s\fR @\fIsetname\fR \fIperm\fR|@\fIsetname\fR[,...] \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBunallow\fR [\fB-rldug\fR] "\fIeveryone\fR"|\fIuser\fR|\fIgroup\fR[,...] [\fIperm\fR|@\fIsetname\fR[,... ]]
-     \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBunallow\fR [\fB-rld\fR] \fB-e\fR [\fIperm\fR|@\fIsetname\fR[,... ]] \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBunallow\fR [\fB-r\fR] \fB-c\fR [\fIperm\fR|@\fIsetname\fR[ ... ]] \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBunallow\fR [\fB-r\fR] \fB-s\fR @\fIsetname\fR [\fIperm\fR|@\fIsetname\fR[,... ]] \fIfilesystem\fR|\fIvolume\fR
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBhold\fR [\fB-r\fR] \fItag\fR \fIsnapshot\fR...
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBholds\fR [\fB-r\fR] \fIsnapshot\fR...
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBrelease\fR [\fB-r\fR] \fItag\fR \fIsnapshot\fR...
-.fi
-
-.LP
-.nf
-\fBzfs\fR \fBdiff\fR [\fB-FHt\fR] \fIsnapshot\fR \fIsnapshot\fR|\fIfilesystem\fR
-
-.SH DESCRIPTION
-.LP
-The \fBzfs\fR command configures \fBZFS\fR datasets within a \fBZFS\fR storage pool, as described in \fBzpool\fR(8). A dataset is identified by a unique path within the \fBZFS\fR namespace. For example:
-.sp
-.in +2
-.nf
+.Dd June 28, 2017
+.Dt ZFS 8 SMM
+.Os Linux
+.Sh NAME
+.Nm zfs
+.Nd configures ZFS file systems
+.Sh SYNOPSIS
+.Nm
+.Fl ?
+.Nm
+.Cm create
+.Op Fl p
+.Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
+.Ar filesystem
+.Nm
+.Cm create
+.Op Fl ps
+.Op Fl b Ar blocksize
+.Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
+.Fl V Ar size Ar volume
+.Nm
+.Cm destroy
+.Op Fl Rfnprv
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm destroy
+.Op Fl Rdnprv
+.Ar filesystem Ns | Ns Ar volume Ns @ Ns Ar snap Ns
+.Oo % Ns Ar snap Ns Oo , Ns Ar snap Ns Oo % Ns Ar snap Oc Oc Oc Ns ...
+.Nm
+.Cm destroy
+.Ar filesystem Ns | Ns Ar volume Ns # Ns Ar bookmark
+.Nm
+.Cm snapshot
+.Op Fl r
+.Oo Fl o Ar property Ns = Ns value Oc Ns ...
+.Ar filesystem Ns @ Ns Ar snapname Ns | Ns Ar volume Ns @ Ns Ar snapname Ns ...
+.Nm
+.Cm rollback
+.Op Fl Rfr
+.Ar snapshot
+.Nm
+.Cm clone
+.Op Fl p
+.Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
+.Ar snapshot Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm promote
+.Ar clone-filesystem
+.Nm
+.Cm rename
+.Op Fl f
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
+.Nm
+.Cm rename
+.Op Fl fp
+.Ar filesystem Ns | Ns Ar volume
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm rename
+.Fl r
+.Ar snapshot Ar snapshot
+.Nm
+.Cm list
+.Op Fl r Ns | Ns Fl d Ar depth
+.Op Fl Hp
+.Oo Fl o Ar property Ns Oo , Ns Ar property Oc Ns ... Oc
+.Oo Fl s Ar property Oc Ns ...
+.Oo Fl S Ar property Oc Ns ...
+.Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
+.Oo Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Oc Ns ...
+.Nm
+.Cm set
+.Ar property Ns = Ns Ar value Oo Ar property Ns = Ns Ar value Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns ...
+.Nm
+.Cm get
+.Op Fl r Ns | Ns Fl d Ar depth
+.Op Fl Hp
+.Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns ... Oc
+.Oo Fl s Ar source Ns Oo , Ns Ar source Oc Ns ... Oc
+.Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
+.Cm all | Ar property Ns Oo , Ns Ar property Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns | Ns Ar bookmark Ns ...
+.Nm
+.Cm inherit
+.Op Fl rS
+.Ar property Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns ...
+.Nm
+.Cm upgrade
+.Nm
+.Cm upgrade
+.Fl v
+.Nm
+.Cm upgrade
+.Op Fl r
+.Op Fl V Ar version
+.Fl a | Ar filesystem
+.Nm
+.Cm userspace
+.Op Fl Hinp
+.Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns ... Oc
+.Oo Fl s Ar field Oc Ns ...
+.Oo Fl S Ar field Oc Ns ...
+.Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar snapshot
+.Nm
+.Cm groupspace
+.Op Fl Hinp
+.Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns ... Oc
+.Oo Fl s Ar field Oc Ns ...
+.Oo Fl S Ar field Oc Ns ...
+.Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar snapshot
+.Nm
+.Cm mount
+.Nm
+.Cm mount
+.Op Fl Ov
+.Op Fl o Ar options
+.Fl a | Ar filesystem
+.Nm
+.Cm unmount
+.Op Fl f
+.Fl a | Ar filesystem Ns | Ns Ar mountpoint
+.Nm
+.Cm share
+.Fl a | Ar filesystem
+.Nm
+.Cm unshare
+.Fl a | Ar filesystem Ns | Ns Ar mountpoint
+.Nm
+.Cm bookmark
+.Ar snapshot bookmark
+.Nm
+.Cm send
+.Op Fl DLPRcenpv
+.Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
+.Ar snapshot
+.Nm
+.Cm send
+.Op Fl Lce
+.Op Fl i Ar snapshot Ns | Ns Ar bookmark
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
+.Nm
+.Cm send
+.Op Fl Penv
+.Fl t Ar receive_resume_token
+.Nm
+.Cm receive
+.Op Fl Fnsuv
+.Op Fl o Sy origin Ns = Ns Ar snapshot
+.Op Fl o Ar property Ns = Ns Ar value
+.Op Fl x Ar property
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
+.Nm
+.Cm receive
+.Op Fl Fnsuv
+.Op Fl d Ns | Ns Fl e
+.Op Fl o Sy origin Ns = Ns Ar snapshot
+.Op Fl o Ar property Ns = Ns Ar value
+.Op Fl x Ar property
+.Ar filesystem
+.Nm
+.Cm receive
+.Fl A
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm allow
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm allow
+.Op Fl dglu
+.Ar user Ns | Ns Ar group Ns Oo , Ns Ar user Ns | Ns Ar group Oc Ns ...
+.Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm allow
+.Op Fl dl
+.Fl e Ns | Ns Sy everyone
+.Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm allow
+.Fl c
+.Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm allow
+.Fl s No @ Ns Ar setname
+.Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm unallow
+.Op Fl dglru
+.Ar user Ns | Ns Ar group Ns Oo , Ns Ar user Ns | Ns Ar group Oc Ns ...
+.Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm unallow
+.Op Fl dlr
+.Fl e Ns | Ns Sy everyone
+.Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm unallow
+.Op Fl r
+.Fl c
+.Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm unallow
+.Op Fl r
+.Fl s @ Ns Ar setname
+.Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar volume
+.Nm
+.Cm hold
+.Op Fl r
+.Ar tag Ar snapshot Ns ...
+.Nm
+.Cm holds
+.Op Fl r
+.Ar snapshot Ns ...
+.Nm
+.Cm release
+.Op Fl r
+.Ar tag Ar snapshot Ns ...
+.Nm
+.Cm diff
+.Op Fl FHt
+.Ar snapshot Ar snapshot Ns | Ns Ar filesystem
+.Sh DESCRIPTION
+The
+.Nm
+command configures ZFS datasets within a ZFS storage pool, as described in
+.Xr zpool 8 .
+A dataset is identified by a unique path within the ZFS namespace.
+For example:
+.Bd -literal
 pool/{filesystem,volume,snapshot}
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-where the maximum length of a dataset name is \fBMAXNAMELEN\fR (256 bytes).
-.sp
-.LP
+.Ed
+.Pp
+where the maximum length of a dataset name is
+.Dv MAXNAMELEN
+.Pq 256 bytes .
+.Pp
 A dataset can be one of the following:
-.sp
-.ne 2
-.na
-\fB\fIfilesystem\fR\fR
-.ad
-.sp .6
-.RS 4n
-A \fBZFS\fR dataset of type \fBfilesystem\fR can be mounted within the standard system namespace and behaves like other file systems. While \fBZFS\fR file systems are designed to be \fBPOSIX\fR compliant, known issues exist that prevent compliance in some cases. Applications that depend on standards conformance might fail due to nonstandard behavior when checking file system free space.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-A logical volume exported as a raw or block device. This type of dataset should only be used under special circumstances. File systems are typically used in most environments.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fIsnapshot\fR\fR
-.ad
-.sp .6
-.RS 4n
-A read-only version of a file system or volume at a given point in time. It is specified as \fIfilesystem@name\fR or \fIvolume@name\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fIbookmark\fR\fR
-.ad
-.sp .6
-.RS 4n
-Much like a \fIsnapshot\fR, but without the hold on on-disk data. It can be used as the source of a send (but not for a receive).
-It is specified as \fIfilesystem#name\fR or \fIvolume#name\fR.
-.RE
-
-.SS "ZFS File System Hierarchy"
-.LP
-A \fBZFS\fR storage pool is a logical collection of devices that provide space for datasets. A storage pool is also the root of the \fBZFS\fR file system hierarchy.
-.sp
-.LP
-The root of the pool can be accessed as a file system, such as mounting and unmounting, taking snapshots, and setting properties. The physical storage characteristics, however, are managed by the \fBzpool\fR(8) command.
-.sp
-.LP
-See \fBzpool\fR(8) for more information on creating and administering pools.
-.SS "Snapshots"
-.LP
-A snapshot is a read-only copy of a file system or volume. Snapshots can be created extremely quickly, and initially consume no additional space within the pool. As data within the active dataset changes, the snapshot consumes more data than would otherwise be shared with the active dataset.
-.sp
-.LP
-Snapshots can have arbitrary names. Snapshots of volumes can be cloned or rolled back.  Visibility is determined by the \fBsnapdev\fR property of the parent volume.
-.sp
-.LP
-File system snapshots can be accessed under the \fB\&.zfs/snapshot\fR directory in the root of the file system. Snapshots are automatically mounted on demand and may be unmounted at regular intervals. The visibility of the \fB\&.zfs\fR directory can be controlled by the \fBsnapdir\fR property.
-.SS "Bookmarks"
-.LP
-A bookmark is like a snapshot, a read-only copy of a file system or volume. Bookmarks can be created extremely quickly, compared to snapshots, and they consume no additional space within the pool.  Bookmarks can also have arbitrary names, much like snapshots.
-.sp
-.LP
-Unlike snapshots, bookmarks can not be accessed through the filesystem in any way. From a storage standpoint a bookmark just provides a way to reference when a snapshot was created as a distinct object.  Bookmarks are initially tied to a snapshot, not the filesystem/volume, and they will survive if the snapshot itself is destroyed.  Since they are very light weight there's little incentive to destroy them.
-.SS "Clones"
-.LP
-A clone is a writable volume or file system whose initial contents are the same as another dataset. As with snapshots, creating a clone is nearly instantaneous, and initially consumes no additional space.
-.sp
-.LP
-Clones can only be created from a snapshot. When a snapshot is cloned, it creates an implicit dependency between the parent and child. Even though the clone is created somewhere else in the dataset hierarchy, the original snapshot cannot be destroyed as long as a clone exists. The \fBorigin\fR property exposes this dependency, and the \fBdestroy\fR command lists any such dependencies, if they exist.
-.sp
-.LP
-The clone parent-child dependency relationship can be reversed by using the \fBpromote\fR subcommand. This causes the "origin" file system to become a clone of the specified file system, which makes it possible to destroy the file system that the clone was created from.
-.SS "Mount Points"
-.LP
-Creating a \fBZFS\fR file system is a simple operation, so the number of file systems per system is likely to be numerous. To cope with this, \fBZFS\fR automatically manages mounting and unmounting file systems without the need to edit the \fB/etc/fstab\fR file. All automatically managed file systems are mounted by \fBZFS\fR at boot time.
-.sp
-.LP
-By default, file systems are mounted under \fB/\fIpath\fR\fR, where \fIpath\fR is the name of the file system in the \fBZFS\fR namespace. Directories are created and destroyed as needed.
-.sp
-.LP
-A file system can also have a mount point set in the \fBmountpoint\fR property. This directory is created as needed, and \fBZFS\fR automatically mounts the file system when the \fBzfs mount -a\fR command is invoked (without editing \fB/etc/fstab\fR). The \fBmountpoint\fR property can be inherited, so if \fBpool/home\fR has a mount point of \fB/export/stuff\fR, then \fBpool/home/user\fR automatically inherits a mount point of \fB/export/stuff/user\fR.
-.sp
-.LP
-A file system \fBmountpoint\fR property of \fBnone\fR prevents the file system from being mounted.
-.sp
-.LP
-If needed, \fBZFS\fR file systems can also be managed with traditional tools (\fBmount\fR, \fBumount\fR, \fB/etc/fstab\fR). If a file system's mount point is set to \fBlegacy\fR, \fBZFS\fR makes no attempt to manage the file system, and the administrator is responsible for mounting and unmounting the file system.
-.SS "Deduplication"
-.LP
-Deduplication is the process for removing redundant data at the block-level, reducing the total amount of data stored. If a file system has the \fBdedup\fR property enabled, duplicate data blocks are removed synchronously.  The result is that only unique data is stored and common components are shared among files.
-.sp
-\fBWARNING: DO NOT ENABLE DEDUPLICATION UNLESS YOU NEED IT AND KNOW EXACTLY WHAT YOU ARE DOING!\fR
-.sp
-Deduplicating data is a very resource-intensive operation. It is generally recommended that you have \fIat least\fR 1.25 GiB of RAM per 1 TiB of storage when you enable deduplication. But calculating the exact requirements is a somewhat complicated affair.
-.sp
-Enabling deduplication on an improperly-designed system will result in extreme performance issues (extremely slow filesystem and snapshot deletions etc.) and can potentially lead to data loss (i.e. unimportable pool due to memory exhaustion) if your system is not built for this purpose. Deduplication affects the processing power (CPU), disks (and the controller) as well as primary (real) memory.
-.sp
-Before creating a pool with deduplication enabled, ensure that you have planned your hardware requirements appropriately and implemented appropriate recovery practices, such as regular backups.
-.sp
-Unless necessary, deduplication should NOT be enabled on a system. Instead, consider using \fIcompression=lz4\fR, as a less resource-intensive alternative.
-.SS "Properties"
-.sp
-.LP
-Properties are divided into two types: native properties and user-defined (or "user") properties. Native properties either export internal statistics or control \fBZFS\fR behavior. User properties have no effect on \fBZFS\fR behavior, but you can use them to annotate datasets and snapshots in a way that is meaningful in your environment.
-.sp
-.LP
-Properties are generally inherited from the parent unless overridden by the child. See the documentation below for exceptions.
-.sp
-.LP
-.SS "Native Properties"
-Native properties apply to all dataset types unless otherwise noted. However, native properties cannot be edited on snapshots.
-.sp
-.LP
-The values of numeric native properties can be specified using human-readable abbreviations (\fBK\fR, \fBM\fR, \fBG\fR, \fBT\fR, \fBP\fR, \fBE\fR, and \fBZ\fR). These abbreviations can optionally use the IEC binary prefixes (e.g. GiB) or SI decimal prefixes (e.g. GB), though the SI prefixes are treated as binary prefixes. Abbreviations are case-insensitive. The following are all valid (and equal) specifications:
-.sp
-.in +2
-.nf
-1536M, 1.5g, 1.50GB, 1.5GiB
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-The values of non-numeric native properties are case-sensitive and must be lowercase, except for \fBmountpoint\fR, \fBsharenfs\fR, and \fBsharesmb\fR.
-.sp
-.LP
-The following native properties consist of read-only statistics about the dataset. These properties can be neither set, nor inherited.
-.sp
-.ne 2
-.na
-\fB\fBavailable\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space available to the dataset and all its children, assuming that there is no other activity in the pool. Because space is shared within a pool, availability can be limited by any number of factors, including physical pool size, quotas, reservations, or other datasets within the pool.
-.sp
-This property can also be referred to by its shortened column name, \fBavail\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBcompressratio\fR\fR
-.ad
-.sp .6
-.RS 4n
-For non-snapshots, the compression ratio achieved for the \fBused\fR space of this dataset, expressed as a multiplier.  The \fBused\fR property includes descendant datasets, and, for clones, does not include the space shared with the origin snapshot.  For snapshots, the \fBcompressratio\fR is the same as the \fBrefcompressratio\fR property.  The \fBcompression\fR property controls whether compression is enabled on a dataset.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBcreatetxg\fR
-.ad
-.sp .6
-.RS 4n
-The transaction group (TXG) in which the dataset was created. Bookmarks have the same \fBcreatetxg\fR as the snapshot they are initially tied to.
-.sp
-\fBcreatetxg\fR is suitable for ordering a list of snapshots, e.g. for incremental \fBsend\fR & \fBrecv\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBcreation\fR\fR
-.ad
-.sp .6
-.RS 4n
-The time this dataset was created.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBclones\fR\fR
-.ad
-.sp .6
-.RS 4n
-For snapshots, this property is a comma-separated list of filesystems or
-volumes which are clones of this snapshot.  The clones' \fBorigin\fR property
-is this snapshot.  If the \fBclones\fR property is not empty, then this
-snapshot can not be destroyed (even with the \fB-r\fR or \fB-f\fR options). The
-roles of origin and clone can be swapped by promoting the clone with the
-\fBzfs promote\fR command.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBdefer_destroy\fR\fR
-.ad
-.sp .6
-.RS 4n
-This property is \fBon\fR if the snapshot has been marked for deferred destruction by using the \fBzfs destroy\fR \fB-d\fR command. Otherwise, the property is \fBoff\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBfilesystem_count\fR
-.ad
-.sp .6
-.RS 4n
-The total number of filesystems and volumes that exist under this location in the
-dataset tree.  This value is only available when a \fBfilesystem_limit\fR has
-been set somewhere in the tree under which the dataset resides.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBguid\fR
-.ad
-.sp .6
-.RS 4n
-The 64 bit GUID of this dataset or bookmark, which does not change over its entire lifetime.
-.sp
-When a snapshot is sent to another pool, the received snapshot has the same GUID. Thus, \fBguid\fR is suitable to identify a snapshot across pools.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBlogicalreferenced\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space that is "logically" accessible by this dataset.  See
-the \fBreferenced\fR property.  The logical space ignores the effect of
-the \fBcompression\fR and \fBcopies\fR properties, giving a quantity
-closer to the amount of data that applications see.  However, it does
-include space consumed by metadata.
-.sp
-This property can also be referred to by its shortened column name,
-\fBlrefer\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBlogicalused\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space that is "logically" consumed by this dataset and all
-its descendents.  See the \fBused\fR property.  The logical space
-ignores the effect of the \fBcompression\fR and \fBcopies\fR properties,
-giving a quantity closer to the amount of data that applications see.
-However, it does include space consumed by metadata.
-.sp
-This property can also be referred to by its shortened column name,
-\fBlused\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBmounted\fR\fR
-.ad
-.sp .6
-.RS 4n
-For file systems, indicates whether the file system is currently mounted. This property can be either \fByes\fR or \fBno\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBorigin\fR\fR
-.ad
-.sp .6
-.RS 4n
-For cloned file systems or volumes, the snapshot from which the clone was created. The origin cannot be destroyed (even with the \fB-r\fR or \fB-f\fR options) so long as a clone exists. See also the \fBclones\fR property.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBreceive_resume_token\fR\fR
-.ad
-.sp .6
-.RS 4n
-For filesystems or volumes which have saved partially-completed state from \fBzfs receive -s\fR , this opaque token can be provided to \fBzfs send -t\fR to resume and complete the \fBzfs receive\fR.
-.RE
-
-.sp
-.ne 2
-.mk
-.na
-\fB\fBreferenced\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of data that is accessible by this dataset, which may or may not be shared with other datasets in the pool. When a snapshot or clone is created, it initially references the same amount of space as the file system or snapshot it was created from, since its contents are identical.
-.sp
-This property can also be referred to by its shortened column name, \fBrefer\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBrefcompressratio\fR\fR
-.ad
-.sp .6
-.RS 4n
-The compression ratio achieved for the \fBreferenced\fR space of this
-dataset, expressed as a multiplier.  See also the \fBcompressratio\fR
+.Bl -tag -width "file system"
+.It Sy file system
+A ZFS dataset of type
+.Sy filesystem
+can be mounted within the standard system namespace and behaves like other file
+systems.
+While ZFS file systems are designed to be POSIX compliant, known issues exist
+that prevent compliance in some cases.
+Applications that depend on standards conformance might fail due to non-standard
+behavior when checking file system free space.
+.It Sy volume
+A logical volume exported as a raw or block device.
+This type of dataset should only be used under special circumstances.
+File systems are typically used in most environments.
+.It Sy snapshot
+A read-only version of a file system or volume at a given point in time.
+It is specified as
+.Ar filesystem Ns @ Ns Ar name
+or
+.Ar volume Ns @ Ns Ar name .
+.It Sy bookmark
+Much like a
+.Sy snapshot ,
+but without the hold on on-disk data. It can be used as the source of a send
+(but not for a receive). It is specified as
+.Ar filesystem Ns # Ns Ar name
+or
+.Ar volume Ns # Ns Ar name .
+.El
+.Ss ZFS File System Hierarchy
+A ZFS storage pool is a logical collection of devices that provide space for
+datasets.
+A storage pool is also the root of the ZFS file system hierarchy.
+.Pp
+The root of the pool can be accessed as a file system, such as mounting and
+unmounting, taking snapshots, and setting properties.
+The physical storage characteristics, however, are managed by the
+.Xr zpool 8
+command.
+.Pp
+See
+.Xr zpool 8
+for more information on creating and administering pools.
+.Ss Snapshots
+A snapshot is a read-only copy of a file system or volume.
+Snapshots can be created extremely quickly, and initially consume no additional
+space within the pool.
+As data within the active dataset changes, the snapshot consumes more data than
+would otherwise be shared with the active dataset.
+.Pp
+Snapshots can have arbitrary names.
+Snapshots of volumes can be cloned or rolled back, visibility is determined
+by the
+.Sy snapdev
+property of the parent volume.
+.Pp
+File system snapshots can be accessed under the
+.Pa .zfs/snapshot
+directory in the root of the file system.
+Snapshots are automatically mounted on demand and may be unmounted at regular
+intervals.
+The visibility of the
+.Pa .zfs
+directory can be controlled by the
+.Sy snapdir
 property.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBsnapshot_count\fR
-.ad
-.sp .6
-.RS 4n
-The total number of snapshots that exist under this location in the dataset tree.
-This value is only available when a \fBsnapshot_limit\fR has been set somewhere
-in the tree under which the dataset resides.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBtype\fR\fR
-.ad
-.sp .6
-.RS 4n
-The type of dataset: \fBfilesystem\fR, \fBvolume\fR, or \fBsnapshot\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBused\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space consumed by this dataset and all its descendents. This is the value that is checked against this dataset's quota and reservation. The space used does not include this dataset's reservation, but does take into account the reservations of any descendent datasets. The amount of space that a dataset consumes from its parent, as well as the amount of space that is freed if this dataset is recursively destroyed, is the greater of its space used and its reservation.
-.sp
-The used space of a snapshot (see the "Snapshots" section) is space that is referenced exclusively by this snapshot. If this snapshot is destroyed, the amount of \fBused\fR space will be freed. Space that is shared by multiple snapshots isn't accounted for in this metric. When a snapshot is destroyed, space that was previously shared with this snapshot can become unique to snapshots adjacent to it, thus changing the used space of those snapshots. The used space of the latest snapshot can also be affected by changes in the file system. Note that the \fBused\fR space of a snapshot is a subset of the \fBwritten\fR space of the snapshot.
-.sp
-The amount of space used, available, or referenced does not take into account pending changes. Pending changes are generally accounted for within a few seconds. Committing a change to a disk using \fBfsync\fR(2) or \fBO_SYNC\fR (see \fBopen\fR(2)) does not necessarily guarantee that the space usage information is updated immediately.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBusedby*\fR\fR
-.ad
-.sp .6
-.RS 4n
-The \fBusedby*\fR properties decompose the \fBused\fR properties into the various reasons that space is used. Specifically, \fBused\fR = \fBusedbychildren\fR + \fBusedbydataset\fR + \fBusedbyrefreservation\fR + \fBusedbysnapshots\fR. These properties are only available for datasets created on \fBzpool\fR version 13 or higher pools.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBusedbychildren\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space used by children of this dataset, which would be freed if all the dataset's children were destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBusedbydataset\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space used by this dataset itself, which would be freed if the dataset were destroyed (after first removing any \fBrefreservation\fR and destroying any necessary snapshots or descendents).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBusedbyrefreservation\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space used by a \fBrefreservation\fR set on this dataset, which would be freed if the \fBrefreservation\fR was removed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBusedbysnapshots\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space consumed by snapshots of this dataset. In particular, it is the amount of space that would be freed if all of this dataset's snapshots were destroyed. Note that this is not simply the sum of the snapshots' \fBused\fR properties because space can be shared by multiple snapshots.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBuserobjused@\fR\fIuser\fR\fR
-.br
-\fB\fBuserused@\fR\fIuser\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space consumed by the specified user in this dataset. Space is charged to the owner of each file, as displayed by \fBls\fR \fB-l\fR. The amount of space charged is displayed by \fBdu\fR and \fBls\fR \fB-s\fR. See the \fBzfs userspace\fR subcommand for more information.
-.sp
-Unprivileged users can access only their own space usage. The root user, or a user who has been granted the \fBuserused\fR privilege with \fBzfs allow\fR, can access everyone's usage.
-.sp
-The \fBuserused@\fR... properties are not displayed by \fBzfs get all\fR. The user's name must be appended after the \fB@\fR symbol, using one of the following forms:
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fIPOSIX name\fR (for example, \fBjoe\fR)
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fIPOSIX numeric ID\fR (for example, \fB789\fR)
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fISID name\fR (for example, \fBjoe.smith@mydomain\fR)
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fISID numeric ID\fR (for example, \fBS-1-123-456-789\fR)
-.RE
-.RE
-.RS 4n
-.sp
-Files created on Linux always have POSIX owners.
-.sp
-The \fBuserobjused\fR is similar to \fBuserused\fR but instead it counts the number of objects consumed by \fIuser\fR. This feature doesn't count the internal objects used by ZFS, therefore it may under count a few objects comparing with the results of third-party tool such as \fBdfs -i\fR.
-When the property \fBxattr=on\fR is set on a fileset, ZFS will create additional objects per-file to store extended attributes. These additional objects are reflected in the \fBuserobjused\fR value and are counted against the user's \fBuserobjquota\fR. When a filesystem is configured to use \fBxattr=sa\fR no additional internal objects are required.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBuserrefs\fR\fR
-.ad
-.sp .6
-.RS 4n
-This property is set to the number of user holds on this snapshot. User holds are set by using the \fBzfs hold\fR command.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBgroupused@\fR\fIgroup\fR\fR
-.br
-\fB\fBgroupobjused@\fR\fIgroup\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space consumed by the specified group in this dataset. Space is charged to the group of each file, as displayed by \fBls\fR \fB-l\fR. See the \fBuserused@\fR\fIuser\fR property for more information.
-.sp
-Unprivileged users can only access their own groups' space usage. The root user, or a user who has been granted the \fBgroupused\fR privilege with \fBzfs allow\fR, can access all groups' usage.
-.RE
-
-.RS 4n
-The \fBgroupobjused\fR is similar to \fBgroupused\fR but instead it counts the number of objects consumed by \fIgroup\fR.
-When the property \fBxattr=on\fR is set on a fileset, ZFS will create additional objects per-file to store extended attributes. These additional objects are reflected in the \fBgroupobjused\fR value and are counted against the group's \fBgroupobjquota.\fR. When a filesystem is configured to use \fBxattr=sa\fR no additional internal objects are required.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBvolblocksize\fR=\fIblocksize\fR\fR
-.ad
-.sp .6
-.RS 4n
-This property, which is only valid on volumes, specifies the block size of the volume. Any power of two from 512B to 128KiB is valid. The default is 8KiB.
-.sp
-This property cannot be changed after the volume is created.
-.sp
-This property can also be referred to by its shortened column name, \fBvolblock\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBwritten\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of space \fBreferenced\fR by this dataset, that was written since the previous snapshot
-(i.e. that is not referenced by the previous snapshot).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBwritten@\fR\fIsnapshot\fR\fR
-.ad
-.sp .6
-.RS 4n
-The amount of \fBreferenced\fR space written to this dataset since the
-specified snapshot.  This is the space that is referenced by this dataset
-but was not referenced by the specified snapshot.
-.sp
-The \fIsnapshot\fR may be specified as a short snapshot name (just the part
-after the \fB@\fR), in which case it will be interpreted as a snapshot in
-the same filesystem as this dataset.
-The \fIsnapshot\fR be a full snapshot name (\fIfilesystem\fR@\fIsnapshot\fR),
-which for clones may be a snapshot in the origin's filesystem (or the origin
-of the origin's filesystem, etc).
-.RE
-
-.sp
-.LP
-The following native properties can be used to change the behavior of a \fBZFS\fR dataset.
-.sp
-.ne 2
-.na
-\fB\fBaclinherit\fR=\fBrestricted\fR | \fBdiscard\fR | \fBnoallow\fR | \fBpassthrough\fR | \fBpassthrough-x\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls how \fBACL\fR entries are inherited when files and directories are created. A file system with an \fBaclinherit\fR property of \fBdiscard\fR does not inherit any \fBACL\fR entries. A file system with an \fBaclinherit\fR property value of \fBnoallow\fR only inherits inheritable \fBACL\fR entries that specify "deny" permissions. The property value \fBrestricted\fR (the default) removes the \fBwrite_acl\fR and \fBwrite_owner\fR permissions when the \fBACL\fR entry is inherited. A file system with an \fBaclinherit\fR property value of \fBpassthrough\fR inherits all inheritable \fBACL\fR entries without any modifications made to the \fBACL\fR entries when they are inherited. A file system with an \fBaclinherit\fR property value of \fBpassthrough-x\fR has the same meaning as \fBpassthrough\fR, except that the \fBowner@\fR, \fBgroup@\fR, and \fBeveryone@\fR \fBACE\fRs inherit the execute permission only if the file creation mode also requests the execute bit.
-.sp
-When the property value is set to \fBpassthrough\fR, files are created with a mode determined by the inheritable \fBACE\fRs. If no inheritable \fBACE\fRs exist that affect the mode, then the mode is set in accordance to the requested mode from the application.
-.sp
-The \fBaclinherit\fR property does not apply to Posix ACLs.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBacltype\fR=\fBoff\fR | \fBnoacl\fR | \fBposixacl\fR \fR
-.ad
-.sp .6
-.RS 4n
-Controls whether ACLs are enabled and if so what type of ACL to use.  When
-a file system has the \fBacltype\fR property set to \fBoff\fR (the default)
-then ACLs are disabled.  Setting the \fBacltype\fR property to \fBposixacl\fR
-indicates Posix ACLs should be used.  Posix ACLs are specific to Linux and
-are not functional on other platforms.  Posix ACLs are stored as an xattr and
-therefore will not overwrite any existing ZFS/NFSv4 ACLs which may be set.
-Currently only \fBposixacls\fR are supported on Linux.
-.sp
-To obtain the best performance when setting \fBposixacl\fR users are strongly
-encouraged to set the \fBxattr=sa\fR property.  This will result in the
-Posix ACL being stored more efficiently on disk.  But as a consequence of this
-all new xattrs will only be accessible from ZFS implementations which support
-the \fBxattr=sa\fR property.  See the \fBxattr\fR property for more details.
-.sp
-The value \fBnoacl\fR is an alias for \fBoff\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBatime\fR=\fBon\fR | \fBoff\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether the access time for files is updated when they are read. Setting this property to \fBoff\fR avoids producing write traffic when reading files and can result in significant performance gains, though it might confuse mailers and other similar utilities. The default value is \fBon\fR.  See also \fBrelatime\fR below.
-.sp
-The values \fBon\fR and \fBoff\fR are equivalent to the \fBatime\fR and \fBnoatime\fR mount options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBcanmount\fR=\fBon\fR | \fBoff\fR | \fBnoauto\fR\fR
-.ad
-.sp .6
-.RS 4n
-If this property is set to \fBoff\fR, the file system cannot be mounted, and is ignored by \fBzfs mount -a\fR. Setting this property to \fBoff\fR is similar to setting the \fBmountpoint\fR property to \fBnone\fR, except that the dataset still has a normal \fBmountpoint\fR property, which can be inherited. Setting this property to \fBoff\fR allows datasets to be used solely as a mechanism to inherit properties. One example of setting \fBcanmount=\fR\fBoff\fR is to have two datasets with the same \fBmountpoint\fR, so that the children of both datasets appear in the same directory, but might have different inherited characteristics.
-.sp
-When the \fBnoauto\fR option is set, a dataset can only be mounted and unmounted explicitly. The dataset is not mounted automatically when the dataset is created or imported, nor is it mounted by the \fBzfs mount -a\fR command or unmounted by the \fBzfs unmount -a\fR command.
-.sp
-This property is not inherited. Every dataset defaults to \fBon\fR independently.
-.sp
-The values \fBon\fR and \fBnoauto\fR are equivalent to the \fBauto\fR and \fBnoauto\fR mount options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBchecksum\fR=\fBon\fR | \fBoff\fR | \fBfletcher2\fR | \fBfletcher4\fR | \fBsha256\fR | \fBnoparity\fR | \fBsha512\fR | \fBskein\fR | \fBedonr\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls the checksum used to verify data integrity. The default value is
-\fBon\fR, which automatically selects an appropriate algorithm (currently,
-\fBfletcher4\fR, but this may change in future releases). The value \fBoff\fR
-disables integrity checking on user data.  The value \fBnoparity\fR not only
-disables integrity but also disables maintaining parity for user data.
-This setting is used internally by a dump device residing on a RAID-Z pool and
-should not be used by any other dataset.  Disabling checksums is \fBNOT\fR a
-recommended practice.
-.sp
-The \fBsha512\fR, \fBskein\fR, and \fBedonr\fR checksum algorithms require
-enabling the appropriate features on the pool. Please see zpool-features for
-more information on these algorithms.
-
-Changing this property affects only newly-written data.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBcompression\fR=\fBoff\fR | \fBon\fR | \fBlzjb\fR | \fBlz4\fR |
-\fBgzip\fR | \fBgzip-\fR\fIN\fR | \fBzle\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls the compression algorithm used for this dataset.
-.sp
-Setting compression to \fBon\fR indicates that the current default
-compression algorithm should be used.  The default balances compression
-and decompression speed, with compression ratio and is expected to
-work well on a wide variety of workloads.  Unlike all other settings for
-this property, \fBon\fR does not select a fixed compression type.  As
-new compression algorithms are added to ZFS and enabled on a pool, the
-default compression algorithm may change.  The current default compression
-algorithm is either \fBlzjb\fR or, if the \fBlz4_compress\fR feature is
-enabled, \fBlz4\fR.
-.sp
-The \fBlzjb\fR compression algorithm is optimized for performance while
-providing decent data compression.
-.sp
-The \fBlz4\fR compression algorithm is a high-performance replacement
-for the \fBlzjb\fR algorithm. It features significantly faster
-compression and decompression, as well as a moderately higher
-compression ratio than \fBlzjb\fR, but can only be used on pools with
-the \fBlz4_compress\fR feature set to \fIenabled\fR. See
-\fBzpool-features\fR(5) for details on ZFS feature flags and the
-\fBlz4_compress\fR feature.
-.sp
-The \fBgzip\fR compression algorithm uses the same compression as
-the \fBgzip\fR(1) command. You can specify the \fBgzip\fR level by using the
-value \fBgzip-\fR\fIN\fR where \fIN\fR is an integer from 1 (fastest) to 9
-(best compression ratio). Currently, \fBgzip\fR is equivalent to \fBgzip-6\fR
-(which is also the default for \fBgzip\fR(1)). The \fBzle\fR compression
-algorithm compresses runs of zeros.
-.sp
-This property can also be referred to by its shortened column name
-\fBcompress\fR. Changing this property affects only newly-written data.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBcopies\fR=\fB1\fR | \fB2\fR | \fB3\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls the number of copies of data stored for this dataset. These copies are in addition to any redundancy provided by the pool, for example, mirroring or RAID-Z. The copies are stored on different disks, if possible. The space used by multiple copies is charged to the associated file and dataset, changing the \fBused\fR property and counting against quotas and reservations.
-.sp
-Changing this property only affects newly-written data.
-.sp
-Remember that \fBZFS\fR will not import a pool with a missing top-level vdev. Do NOT create, for example, a two-disk, striped pool and set \fBcopies=\fR\fI2\fR on some datasets thinking you have setup redundancy for them. When one disk dies, you will not be able to import the pool and will have lost all of your data.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBdedup\fR=\fBoff\fR | \fBon\fR | \fBverify\fR | \fBsha256\fR[,\fBverify\fR]\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether deduplication is in effect for a dataset. The default value is \fBoff\fR. The default checksum used for deduplication is \fBsha256\fR (subject to change). When \fBdedup\fR is enabled, the \fBdedup\fR checksum algorithm overrides the \fBchecksum\fR property. Setting the value to \fBverify\fR is equivalent to specifying \fBsha256,verify\fR.
-.sp
-If the property is set to \fBverify\fR, then, whenever two blocks have the same signature, ZFS will do a byte-for-byte comparison with the existing block to ensure that the contents are identical.
-.sp
-Unless necessary, deduplication should NOT be enabled on a system. See \fBDeduplication\fR above.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBdevices\fR=\fBon\fR | \fBoff\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether device nodes can be opened on this file system. The default value is \fBon\fR.
-.sp
-The values \fBon\fR and \fBoff\fR are equivalent to the \fBdev\fR and \fBnodev\fR mount options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBdnodesize\fR=\fBlegacy\fR | \fBauto\fR | \fB1k\fR | \fB2k\fR | \fB4k\fR | \fB8k\fR | \fB16k\fR\fR
-.ad
-.sp .6
-.RS 4n
-Specifies a compatibility mode or literal value for the size of dnodes
-in the file system. The default value is \fBlegacy\fR. Setting this
-property to a value other than \fBlegacy\fR requires the
-\fBlarge_dnode\fR pool feature to be enabled.
-.sp
-Consider setting \fBdnodesize\fR to \fBauto\fR if the dataset uses the
-\fBxattr=sa\fR property setting and the workload makes heavy use of
-extended attributes. This may be applicable to SELinux-enabled systems,
-Lustre servers, and Samba servers, for example. Literal values are
-supported for cases where the optimal size is known in advance and for
-performance testing.
-.sp
-Leave \fBdnodesize\fR set to \fBlegacy\fR if you need to receive
-a \fBzfs send\fR stream of this dataset on a pool that doesn't enable
-the \fBlarge_dnode\fR feature, or if you need to import this pool on a
-system that doesn't support the \fBlarge_dnode\fR feature.
-.sp
+.Ss Bookmarks
+A bookmark is like a snapshot, a read-only copy of a file system or volume.
+Bookmarks can be created extremely quickly, compared to snapshots, and they
+consume no additional space within the pool. Bookmarks can also have arbitrary
+names, much like snapshots.
+.Pp
+Unlike snapshots, bookmarks can not be accessed through the filesystem in any
+way. From a storage standpoint a bookmark just provides a way to reference
+when a snapshot was created as a distinct object. Bookmarks are initially
+tied to a snapshot, not the filesystem or volume, and they will survive if the
+snapshot itself is destroyed. Since they are very light weight there's little
+incentive to destroy them.
+.Ss Clones
+A clone is a writable volume or file system whose initial contents are the same
+as another dataset.
+As with snapshots, creating a clone is nearly instantaneous, and initially
+consumes no additional space.
+.Pp
+Clones can only be created from a snapshot.
+When a snapshot is cloned, it creates an implicit dependency between the parent
+and child.
+Even though the clone is created somewhere else in the dataset hierarchy, the
+original snapshot cannot be destroyed as long as a clone exists.
+The
+.Sy origin
+property exposes this dependency, and the
+.Cm destroy
+command lists any such dependencies, if they exist.
+.Pp
+The clone parent-child dependency relationship can be reversed by using the
+.Cm promote
+subcommand.
+This causes the
+.Qq origin
+file system to become a clone of the specified file system, which makes it
+possible to destroy the file system that the clone was created from.
+.Ss "Mount Points"
+Creating a ZFS file system is a simple operation, so the number of file systems
+per system is likely to be numerous.
+To cope with this, ZFS automatically manages mounting and unmounting file
+systems without the need to edit the
+.Pa /etc/fstab
+file.
+All automatically managed file systems are mounted by ZFS at boot time.
+.Pp
+By default, file systems are mounted under
+.Pa /path ,
+where
+.Ar path
+is the name of the file system in the ZFS namespace.
+Directories are created and destroyed as needed.
+.Pp
+A file system can also have a mount point set in the
+.Sy mountpoint
+property.
+This directory is created as needed, and ZFS automatically mounts the file
+system when the
+.Nm zfs Cm mount Fl a
+command is invoked
+.Po without editing
+.Pa /etc/fstab
+.Pc .
+The
+.Sy mountpoint
+property can be inherited, so if
+.Em pool/home
+has a mount point of
+.Pa /export/stuff ,
+then
+.Em pool/home/user
+automatically inherits a mount point of
+.Pa /export/stuff/user .
+.Pp
+A file system
+.Sy mountpoint
+property of
+.Sy none
+prevents the file system from being mounted.
+.Pp
+If needed, ZFS file systems can also be managed with traditional tools
+.Po
+.Nm mount ,
+.Nm umount ,
+.Pa /etc/fstab
+.Pc .
+If a file system's mount point is set to
+.Sy legacy ,
+ZFS makes no attempt to manage the file system, and the administrator is
+responsible for mounting and unmounting the file system.
+.Ss Deduplication
+Deduplication is the process for removing redundant data at the block level,
+reducing the total amount of data stored. If a file system has the
+.Sy dedup
+property enabled, duplicate data blocks are removed synchronously. The result
+is that only unique data is stored and common components are shared among files.
+.Pp
+Deduplicating data is a very resource-intensive operation. It is generally
+recommended that you have at least 1.25 GiB of RAM per 1 TiB of storage when
+you enable deduplication. Calculating the exact requirement depends heavily
+on the type of data stored in the pool.
+.Pp
+Enabling deduplication on an improperly-designed system can result in
+performance issues (slow IO and administrative operations). It can potentially
+lead to problems importing a pool due to memory exhaustion. Deduplication
+can consume significant processing power (CPU) and memory as well as generate
+additional disk IO.
+.Pp
+Before creating a pool with deduplication enabled, ensure that you have planned
+your hardware requirements appropriately and implemented appropriate recovery
+practices, such as regular backups. As an alternative to deduplication
+consider using
+.Sy compression=lz4 ,
+as a less resource-intensive alternative.
+.Ss Native Properties
+Properties are divided into two types, native properties and user-defined
+.Po or
+.Qq user
+.Pc
+properties.
+Native properties either export internal statistics or control ZFS behavior.
+In addition, native properties are either editable or read-only.
+User properties have no effect on ZFS behavior, but you can use them to annotate
+datasets in a way that is meaningful in your environment.
+For more information about user properties, see the
+.Sx User Properties
+section, below.
+.Pp
+Every dataset has a set of properties that export statistics about the dataset
+as well as control various behaviors.
+Properties are inherited from the parent unless overridden by the child.
+Some properties apply only to certain types of datasets
+.Pq file systems, volumes, or snapshots .
+.Pp
+The values of numeric properties can be specified using human-readable suffixes
+.Po for example,
+.Sy k ,
+.Sy KB ,
+.Sy M ,
+.Sy Gb ,
+and so forth, up to
+.Sy Z
+for zettabyte
+.Pc .
+The following are all valid
+.Pq and equal
+specifications:
+.Li 1536M, 1.5g, 1.50GB .
+.Pp
+The values of non-numeric properties are case sensitive and must be lowercase,
+except for
+.Sy mountpoint ,
+.Sy sharenfs ,
+and
+.Sy sharesmb .
+.Pp
+The following native properties consist of read-only statistics about the
+dataset.
+These properties can be neither set, nor inherited.
+Native properties apply to all dataset types unless otherwise noted.
+.Bl -tag -width "usedbyrefreservation"
+.It Sy available
+The amount of space available to the dataset and all its children, assuming that
+there is no other activity in the pool.
+Because space is shared within a pool, availability can be limited by any number
+of factors, including physical pool size, quotas, reservations, or other
+datasets within the pool.
+.Pp
 This property can also be referred to by its shortened column name,
-\fBdnsize\fR.
-.RE
-
-.sp
-.ne 2
-.mk
-.na
-\fB\fBexec\fR=\fBon\fR | \fBoff\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether processes can be executed from within this file system. The default value is \fBon\fR.
-.sp
-The values \fBon\fR and \fBoff\fR are equivalent to the \fBexec\fR and \fBnoexec\fR mount options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBmlslabel\fR=\fBnone\fR\fR | \fIlabel\fR
-.ad
-.sp .6
-.RS 4n
-The \fBmlslabel\fR property is a sensitivity label that determines if a dataset  can be mounted in a zone on a system with Trusted Extensions enabled. If the labeled dataset matches the labeled zone, the dataset can be mounted  and accessed from the labeled zone.
-.sp
-When the \fBmlslabel\fR property is not set, the default value is \fBnone\fR. Setting the  \fBmlslabel\fR property to \fBnone\fR is equivalent to removing the property.
-.sp
-The \fBmlslabel\fR property can be modified only when Trusted Extensions is enabled and only with appropriate privilege. Rights to modify it cannot be delegated. When changing a label to a higher label or setting the initial dataset label, the \fB{PRIV_FILE_UPGRADE_SL}\fR privilege is required. When changing a label to a lower label or the default (\fBnone\fR), the \fB{PRIV_FILE_DOWNGRADE_SL}\fR privilege is required. Changing the dataset to labels other than the default can be done only when the dataset is not mounted. When a dataset with the default label is mounted into a labeled-zone, the mount operation automatically sets the \fBmlslabel\fR property to the label of that zone.
-.sp
-When Trusted Extensions is \fBnot\fR enabled, only datasets with the default label (\fBnone\fR) can be mounted.
-.sp
-Zones are a Solaris feature and are not relevant on Linux.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBfilesystem_limit\fR=\fBnone\fR\fR | \fIcount\fR
-.ad
-.sp .6
-.RS 4n
-Limits the number of filesystems and volumes that can exist under this point in
-the dataset tree.  The limit is not enforced if the user is allowed to change
-the limit. Setting a filesystem_limit on a descendent of a filesystem that
-already has a filesystem_limit does not override the ancestor's filesystem_limit,
-but rather imposes an additional limit. This feature must be enabled to be used
-(see \fBzpool-features\fR(5)).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBmountpoint\fR=\fIpath\fR | \fBnone\fR | \fBlegacy\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls the mount point used for this file system. See the "Mount Points" section for more information on how this property is used.
-.sp
-When the \fBmountpoint\fR property is changed for a file system, the file system and any children that inherit the mount point are unmounted. If the new value is \fBlegacy\fR, then they remain unmounted. Otherwise, they are automatically remounted in the new location if the property was previously \fBlegacy\fR or \fBnone\fR, or if they were mounted before the property was changed. In addition, any shared file systems are unshared and shared in the new location.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBnbmand\fR=\fBoff\fR | \fBon\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether the file system should be mounted with \fBnbmand\fR (Non Blocking mandatory locks). This is used for \fBCIFS\fR clients. Changes to this property only take effect when the file system is umounted and remounted. See \fBmount\fR(1M) on a Solaris system for more information on \fBnbmand\fR mounts.
-.sp
-The values \fBon\fR and \fBoff\fR are equivalent to the \fBnbmand\fR and \fBnonbmand\fR mount options.
-.sp
-This property is not used on Linux.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBprimarycache\fR=\fBall\fR | \fBnone\fR | \fBmetadata\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls what is cached in the primary cache (ARC). If this property is set to \fBall\fR, then both user data and metadata is cached. If this property is set to \fBnone\fR, then neither user data nor metadata is cached. If this property is set to \fBmetadata\fR, then only metadata is cached. The default value is \fBall\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBquota\fR=\fBnone\fR | \fIsize\fR\fR
-.ad
-.sp .6
-.RS 4n
-Limits the amount of space a dataset and its descendents can consume. This property enforces a hard limit on the amount of space used. This includes all space consumed by descendents, including file systems and snapshots. Setting a quota on a descendent of a dataset that already has a quota does not override the ancestor's quota, but rather imposes an additional limit.
-.sp
-Quotas cannot be set on volumes, as the \fBvolsize\fR property acts as an implicit quota.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBsnapshot_limit\fR=\fBnone\fR\fR | \fIcount\fR
-.ad
-.sp .6
-.RS 4n
-Limits the number of snapshots that can be created on a dataset and its
-descendents. Setting a snapshot_limit on a descendent of a dataset that already
-has a snapshot_limit does not override the ancestor's snapshot_limit, but
-rather imposes an additional limit. The limit is not enforced if the user is
-allowed to change the limit. For example, this means that recursive snapshots
-taken from the global zone are counted against each delegated dataset within
-a zone. This feature must be enabled to be used (see \fBzpool-features\fR(5)).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBuserquota@\fR\fIuser\fR=\fBnone\fR | \fIsize\fR\fR
-.br
-\fB\fBuserobjquota@\fR\fIuser\fR=\fBnone\fR | \fIcount\fR\fR
-.ad
-.sp .6
-.RS 4n
-Limits the amount of space consumed by the specified user. Similar to the \fBrefquota\fR property, the \fBuserquota\fR space calculation does not include space that is used by descendent datasets, such as snapshots and clones. User space consumption is identified by the \fBuserspace@\fR\fIuser\fR property. See the \fBzfs userspace\fR subcommand for more information.
-.sp
-Enforcement of user quotas may be delayed by several seconds. This delay means that a user might exceed their quota before the system notices that they are over quota and begins to refuse additional writes with the \fBEDQUOT\fR error message.
-.sp
-Unprivileged users can only access their own groups' space usage. The root user, or a user who has been granted the \fBuserquota\fR privilege with \fBzfs allow\fR, can get and set everyone's quota.
-.sp
-This property is not available on volumes, on file systems before version 4, or on pools before version 15. The \fBuserquota@\fR... properties are not displayed by \fBzfs get all\fR. The user's name must be appended after the \fB@\fR symbol, using one of the following forms:
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fIPOSIX name\fR (for example, \fBjoe\fR)
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fIPOSIX numeric ID\fR (for example, \fB789\fR)
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fISID name\fR (for example, \fBjoe.smith@mydomain\fR)
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fISID numeric ID\fR (for example, \fBS-1-123-456-789\fR)
-.RE
-.RE
+.Sy avail .
+.It Sy compressratio
+For non-snapshots, the compression ratio achieved for the
+.Sy used
+space of this dataset, expressed as a multiplier.
+The
+.Sy used
+property includes descendant datasets, and, for clones, does not include the
+space shared with the origin snapshot.
+For snapshots, the
+.Sy compressratio
+is the same as the
+.Sy refcompressratio
+property.
+Compression can be turned on by running:
+.Nm zfs Cm set Sy compression Ns = Ns Sy on Ar dataset .
+The default value is
+.Sy off .
+.It Sy createtxg
+The transaction group (txg) in which the dataset was created. Bookmarks have
+the same
+.Sy createtxg
+as the snapshot they are initially tied to. This property is suitable for
+ordering a list of snapshots, e.g. for incremental send and receive.
+.It Sy creation
+The time this dataset was created.
+.It Sy clones
+For snapshots, this property is a comma-separated list of filesystems or volumes
+which are clones of this snapshot.
+The clones'
+.Sy origin
+property is this snapshot.
+If the
+.Sy clones
+property is not empty, then this snapshot can not be destroyed
+.Po even with the
+.Fl r
+or
+.Fl f
+options
+.Pc .
+The roles of origin and clone can be swapped by promoting the clone with the
+.Nm zfs Cm promote
+command.
+.It Sy defer_destroy
+This property is
+.Sy on
+if the snapshot has been marked for deferred destroy by using the
+.Nm zfs Cm destroy Fl d
+command.
+Otherwise, the property is
+.Sy off .
+.It Sy filesystem_count
+The total number of filesystems and volumes that exist under this location in
+the dataset tree.
+This value is only available when a
+.Sy filesystem_limit
+has been set somewhere in the tree under which the dataset resides.
+.It Sy guid
+The 64 bit GUID of this dataset or bookmark which does not change over its
+entire lifetime. When a snapshot is sent to another pool, the received
+snapshot has the same GUID. Thus, the
+.Sy guid
+is suitable to identify a snapshot across pools.
+.It Sy logicalreferenced
+The amount of space that is
+.Qq logically
+accessible by this dataset.
+See the
+.Sy referenced
+property.
+The logical space ignores the effect of the
+.Sy compression
+and
+.Sy copies
+properties, giving a quantity closer to the amount of data that applications
+see.
+However, it does include space consumed by metadata.
+.Pp
+This property can also be referred to by its shortened column name,
+.Sy lrefer .
+.It Sy logicalused
+The amount of space that is
+.Qq logically
+consumed by this dataset and all its descendents.
+See the
+.Sy used
+property.
+The logical space ignores the effect of the
+.Sy compression
+and
+.Sy copies
+properties, giving a quantity closer to the amount of data that applications
+see.
+However, it does include space consumed by metadata.
+.Pp
+This property can also be referred to by its shortened column name,
+.Sy lused .
+.It Sy mounted
+For file systems, indicates whether the file system is currently mounted.
+This property can be either
+.Sy yes
+or
+.Sy no .
+.It Sy origin
+For cloned file systems or volumes, the snapshot from which the clone was
+created.
+See also the
+.Sy clones
+property.
+.It Sy receive_resume_token
+For filesystems or volumes which have saved partially-completed state from
+.Sy zfs receive -s ,
+this opaque token can be provided to
+.Sy zfs send -t
+to resume and complete the
+.Sy zfs receive .
+.It Sy referenced
+The amount of data that is accessible by this dataset, which may or may not be
+shared with other datasets in the pool.
+When a snapshot or clone is created, it initially references the same amount of
+space as the file system or snapshot it was created from, since its contents are
+identical.
+.Pp
+This property can also be referred to by its shortened column name,
+.Sy refer .
+.It Sy refcompressratio
+The compression ratio achieved for the
+.Sy referenced
+space of this dataset, expressed as a multiplier.
+See also the
+.Sy compressratio
+property.
+.It Sy snapshot_count
+The total number of snapshots that exist under this location in the dataset
+tree.
+This value is only available when a
+.Sy snapshot_limit
+has been set somewhere in the tree under which the dataset resides.
+.It Sy type
+The type of dataset:
+.Sy filesystem ,
+.Sy volume ,
+or
+.Sy snapshot .
+.It Sy used
+The amount of space consumed by this dataset and all its descendents.
+This is the value that is checked against this dataset's quota and reservation.
+The space used does not include this dataset's reservation, but does take into
+account the reservations of any descendent datasets.
+The amount of space that a dataset consumes from its parent, as well as the
+amount of space that is freed if this dataset is recursively destroyed, is the
+greater of its space used and its reservation.
+.Pp
+The used space of a snapshot
+.Po see the
+.Sx Snapshots
+section
+.Pc
+is space that is referenced exclusively by this snapshot.
+If this snapshot is destroyed, the amount of
+.Sy used
+space will be freed.
+Space that is shared by multiple snapshots isn't accounted for in this metric.
+When a snapshot is destroyed, space that was previously shared with this
+snapshot can become unique to snapshots adjacent to it, thus changing the used
+space of those snapshots.
+The used space of the latest snapshot can also be affected by changes in the
+file system.
+Note that the
+.Sy used
+space of a snapshot is a subset of the
+.Sy written
+space of the snapshot.
+.Pp
+The amount of space used, available, or referenced does not take into account
+pending changes.
+Pending changes are generally accounted for within a few seconds.
+Committing a change to a disk using
+.Xr fsync 2
+or
+.Dv O_SYNC
+does not necessarily guarantee that the space usage information is updated
+immediately.
+.It Sy usedby*
+The
+.Sy usedby*
+properties decompose the
+.Sy used
+properties into the various reasons that space is used.
+Specifically,
+.Sy used No =
+.Sy usedbychildren No +
+.Sy usedbydataset No +
+.Sy usedbyrefreservation No +
+.Sy usedbysnapshots .
+These properties are only available for datasets created on
+.Nm zpool
+.Qo version 13 Qc
+pools.
+.It Sy usedbychildren
+The amount of space used by children of this dataset, which would be freed if
+all the dataset's children were destroyed.
+.It Sy usedbydataset
+The amount of space used by this dataset itself, which would be freed if the
+dataset were destroyed
+.Po after first removing any
+.Sy refreservation
+and destroying any necessary snapshots or descendents
+.Pc .
+.It Sy usedbyrefreservation
+The amount of space used by a
+.Sy refreservation
+set on this dataset, which would be freed if the
+.Sy refreservation
+was removed.
+.It Sy usedbysnapshots
+The amount of space consumed by snapshots of this dataset.
+In particular, it is the amount of space that would be freed if all of this
+dataset's snapshots were destroyed.
+Note that this is not simply the sum of the snapshots'
+.Sy used
+properties because space can be shared by multiple snapshots.
+.It Sy userused Ns @ Ns Em user
+The amount of space consumed by the specified user in this dataset.
+Space is charged to the owner of each file, as displayed by
+.Nm ls Fl l .
+The amount of space charged is displayed by
+.Nm du
+and
+.Nm ls Fl s .
+See the
+.Nm zfs Cm userspace
+subcommand for more information.
+.Pp
+Unprivileged users can access only their own space usage.
+The root user, or a user who has been granted the
+.Sy userused
+privilege with
+.Nm zfs Cm allow ,
+can access everyone's usage.
+.Pp
+The
+.Sy userused Ns @ Ns Em ...
+properties are not displayed by
+.Nm zfs Cm get Sy all .
+The user's name must be appended after the @ symbol, using one of the following
+forms:
+.Bl -bullet -width ""
+.It
+.Em POSIX name
+.Po for example,
+.Sy joe
+.Pc
+.It
+.Em POSIX numeric ID
+.Po for example,
+.Sy 789
+.Pc
+.It
+.Em SID name
+.Po for example,
+.Sy joe.smith@mydomain
+.Pc
+.It
+.Em SID numeric ID
+.Po for example,
+.Sy S-1-123-456-789
+.Pc
+.El
+.Pp
 Files created on Linux always have POSIX owners.
-
-.RS 4
-The \fBuserobjquota\fR is similar to \fBuserquota\fR but it limits the number of objects a \fIuser\fR can create.
-Please refer to \fBuserobjused\fR for more information about how ZFS counts object usage.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBgroupquota@\fR\fIgroup\fR=\fBnone\fR\fR | \fIsize\fR
-.br
-\fB\fBgroupobjquota@\fR\fIgroup\fR=\fBnone\fR\fR | \fIcount\fR
-.ad
-.sp .6
-.RS 4n
-Limits the amount of space consumed by the specified group. Group space consumption is identified by the \fBuserquota@\fR\fIuser\fR property.
-.sp
-Unprivileged users can access only their own groups' space usage. The root user, or a user who has been granted the \fBgroupquota\fR privilege with \fBzfs allow\fR, can get and set all groups' quotas.
-
-The \fBgroupobjquota\fR is similar to \fBgroupquota\fR but it limits that the \fIgroup\fR can consume \fIcount\fR number of objects at most.
-Please refer to \fBuserobjused\fR for more information about how zfs counts object usage.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBreadonly\fR=\fBoff\fR | \fBon\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether this dataset can be modified. The default value is \fBoff\fR.
-.sp
-This property can also be referred to by its shortened column name, \fBrdonly\fR.
-.sp
-The values \fBon\fR and \fBoff\fR are equivalent to the \fBro\fR and \fBrw\fR mount options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBrecordsize\fR=\fIsize\fR\fR
-.ad
-.sp .6
-.RS 4n
-Specifies a suggested block size for files in the file system. This property is designed solely for use with database workloads that access files in fixed-size records. \fBZFS\fR automatically tunes block sizes according to internal algorithms optimized for typical access patterns.
-.sp
-For databases that create very large files but access them in small random chunks, these algorithms may be suboptimal. Specifying a \fBrecordsize\fR greater than or equal to the record size of the database can result in significant performance gains. Use of this property for general purpose file systems is strongly discouraged, and may adversely affect performance.
-.sp
-Any power of two from 512B to 1MiB is valid. The default is 128KiB. Values larger than 128KiB require the pool have the \fBlarge_blocks\fR feature enabled. See \fBzpool-features\fR(5) for details on ZFS feature flags and the \fBlarge_blocks\fR feature.
-.sp
-Changing the file system's \fBrecordsize\fR affects only files created afterward; existing files are unaffected.
-.sp
-This property can also be referred to by its shortened column name, \fBrecsize\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBredundant_metadata\fR=\fBall\fR | \fBmost\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls what types of metadata are stored redundantly.  ZFS stores an
-extra copy of metadata, so that if a single block is corrupted, the
-amount of user data lost is limited.  This extra copy is in addition to
-any redundancy provided at the pool level (e.g. by mirroring or RAID-Z),
-and is in addition to an extra copy specified by the \fBcopies\fR
-property (up to a total of 3 copies).  For example if the pool is
-mirrored, \fBcopies\fR=2, and \fBredundant_metadata\fR=most, then ZFS
-stores 6 copies of most metadata, and 4 copies of data and some
+.It Sy userobjused Ns @ Ns Em user
+The
+.Sy userobjused
+property is similar to
+.Sy userused
+but instead it counts the number of objects consumed by a user. This property
+counts all objects allocated on behalf of the user, it may differ from the
+results of system tools such as
+.Nm df Fl i .
+.Pp
+When the property
+.Sy xattr=on
+is set on a file system additional objects will be created per-file to store
+extended attributes. These additional objects are reflected in the
+.Sy userobjused
+value and are counted against the user's
+.Sy userobjquota .
+When a file system is configured to use
+.Sy xattr=sa
+no additional internal objects are normally required.
+.It Sy userrefs
+This property is set to the number of user holds on this snapshot.
+User holds are set by using the
+.Nm zfs Cm hold
+command.
+.It Sy groupused Ns @ Ns Em group
+The amount of space consumed by the specified group in this dataset.
+Space is charged to the group of each file, as displayed by
+.Nm ls Fl l .
+See the
+.Sy userused Ns @ Ns Em user
+property for more information.
+.Pp
+Unprivileged users can only access their own groups' space usage.
+The root user, or a user who has been granted the
+.Sy groupused
+privilege with
+.Nm zfs Cm allow ,
+can access all groups' usage.
+.It Sy groupobjused Ns @ Ns Em group
+The number of objects consumed by the specified group in this dataset.
+Multiple objects may be charged to the group for each file when extended
+attributes are in use. See the
+.Sy userobjused Ns @ Ns Em user
+property for more information.
+.Pp
+Unprivileged users can only access their own groups' space usage.
+The root user, or a user who has been granted the
+.Sy groupobjused
+privilege with
+.Nm zfs Cm allow ,
+can access all groups' usage.
+.It Sy volblocksize
+For volumes, specifies the block size of the volume.
+The
+.Sy blocksize
+cannot be changed once the volume has been written, so it should be set at
+volume creation time.
+The default
+.Sy blocksize
+for volumes is 8 Kbytes.
+Any power of 2 from 512 bytes to 128 Kbytes is valid.
+.Pp
+This property can also be referred to by its shortened column name,
+.Sy volblock .
+.It Sy written
+The amount of space
+.Sy referenced
+by this dataset, that was written since the previous snapshot
+.Pq i.e. that is not referenced by the previous snapshot .
+.It Sy written Ns @ Ns Em snapshot
+The amount of
+.Sy referenced
+space written to this dataset since the specified snapshot.
+This is the space that is referenced by this dataset but was not referenced by
+the specified snapshot.
+.Pp
+The
+.Em snapshot
+may be specified as a short snapshot name
+.Po just the part after the
+.Sy @
+.Pc ,
+in which case it will be interpreted as a snapshot in the same filesystem as
+this dataset.
+The
+.Em snapshot
+may be a full snapshot name
+.Po Em filesystem Ns @ Ns Em snapshot Pc ,
+which for clones may be a snapshot in the origin's filesystem
+.Pq or the origin of the origin's filesystem, etc.
+.El
+.Pp
+The following native properties can be used to change the behavior of a ZFS
+dataset.
+.Bl -tag -width ""
+.It Xo
+.Sy aclinherit Ns = Ns Sy discard Ns | Ns Sy noallow Ns | Ns
+.Sy restricted Ns | Ns Sy passthrough Ns | Ns Sy passthrough-x
+.Xc
+Controls how ACEs are inherited when files and directories are created.
+.Bl -tag -width "passthrough-x"
+.It Sy discard
+does not inherit any ACEs.
+.It Sy noallow
+only inherits inheritable ACEs that specify
+.Qq deny
+permissions.
+.It Sy restricted
+default, removes the
+.Sy write_acl
+and
+.Sy write_owner
+permissions when the ACE is inherited.
+.It Sy passthrough
+inherits all inheritable ACEs without any modifications.
+.It Sy passthrough-x
+same meaning as
+.Sy passthrough ,
+except that the
+.Sy owner@ ,
+.Sy group@ ,
+and
+.Sy everyone@
+ACEs inherit the execute permission only if the file creation mode also requests
+the execute bit.
+.El
+.Pp
+When the property value is set to
+.Sy passthrough ,
+files are created with a mode determined by the inheritable ACEs.
+If no inheritable ACEs exist that affect the mode, then the mode is set in
+accordance to the requested mode from the application.
+.Pp
+The
+.Sy aclinherit
+property does not apply to posix ACLs.
+.It Sy acltype Ns = Ns Sy off Ns | Ns Sy noacl Ns | Ns Sy posixacl
+Controls whether ACLs are enabled and if so what type of ACL to use.
+.Bl -tag -width "posixacl"
+.It Sy off
+default, when a file system has the
+.Sy acltype
+property set to off then ACLs are disabled.
+.It Sy noacl
+an alias for
+.Sy off
+.It Sy posixacl
+indicates posix ACLs should be used. Posix ACLs are specific to Linux and are
+not functional on other platforms. Posix ACLs are stored as an extended
+attribute and therefore will not overwrite any existing NFSv4 ACLs which
+may be set.
+.El
+.Pp
+To obtain the best performance when setting
+.Sy posixacl
+users are strongly encouraged to set the
+.Sy xattr=sa
+property. This will result in the posix ACL being stored more efficiently on
+disk. But as a consequence of this all new extended attributes will only be
+accessible from OpenZFS implementations which support the
+.Sy xattr=sa
+property. See the
+.Sy xattr
+property for more details.
+.It Sy atime Ns = Ns Sy on Ns | Ns Sy off
+Controls whether the access time for files is updated when they are read.
+Turning this property off avoids producing write traffic when reading files and
+can result in significant performance gains, though it might confuse mailers
+and other similar utilities. The values
+.Sy on
+and
+.Sy off
+are equivalent to the
+.Sy atime
+and
+.Sy noatime
+mount options. The default value is
+.Sy on .
+See also
+.Sy relatime
+below.
+.It Sy canmount Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy noauto
+If this property is set to
+.Sy off ,
+the file system cannot be mounted, and is ignored by
+.Nm zfs Cm mount Fl a .
+Setting this property to
+.Sy off
+is similar to setting the
+.Sy mountpoint
+property to
+.Sy none ,
+except that the dataset still has a normal
+.Sy mountpoint
+property, which can be inherited.
+Setting this property to
+.Sy off
+allows datasets to be used solely as a mechanism to inherit properties.
+One example of setting
+.Sy canmount Ns = Ns Sy off
+is to have two datasets with the same
+.Sy mountpoint ,
+so that the children of both datasets appear in the same directory, but might
+have different inherited characteristics.
+.Pp
+When set to
+.Sy noauto ,
+a dataset can only be mounted and unmounted explicitly.
+The dataset is not mounted automatically when the dataset is created or
+imported, nor is it mounted by the
+.Nm zfs Cm mount Fl a
+command or unmounted by the
+.Nm zfs Cm unmount Fl a
+command.
+.Pp
+This property is not inherited.
+.It Xo
+.Sy checksum Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy fletcher2 Ns | Ns
+.Sy fletcher4 Ns | Ns Sy sha256 Ns | Ns Sy noparity Ns | Ns
+.Sy sha512 Ns | Ns Sy skein Ns | Ns Sy edonr
+.Xc
+Controls the checksum used to verify data integrity.
+The default value is
+.Sy on ,
+which automatically selects an appropriate algorithm
+.Po currently,
+.Sy fletcher4 ,
+but this may change in future releases
+.Pc .
+The value
+.Sy off
+disables integrity checking on user data.
+The value
+.Sy noparity
+not only disables integrity but also disables maintaining parity for user data.
+This setting is used internally by a dump device residing on a RAID-Z pool and
+should not be used by any other dataset.
+Disabling checksums is
+.Sy NOT
+a recommended practice.
+.Pp
+The
+.Sy sha512 ,
+.Sy skein ,
+and
+.Sy edonr
+checksum algorithms require enabling the appropriate features on the pool.
+Please see
+.Xr zpool-features 5
+for more information on these algorithms.
+.Pp
+Changing this property affects only newly-written data.
+.It Xo
+.Sy compression Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy gzip Ns | Ns
+.Sy gzip- Ns Em N Ns | Ns Sy lz4 Ns | Ns Sy lzjb Ns | Ns Sy zle
+.Xc
+Controls the compression algorithm used for this dataset.
+.Pp
+Setting compression to
+.Sy on
+indicates that the current default compression algorithm should be used.
+The default balances compression and decompression speed, with compression ratio
+and is expected to work well on a wide variety of workloads.
+Unlike all other settings for this property,
+.Sy on
+does not select a fixed compression type.
+As new compression algorithms are added to ZFS and enabled on a pool, the
+default compression algorithm may change.
+The current default compression algorithm is either
+.Sy lzjb
+or, if the
+.Sy lz4_compress
+feature is enabled,
+.Sy lz4 .
+.Pp
+The
+.Sy lz4
+compression algorithm is a high-performance replacement for the
+.Sy lzjb
+algorithm.
+It features significantly faster compression and decompression, as well as a
+moderately higher compression ratio than
+.Sy lzjb ,
+but can only be used on pools with the
+.Sy lz4_compress
+feature set to
+.Sy enabled .
+See
+.Xr zpool-features 5
+for details on ZFS feature flags and the
+.Sy lz4_compress
+feature.
+.Pp
+The
+.Sy lzjb
+compression algorithm is optimized for performance while providing decent data
+compression.
+.Pp
+The
+.Sy gzip
+compression algorithm uses the same compression as the
+.Xr gzip 1
+command.
+You can specify the
+.Sy gzip
+level by using the value
+.Sy gzip- Ns Em N ,
+where
+.Em N
+is an integer from 1
+.Pq fastest
+to 9
+.Pq best compression ratio .
+Currently,
+.Sy gzip
+is equivalent to
+.Sy gzip-6
+.Po which is also the default for
+.Xr gzip 1
+.Pc .
+.Pp
+The
+.Sy zle
+compression algorithm compresses runs of zeros.
+.Pp
+This property can also be referred to by its shortened column name
+.Sy compress .
+Changing this property affects only newly-written data.
+.It Xo
+.Sy context Ns = Ns Sy none Ns | Ns
+.Em SELinux_User:SElinux_Role:Selinux_Type:Sensitivity_Level
+.Xc
+This flag sets the SELinux context for all files in the file system under
+a mount point for that file system. See
+.Xr selinux 8
+for more information.
+.It Xo
+.Sy fscontext Ns = Ns Sy none Ns | Ns
+.Em SELinux_User:SElinux_Role:Selinux_Type:Sensitivity_Level
+.Xc
+This flag sets the SELinux context for the file system file system being
+mounted. See
+.Xr selinux 8
+for more information.
+.It Xo
+.Sy defcontext Ns = Ns Sy none Ns | Ns
+.Em SELinux_User:SElinux_Role:Selinux_Type:Sensitivity_Level
+.Xc
+This flag sets the SELinux default context for unlabeled files. See
+.Xr selinux 8
+for more information.
+.It Xo
+.Sy rootcontext Ns = Ns Sy none Ns | Ns
+.Em SELinux_User:SElinux_Role:Selinux_Type:Sensitivity_Level
+.Xc
+This flag sets the SELinux context for the root inode of the file system. See
+.Xr selinux 8
+for more information.
+.It Sy copies Ns = Ns Sy 1 Ns | Ns Sy 2 Ns | Ns Sy 3
+Controls the number of copies of data stored for this dataset.
+These copies are in addition to any redundancy provided by the pool, for
+example, mirroring or RAID-Z.
+The copies are stored on different disks, if possible.
+The space used by multiple copies is charged to the associated file and dataset,
+changing the
+.Sy used
+property and counting against quotas and reservations.
+.Pp
+Changing this property only affects newly-written data.
+Therefore, set this property at file system creation time by using the
+.Fl o Sy copies Ns = Ns Ar N
+option.
+.Pp
+Remember that ZFS will not import a pool with a missing top-level vdev. Do
+.Sy NOT
+create, for example a two-disk striped pool and set
+.Sy copies=2
+on some datasets thinking you have setup redundancy for them. When a disk
+fails you will not be able to import the pool and will have lost all of your
+data.
+.It Sy devices Ns = Ns Sy on Ns | Ns Sy off
+Controls whether device nodes can be opened on this file system.
+The default value is
+.Sy on .
+The values
+.Sy on
+and
+.Sy off
+are equivalent to the
+.Sy dev
+and
+.Sy nodev
+mount options.
+.It Xo
+.Sy dnodesize Ns = Ns Sy legacy Ns | Ns Sy auto Ns | Ns Sy 1k Ns | Ns
+.Sy 2k Ns | Ns Sy 4k Ns | Ns Sy 8k Ns | Ns Sy 16k
+.Xc
+Specifies a compatibility mode or literal value for the size of dnodes in the
+file system. The default value is
+.Sy legacy .
+Setting this property to a value other than
+.Sy legacy
+requires the large_dnode pool feature to be enabled.
+.Pp
+Consider setting
+.Sy dnodesize
+to
+.Sy auto
+if the dataset uses the
+.Sy xattr=sa
+property setting and the workload makes heavy use of extended attributes. This
+may be applicable to SELinux-enabled systems, Lustre servers, and Samba
+servers, for example. Literal values are supported for cases where the optimal
+size is known in advance and for performance testing.
+.Pp
+Leave
+.Sy dnodesize
+set to
+.Sy legacy
+if you need to receive a send stream of this dataset on a pool that doesn't
+enable the large_dnode feature, or if you need to import this pool on a system
+that doesn't support the large_dnode feature.
+.Pp
+This property can also be referred to by its shortened column name,
+.Sy dnsize .
+.It Sy exec Ns = Ns Sy on Ns | Ns Sy off
+Controls whether processes can be executed from within this file system.
+The default value is
+.Sy on .
+The values
+.Sy on
+and
+.Sy off
+are equivalent to the
+.Sy exec
+and
+.Sy noexec
+mount options.
+.It Sy filesystem_limit Ns = Ns Em count Ns | Ns Sy none
+Limits the number of filesystems and volumes that can exist under this point in
+the dataset tree.
+The limit is not enforced if the user is allowed to change the limit.
+Setting a
+.Sy filesystem_limit
+to
+.Sy on
+a descendent of a filesystem that already has a
+.Sy filesystem_limit
+does not override the ancestor's
+.Sy filesystem_limit ,
+but rather imposes an additional limit.
+This feature must be enabled to be used
+.Po see
+.Xr zpool-features 5
+.Pc .
+.It Sy mountpoint Ns = Ns Pa path Ns | Ns Sy none Ns | Ns Sy legacy
+Controls the mount point used for this file system.
+See the
+.Sx Mount Points
+section for more information on how this property is used.
+.Pp
+When the
+.Sy mountpoint
+property is changed for a file system, the file system and any children that
+inherit the mount point are unmounted.
+If the new value is
+.Sy legacy ,
+then they remain unmounted.
+Otherwise, they are automatically remounted in the new location if the property
+was previously
+.Sy legacy
+or
+.Sy none ,
+or if they were mounted before the property was changed.
+In addition, any shared file systems are unshared and shared in the new
+location.
+.It Sy nbmand Ns = Ns Sy on Ns | Ns Sy off
+Controls whether the file system should be mounted with
+.Sy nbmand
+.Pq Non Blocking mandatory locks .
+This is used for SMB clients.
+Changes to this property only take effect when the file system is umounted and
+remounted.
+See
+.Xr mount 8
+for more information on
+.Sy nbmand
+mounts. This property is not used on Linux.
+.It Sy overlay Ns = Ns Sy off Ns | Ns Sy on
+Allow mounting on a busy directory or a directory which already contains
+files or directories. This is the default mount behavior for Linux file systems.
+For consistency with OpenZFS on other platforms overlay mounts are
+.Sy off
+by default. Set to
+.Sy on
+to enable overlay mounts.
+.It Sy primarycache Ns = Ns Sy all Ns | Ns Sy none Ns | Ns Sy metadata
+Controls what is cached in the primary cache
+.Pq ARC .
+If this property is set to
+.Sy all ,
+then both user data and metadata is cached.
+If this property is set to
+.Sy none ,
+then neither user data nor metadata is cached.
+If this property is set to
+.Sy metadata ,
+then only metadata is cached.
+The default value is
+.Sy all .
+.It Sy quota Ns = Ns Em size Ns | Ns Sy none
+Limits the amount of space a dataset and its descendents can consume.
+This property enforces a hard limit on the amount of space used.
+This includes all space consumed by descendents, including file systems and
+snapshots.
+Setting a quota on a descendent of a dataset that already has a quota does not
+override the ancestor's quota, but rather imposes an additional limit.
+.Pp
+Quotas cannot be set on volumes, as the
+.Sy volsize
+property acts as an implicit quota.
+.It Sy snapshot_limit Ns = Ns Em count Ns | Ns Sy none
+Limits the number of snapshots that can be created on a dataset and its
+descendents.
+Setting a
+.Sy snapshot_limit
+on a descendent of a dataset that already has a
+.Sy snapshot_limit
+does not override the ancestor's
+.Sy snapshot_limit ,
+but rather imposes an additional limit.
+The limit is not enforced if the user is allowed to change the limit.
+For example, this means that recursive snapshots taken from the global zone are
+counted against each delegated dataset within a zone.
+This feature must be enabled to be used
+.Po see
+.Xr zpool-features 5
+.Pc .
+.It Sy userquota@ Ns Em user Ns = Ns Em size Ns | Ns Sy none
+Limits the amount of space consumed by the specified user.
+User space consumption is identified by the
+.Sy userspace@ Ns Em user
+property.
+.Pp
+Enforcement of user quotas may be delayed by several seconds.
+This delay means that a user might exceed their quota before the system notices
+that they are over quota and begins to refuse additional writes with the
+.Er EDQUOT
+error message.
+See the
+.Nm zfs Cm userspace
+subcommand for more information.
+.Pp
+Unprivileged users can only access their own groups' space usage.
+The root user, or a user who has been granted the
+.Sy userquota
+privilege with
+.Nm zfs Cm allow ,
+can get and set everyone's quota.
+.Pp
+This property is not available on volumes, on file systems before version 4, or
+on pools before version 15.
+The
+.Sy userquota@ Ns Em ...
+properties are not displayed by
+.Nm zfs Cm get Sy all .
+The user's name must be appended after the
+.Sy @
+symbol, using one of the following forms:
+.Bl -bullet
+.It
+.Em POSIX name
+.Po for example,
+.Sy joe
+.Pc
+.It
+.Em POSIX numeric ID
+.Po for example,
+.Sy 789
+.Pc
+.It
+.Em SID name
+.Po for example,
+.Sy joe.smith@mydomain
+.Pc
+.It
+.Em SID numeric ID
+.Po for example,
+.Sy S-1-123-456-789
+.Pc
+.El
+.Pp
+Files created on Linux always have POSIX owners.
+.It Sy userobjquota@ Ns Em user Ns = Ns Em size Ns | Ns Sy none
+The
+.Sy userobjquota
+is similar to
+.Sy userquota
+but it limits the number of objects a user can create. Please refer to
+.Sy userobjused
+for more information about how objects are counted.
+.It Sy groupquota@ Ns Em group Ns = Ns Em size Ns | Ns Sy none
+Limits the amount of space consumed by the specified group.
+Group space consumption is identified by the
+.Sy groupused@ Ns Em group
+property.
+.Pp
+Unprivileged users can access only their own groups' space usage.
+The root user, or a user who has been granted the
+.Sy groupquota
+privilege with
+.Nm zfs Cm allow ,
+can get and set all groups' quotas.
+.It Sy groupobjquota@ Ns Em group Ns = Ns Em size Ns | Ns Sy none
+The
+.Sy groupobjquota
+is similar to
+.Sy groupquota
+but it limits number of objects a group can consume. Please refer to
+.Sy userobjused
+for more information about how objects are counted.
+.It Sy readonly Ns = Ns Sy on Ns | Ns Sy off
+Controls whether this dataset can be modified.
+The default value is
+.Sy off .
+The values
+.Sy on
+and
+.Sy off
+are equivalent to the
+.Sy ro
+and
+.Sy rw
+mount options.
+.Pp
+This property can also be referred to by its shortened column name,
+.Sy rdonly .
+.It Sy recordsize Ns = Ns Em size
+Specifies a suggested block size for files in the file system.
+This property is designed solely for use with database workloads that access
+files in fixed-size records.
+ZFS automatically tunes block sizes according to internal algorithms optimized
+for typical access patterns.
+.Pp
+For databases that create very large files but access them in small random
+chunks, these algorithms may be suboptimal.
+Specifying a
+.Sy recordsize
+greater than or equal to the record size of the database can result in
+significant performance gains.
+Use of this property for general purpose file systems is strongly discouraged,
+and may adversely affect performance.
+.Pp
+The size specified must be a power of two greater than or equal to 512 and less
+than or equal to 128 Kbytes.
+If the
+.Sy large_blocks
+feature is enabled on the pool, the size may be up to 1 Mbyte.
+See
+.Xr zpool-features 5
+for details on ZFS feature flags.
+.Pp
+Changing the file system's
+.Sy recordsize
+affects only files created afterward; existing files are unaffected.
+.Pp
+This property can also be referred to by its shortened column name,
+.Sy recsize .
+.It Sy redundant_metadata Ns = Ns Sy all Ns | Ns Sy most
+Controls what types of metadata are stored redundantly.
+ZFS stores an extra copy of metadata, so that if a single block is corrupted,
+the amount of user data lost is limited.
+This extra copy is in addition to any redundancy provided at the pool level
+.Pq e.g. by mirroring or RAID-Z ,
+and is in addition to an extra copy specified by the
+.Sy copies
+property
+.Pq up to a total of 3 copies .
+For example if the pool is mirrored,
+.Sy copies Ns = Ns 2 ,
+and
+.Sy redundant_metadata Ns = Ns Sy most ,
+then ZFS stores 6 copies of most metadata, and 4 copies of data and some
 metadata.
-.sp
-When set to \fBall\fR, ZFS stores an extra copy of all metadata.  If a
-single on-disk block is corrupt, at worst a single block of user data
-(which is \fBrecordsize\fR bytes long) can be lost.
-.sp
-When set to \fBmost\fR, ZFS stores an extra copy of most types of
-metadata.  This can improve performance of random writes, because less
-metadata must be written.  In practice, at worst about 100 blocks (of
-\fBrecordsize\fR bytes each) of user data can be lost if a single
-on-disk block is corrupt.  The exact behavior of which metadata blocks
-are stored redundantly may change in future releases.
-.sp
-The default value is \fBall\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBrefquota\fR=\fBnone\fR | \fIsize\fR\fR
-.ad
-.sp .6
-.RS 4n
-Limits the amount of space a dataset can consume. This property enforces a hard limit on the amount of space used. This hard limit does not include space used by descendents, including file systems and snapshots.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBrefreservation\fR=\fBnone\fR | \fIsize\fR\fR
-.ad
-.sp .6
-.RS 4n
-The minimum amount of space guaranteed to a dataset, not including its descendents. When the amount of space used is below this value, the dataset is treated as if it were taking up the amount of space specified by \fBrefreservation\fR. The \fBrefreservation\fR reservation is accounted for in the parent datasets' space used, and counts against the parent datasets' quotas and reservations.
-.sp
-If \fBrefreservation\fR is set, a snapshot is only allowed if there is enough free pool space outside of this reservation to accommodate the current number of \fBreferenced\fR bytes in the dataset (which are the bytes to be referenced by the snapshot). This is necessary to continue to provide the \fBrefreservation\fRguarantee to the dataset.
-.sp
-For volumes, see also \fBvolsize\fR.
-.sp
-This property can also be referred to by its shortened column name, \fBrefreserv\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBrelatime\fR=\fBoff\fR | \fBon\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls the manner in which the access time is updated when \fBatime=on\fR is set.  Turning this property \fBon\fR causes the access time to be updated relative to the modify or change time.  Access time is only updated if the previous access time was earlier than the current modify or change time or if the existing access time hasn't been updated within the past 24 hours.  The default value is \fBoff\fR.
-.sp
-The values \fBon\fR and \fBoff\fR are equivalent to the \fBrelatime\fR and \fBnorelatime\fR mount options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBreservation\fR=\fBnone\fR | \fIsize\fR\fR
-.ad
-.sp .6
-.RS 4n
-The minimum amount of space guaranteed to a dataset and its descendents. When the amount of space used is below this value, the dataset is treated as if it were taking up the amount of space specified by its reservation. Reservations are accounted for in the parent datasets' space used, and count against the parent datasets' quotas and reservations.
-.sp
-This property can also be referred to by its shortened column name, \fBreserv\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBsecondarycache\fR=\fBall\fR | \fBnone\fR | \fBmetadata\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls what is cached in the secondary cache (L2ARC). If this property is set to \fBall\fR, then both user data and metadata is cached. If this property is set to \fBnone\fR, then neither user data nor metadata is cached. If this property is set to \fBmetadata\fR, then only metadata is cached. The default value is \fBall\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBsetuid\fR=\fBon\fR | \fBoff\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether the setuid bit is respected for the file system. The default value is \fBon\fR.
-.sp
-The values \fBon\fR and \fBoff\fR are equivalent to the \fBsuid\fR and \fBnosuid\fR mount options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBsharesmb\fR=\fBoff\fR | \fBon\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether the file system is shared by using \fBSamba USERSHARES\fR, and what options are to be used. Otherwise, the file system is automatically shared and unshared with the \fBzfs share\fR and \fBzfs unshare\fR commands. If the property is set to \fBon\fR, the \fBnet\fR(8) command is invoked to create a \fBUSERSHARE\fR.
-.sp
-Because \fBSMB\fR shares requires a resource name, a unique resource name is constructed from the dataset name. The constructed name is a copy of the dataset name except that the characters in the dataset name, which would be invalid in the resource name, are replaced with underscore (\fB_\fR) characters. Linux does not currently support additional options which might be available on Solaris.
-.sp
-If the \fBsharesmb\fR property is set to \fBoff\fR, the file systems are unshared.
-.sp
-In Linux, the share is created with the ACL (Access Control List) "Everyone:F" ("F" stands for "full permissions", ie. read and write permissions) and no guest access (which means Samba must be able to authenticate a real user, system passwd/shadow, LDAP or smbpasswd based) by default. This means that any additional access control (disallow specific user specific access etc) must be done on the underlaying filesystem.
-.sp
-.in +2
-Example to mount a SMB filesystem shared through ZFS (share/tmp):
-Note that a user and his/her password \fBmust\fR be given!
-.sp
-.in +2
-smbmount //127.0.0.1/share_tmp /mnt/tmp -o user=workgroup/turbo,password=obrut,uid=1000
-.in -2
-.in -2
-.sp
-.ne 2
-.na
-\fBMinimal /etc/samba/smb.conf configuration\fR
-.sp
-.in +2
-* Samba will need to listen to 'localhost' (127.0.0.1) for the zfs utilities to communicate with Samba.  This is the default behavior for most Linux distributions.
-.sp
-* Samba must be able to authenticate a user. This can be done in a number of ways, depending on if using the system password file, LDAP or the Samba specific smbpasswd file. How to do this is outside the scope of this manual. Please refer to the smb.conf(5) manpage for more information.
-.sp
-* See the \fBUSERSHARE\fR section of the \fBsmb.conf\fR(5) man page for all configuration options in case you need to modify any options to the share afterwards. Do note that any changes done with the 'net' command will be undone if the share is every unshared (such as at a reboot etc). In the future, ZoL will be able to set specific options directly using sharesmb=<option>.
-.sp
-.in -2
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBsharenfs\fR=\fBoff\fR | \fBon\fR | \fIopts\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether the file system is shared via \fBNFS\fR, and what options are used. A file system with a \fBsharenfs\fR property of \fBoff\fR is managed with the \fBexportfs\fR(8) command and entries in \fB/etc/exports\fR file. Otherwise, the file system is automatically shared and unshared with the \fBzfs share\fR and \fBzfs unshare\fR commands. If the property is set to \fBon\fR, the dataset is shared using the \fBexportfs\fR(8) command in the following manner (see \fBexportfs\fR(8) for the meaning of the different options):
-.sp
-.in +4
-.nf
-/usr/sbin/exportfs -i -o sec=sys,rw,crossmnt,no_subtree_check,no_root_squash,mountpoint *:<mountpoint of dataset>
-.fi
-.in -4
-.sp
-Otherwise, the \fBexportfs\fR(8) command is invoked with options equivalent to the contents of this property.
-.sp
-When the \fBsharenfs\fR property is changed for a dataset, the dataset and any children inheriting the property are re-shared with the new options, only if the property was previously \fBoff\fR, or if they were shared before the property was changed. If the new property is \fBoff\fR, the file systems are unshared.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBlogbias\fR=\fBlatency\fR | \fBthroughput\fR\fR
-.ad
-.sp .6
-.RS 4n
-Provide a hint to ZFS about handling of synchronous requests in this dataset. If \fBlogbias\fR is set to \fBlatency\fR (the default), ZFS will use pool log devices (if configured) to handle the requests at low latency. If \fBlogbias\fR is set to \fBthroughput\fR, ZFS will not use configured pool log devices. ZFS will instead optimize synchronous operations for global pool throughput and efficient use of resources.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBsnapdev\fR=\fBhidden\fR | \fBvisible\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether the snapshots devices of zvol's are hidden or visible. The default value is \fBhidden\fR.
-.sp
-In this context, hidden does not refer to the concept of hiding files or directories by starting their name with a "." character. Even with \fBvisible\fR, the directory is still named \fB\&.zfs\fR. Instead, \fBhidden\fR means that the directory is not returned by \fBreaddir\fR(3), so it doesn't show up in directory listings done by any program, including \fBls\fR \fB-a\fR. It is still possible to chdir(2) into the directory, so \fBcd\fR \fB\&.zfs\fR works even with \fBhidden\fR. This unusual behavior is to protect against unwanted effects from applications recursing into the special \fB\&.zfs\fR directory.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBsnapdir\fR=\fBhidden\fR | \fBvisible\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether the \fB\&.zfs\fR directory is hidden or visible in the root of the file system as discussed in the "Snapshots" section. The default value is \fBhidden\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBsync\fR=\fBstandard\fR | \fBalways\fR | \fBdisabled\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls the behavior of synchronous requests (e.g. fsync, O_DSYNC).
-\fBstandard\fR is the POSIX specified behavior of ensuring all synchronous
-requests are written to stable storage and all devices are flushed to ensure
-data is not cached by device controllers (this is the default). \fBalways\fR
+.Pp
+When set to
+.Sy all ,
+ZFS stores an extra copy of all metadata.
+If a single on-disk block is corrupt, at worst a single block of user data
+.Po which is
+.Sy recordsize
+bytes long
+.Pc
+can be lost.
+.Pp
+When set to
+.Sy most ,
+ZFS stores an extra copy of most types of metadata.
+This can improve performance of random writes, because less metadata must be
+written.
+In practice, at worst about 100 blocks
+.Po of
+.Sy recordsize
+bytes each
+.Pc
+of user data can be lost if a single on-disk block is corrupt.
+The exact behavior of which metadata blocks are stored redundantly may change in
+future releases.
+.Pp
+The default value is
+.Sy all .
+.It Sy refquota Ns = Ns Em size Ns | Ns Sy none
+Limits the amount of space a dataset can consume.
+This property enforces a hard limit on the amount of space used.
+This hard limit does not include space used by descendents, including file
+systems and snapshots.
+.It Sy refreservation Ns = Ns Em size Ns | Ns Sy none
+The minimum amount of space guaranteed to a dataset, not including its
+descendents.
+When the amount of space used is below this value, the dataset is treated as if
+it were taking up the amount of space specified by
+.Sy refreservation .
+The
+.Sy refreservation
+reservation is accounted for in the parent datasets' space used, and counts
+against the parent datasets' quotas and reservations.
+.Pp
+If
+.Sy refreservation
+is set, a snapshot is only allowed if there is enough free pool space outside of
+this reservation to accommodate the current number of
+.Qq referenced
+bytes in the dataset.
+.Pp
+This property can also be referred to by its shortened column name,
+.Sy refreserv .
+.It Sy relatime Ns = Ns Sy on Ns | Ns Sy off
+Controls the manner in which the access time is updated when
+.Sy atime=on
+is set. Turning this property on causes the access time to be updated relative
+to the modify or change time. Access time is only updated if the previous
+access time was earlier than the current modify or change time or if the
+existing access time hasn't been updated within the past 24 hours. The default
+value is
+.Sy off .
+The values
+.Sy on
+and
+.Sy off
+are equivalent to the
+.Sy relatime
+and
+.Sy norelatime
+mount options.
+.It Sy reservation Ns = Ns Em size Ns | Ns Sy none
+The minimum amount of space guaranteed to a dataset and its descendants.
+When the amount of space used is below this value, the dataset is treated as if
+it were taking up the amount of space specified by its reservation.
+Reservations are accounted for in the parent datasets' space used, and count
+against the parent datasets' quotas and reservations.
+.Pp
+This property can also be referred to by its shortened column name,
+.Sy reserv .
+.It Sy secondarycache Ns = Ns Sy all Ns | Ns Sy none Ns | Ns Sy metadata
+Controls what is cached in the secondary cache
+.Pq L2ARC .
+If this property is set to
+.Sy all ,
+then both user data and metadata is cached.
+If this property is set to
+.Sy none ,
+then neither user data nor metadata is cached.
+If this property is set to
+.Sy metadata ,
+then only metadata is cached.
+The default value is
+.Sy all .
+.It Sy setuid Ns = Ns Sy on Ns | Ns Sy off
+Controls whether the setuid bit is respected for the file system.
+The default value is
+.Sy on .
+The values
+.Sy on
+and
+.Sy off
+are equivalent to the
+.Sy suid
+and
+.Sy nosuid
+mount options.
+.It Sy sharesmb Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Em opts
+Controls whether the file system is shared by using
+.Sy Samba USERSHARES
+and what options are to be used. Otherwise, the file system is automatically
+shared and unshared with the
+.Nm zfs Cm share
+and
+.Nm zfs Cm unshare
+commands. If the property is set to on, the
+.Xr net 8
+command is invoked to create a
+.Sy USERSHARE .
+.Pp
+Because SMB shares requires a resource name, a unique resource name is
+constructed from the dataset name. The constructed name is a copy of the
+dataset name except that the characters in the dataset name, which would be
+invalid in the resource name, are replaced with underscore (_) characters.
+Linux does not currently support additional options which might be available
+on Solaris.
+.Pp
+If the
+.Sy sharesmb
+property is set to
+.Sy off ,
+the file systems are unshared.
+.Pp
+The share is created with the ACL (Access Control List) "Everyone:F" ("F"
+stands for "full permissions", ie. read and write permissions) and no guest
+access (which means Samba must be able to authenticate a real user, system
+passwd/shadow, LDAP or smbpasswd based) by default. This means that any
+additional access control (disallow specific user specific access etc) must
+be done on the underlying file system.
+.It Sy sharenfs Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Em opts
+Controls whether the file system is shared via NFS, and what options are to be
+used.
+A file system with a
+.Sy sharenfs
+property of
+.Sy off
+is managed with the
+.Xr exportfs 8
+command and entries in the
+.Em /etc/exports
+file.
+Otherwise, the file system is automatically shared and unshared with the
+.Nm zfs Cm share
+and
+.Nm zfs Cm unshare
+commands.
+If the property is set to
+.Sy on ,
+the dataset is shared using the default options:
+.Pp
+.Em sec=sys,rw,crossmnt,no_subtree_check,no_root_squash
+.Pp
+See
+.Xr exports 5
+for the meaning of the default options. Otherwise, the
+.Xr exportfs 8
+command is invoked with options equivalent to the contents of this property.
+.Pp
+When the
+.Sy sharenfs
+property is changed for a dataset, the dataset and any children inheriting the
+property are re-shared with the new options, only if the property was previously
+.Sy off ,
+or if they were shared before the property was changed.
+If the new property is
+.Sy off ,
+the file systems are unshared.
+.It Sy logbias Ns = Ns Sy latency Ns | Ns Sy throughput
+Provide a hint to ZFS about handling of synchronous requests in this dataset.
+If
+.Sy logbias
+is set to
+.Sy latency
+.Pq the default ,
+ZFS will use pool log devices
+.Pq if configured
+to handle the requests at low latency.
+If
+.Sy logbias
+is set to
+.Sy throughput ,
+ZFS will not use configured pool log devices.
+ZFS will instead optimize synchronous operations for global pool throughput and
+efficient use of resources.
+.It Sy snapdev Ns = Ns Sy hidden Ns | Ns Sy visible
+Controls whether the volume snapshot devices under
+.Em /dev/zvol/<pool>
+are hidden or visible. The default value is
+.Sy hidden .
+.It Sy snapdir Ns = Ns Sy hidden Ns | Ns Sy visible
+Controls whether the
+.Pa .zfs
+directory is hidden or visible in the root of the file system as discussed in
+the
+.Sx Snapshots
+section.
+The default value is
+.Sy hidden .
+.It Sy sync Ns = Ns Sy standard Ns | Ns Sy always Ns | Ns Sy disabled
+Controls the behavior of synchronous requests
+.Pq e.g. fsync, O_DSYNC .
+.Sy standard
+is the
+.Tn POSIX
+specified behavior of ensuring all synchronous requests are written to stable
+storage and all devices are flushed to ensure data is not cached by device
+controllers
+.Pq this is the default .
+.Sy always
 causes every file system transaction to be written and flushed before its
-system call returns. This has a large performance penalty. \fBdisabled\fR
-disables synchronous requests. File system transactions are only committed to
-stable storage periodically. This option will give the highest performance.
+system call returns.
+This has a large performance penalty.
+.Sy disabled
+disables synchronous requests.
+File system transactions are only committed to stable storage periodically.
+This option will give the highest performance.
 However, it is very dangerous as ZFS would be ignoring the synchronous
-transaction demands of applications such as databases or NFS.  Administrators
-should only use this option when the risks are understood.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBversion\fR=\fB5\fR | \fB4\fR | \fB3\fR | \fB2\fR | \fB1\fR | \fBcurrent\fR\fR
-.ad
-.sp .6
-.RS 4n
-The on-disk version of this file system, which is independent of the pool version. This property can only be set to later supported versions. The value \fBcurrent\fR automatically selects the latest supported version. See the \fBzfs upgrade\fR command.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBvolsize\fR=\fIsize\fR\fR
-.ad
-.sp .6
-.RS 4n
-For volumes, specifies the logical size of the volume. By default, creating a volume establishes a \fBrefreservation\fR equal to the volume size plus the metadata required for a fully-written volume. (For pool version 8 or lower, a \fBreservation\fR is set instead.) Any changes to \fBvolsize\fR are reflected in an equivalent change to the \fBrefreservation\fR. The \fBvolsize\fR can only be set to a multiple of \fBvolblocksize\fR, and cannot be zero.
-.sp
-Without the reservation, the volume could run out of space, resulting in undefined behavior or data corruption, depending on how the volume is used. These effects can also occur when the volume size is changed while it is in use (particularly when shrinking the size). Extreme care should be used when adjusting the volume size.
-.sp
-A "sparse volume" (also known as "thin provisioning") can be created by specifying the \fB-s\fR option to the \fBzfs create -V\fR command, or by removing (or changing) the \fBrefreservation\fR after the volume has been created. A "sparse volume" is a volume where the \fBrefreservation\fR is unset or less then the volume size. Consequently, writes to a sparse volume can fail with \fBENOSPC\fR when the pool is low on space. For a sparse volume, changes to \fBvolsize\fR are not reflected in the reservation.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBvscan\fR=\fBoff\fR | \fBon\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether regular files should be scanned for viruses when a file is opened and closed. In addition to enabling this property, the virus scan service must also be enabled for virus scanning to occur. The default value is \fBoff\fR.
-.sp
+transaction demands of applications such as databases or NFS.
+Administrators should only use this option when the risks are understood.
+.It Sy version Ns = Ns Em N Ns | Ns Sy current
+The on-disk version of this file system, which is independent of the pool
+version.
+This property can only be set to later supported versions.
+See the
+.Nm zfs Cm upgrade
+command.
+.It Sy volsize Ns = Ns Em size
+For volumes, specifies the logical size of the volume.
+By default, creating a volume establishes a reservation of equal size.
+For storage pools with a version number of 9 or higher, a
+.Sy refreservation
+is set instead.
+Any changes to
+.Sy volsize
+are reflected in an equivalent change to the reservation
+.Po or
+.Sy refreservation
+.Pc .
+The
+.Sy volsize
+can only be set to a multiple of
+.Sy volblocksize ,
+and cannot be zero.
+.Pp
+The reservation is kept equal to the volume's logical size to prevent unexpected
+behavior for consumers.
+Without the reservation, the volume could run out of space, resulting in
+undefined behavior or data corruption, depending on how the volume is used.
+These effects can also occur when the volume size is changed while it is in use
+.Pq particularly when shrinking the size .
+Extreme care should be used when adjusting the volume size.
+.Pp
+Though not recommended, a
+.Qq sparse volume
+.Po also known as
+.Qq thin provisioning
+.Pc
+can be created by specifying the
+.Fl s
+option to the
+.Nm zfs Cm create Fl V
+command, or by changing the reservation after the volume has been created.
+A
+.Qq sparse volume
+is a volume where the reservation is less then the volume size.
+Consequently, writes to a sparse volume can fail with
+.Er ENOSPC
+when the pool is low on space.
+For a sparse volume, changes to
+.Sy volsize
+are not reflected in the reservation.
+.It Sy vscan Ns = Ns Sy on Ns | Ns Sy off
+Controls whether regular files should be scanned for viruses when a file is
+opened and closed.
+In addition to enabling this property, the virus scan service must also be
+enabled for virus scanning to occur.
+The default value is
+.Sy off .
 This property is not used on Linux.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBxattr\fR=\fBon\fR | \fBoff\fR | \fBsa\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether extended attributes are enabled for this file system.  Two
+.It Sy xattr Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy sa
+Controls whether extended attributes are enabled for this file system. Two
 styles of extended attributes are supported either directory based or system
 attribute based.
-.sp
-The default value of \fBon\fR enables directory based extended attributes.
-This style of xattr imposes no practical limit on either the size or number of
-xattrs which may be set on a file.  Although under Linux the \fBgetxattr\fR(2)
-and \fBsetxattr\fR(2) system calls limit the maximum xattr size to 64K.  This
-is the most compatible style of xattr and it is supported by the majority of
-ZFS implementations.
-.sp
-System attribute based xattrs may be enabled by setting the value to \fBsa\fR.
-The key advantage of this type of xattr is improved performance.  Storing
-xattrs as system attributes significantly decreases the amount of disk IO
-required.  Up to 64K of xattr data may be stored per file in the space reserved
-for system attributes.  If there is not enough space available for an xattr then
-it will be automatically written as a directory based xattr.  System attribute
-based xattrs are not accessible on platforms which do not support the
-\fBxattr=sa\fR feature.
-.sp
+.Pp
+The default value of
+.Sy on
+enables directory based extended attributes. This style of extended attribute
+imposes no practical limit on either the size or number of attributes which
+can be set on a file. Although under Linux the
+.Xr getxattr 2
+and
+.Xr setxattr 2
+system calls limit the maximum size to 64K. This is the most compatible
+style of extended attribute and is supported by all OpenZFS implementations.
+.Pp
+System attribute based xattrs can be enabled by setting the value to
+.Sy sa .
+The key advantage of this type of xattr is improved performance. Storing
+extended attributes as system attributes significantly decreases the amount of
+disk IO required. Up to 64K of data may be stored per-file in the space
+reserved for system attributes. If there is not enough space available for
+an extended attribute then it will be automatically written as a directory
+based xattr. System attribute based extended attributes are not accessible
+on platforms which do not support the
+.Sy xattr=sa
+feature.
+.Pp
 The use of system attribute based xattrs is strongly encouraged for users of
-SELinux or Posix ACLs.  Both of these features heavily rely of xattrs and
-benefit significantly from the reduced xattr access time.
-.sp
-The values \fBon\fR and \fBoff\fR are equivalent to the \fBxattr\fR and \fBnoxattr\fR mount options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzoned\fR=\fBoff\fR | \fBon\fR\fR
-.ad
-.sp .6
-.RS 4n
-Controls whether the dataset is managed from a non-global zone. Zones are a Solaris feature and are not relevant on Linux. The default value is \fBoff\fR.
-.RE
-
-.sp
-.LP
-The following three properties cannot be changed after the file system is created, and therefore, should be set when the file system is created. If the properties are not set with the \fBzfs create\fR or \fBzpool create\fR commands, these properties are inherited from the parent dataset. If the parent dataset lacks these properties due to having been created prior to these features being supported, the new file system will have the default values for these properties.
-.sp
-.ne 2
-.na
-\fB\fBcasesensitivity\fR=\fBsensitive\fR | \fBinsensitive\fR | \fBmixed\fR\fR
-.ad
-.sp .6
-.RS 4n
-Indicates whether the file name matching algorithm used by the file system should be case-sensitive, case-insensitive, or allow a combination of both styles of matching. The default value for the \fBcasesensitivity\fR property is \fBsensitive\fR. Traditionally, UNIX and POSIX file systems have case-sensitive file names.
-.sp
-The \fBmixed\fR value for the \fBcasesensitivity\fR property indicates that the file system can support requests for both case-sensitive and case-insensitive matching behavior. Currently, case-insensitive matching behavior on a file system that supports mixed behavior is limited to the Solaris CIFS server product.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBnormalization\fR = \fBnone\fR | \fBformC\fR | \fBformD\fR | \fBformKC\fR | \fBformKD\fR\fR
-.ad
-.sp .6
-.RS 4n
-Indicates whether the file system should perform a Unicode normalization of file names whenever two file names are compared, and which normalization algorithm should be used.
-.sp
-If this property is set to a value other than \fBnone\fR (the default), and the \fButf8only\fR property was left unspecified, the \fButf8only\fR property is automatically set to \fBon\fR. See the cautionary note in the \fButf8only\fR section before modifying \fBnormalization\fR.
-.sp
-File names are always stored unmodified; names are normalized as part of any comparison process. Thus, \fBformC\fR and \fBformD\fR are equivalent, as are \fBformKC\fR and \fBformKD\fR. Given that, only \fBformD\fR and \fBformKD\fR make sense, as they are slightly faster because they avoid the additional canonical composition step.
-.\" unicode.org says it's possible to quickly detect if a string is already in a given form. Since most text (basically everything but OS X) is already in NFC, this means formC could potentially be made faster. But the additional complexity probably isn't worth the likely undetectable in practice speed improvement.
-.sp
-The practical impact of this property is: \fBnone\fR (like traditional filesystems) allows a directory to contain two files that appear (to humans) to have the same name. The other options solve this problem, for different definitions of "the same". If you need to solve this problem and are not sure what to choose,\fBformD\fR.
-.sp
+SELinux or posix ACLs. Both of these features heavily rely of extended
+attributes and benefit significantly from the reduced access time.
+.Pp
+The values
+.Sy on
+and
+.Sy off
+are equivalent to the
+.Sy xattr
+and
+.Sy noxattr
+mount options.
+.It Sy zoned Ns = Ns Sy on Ns | Ns Sy off
+Controls whether the dataset is managed from a non-global zone. Zones are a
+Solaris feature and are not relevant on Linux. The default value is
+.Sy off .
+.El
+.Pp
+The following three properties cannot be changed after the file system is
+created, and therefore, should be set when the file system is created.
+If the properties are not set with the
+.Nm zfs Cm create
+or
+.Nm zpool Cm create
+commands, these properties are inherited from the parent dataset.
+If the parent dataset lacks these properties due to having been created prior to
+these features being supported, the new file system will have the default values
+for these properties.
+.Bl -tag -width ""
+.It Xo
+.Sy casesensitivity Ns = Ns Sy sensitive Ns | Ns
+.Sy insensitive Ns | Ns Sy mixed
+.Xc
+Indicates whether the file name matching algorithm used by the file system
+should be case-sensitive, case-insensitive, or allow a combination of both
+styles of matching.
+The default value for the
+.Sy casesensitivity
+property is
+.Sy sensitive .
+Traditionally,
+.Ux
+and
+.Tn POSIX
+file systems have case-sensitive file names.
+.Pp
+The
+.Sy mixed
+value for the
+.Sy casesensitivity
+property indicates that the file system can support requests for both
+case-sensitive and case-insensitive matching behavior.
+Currently, case-insensitive matching behavior on a file system that supports
+mixed behavior is limited to the SMB server product.
+For more information about the
+.Sy mixed
+value behavior, see the "ZFS Administration Guide".
+.It Xo
+.Sy normalization Ns = Ns Sy none Ns | Ns Sy formC Ns | Ns
+.Sy formD Ns | Ns Sy formKC Ns | Ns Sy formKD
+.Xc
+Indicates whether the file system should perform a
+.Sy unicode
+normalization of file names whenever two file names are compared, and which
+normalization algorithm should be used.
+File names are always stored unmodified, names are normalized as part of any
+comparison process.
+If this property is set to a legal value other than
+.Sy none ,
+and the
+.Sy utf8only
+property was left unspecified, the
+.Sy utf8only
+property is automatically set to
+.Sy on .
+The default value of the
+.Sy normalization
+property is
+.Sy none .
 This property cannot be changed after the file system is created.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fButf8only\fR=\fBoff\fR | \fBon\fR\fR
-.ad
-.sp .6
-.RS 4n
-Indicates whether the file system should reject file names that include characters that are not present in the \fBUTF-8\fR character set. If this property is explicitly set to \fBoff\fR, the \fBnormalization\fR property must either not be explicitly set or be set to \fBnone\fR. The default value for the \fButf8only\fR property is \fBoff\fR.
-.sp
-Note that forcing the use of \fBUTF-8\fR filenames may cause pain for users. For example, extracting files from an archive will fail if the filenames within the archive are encoded in another character set.
-.sp
-If you are thinking of setting this (to \fBon\fR), you probably want to set \fBnormalization\fR=\fBformD\fR which will set this property to \fBon\fR implicitly.
-.sp
+.It Sy utf8only Ns = Ns Sy on Ns | Ns Sy off
+Indicates whether the file system should reject file names that include
+characters that are not present in the
+.Sy UTF-8
+character code set.
+If this property is explicitly set to
+.Sy off ,
+the normalization property must either not be explicitly set or be set to
+.Sy none .
+The default value for the
+.Sy utf8only
+property is
+.Sy off .
 This property cannot be changed after the file system is created.
-.RE
-
-.sp
-.LP
-The \fBcasesensitivity\fR, \fBnormalization\fR, and \fButf8only\fR properties are also permissions that can be assigned to non-privileged users by using the \fBZFS\fR delegated administration feature.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBcontext\fR=\fBnone\fR | \fISELinux_User:SElinux_Role:Selinux_Type:Sensitivity_Level\fR\fR
-.ad
-.sp .6
-.RS 4n
-This flag sets the SELinux context for all files in the filesystem under the mountpoint for that filesystem.  See \fBselinux\fR(8) for more information.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBfscontext\fR=\fBnone\fR | \fISELinux_User:SElinux_Role:Selinux_Type:Sensitivity_Level\fR\fR
-.ad
-.sp .6
-.RS 4n
-This flag sets the SELinux context for the filesystem being mounted.  See \fBselinux\fR(8) for more information.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBdefcontext\fR=\fBnone\fR | \fISELinux_User:SElinux_Role:Selinux_Type:Sensitivity_Level\fR\fR
-.ad
-.sp .6
-.RS 4n
-This flag sets the SELinux context for unlabeled files.  See \fBselinux\fR(8) for more information.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBrootcontext\fR=\fBnone\fR | \fISELinux_User:SElinux_Role:Selinux_Type:Sensitivity_Level\fR\fR
-.ad
-.sp .6
-.RS 4n
-This flag sets the SELinux context for the root inode of the filesystem.  See \fBselinux\fR(8) for more information.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBoverlay\fR=\fBoff\fR | \fBon\fR\fR
-.ad
-.sp .6
-.RS 4n
-Allow mounting on a busy directory or a directory which already contains files/directories. This is the default mount behavior for Linux filesystems.  However, for consistency with ZFS on other platforms overlay mounts are disabled by default.  Set \fBoverlay=on\fR to enable overlay mounts.
-.RE
-
-.SS "Temporary Mount Point Properties"
-.LP
-When a file system is mounted, either through \fBmount\fR(8) for legacy mounts or the \fBzfs mount\fR command for normal file systems, its mount options are set according to its properties. The correlation between properties and mount options is as follows:
-.sp
-.in +2
-.nf
+.El
+.Pp
+The
+.Sy casesensitivity ,
+.Sy normalization ,
+and
+.Sy utf8only
+properties are also new permissions that can be assigned to non-privileged users
+by using the ZFS delegated administration feature.
+.Ss "Temporary Mount Point Properties"
+When a file system is mounted, either through
+.Xr mount 8
+for legacy mounts or the
+.Nm zfs Cm mount
+command for normal file systems, its mount options are set according to its
+properties.
+The correlation between properties and mount options is as follows:
+.Bd -literal
     PROPERTY                MOUNT OPTION
-     atime                   atime/noatime
-     canmount                auto/noauto
-     devices                 devices/nodevices
-     exec                    exec/noexec
-     readonly                ro/rw
-     relatime                relatime/norelatime
-     setuid                  suid/nosuid
-     xattr                   xattr/noxattr
-     nbmand                  nbmand/nonbmand (Solaris)
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-In addition, these options can be set on a per-mount basis using the \fB-o\fR option, without affecting the property that is stored on disk. The values specified on the command line override the values stored in the dataset. The \fB-nosuid\fR option is an alias for \fBnodevices,nosetuid\fR. These properties are reported as "temporary" by the \fBzfs get\fR command. If the properties are changed while the dataset is mounted, the new setting overrides any temporary settings.
-.SS "User Properties"
-.LP
-In addition to the standard native properties, \fBZFS\fR supports arbitrary user properties. User properties have no effect on \fBZFS\fR behavior, but applications or administrators can use them to annotate datasets (file systems, volumes, and snapshots). Unlike native properties, user properties are editable on snapshots.
-.sp
-.LP
-User property names must contain a colon (\fB:\fR) character to distinguish them from native properties. They may contain lowercase letters, numbers, and the following punctuation characters: colon (\fB:\fR), dash (\fB-\fR), period (\fB\&.\fR), and underscore (\fB_\fR). The expected convention is that the property name is divided into two portions such as \fImodule\fR\fB:\fR\fIproperty\fR, but this namespace is not enforced by \fBZFS\fR. User property names can be at most 256 characters, and cannot begin with a dash (\fB-\fR).
-.sp
-.LP
-When making programmatic use of user properties, it is strongly suggested to use a reversed \fBDNS\fR domain name for the \fImodule\fR component of property names to reduce the chance that two independently-developed packages use the same property name for different purposes. For example, property names beginning with \fBcom.sun\fR. are reserved for definition by Oracle Corporation (which acquired Sun Microsystems).
-.sp
-.LP
-The values of user properties are arbitrary strings, are always inherited, and are never validated. All of the commands that operate on properties (\fBzfs list\fR, \fBzfs get\fR, \fBzfs set\fR, and so forth) can be used to manipulate both native properties and user properties. Use the \fBzfs inherit\fR command to clear a user property. If the property is not defined in any parent dataset, it is removed entirely. Property values are limited to 8192 bytes.
-.SS "ZFS Volumes as Swap"
-.LP
-\fBZFS\fR volumes may be used as Linux swap devices.  After creating the volume
-with the \fBzfs create\fR command set up and enable the swap area using the
-\fBmkswap\fR(8) and \fBswapon\fR(8) commands.  Do not swap to a file on a
-\fBZFS\fR file system. A \fBZFS\fR swap file configuration is not supported.
-.SH SUBCOMMANDS
-.LP
-All subcommands that modify state are logged persistently to the pool in their original form. The log can be viewed with \fBzpool history\fR.
-.sp
-.ne 2
-.na
-\fB\fBzfs ?\fR\fR
-.ad
-.sp .6
-.RS 4n
+    atime                   atime/noatime
+    canmount                auto/noauto
+    devices                 dev/nodev
+    exec                    exec/noexec
+    readonly                ro/rw
+    relatime                relatime/norelatime
+    setuid                  suid/nosuid
+    xattr                   xattr/noxattr
+.Ed
+.Pp
+In addition, these options can be set on a per-mount basis using the
+.Fl o
+option, without affecting the property that is stored on disk.
+The values specified on the command line override the values stored in the
+dataset.
+The
+.Sy nosuid
+option is an alias for
+.Sy nodevices Ns , Ns Sy nosetuid .
+These properties are reported as
+.Qq temporary
+by the
+.Nm zfs Cm get
+command.
+If the properties are changed while the dataset is mounted, the new setting
+overrides any temporary settings.
+.Ss "User Properties"
+In addition to the standard native properties, ZFS supports arbitrary user
+properties.
+User properties have no effect on ZFS behavior, but applications or
+administrators can use them to annotate datasets
+.Pq file systems, volumes, and snapshots .
+.Pp
+User property names must contain a colon
+.Pq Qq Sy \&:
+character to distinguish them from native properties.
+They may contain lowercase letters, numbers, and the following punctuation
+characters: colon
+.Pq Qq Sy \&: ,
+dash
+.Pq Qq Sy - ,
+period
+.Pq Qq Sy \&. ,
+and underscore
+.Pq Qq Sy _ .
+The expected convention is that the property name is divided into two portions
+such as
+.Em module Ns : Ns Em property ,
+but this namespace is not enforced by ZFS.
+User property names can be at most 256 characters, and cannot begin with a dash
+.Pq Qq Sy - .
+.Pp
+When making programmatic use of user properties, it is strongly suggested to use
+a reversed
+.Sy DNS
+domain name for the
+.Em module
+component of property names to reduce the chance that two
+independently-developed packages use the same property name for different
+purposes.
+.Pp
+The values of user properties are arbitrary strings, are always inherited, and
+are never validated.
+All of the commands that operate on properties
+.Po Nm zfs Cm list ,
+.Nm zfs Cm get ,
+.Nm zfs Cm set ,
+and so forth
+.Pc
+can be used to manipulate both native properties and user properties.
+Use the
+.Nm zfs Cm inherit
+command to clear a user property.
+If the property is not defined in any parent dataset, it is removed entirely.
+Property values are limited to 8192 bytes.
+.Ss ZFS Volumes as Swap
+ZFS volumes may be used as swap devices. After creating the volume with the
+.Nm zfs Cm create Fl V
+command set up and enable the swap area using the
+.Xr mkswap 8
+and
+.Xr swapon 8
+commands. Do not swap to a file on a ZFS file system. A ZFS swap file
+configuration is not supported.
+.Sh SUBCOMMANDS
+All subcommands that modify state are logged persistently to the pool in their
+original form.
+.Bl -tag -width ""
+.It Nm Fl ?
 Displays a help message.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs create\fR [\fB-p\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... \fIfilesystem\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates a new \fBZFS\fR file system. The file system is automatically mounted according to the \fBmountpoint\fR and \fBcanmount\fR properties.
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates all the non-existing parent datasets. Datasets created in this manner inherit their properties; any property specified on the command line using the \fB-o\fR option applies only to the final child file system. If the target filesystem already exists, the operation completes successfully and no properties are changed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIproperty\fR=\fIvalue\fR\fR
-.ad
-.sp .6
-.RS 4n
-Sets the specified property as if the command \fBzfs set\fR \fIproperty\fR=\fIvalue\fR was invoked at the same time the dataset was created. Any editable \fBZFS\fR property can also be set at creation time. Multiple \fB-o\fR options can be specified. An error results if the same property is specified in multiple \fB-o\fR options.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs create\fR [\fB-ps\fR] [\fB-b\fR \fIblocksize\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... \fB-V\fR \fIsize\fR \fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates a volume of the given size. The volume is exported as a block device in \fB/dev/zvol/\fR\fIpath\fR, where \fIpath\fR is the name of the volume in the \fBZFS\fR namespace. The size represents the logical size as exported by the device. By default, a \fBrefreservation\fR is created.
-.sp
-\fIsize\fR is automatically rounded up to the nearest 128KiB to ensure that the volume has an integral number of blocks regardless of \fIblocksize\fR.
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates all the non-existing parent datasets as file systems. Datasets created in this manner inherit their properties; any property specified on the command line using the \fB-o\fR option applies only to the final child volume. If the target volume already exists, the operation completes successfully and no properties are changed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-s\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates a sparse volume by omitting the automatic creation of a \fBrefreservation\fR. See \fBvolsize\fR in the Native Properties section for more information about sparse volumes. If this option is specified in conjunction with \fB-o\fR \fBrefreservation\fR, the \fBrefreservation\fR will be honored; this allows for a partial reservation on a sparse volume.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIproperty\fR=\fIvalue\fR\fR
-.ad
-.sp .6
-.RS 4n
-Sets the specified property as if the \fBzfs set\fR \fIproperty\fR=\fIvalue\fR command was invoked at the same time the dataset was created. Any editable \fBZFS\fR property can also be set at creation time. Multiple \fB-o\fR options can be specified. An error results if the same property is specified in multiple \fB-o\fR options.
-.sp
-If \fB-o\fR \fBvolsize\fR is provided, the resulting behavior is undefined; it conflicts with the -V option, which is required in this mode.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-b\fR \fIblocksize\fR\fR
-.ad
-.sp .6
-.RS 4n
-Equivalent to \fB-o\fR \fBvolblocksize\fR=\fIblocksize\fR. If this option is specified in conjunction with \fB-o\fR \fBvolblocksize\fR, the resulting behavior is undefined.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs destroy\fR [\fB-fnpRrv\fR] \fIfilesystem\fR|\fIvolume\fR
-.ad
-.sp .6
-.RS 4n
-Destroys the given dataset. By default, the command unshares any file systems that are currently shared, unmounts any file systems that are currently mounted, and refuses to destroy a dataset that has active dependents (children or clones).
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
+.It Xo
+.Nm
+.Cm create
+.Op Fl p
+.Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
+.Ar filesystem
+.Xc
+Creates a new ZFS file system.
+The file system is automatically mounted according to the
+.Sy mountpoint
+property inherited from the parent.
+.Bl -tag -width "-o"
+.It Fl o Ar property Ns = Ns Ar value
+Sets the specified property as if the command
+.Nm zfs Cm set Ar property Ns = Ns Ar value
+was invoked at the same time the dataset was created.
+Any editable ZFS property can also be set at creation time.
+Multiple
+.Fl o
+options can be specified.
+An error results if the same property is specified in multiple
+.Fl o
+options.
+.It Fl p
+Creates all the non-existing parent datasets.
+Datasets created in this manner are automatically mounted according to the
+.Sy mountpoint
+property inherited from their parent.
+Any property specified on the command line using the
+.Fl o
+option is ignored.
+If the target filesystem already exists, the operation completes successfully.
+.El
+.It Xo
+.Nm
+.Cm create
+.Op Fl ps
+.Op Fl b Ar blocksize
+.Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
+.Fl V Ar size Ar volume
+.Xc
+Creates a volume of the given size.
+The volume is exported as a block device in
+.Pa /dev/zvol/path ,
+where
+.Em path
+is the name of the volume in the ZFS namespace.
+The size represents the logical size as exported by the device.
+By default, a reservation of equal size is created.
+.Pp
+.Ar size
+is automatically rounded up to the nearest 128 Kbytes to ensure that the volume
+has an integral number of blocks regardless of
+.Sy blocksize .
+.Bl -tag -width "-b"
+.It Fl b Ar blocksize
+Equivalent to
+.Fl o Sy volblocksize Ns = Ns Ar blocksize .
+If this option is specified in conjunction with
+.Fl o Sy volblocksize ,
+the resulting behavior is undefined.
+.It Fl o Ar property Ns = Ns Ar value
+Sets the specified property as if the
+.Nm zfs Cm set Ar property Ns = Ns Ar value
+command was invoked at the same time the dataset was created.
+Any editable ZFS property can also be set at creation time.
+Multiple
+.Fl o
+options can be specified.
+An error results if the same property is specified in multiple
+.Fl o
+options.
+.It Fl p
+Creates all the non-existing parent datasets.
+Datasets created in this manner are automatically mounted according to the
+.Sy mountpoint
+property inherited from their parent.
+Any property specified on the command line using the
+.Fl o
+option is ignored.
+If the target filesystem already exists, the operation completes successfully.
+.It Fl s
+Creates a sparse volume with no reservation.
+See
+.Sy volsize
+in the
+.Sx Native Properties
+section for more information about sparse volumes.
+.El
+.It Xo
+.Nm
+.Cm destroy
+.Op Fl Rfnprv
+.Ar filesystem Ns | Ns Ar volume
+.Xc
+Destroys the given dataset.
+By default, the command unshares any file systems that are currently shared,
+unmounts any file systems that are currently mounted, and refuses to destroy a
+dataset that has active dependents
+.Pq children or clones .
+.Bl -tag -width "-R"
+.It Fl R
+Recursively destroy all dependents, including cloned file systems outside the
+target hierarchy.
+.It Fl f
+Force an unmount of any file systems using the
+.Nm unmount Fl f
+command.
+This option has no effect on non-file systems or unmounted file systems.
+.It Fl n
+Do a dry-run
+.Pq Qq No-op
+deletion.
+No data will be deleted.
+This is useful in conjunction with the
+.Fl v
+or
+.Fl p
+flags to determine what data would be deleted.
+.It Fl p
+Print machine-parsable verbose information about the deleted data.
+.It Fl r
 Recursively destroy all children.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-R\fR\fR
-.ad
-.sp .6
-.RS 4n
-Recursively destroy all dependents, including cloned file systems outside the target hierarchy.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-f\fR\fR
-.ad
-.sp .6
-.RS 4n
-Force an unmount of any file systems using the \fBzfs unmount -f\fR command. This option has no effect on non-file systems or unmounted file systems.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-n\fR\fR
-.ad
-.sp .6
-.RS 4n
-Do a dry-run ("No-op") deletion.  No data will be deleted.  This is
-useful in conjunction with the \fB-v\fR or \fB-p\fR flags to determine what
-data would be deleted.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.ad
-.sp .6
-.RS 4n
-Print machine-parsable verbose information about the deleted data.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-v\fR\fR
-.ad
-.sp .6
-.RS 4n
+.It Fl v
 Print verbose information about the deleted data.
-.RE
-.sp
-
-Extreme care should be taken when applying either the \fB-r\fR or the \fB-R\fR options, as they can destroy large portions of a pool.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs destroy\fR [\fB-dnpRrv\fR] \fIfilesystem\fR|\fIvolume\fR@\fIsnap\fR[%\fIsnap\fR][,...]
-.ad
-.sp .6
-.RS 4n
-The specified snapshots are destroyed immediately if they have no clones and the user-initiated reference count is zero (i.e. there are no holds set with \fBzfs hold\fR). If these conditions are not met, this command returns an error, unless \fB-d\fR is supplied.
-.sp
-An inclusive range of snapshots may be specified by separating the
-first and last snapshots with a percent sign.
-The first and/or last snapshots may be left blank, in which case the
-filesystem's oldest or newest snapshot will be implied.
-.sp
-Multiple snapshots
-(or ranges of snapshots) of the same filesystem or volume may be specified
-in a comma-separated list of snapshots.
-Only the snapshot's short name (the
-part after the \fB@\fR) should be specified when using a range or
-comma-separated list to identify multiple snapshots.
-.sp
-.ne 2
-.na
-\fB\fB-d\fR\fR
-.ad
-.sp .6
-.RS 4n
-If a snapshot does not qualify for immediate destruction, rather than returning an error, it is marked for deferred destruction. In this state, it exists as a usable, visible snapshot until both of the preconditions listed above are met, at which point it is destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
-Destroy (or mark for deferred destruction) all snapshots with this name in descendent file systems.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-R\fR\fR
-.ad
-.sp .6
-.RS 4n
-Recursively destroy all clones of these snapshots, including the clones,
-snapshots, and children.  If this flag is specified, the \fB-d\fR flag will
-have no effect.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-n\fR\fR
-.ad
-.sp .6
-.RS 4n
-Do a dry-run ("No-op") deletion.  No data will be deleted.  This is
-useful in conjunction with the \fB-v\fR or \fB-p\fR flags to determine what
-data would be deleted.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.ad
-.sp .6
-.RS 4n
-Print machine-parsable verbose information about the deleted data.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-v\fR\fR
-.ad
-.sp .6
-.RS 4n
-Print verbose information about the deleted data.
-.RE
-
-.sp
-Extreme care should be taken when applying either the \fB-r\fR or the \fB-R\fR
+.El
+.Pp
+Extreme care should be taken when applying either the
+.Fl r
+or the
+.Fl R
 options, as they can destroy large portions of a pool and cause unexpected
 behavior for mounted file systems in use.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs destroy\fR \fIfilesystem\fR|\fIvolume\fR#\fIbookmark\fR
-.ad
-.sp .6
-.RS 4n
+.It Xo
+.Nm
+.Cm destroy
+.Op Fl Rdnprv
+.Ar filesystem Ns | Ns Ar volume Ns @ Ns Ar snap Ns
+.Oo % Ns Ar snap Ns Oo , Ns Ar snap Ns Oo % Ns Ar snap Oc Oc Oc Ns ...
+.Xc
+The given snapshots are destroyed immediately if and only if the
+.Nm zfs Cm destroy
+command without the
+.Fl d
+option would have destroyed it.
+Such immediate destruction would occur, for example, if the snapshot had no
+clones and the user-initiated reference count were zero.
+.Pp
+If a snapshot does not qualify for immediate destruction, it is marked for
+deferred deletion.
+In this state, it exists as a usable, visible snapshot until both of the
+preconditions listed above are met, at which point it is destroyed.
+.Pp
+An inclusive range of snapshots may be specified by separating the first and
+last snapshots with a percent sign.
+The first and/or last snapshots may be left blank, in which case the
+filesystem's oldest or newest snapshot will be implied.
+.Pp
+Multiple snapshots
+.Pq or ranges of snapshots
+of the same filesystem or volume may be specified in a comma-separated list of
+snapshots.
+Only the snapshot's short name
+.Po the part after the
+.Sy @
+.Pc
+should be specified when using a range or comma-separated list to identify
+multiple snapshots.
+.Bl -tag -width "-R"
+.It Fl R
+Recursively destroy all clones of these snapshots, including the clones,
+snapshots, and children.
+If this flag is specified, the
+.Fl d
+flag will have no effect.
+.It Fl d
+Defer snapshot deletion.
+.It Fl n
+Do a dry-run
+.Pq Qq No-op
+deletion.
+No data will be deleted.
+This is useful in conjunction with the
+.Fl p
+or
+.Fl v
+flags to determine what data would be deleted.
+.It Fl p
+Print machine-parsable verbose information about the deleted data.
+.It Fl r
+Destroy
+.Pq or mark for deferred deletion
+all snapshots with this name in descendent file systems.
+.It Fl v
+Print verbose information about the deleted data.
+.Pp
+Extreme care should be taken when applying either the
+.Fl r
+or the
+.Fl R
+options, as they can destroy large portions of a pool and cause unexpected
+behavior for mounted file systems in use.
+.El
+.It Xo
+.Nm
+.Cm destroy
+.Ar filesystem Ns | Ns Ar volume Ns # Ns Ar bookmark
+.Xc
 The given bookmark is destroyed.
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs snapshot\fR [\fB-r\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... \fIfilesystem@snapname\fR|\fIvolume@snapname\fR\fR ...
-.ad
-.sp .6
-.RS 4n
-Creates snapshots with the given names. All previous modifications by successful system calls to the file system are part of the snapshots. Snapshots are taken atomically, so that all snapshots correspond to the same moment in time. See the "Snapshots" section for details.
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
-Recursively create snapshots of all descendent datasets.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIproperty\fR=\fIvalue\fR\fR
-.ad
-.sp .6
-.RS 4n
-Sets the specified property; see \fBzfs set\fR for details.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs rollback\fR [\fB-rRf\fR] \fIsnapshot\fR\fR
-.ad
-.sp .6
-.RS 4n
-Roll back the given dataset to a previous snapshot. When a dataset is rolled back, all data that has changed since the snapshot is discarded, and the dataset reverts to the state at the time of the snapshot. By default, the command refuses to roll back to a snapshot other than the most recent one. In order to do so, all intermediate snapshots and bookmarks must be destroyed by specifying the \fB-r\fR option.
-.sp
-The \fB-rR\fR options do not recursively destroy the child snapshots of a recursive snapshot. Only direct snapshots of the specified filesystem are destroyed by either of these options. To completely roll back a recursive snapshot, you must rollback the individual child snapshots.
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
+.It Xo
+.Nm
+.Cm snapshot
+.Op Fl r
+.Oo Fl o Ar property Ns = Ns value Oc Ns ...
+.Ar filesystem Ns @ Ns Ar snapname Ns | Ns Ar volume Ns @ Ns Ar snapname Ns ...
+.Xc
+Creates snapshots with the given names.
+All previous modifications by successful system calls to the file system are
+part of the snapshots.
+Snapshots are taken atomically, so that all snapshots correspond to the same
+moment in time.
+See the
+.Sx Snapshots
+section for details.
+.Bl -tag -width "-o"
+.It Fl o Ar property Ns = Ns Ar value
+Sets the specified property; see
+.Nm zfs Cm create
+for details.
+.It Fl r
+Recursively create snapshots of all descendent datasets
+.El
+.It Xo
+.Nm
+.Cm rollback
+.Op Fl Rfr
+.Ar snapshot
+.Xc
+Roll back the given dataset to a previous snapshot.
+When a dataset is rolled back, all data that has changed since the snapshot is
+discarded, and the dataset reverts to the state at the time of the snapshot.
+By default, the command refuses to roll back to a snapshot other than the most
+recent one.
+In order to do so, all intermediate snapshots and bookmarks must be destroyed by
+specifying the
+.Fl r
+option.
+.Pp
+The
+.Fl rR
+options do not recursively destroy the child snapshots of a recursive snapshot.
+Only direct snapshots of the specified filesystem are destroyed by either of
+these options.
+To completely roll back a recursive snapshot, you must rollback the individual
+child snapshots.
+.Bl -tag -width "-R"
+.It Fl R
+Destroy any more recent snapshots and bookmarks, as well as any clones of those
+snapshots.
+.It Fl f
+Used with the
+.Fl R
+option to force an unmount of any clone file systems that are to be destroyed.
+.It Fl r
 Destroy any snapshots and bookmarks more recent than the one specified.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-R\fR\fR
-.ad
-.sp .6
-.RS 4n
-Recursively destroy any more recent snapshots and bookmarks, as well as any clones of those snapshots.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-f\fR\fR
-.ad
-.sp .6
-.RS 4n
-Used with the \fB-R\fR option to force an unmount (see \fBzfs unmount -f\fR) of any clone file systems that are to be destroyed.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs clone\fR [\fB-p\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... \fIsnapshot\fR \fIfilesystem\fR|\fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates a clone of the given snapshot. See the "Clones" section for details. The target dataset can be located anywhere in the \fBZFS\fR hierarchy, and is created as the same type as the original.
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates all the non-existing parent datasets; see \fBzfs create\fR for details.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIproperty\fR=\fIvalue\fR\fR
-.ad
-.sp .6
-.RS 4n
-Sets the specified property; see \fBzfs set\fR for details.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs promote\fR \fIclone-filesystem\fR\fR
-.ad
-.sp .6
-.RS 4n
-Promotes a clone file system to no longer be dependent on its "origin" snapshot. This makes it possible to destroy the file system that the clone was created from. The clone parent-child dependency relationship is reversed, so that the origin file system becomes a clone of the specified file system.
-.sp
-The snapshot that was cloned, and any snapshots previous to this snapshot, are now owned by the promoted clone. The space they use moves from the origin file system to the promoted clone, so enough space must be available to accommodate these snapshots. No new space is consumed by this operation, but the space accounting is adjusted. The promoted clone must not have any conflicting snapshot names of its own. The \fBzfs rename\fR command can be used to rename any conflicting snapshots.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs rename\fR [\fB-f\fR] \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR\fR
-.ad
-.br
-.na
-\fB\fBzfs rename\fR [\fB-fp\fR] \fIfilesystem\fR|\fIvolume\fR \fIfilesystem\fR|\fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Renames the given dataset. The new target can be located anywhere in the \fBZFS\fR hierarchy, with the exception of snapshots. Snapshots can only be renamed within the parent file system or volume. When renaming a snapshot, the parent file system of the snapshot does not need to be specified as part of the second argument. Renamed file systems can inherit new mount points, in which case they are unmounted and remounted at the new mount point.
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates all the nonexistent parent datasets; see \fBzfs create\fR for details.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-f\fR\fR
-.ad
-.sp .6
-.RS 4n
+.El
+.It Xo
+.Nm
+.Cm clone
+.Op Fl p
+.Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
+.Ar snapshot Ar filesystem Ns | Ns Ar volume
+.Xc
+Creates a clone of the given snapshot.
+See the
+.Sx Clones
+section for details.
+The target dataset can be located anywhere in the ZFS hierarchy, and is created
+as the same type as the original.
+.Bl -tag -width "-o"
+.It Fl o Ar property Ns = Ns Ar value
+Sets the specified property; see
+.Nm zfs Cm create
+for details.
+.It Fl p
+Creates all the non-existing parent datasets.
+Datasets created in this manner are automatically mounted according to the
+.Sy mountpoint
+property inherited from their parent.
+If the target filesystem or volume already exists, the operation completes
+successfully.
+.El
+.It Xo
+.Nm
+.Cm promote
+.Ar clone-filesystem
+.Xc
+Promotes a clone file system to no longer be dependent on its
+.Qq origin
+snapshot.
+This makes it possible to destroy the file system that the clone was created
+from.
+The clone parent-child dependency relationship is reversed, so that the origin
+file system becomes a clone of the specified file system.
+.Pp
+The snapshot that was cloned, and any snapshots previous to this snapshot, are
+now owned by the promoted clone.
+The space they use moves from the origin file system to the promoted clone, so
+enough space must be available to accommodate these snapshots.
+No new space is consumed by this operation, but the space accounting is
+adjusted.
+The promoted clone must not have any conflicting snapshot names of its own.
+The
+.Cm rename
+subcommand can be used to rename any conflicting snapshots.
+.It Xo
+.Nm
+.Cm rename
+.Op Fl f
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
+.Xc
+.It Xo
+.Nm
+.Cm rename
+.Op Fl fp
+.Ar filesystem Ns | Ns Ar volume
+.Ar filesystem Ns | Ns Ar volume
+.Xc
+Renames the given dataset.
+The new target can be located anywhere in the ZFS hierarchy, with the exception
+of snapshots.
+Snapshots can only be renamed within the parent file system or volume.
+When renaming a snapshot, the parent file system of the snapshot does not need
+to be specified as part of the second argument.
+Renamed file systems can inherit new mount points, in which case they are
+unmounted and remounted at the new mount point.
+.Bl -tag -width "-a"
+.It Fl f
 Force unmount any filesystems that need to be unmounted in the process.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs rename\fR \fB-r\fR \fIsnapshot\fR \fIsnapshot\fR\fR
-.ad
-.sp .6
-.RS 4n
-Recursively rename the snapshots of all descendent datasets. Snapshots are the only dataset that can be renamed recursively.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs\fR \fBlist\fR [\fB-r\fR|\fB-d\fR \fIdepth\fR] [\fB-Hp\fR] [\fB-o\fR \fIproperty\fR[,\fI\&...\fR]] [ \fB-t\fR \fItype\fR[,\fI\&...\fR]] [ \fB-s\fR \fIproperty\fR ] ... [ \fB-S\fR \fIproperty\fR ] ... [\fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR|\fImountpoint\fR] ...\fR
-.ad
-.sp .6
-.RS 4n
-Lists the property information for the given datasets in tabular form. If a mount point is specified, it can be an absolute pathname or a relative pathname starting with "./"  (e.g. \fBzfs list ./\fR). By default, all file systems and volumes are displayed. Snapshots are displayed if the pool's \fBlistsnapshots\fR property is \fBon\fR (the default is \fBoff\fR). When listing hundreds or thousands of snapshots performance can be improved by restricting the output to only the name.  In that case, it is recommended to use \fB-o name -s name\fR. The following fields are displayed by default: \fBname, used, available, referenced, mountpoint\fR
-.sp
-.ne 2
-.na
-\fB\fB-H\fR\fR
-.ad
-.sp .6
-.RS 4n
-Used for scripting mode. Do not print headers and separate fields by a single tab instead of arbitrary white space.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.sp .6
-.RS 4n
-Display numbers in parsable (exact) values.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
-Recursively display any children of the dataset on the command line.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-d\fR \fIdepth\fR\fR
-.ad
-.sp .6
-.RS 4n
-Recursively display any children of the dataset, limiting the recursion to \fIdepth\fR. A depth of \fB1\fR will display only the dataset and its direct children.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIproperty\fR\fR
-.ad
-.sp .6
-.RS 4n
-A comma-separated list of properties to display. The property must be:
-.RS +4
-.TP
-.ie t \(bu
-.el o
-One of the properties described in the "Native Properties" section
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
+.It Fl p
+Creates all the nonexistent parent datasets.
+Datasets created in this manner are automatically mounted according to the
+.Sy mountpoint
+property inherited from their parent.
+.El
+.It Xo
+.Nm
+.Cm rename
+.Fl r
+.Ar snapshot Ar snapshot
+.Xc
+Recursively rename the snapshots of all descendent datasets.
+Snapshots are the only dataset that can be renamed recursively.
+.It Xo
+.Nm
+.Cm list
+.Op Fl r Ns | Ns Fl d Ar depth
+.Op Fl Hp
+.Oo Fl o Ar property Ns Oo , Ns Ar property Oc Ns ... Oc
+.Oo Fl s Ar property Oc Ns ...
+.Oo Fl S Ar property Oc Ns ...
+.Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
+.Oo Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Oc Ns ...
+.Xc
+Lists the property information for the given datasets in tabular form.
+If specified, you can list property information by the absolute pathname or the
+relative pathname.
+By default, all file systems and volumes are displayed.
+Snapshots are displayed if the
+.Sy listsnaps
+property is
+.Sy on
+.Po the default is
+.Sy off
+.Pc .
+The following fields are displayed,
+.Sy name Ns , Ns Sy used Ns , Ns Sy available Ns , Ns Sy referenced Ns , Ns
+.Sy mountpoint .
+.Bl -tag -width "-H"
+.It Fl H
+Used for scripting mode.
+Do not print headers and separate fields by a single tab instead of arbitrary
+white space.
+.It Fl S Ar property
+Same as the
+.Fl s
+option, but sorts by property in descending order.
+.It Fl d Ar depth
+Recursively display any children of the dataset, limiting the recursion to
+.Ar depth .
+A
+.Ar depth
+of
+.Sy 1
+will display only the dataset and its direct children.
+.It Fl o Ar property
+A comma-separated list of properties to display.
+The property must be:
+.Bl -bullet
+.It
+One of the properties described in the
+.Sx Native Properties
+section
+.It
 A user property
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-The value \fBname\fR to display the dataset name
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-The value \fBspace\fR to display space usage properties on file systems and volumes. This is a shortcut for specifying \fB-o name,avail,used,usedsnap,usedds,usedrefreserv,usedchild\fR \fB-t filesystem,volume\fR syntax.
-.RE
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-s\fR \fIproperty\fR\fR
-.ad
-.sp .6
-.RS 4n
-A property for sorting the output by column in ascending order based on the value of the property. The property must be one of the properties described in the "Properties" section, or the special value \fBname\fR to sort by the dataset name. Multiple properties can be specified at one time using multiple \fB-s\fR property options. Multiple \fB-s\fR options are evaluated from left to right in decreasing order of importance.
-.sp
+.It
+The value
+.Sy name
+to display the dataset name
+.It
+The value
+.Sy space
+to display space usage properties on file systems and volumes.
+This is a shortcut for specifying
+.Fl o Sy name Ns , Ns Sy avail Ns , Ns Sy used Ns , Ns Sy usedsnap Ns , Ns
+.Sy usedds Ns , Ns Sy usedrefreserv Ns , Ns Sy usedchild Fl t
+.Sy filesystem Ns , Ns Sy volume
+syntax.
+.El
+.It Fl p
+Display numbers in parsable
+.Pq exact
+values.
+.It Fl r
+Recursively display any children of the dataset on the command line.
+.It Fl s Ar property
+A property for sorting the output by column in ascending order based on the
+value of the property.
+The property must be one of the properties described in the
+.Sx Properties
+section, or the special value
+.Sy name
+to sort by the dataset name.
+Multiple properties can be specified at one time using multiple
+.Fl s
+property options.
+Multiple
+.Fl s
+options are evaluated from left to right in decreasing order of importance.
 The following is a list of sorting criteria:
-.RS +4
-.TP
-.ie t \(bu
-.el o
+.Bl -bullet
+.It
 Numeric types sort in numeric order.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
+.It
 String types sort in alphabetical order.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-Types inappropriate for a row sort that row to the literal bottom, regardless of the specified ordering.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-If no sorting options are specified the existing behavior of \fBzfs list\fR is preserved.
-.RE
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-S\fR \fIproperty\fR\fR
-.ad
-.sp .6
-.RS 4n
-Same as the \fB-s\fR option, but sorts by property in descending order.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-t\fR \fItype\fR\fR
-.ad
-.sp .6
-.RS 4n
-A comma-separated list of types to display, where \fItype\fR is one of \fBfilesystem\fR, \fBsnapshot\fR, \fBsnap\fR, \fBvolume\fR, \fBbookmark\fR, or \fBall\fR. For example, specifying \fB-t snapshot\fR displays only snapshots.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs set\fR \fIproperty\fR=\fIvalue\fR[ \fIproperty\fR=\fIvalue\fR]...
-\fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR|\fIbookmark\fR ...\fR
-.ad
-.sp .6
-.RS 4n
+.It
+Types inappropriate for a row sort that row to the literal bottom, regardless of
+the specified ordering.
+.El
+.Pp
+If no sorting options are specified the existing behavior of
+.Nm zfs Cm list
+is preserved.
+.It Fl t Ar type
+A comma-separated list of types to display, where
+.Ar type
+is one of
+.Sy filesystem ,
+.Sy snapshot ,
+.Sy volume ,
+.Sy bookmark ,
+or
+.Sy all .
+For example, specifying
+.Fl t Sy snapshot
+displays only snapshots.
+.El
+.It Xo
+.Nm
+.Cm set
+.Ar property Ns = Ns Ar value Oo Ar property Ns = Ns Ar value Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns ...
+.Xc
 Sets the property or list of properties to the given value(s) for each dataset.
-Only some properties can be edited. See the "Properties" section for more
-information on which properties can be set and acceptable values. User properties
-can be set on snapshots. For more information, see the "User Properties" section.
-.RE
-
-.sp
-.ne 2
-\fB\fBzfs get\fR [\fB-r\fR|\fB-d\fR \fIdepth\fR] [\fB-Hp\fR] [\fB-o\fR \fIfield\fR[,...] [\fB-t\fR \fItype\fR[,...]] [\fB-s\fR \fIsource\fR[,...] "\fIall\fR" | \fIproperty\fR[,...] \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR ...\fR|\fIbookmark\fR ...\fR
-.ad
-.sp .6
-.RS 4n
-Displays properties for the given datasets. If no datasets are specified, then the command displays properties for all datasets on the system. For each property, the following columns are displayed:
-.sp
-.in +2
-.nf
+Only some properties can be edited.
+See the
+.Sx Properties
+section for more information on what properties can be set and acceptable
+values.
+Numeric values can be specified as exact values, or in a human-readable form
+with a suffix of
+.Sy B , K , M , G , T , P , E , Z
+.Po for bytes, kilobytes, megabytes, gigabytes, terabytes, petabytes, exabytes,
+or zettabytes, respectively
+.Pc .
+User properties can be set on snapshots.
+For more information, see the
+.Sx User Properties
+section.
+.It Xo
+.Nm
+.Cm get
+.Op Fl r Ns | Ns Fl d Ar depth
+.Op Fl Hp
+.Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns ... Oc
+.Oo Fl s Ar source Ns Oo , Ns Ar source Oc Ns ... Oc
+.Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
+.Cm all | Ar property Ns Oo , Ns Ar property Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns | Ns Ar bookmark Ns ...
+.Xc
+Displays properties for the given datasets.
+If no datasets are specified, then the command displays properties for all
+datasets on the system.
+For each property, the following columns are displayed:
+.Bd -literal
     name      Dataset name
-     property  Property name
-     value     Property value
-     source    Property source. Can either be local, default,
-               temporary, inherited, received, or none (-).
-.fi
-.in -2
-.sp
-
-All columns are displayed by default, though this can be controlled by using the \fB-o\fR option. This command takes a comma-separated list of properties as described in the "Native Properties" and "User Properties" sections.
-.sp
-The special value \fBall\fR can be used to display all properties that apply to the given dataset's type (filesystem, volume snapshot, or bookmark).
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
+    property  Property name
+    value     Property value
+    source    Property source.  Can either be local, default,
+              temporary, inherited, or none (-).
+.Ed
+.Pp
+All columns are displayed by default, though this can be controlled by using the
+.Fl o
+option.
+This command takes a comma-separated list of properties as described in the
+.Sx Native Properties
+and
+.Sx User Properties
+sections.
+.Pp
+The special value
+.Sy all
+can be used to display all properties that apply to the given dataset's type
+.Pq filesystem, volume, snapshot, or bookmark .
+.Bl -tag -width "-H"
+.It Fl H
+Display output in a form more easily parsed by scripts.
+Any headers are omitted, and fields are explicitly separated by a single tab
+instead of an arbitrary amount of space.
+.It Fl d Ar depth
+Recursively display any children of the dataset, limiting the recursion to
+.Ar depth .
+A depth of
+.Sy 1
+will display only the dataset and its direct children.
+.It Fl o Ar field
+A comma-separated list of columns to display.
+.Sy name Ns , Ns Sy property Ns , Ns Sy value Ns , Ns Sy source
+is the default value.
+.It Fl p
+Display numbers in parsable
+.Pq exact
+values.
+.It Fl r
 Recursively display properties for any children.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-d\fR \fIdepth\fR\fR
-.ad
-.sp .6
-.RS 4n
-Recursively display any children of the dataset, limiting the recursion to \fIdepth\fR. A depth of \fB1\fR will display only the dataset and its direct children.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-H\fR\fR
-.ad
-.sp .6
-.RS 4n
-Display output in a form more easily parsed by scripts. Any headers are omitted, and fields are explicitly separated by a single tab instead of an arbitrary amount of space.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIfield\fR\fR
-.ad
-.sp .6
-.RS 4n
-A comma-separated list of columns to display. \fBname,property,value,source\fR is the default value.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-s\fR \fIsource\fR\fR
-.ad
-.sp .6
-.RS 4n
-A comma-separated list of sources to display. Those properties coming from a source other than those in this list are ignored. Each source must be one of the following: \fBlocal,default,inherited,received,temporary,none\fR. The default value is all sources.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.ad
-.sp .6
-.RS 4n
-Display numbers in parsable (exact) values.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs inherit\fR [\fB-rS\fR] \fIproperty\fR \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR ...\fR
-.ad
-.sp .6
-.RS 4n
-Clears the specified property, causing it to be inherited from an ancestor, restored to default if no ancestor has the property set, or with the \fB-S\fR option reverted to the received value if one exists.  See the "Properties" section for a listing of default values, and details on which properties can be inherited.
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
+.It Fl s Ar source
+A comma-separated list of sources to display.
+Those properties coming from a source other than those in this list are ignored.
+Each source must be one of the following:
+.Sy local ,
+.Sy default ,
+.Sy inherited ,
+.Sy temporary ,
+and
+.Sy none .
+The default value is all sources.
+.It Fl t Ar type
+A comma-separated list of types to display, where
+.Ar type
+is one of
+.Sy filesystem ,
+.Sy snapshot ,
+.Sy volume ,
+.Sy bookmark ,
+or
+.Sy all .
+.El
+.It Xo
+.Nm
+.Cm inherit
+.Op Fl rS
+.Ar property Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot Ns ...
+.Xc
+Clears the specified property, causing it to be inherited from an ancestor,
+restored to default if no ancestor has the property set, or with the
+.Fl S
+option reverted to the received value if one exists.
+See the
+.Sx Properties
+section for a listing of default values, and details on which properties can be
+inherited.
+.Bl -tag -width "-r"
+.It Fl r
 Recursively inherit the given property for all children.
-.RE
-.sp
-.ne 2
-.na
-\fB\fB-S\fR\fR
-.ad
-.sp .6
-.RS 4n
+.It Fl S
 Revert the property to the received value if one exists; otherwise operate as
-if the \fB-S\fR option was not specified.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs upgrade\fR
-.ad
-.sp .6
-.RS 4n
+if the
+.Fl S
+option was not specified.
+.El
+.It Xo
+.Nm
+.Cm upgrade
+.Xc
 Displays a list of file systems that are not the most recent version.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs upgrade\fR \fB-v\fR\fR
-.ad
-.sp .6
-.RS 4n
-Displays a list of file system versions.
-.RE
-
-
-.sp
-.ne 2
-.na
-\fB\fBzfs upgrade\fR [\fB-r\fR] [\fB-V\fR \fIversion\fR] [\fB-a\fR | \fIfilesystem\fR]\fR
-.ad
-.sp .6
-.RS 4n
-Upgrades file systems to a new on-disk version. Once this is done, the file systems will no longer be accessible on systems running older versions of the software. \fBzfs send\fR streams generated from new snapshots of these file systems cannot be accessed on systems running older versions of the software.
-.sp
-In general, the file system version is independent of the pool version. See \fBzpool\fR(8) for information on the \fBzpool upgrade\fR command.
-.sp
-In some cases, the file system version and the pool version are interrelated and the pool version must be upgraded before the file system version can be upgraded.
-.sp
-.ne 2
-.na
-\fB\fB-a\fR\fR
-.ad
-.sp .6
-.RS 4n
-Upgrades all file systems on all imported pools.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fIfilesystem\fR\fR
-.ad
-.sp .6
-.RS 4n
-Upgrades the specified file system.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
-Upgrades the specified file system and all descendent file systems
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-V\fR \fIversion\fR\fR
-.ad
-.sp .6
-.RS 4n
-Upgrades to the specified \fIversion\fR. If the \fB-V\fR flag is not specified, this command upgrades to the most recent version. This option can only be used to increase the version number, and only up to the most recent version supported by this software.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs\fR \fBuserspace\fR [\fB-Hinp\fR] [\fB-o\fR \fIfield\fR[,...]]
-[\fB-s\fR \fIfield\fR] ...
-[\fB-S\fR \fIfield\fR] ...
-[\fB-t\fR \fItype\fR[,...]] \fIfilesystem\fR|\fIsnapshot\fR
-.ad
-.sp .6
-.RS 4n
-Displays space consumed by, and quotas on, each user in the specified
-filesystem or snapshot. This corresponds to the \fBuserused@\fR\fIuser\fR, \fBuserobjused@\fR\fIuser\fR,
-\fBuserquota@\fR\fIuser\fR, and \fBuserobjquota@\fR\fIuser\fR properties.
-.sp
-.ne 2
-.na
-\fB\fB-n\fR\fR
-.ad
-.sp .6
-.RS 4n
-Print numeric ID instead of user/group name.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-H\fR\fR
-.ad
-.sp .6
-.RS 4n
-Display output in a form more easily parsed by scripts. Any headers are omitted, and fields are explicitly separated by a single tab instead of an arbitrary amount of space.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.ad
-.sp .6
-.RS 4n
-Use exact (parsable) numeric output.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIfield\fR[,...]\fR
-.ad
-.sp .6
-.RS 4n
-Display only the specified fields from the following
-set: \fBtype, name, used, quota\fR. The default is to display all fields.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-s\fR \fIfield\fR\fR
-.ad
-.sp .6
-.RS 4n
-Sort output by this field. The \fIs\fR and \fIS\fR flags may be specified
-multiple times to sort first by one field, then by another. The default is
-\fB-s type\fR \fB-s name\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-S\fR \fIfield\fR\fR
-.ad
-.sp .6
-.RS 4n
-Sort by this field in reverse order. See \fB-s\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-t\fR \fItype\fR[,...]\fR
-.ad
-.sp .6
-.RS 4n
-Print only the specified types from the following
-set: \fBall, posixuser, smbuser, posixgroup, smbgroup\fR. The default
-is \fB-t posixuser,smbuser\fR. The default can be changed to include group
-types.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-i\fR\fR
-.ad
-.sp .6
-.RS 4n
-Translate SID to POSIX ID. The POSIX ID may be ephemeral if no mapping exists.
-Normal POSIX interfaces (for example, \fBstat\fR(2), \fBls\fR(1) \fB-l\fR) perform
-this translation, so the \fB-i\fR option allows the output from \fBzfs
-userspace\fR to be compared directly with those utilities. However, \fB-i\fR
+.It Xo
+.Nm
+.Cm upgrade
+.Fl v
+.Xc
+Displays a list of currently supported file system versions.
+.It Xo
+.Nm
+.Cm upgrade
+.Op Fl r
+.Op Fl V Ar version
+.Fl a | Ar filesystem
+.Xc
+Upgrades file systems to a new on-disk version.
+Once this is done, the file systems will no longer be accessible on systems
+running older versions of the software.
+.Nm zfs Cm send
+streams generated from new snapshots of these file systems cannot be accessed on
+systems running older versions of the software.
+.Pp
+In general, the file system version is independent of the pool version.
+See
+.Xr zpool 8
+for information on the
+.Nm zpool Cm upgrade
+command.
+.Pp
+In some cases, the file system version and the pool version are interrelated and
+the pool version must be upgraded before the file system version can be
+upgraded.
+.Bl -tag -width "-V"
+.It Fl V Ar version
+Upgrade to the specified
+.Ar version .
+If the
+.Fl V
+flag is not specified, this command upgrades to the most recent version.
+This
+option can only be used to increase the version number, and only up to the most
+recent version supported by this software.
+.It Fl a
+Upgrade all file systems on all imported pools.
+.It Ar filesystem
+Upgrade the specified file system.
+.It Fl r
+Upgrade the specified file system and all descendent file systems.
+.El
+.It Xo
+.Nm
+.Cm userspace
+.Op Fl Hinp
+.Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns ... Oc
+.Oo Fl s Ar field Oc Ns ...
+.Oo Fl S Ar field Oc Ns ...
+.Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar snapshot
+.Xc
+Displays space consumed by, and quotas on, each user in the specified filesystem
+or snapshot.
+This corresponds to the
+.Sy userused@ Ns Em user ,
+.Sy userobjused@ Ns Em user ,
+.Sy userquota@ Ns Em user,
+and
+.Sy userobjquota@ Ns Em user
+properties.
+.Bl -tag -width "-H"
+.It Fl H
+Do not print headers, use tab-delimited output.
+.It Fl S Ar field
+Sort by this field in reverse order.
+See
+.Fl s .
+.It Fl i
+Translate SID to POSIX ID.
+The POSIX ID may be ephemeral if no mapping exists.
+Normal POSIX interfaces
+.Po for example,
+.Xr stat 2 ,
+.Nm ls Fl l
+.Pc
+perform this translation, so the
+.Fl i
+option allows the output from
+.Nm zfs Cm userspace
+to be compared directly with those utilities.
+However,
+.Fl i
 may lead to confusion if some files were created by an SMB user before a
-SMB-to-POSIX name mapping was established. In such a case, some files will be owned
-by the SMB entity and some by the POSIX entity. However, the \fB-i\fR option
-will report that the POSIX entity has the total usage and quota for both.
-.sp
-This option is not useful on Linux.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs\fR \fBgroupspace\fR [\fB-Hinp\fR] [\fB-o\fR \fIfield\fR[,...]]
-[\fB-s\fR \fIfield\fR] ...
-[\fB-S\fR \fIfield\fR] ...
-[\fB-t\fR \fItype\fR[,...]] \fIfilesystem\fR|\fIsnapshot\fR
-.ad
-.sp .6
-.RS 4n
+SMB-to-POSIX name mapping was established.
+In such a case, some files will be owned by the SMB entity and some by the POSIX
+entity.
+However, the
+.Fl i
+option will report that the POSIX entity has the total usage and quota for both.
+.It Fl n
+Print numeric ID instead of user/group name.
+.It Fl o Ar field Ns Oo , Ns Ar field Oc Ns ...
+Display only the specified fields from the following set:
+.Sy type ,
+.Sy name ,
+.Sy used ,
+.Sy quota .
+The default is to display all fields.
+.It Fl p
+Use exact
+.Pq parsable
+numeric output.
+.It Fl s Ar field
+Sort output by this field.
+The
+.Fl s
+and
+.Fl S
+flags may be specified multiple times to sort first by one field, then by
+another.
+The default is
+.Fl s Sy type Fl s Sy name .
+.It Fl t Ar type Ns Oo , Ns Ar type Oc Ns ...
+Print only the specified types from the following set:
+.Sy all ,
+.Sy posixuser ,
+.Sy smbuser ,
+.Sy posixgroup ,
+.Sy smbgroup .
+The default is
+.Fl t Sy posixuser Ns , Ns Sy smbuser .
+The default can be changed to include group types.
+.El
+.It Xo
+.Nm
+.Cm groupspace
+.Op Fl Hinp
+.Oo Fl o Ar field Ns Oo , Ns Ar field Oc Ns ... Oc
+.Oo Fl s Ar field Oc Ns ...
+.Oo Fl S Ar field Oc Ns ...
+.Oo Fl t Ar type Ns Oo , Ns Ar type Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar snapshot
+.Xc
 Displays space consumed by, and quotas on, each group in the specified
-filesystem or snapshot. This subcommand is identical to \fBzfs userspace\fR,
-except that the default types to display are \fB-t posixgroup,smbgroup\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs mount\fR\fR
-.ad
-.sp .6
-.RS 4n
-Displays all \fBZFS\fR file systems currently mounted.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs mount\fR [\fB-vO\fR] [\fB-o\fR \fIoptions\fR] \fB-a\fR | \fIfilesystem\fR\fR
-.ad
-.sp .6
-.RS 4n
-Mounts \fBZFS\fR file systems. This is invoked automatically as part of the boot process.
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIoptions\fR\fR
-.ad
-.sp .6
-.RS 4n
-An optional, comma-separated list of mount options to use temporarily for the
-duration of the mount. See the "Temporary Mount Point Properties" section for
-details.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-O\fR\fR
-.ad
-.sp .6
-.RS 4n
-Allow mounting the filesystem even if the target directory is not empty.
-.sp
-On Solaris, the behavior of \fBzfs mount\fR matches \fBmount\fR and \fBzfs mount -O\fR matches \fBmount -O\fR. See \fBmount\fR(1M).
-.sp
-On Linux, this is the default for \fBmount\fR(8). In other words, \fBzfs mount -O\fR matches \fBmount\fR and there is no \fBmount\fR equivalent to a plain \fBzfs mount\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-v\fR\fR
-.ad
-.sp .6
-.RS 4n
-Report mount progress. This is intended for use with \fBzfs mount -a\fR on a system with a significant number of filesystems.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-a\fR\fR
-.ad
-.sp .6
-.RS 4n
-Mount all available \fBZFS\fR file systems. Invoked automatically as part of
-the boot process.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fIfilesystem\fR\fR
-.ad
-.sp .6
-.RS 4n
+filesystem or snapshot.
+This subcommand is identical to
+.Nm zfs Cm userspace ,
+except that the default types to display are
+.Fl t Sy posixgroup Ns , Ns Sy smbgroup .
+.It Xo
+.Nm
+.Cm mount
+.Xc
+Displays all ZFS file systems currently mounted.
+.It Xo
+.Nm
+.Cm mount
+.Op Fl Ov
+.Op Fl o Ar options
+.Fl a | Ar filesystem
+.Xc
+Mounts ZFS file systems.
+.Bl -tag -width "-O"
+.It Fl O
+Perform an overlay mount.
+See
+.Xr mount 8
+for more information.
+.It Fl a
+Mount all available ZFS file systems.
+Invoked automatically as part of the boot process.
+.It Ar filesystem
 Mount the specified filesystem.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs unmount\fR [\fB-f\fR] \fB-a\fR | \fIfilesystem\fR|\fImountpoint\fR\fR
-.ad
-.sp .6
-.RS 4n
-Unmounts currently mounted \fBZFS\fR file systems. Invoked automatically as part of the shutdown process.
-.sp
-.ne 2
-.na
-\fB\fB-f\fR\fR
-.ad
-.sp .6
-.RS 4n
+.It Fl o Ar options
+An optional, comma-separated list of mount options to use temporarily for the
+duration of the mount.
+See the
+.Sx Temporary Mount Point Properties
+section for details.
+.It Fl v
+Report mount progress.
+.El
+.It Xo
+.Nm
+.Cm unmount
+.Op Fl f
+.Fl a | Ar filesystem Ns | Ns Ar mountpoint
+.Xc
+Unmounts currently mounted ZFS file systems.
+.Bl -tag -width "-a"
+.It Fl a
+Unmount all available ZFS file systems.
+Invoked automatically as part of the shutdown process.
+.It Ar filesystem Ns | Ns Ar mountpoint
+Unmount the specified filesystem.
+The command can also be given a path to a ZFS file system mount point on the
+system.
+.It Fl f
 Forcefully unmount the file system, even if it is currently in use.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-a\fR\fR
-.ad
-.sp .6
-.RS 4n
-Unmount all available \fBZFS\fR file systems. Invoked automatically as part of the shutdown process.
-.RE
-
-.sp
-.ne 2
-.na
-\fIfilesystem\fR|\fImountpoint\fR
-.ad
-.sp .6
-.RS 4n
-Unmount the specified filesystem. The command can also be given a path to a \fBZFS\fR file system mount point on the system.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs share\fR [\fBnfs\fR|\fBsmb\fR] \fB-a\fR | \fIfilesystem\fR\fR
-.ad
-.sp .6
-.RS 4n
-Shares available \fBZFS\fR file systems.
-.sp
-.ne 2
-.na
-\fB\fB-a\fR\fR
-.ad
-.sp .6
-.RS 4n
-Share all available \fBZFS\fR file systems. Invoked automatically as part of the boot process. Additionally if one of \fBnfs\fR|\fBsmb\fR protocols is specified only share file systems whose \fBsharenfs\fR|\fBsharesmb\fR is set.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fIfilesystem\fR\fR
-.ad
-.sp .6
-.RS 4n
-Share the specified filesystem according to the \fBsharenfs\fR and \fBsharesmb\fR properties. File systems are shared when the \fBsharenfs\fR or \fBsharesmb\fR property is set.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs unshare\fR [\fBnfs\fR|\fBsmb\fR] \fB-a\fR | \fIfilesystem\fR|\fImountpoint\fR\fR
-.ad
-.sp .6
-.RS 4n
-Unshares currently shared \fBZFS\fR file systems. This is invoked automatically as part of the shutdown process. Additionally if one of \fBnfs\fR|\fBsmb\fR is specified unshare only file systems currently shared by that protocol.
-.sp
-.ne 2
-.na
-\fB\fB-a\fR\fR
-.ad
-.sp .6
-.RS 4n
-Unshare all available \fBZFS\fR file systems. Invoked automatically as part of the boot process.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fIfilesystem\fR|\fImountpoint\fR\fR
-.ad
-.sp .6
-.RS 4n
-Unshare the specified filesystem. The command can also be given a path to a \fBZFS\fR file system shared on the system.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs bookmark\fR \fIsnapshot\fR \fIbookmark\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates a bookmark of the given snapshot.  Bookmarks mark the point in time
-when the snapshot was created, and can be used as the incremental source for
-a \fBzfs send\fR command.
-.sp
+.El
+.It Xo
+.Nm
+.Cm share
+.Fl a | Ar filesystem
+.Xc
+Shares available ZFS file systems.
+.Bl -tag -width "-a"
+.It Fl a
+Share all available ZFS file systems.
+Invoked automatically as part of the boot process.
+.It Ar filesystem
+Share the specified filesystem according to the
+.Sy sharenfs
+and
+.Sy sharesmb
+properties.
+File systems are shared when the
+.Sy sharenfs
+or
+.Sy sharesmb
+property is set.
+.El
+.It Xo
+.Nm
+.Cm unshare
+.Fl a | Ar filesystem Ns | Ns Ar mountpoint
+.Xc
+Unshares currently shared ZFS file systems.
+.Bl -tag -width "-a"
+.It Fl a
+Unshare all available ZFS file systems.
+Invoked automatically as part of the shutdown process.
+.It Ar filesystem Ns | Ns Ar mountpoint
+Unshare the specified filesystem.
+The command can also be given a path to a ZFS file system shared on the system.
+.El
+.It Xo
+.Nm
+.Cm bookmark
+.Ar snapshot bookmark
+.Xc
+Creates a bookmark of the given snapshot.
+Bookmarks mark the point in time when the snapshot was created, and can be used
+as the incremental source for a
+.Nm zfs Cm send
+command.
+.Pp
 This feature must be enabled to be used.
-See \fBzpool-features\fR(5) for details on ZFS feature flags and the
-\fBbookmarks\fR feature.
-.RE
-
-
-.RE
-.sp
-.ne 2
-.na
-\fBzfs send\fR [\fB-DnPpRveLc\fR] [\fB-\fR[\fBi\fR|\fBI\fR] \fIsnapshot\fR] \fIsnapshot\fR
-.ad
-.sp .6
-.RS 4n
-Creates a stream representation of the (second, if \fB-i\fR is specified) \fIsnapshot\fR, which is written to standard output. The output can be redirected to a file or to a pipe (for example, using \fBssh\fR(1) to send it to a different system with \fBzfs receive\fR). By default, a full stream is generated; specifying \fB-i\fR or \fB-I\fR changes this behavior.
-.sp
-.ne 2
-.na
-\fB\fB-i\fR \fIsnapshot\fR\fR
-.ad
-.sp .6
-.RS 4n
-Generate an incremental stream from the first \fIsnapshot\fR (the incremental source) to the second \fIsnapshot\fR (the incremental target).  The incremental source can be specified as the last component of the snapshot name (the \fB@\fR character and following) and it is assumed to be from the same file system as the incremental target.
-.sp
-If the destination is a clone, the source may be the origin snapshot, which must be fully specified (for example, \fBpool/fs@origin\fR, not just \fB@origin\fR).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-I\fR \fIsnapshot\fR\fR
-.ad
-.sp .6
-.RS 4n
-Generate a stream package that sends all intermediary snapshots from the first snapshot to the second snapshot. For example, \fB-I @a fs@d\fR is similar to \fB-i @a fs@b; -i @b fs@c; -i @c fs@d\fR. The incremental source may be specified as with the \fB-i\fR option.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-R\fR, \fB--replicate\fR\fR
-.ad
-.sp .6
-.RS 4n
-Generate a replication stream package, which will replicate the specified filesystem, and all descendent file systems, up to the named snapshot. When received, all properties, snapshots, descendent file systems, and clones are preserved.
-.sp
-If the \fB-i\fR or \fB-I\fR flags are used in conjunction with the \fB-R\fR flag, an incremental replication stream is generated. The current values of properties, and current snapshot and file system names are set when the stream is received. If the \fB-F\fR flag is specified when this stream is received, snapshots and file systems that do not exist on the sending side are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-D\fR, \fB--dedup\fR\fR
-.ad
-.sp .6
-.RS 4n
-Generate a deduplicated stream. Blocks which would have been sent multiple times in the send stream will only be sent once. The receiving system must also support this feature to receive a deduplicated stream.  This flag can be used regardless of the dataset's dedup  property, but performance will be much better if the filesystem uses a dedup-capable checksum (eg.  sha256).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-L\fR, \fB--large-block\fR\fR
-.ad
-.sp .6
-.RS 4n
-Generate a stream which may contain blocks larger than 128KiB.  This flag
-has no effect if the \fBlarge_blocks\fR pool feature is disabled, or if
-the \fRrecordsize\fR property of this filesystem has never been set above
-128KiB.  The receiving system must have the \fBlarge_blocks\fR pool feature
-enabled as well.  See \fBzpool-features\fR(5) for details on ZFS feature
-flags and the \fBlarge_blocks\fR feature.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-e\fR, \fB--embed\fR\fR
-.ad
-.sp .6
-.RS 4n
-Generate a more compact stream by using WRITE_EMBEDDED records for blocks
-which are stored more compactly on disk by the \fBembedded_data\fR pool
-feature.  This flag has no effect if the \fBembedded_data\fR feature is
-disabled.  The receiving system must have the \fBembedded_data\fR feature
-enabled.  If the \fBlz4_compress\fR feature is active on the sending system,
-then the receiving system must have that feature enabled as well. See
-\fBzpool-features\fR(5) for details on ZFS feature flags and the
-\fBembedded_data\fR feature.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-c\fR, \fB--compressed\fR\fR
-.ad
-.sp .6
-.RS 4n
-Generate a more compact stream by using compressed WRITE records for blocks
-which are compressed on disk and in memory (see the \fBcompression\fR property
-for details).  If the \fBlz4_compress\fR feature is active on the sending
-system, then the receiving system must have that feature enabled as well.  If
-the \fBlarge_blocks\fR feature is enabled on the sending system but the \fB-L\fR
-option is not supplied in conjunction with \fB-c\fR, then the data will be
-decompressed before sending so it can be split into smaller block sizes.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR, \fB--props\fR\fR
-.ad
-.sp .6
-.RS 4n
-Include the dataset's properties in the stream.  This flag is implicit when -R is specified.  The receiving system must also support this feature.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-n\fR, \fB--dryrun\fR\fR
-.ad
-.sp .6
-.RS 4n
-Do a dry-run ("No-op") send.  Do not generate any actual send data.  This is
-useful in conjunction with the \fB-v\fR or \fB-P\fR flags to determine what
-data will be sent.  In this case, the verbose output will be written to
-standard output (contrast with a non-dry-run, where the stream is written
-to standard output and the verbose output goes to standard error).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-P\fR, \fB--parsable\fR\fR
-.ad
-.sp .6
-.RS 4n
+See
+.Xr zpool-features 5
+for details on ZFS feature flags and the
+.Sy bookmarks
+feature.
+.It Xo
+.Nm
+.Cm send
+.Op Fl DLPRcenpv
+.Op Oo Fl I Ns | Ns Fl i Oc Ar snapshot
+.Ar snapshot
+.Xc
+Creates a stream representation of the second
+.Ar snapshot ,
+which is written to standard output.
+The output can be redirected to a file or to a different system
+.Po for example, using
+.Xr ssh 1
+.Pc .
+By default, a full stream is generated.
+.Bl -tag -width "-D"
+.It Fl D, -dedup
+Generate a deduplicated stream.
+Blocks which would have been sent multiple times in the send stream will only be
+sent once.
+The receiving system must also support this feature to receive a deduplicated
+stream.
+This flag can be used regardless of the dataset's
+.Sy dedup
+property, but performance will be much better if the filesystem uses a
+dedup-capable checksum
+.Po for example,
+.Sy sha256
+.Pc .
+.It Fl I Ar snapshot
+Generate a stream package that sends all intermediary snapshots from the first
+snapshot to the second snapshot.
+For example,
+.Fl I Em @a Em fs@d
+is similar to
+.Fl i Em @a Em fs@b Ns ; Fl i Em @b Em fs@c Ns ; Fl i Em @c Em fs@d .
+The incremental source may be specified as with the
+.Fl i
+option.
+.It Fl L, -large-block
+Generate a stream which may contain blocks larger than 128KB.
+This flag has no effect if the
+.Sy large_blocks
+pool feature is disabled, or if the
+.Sy recordsize
+property of this filesystem has never been set above 128KB.
+The receiving system must have the
+.Sy large_blocks
+pool feature enabled as well.
+See
+.Xr zpool-features 5
+for details on ZFS feature flags and the
+.Sy large_blocks
+feature.
+.It Fl P, -parsable
 Print machine-parsable verbose information about the stream package generated.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-v\fR, \fB--verbose\fR\fR
-.ad
-.sp .6
-.RS 4n
-Print verbose information about the stream package generated.  This information
-includes a per-second report of how much data has been sent.
-.RE
-
-The format of the stream is committed. You will be able to receive your streams on future versions of \fBZFS\fR.
-.RE
-
-.RE
-.sp
-.ne 2
-.na
-\fBzfs send\fR [\fB-Lec\fR] [\fB-i\fR \fIsnapshot\fR|\fIbookmark\fR] \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR
-.ad
-.sp .6
-.RS 4n
-Generate a send stream, which may be of a filesystem, and may be
-incremental from a bookmark.  If the destination is a filesystem or volume,
-the pool must be read-only, or the filesystem must not be mounted.  When the
-stream generated from a filesystem or volume is received, the default snapshot
-name will be "--head--".
-
-.sp
-.ne 2
-.na
-\fB\fB-L\fR, \fB--large-block\fR\fR
-.ad
-.sp .6
-.RS 4n
-Generate a stream which may contain blocks larger than 128KiB.  This flag
-has no effect if the \fBlarge_blocks\fR pool feature is disabled, or if
-the \fRrecordsize\fR property of this filesystem has never been set above
-128KiB.  The receiving system must have the \fBlarge_blocks\fR pool feature
-enabled as well.  See \fBzpool-features\fR(5) for details on ZFS feature
-flags and the \fBlarge_blocks\fR feature.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-e\fR, \fB--embed\fR\fR
-.ad
-.sp .6
-.RS 4n
-Generate a more compact stream by using WRITE_EMBEDDED records for blocks
-which are stored more compactly on disk by the \fBembedded_data\fR pool
-feature.  This flag has no effect if the \fBembedded_data\fR feature is
-disabled.  The receiving system must have the \fBembedded_data\fR feature
-enabled.  If the \fBlz4_compress\fR feature is active on the sending system,
-then the receiving system must have that feature enabled as well. See
-\fBzpool-features\fR(5) for details on ZFS feature flags and the
-\fBembedded_data\fR feature.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-c\fR, \fB--compressed\fR\fR
-.ad
-.sp .6
-.RS 4n
+.It Fl R, -replicate
+Generate a replication stream package, which will replicate the specified
+file system, and all descendent file systems, up to the named snapshot.
+When received, all properties, snapshots, descendent file systems, and clones
+are preserved.
+.Pp
+If the
+.Fl i
+or
+.Fl I
+flags are used in conjunction with the
+.Fl R
+flag, an incremental replication stream is generated.
+The current values of properties, and current snapshot and file system names are
+set when the stream is received.
+If the
+.Fl F
+flag is specified when this stream is received, snapshots and file systems that
+do not exist on the sending side are destroyed.
+.It Fl e, -embed
+Generate a more compact stream by using
+.Sy WRITE_EMBEDDED
+records for blocks which are stored more compactly on disk by the
+.Sy embedded_data
+pool feature.
+This flag has no effect if the
+.Sy embedded_data
+feature is disabled.
+The receiving system must have the
+.Sy embedded_data
+feature enabled.
+If the
+.Sy lz4_compress
+feature is active on the sending system, then the receiving system must have
+that feature enabled as well.
+See
+.Xr zpool-features 5
+for details on ZFS feature flags and the
+.Sy embedded_data
+feature.
+.It Fl c, -compressed
 Generate a more compact stream by using compressed WRITE records for blocks
-which are compressed on disk and in memory (see the \fBcompression\fR property
-for details).  If the \fBlz4_compress\fR feature is active on the sending
-system, then the receiving system must have that feature enabled as well.  If
-the \fBlarge_blocks\fR feature is enabled on the sending system but the \fB-L\fR
-option is not supplied in conjunction with \fB-c\fR, then the data will be
-decompressed before sending so it can be split into smaller block sizes.
-.RE
-
-.sp
-.ne 2
-.na
-\fB-i\fR \fIsnapshot\fR|\fIbookmark\fR
-.ad
-.sp .6
-.RS 4n
-Generate an incremental send stream.  The incremental source must be an earlier snapshot in the destination's history. It will commonly be an earlier snapshot in the destination's filesystem, in which case it can be specified as the last component of the name (the \fB#\fR or \fB@\fR character and following).
-.sp
-If the incremental target is a clone, the incremental source can be the origin snapshot, or an earlier snapshot in the origin's filesystem, or the origin's origin, etc.
-.RE
-
-.RE
-.sp
-.ne 2
-.na
-\fB\fBzfs send\fR [\fB-Penv\fR] \fB-t\fR \fIreceive_resume_token\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates a send stream which resumes an interrupted receive. The \fIreceive_resume_token\fR is the value of this property on the filesystem or volume that was being received into. See the documentation for \fBzfs receive -s\fR for more details.
-
-.RE
-
-.RE
-.sp
-.ne 2
-.na
-\fB\fBzfs receive\fR [\fB-Fnsuv\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... [\fB-x\fR \fIproperty\fR] ... \fIfilesystem\fR|\fIvolume\fR|\fIsnapshot\fR\fR
-.ad
-.br
-.na
-\fB\fBzfs receive\fR [\fB-Fnsuv\fR] [\fB-o\fR \fIproperty\fR=\fIvalue\fR] ... [\fB-x\fR \fIproperty\fR] ... [\fB-d\fR|\fB-e\fR] \fIfilesystem\fR\fR
-.ad
-.sp .6
-.RS 4n
-Creates a snapshot whose contents are as specified in the stream provided on standard input. If a full stream is received, then a new file system is created as well. Streams are created using the \fBzfs send\fR subcommand, which by default creates a full stream. \fBzfs recv\fR can be used as an alias for \fBzfs receive\fR.
-.sp
-If an incremental stream is received, then the destination file system must already exist, and its most recent snapshot must match the incremental stream's source. For \fBzvols\fR, the destination device link is destroyed and recreated, which means the \fBzvol\fR cannot be accessed during the \fBreceive\fR operation.
-.sp
-When a snapshot replication package stream that is generated by using the \fBzfs send\fR \fB-R\fR command is received, any snapshots that do not exist on the sending location are destroyed by using the \fBzfs destroy\fR \fB-d\fR command.
-.sp
-If \fB-o\fR \fIproperty\fR=\fIvalue\fR or \fB-x\fR \fIproperty\fR is specified, it applies to the effective value of the property throughout the entire subtree of replicated datasets. Effective property values will be set (-o) or inherited (-x) on the topmost in the replicated subtree. In descendant datasets, if the property is set by the send stream, it will be overridden by forcing the property to be inherited from the topmost filesystem. Received properties are retained in spite of being overridden and may be restored with \fBzfs inherit\fR \fB-S\fR. Specifying \fB-o origin\fR=\fIsnapshot\fR is a special case because, even if \fBorigin\fR is a read-only property and cannot be set, it allows to receive the send stream as a clone of the given snapshot.
-.sp
-The name of the snapshot (and file system, if a full stream is received) that this subcommand creates depends on the argument type and the use of the \fB-d\fR or \fB-e\fR options.
-.sp
-If the argument is a snapshot name, the specified \fIsnapshot\fR is created. If the argument is a file system or volume name, a snapshot with the same name as the sent snapshot is created within the specified \fIfilesystem\fR or \fIvolume\fR.  If neither of the \fB-d\fR or \fB-e\fR options are specified, the provided target snapshot name is used exactly as provided.
-.sp
-The \fB-d\fR and \fB-e\fR options cause the file system name of the target snapshot to be determined by appending a portion of the sent snapshot's name to the specified target \fIfilesystem\fR. If the \fB-d\fR option is specified, all but the first element of the sent snapshot's file system path (usually the pool name) is used and any required intermediate file systems within the specified one are created.  If the \fB-e\fR option is specified, then only the last element of the sent snapshot's file system name (i.e. the name of the source file system itself) is used as the target file system name.
-.sp
-.ne 2
-.na
-\fB\fB-F\fR\fR
-.ad
-.sp .6
-.RS 4n
-Force a rollback of the file system to the most recent snapshot before performing the receive operation. If receiving an incremental replication stream (for example, one generated by \fBzfs send -R -[iI]\fR), destroy snapshots and file systems that do not exist on the sending side.
-.RE
-
-.sp
-.ne 2
-.mk
-.na
-\fB\fB-n\fR\fR
-.ad
-.sp .6
-.RS 4n
-Do not actually receive the stream. This can be useful in conjunction with the \fB-v\fR option to verify the name the receive operation would use.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-s\fR\fR
-.ad
-.sp .6
-.RS 4n
-If the receive is interrupted, save the partially received state, rather than deleting it. Interruption may be due to premature termination of the stream (e.g. due to network failure or failure of the remote system if the stream is being read over a network connection), a checksum error in the stream, termination of the \fBzfs receive\fR process, or unclean shutdown of the system.
-.sp
-The receive can be resumed with a stream generated by \fBzfs send -t\fR token, where the \fItoken\fR is the value of the \fBreceive_resume_token\fR property of the filesystem or volume which is received into.
-.sp
-To use this flag, the storage pool must have the \fBextensible_dataset\fR feature enabled.  See \fBzpool-features\fR(5) for details on ZFS feature flags.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-u\fR\fR
-.ad
-.sp .6
-.RS 4n
-Do not mount the file system that is associated with the received stream.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-v\fR\fR
-.ad
-.sp .6
-.RS 4n
-Print verbose information about the stream and the time required to perform the receive operation.
-.RE
-
-.sp
-.ne 2
-.mk
-.na
-\fB-o\fR \fIproperty\fR=\fIvalue\fR
-.ad
-.sp .6
-.RS 4n
-Sets the specified property as if the command \fBzfs set\fR \fIproperty\fR=\fIvalue\fR was invoked immediately before the receive. When receiving a stream from \fBzfs send -R\fR, causes the property to be inherited by all descendant datasets, as through \fBzfs inherit\fR \fIproperty\fR was run on any descendant datasets that have this property set on the sending system.
-.sp
-Any editable ZFS property can be set at receive time. Set-once properties bound to the received data, such as \fBnormalization\fR and \fBcasesensitivity\fR, cannot be set at receive time even when the datasets are newly created by zfs receive. Additionally both settable properties \fBversion\fR and \fBvolsize\fR cannot be set at receive time.
-.sp
-The \fB-o\fR option may be specified multiple times, for different properties. An error results if the same property is specified in multiple \fB-o\fR or \fB-x\fR options.
-.RE
-
-.sp
-.ne 2
-.mk
-.na
-\fB-x\fR \fIproperty\fR
-.ad
-.sp .6
-.RS 4n
-Ensures that the effective value of the specified property after the receive is unaffected by the value of that property in the send stream (if any), as if the property had been excluded from the send stream.
-.sp
-If the specified property is not present in the send stream, this option does nothing.
-.sp
-If a received property needs to be overridden, the effective value will be set or inherited, depending on whether the property is inheritable or not.
-.sp
-In the case of an incremental update, \fB-x\fR leaves any existing local setting or explicit inheritance unchanged.
-.sp
-All \fB-o\fR restrictions on set-once and special properties apply equally to \fB-x\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-d\fR\fR
-.ad
-.sp .6
-.RS 4n
-Discard the first element of the sent snapshot's file system name, using the remaining elements to determine the name of the target file system for the new snapshot as described in the paragraph above.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-e\fR\fR
-.ad
-.sp .6
-.RS 4n
-Discard all but the last element of the sent snapshot's file system name, using that element to determine the name of the target file system for the new snapshot as described in the paragraph above.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fBorigin\fR=\fIsnapshot\fR
-.ad
-.sp .6
-.RS 4n
+which are compressed on disk and in memory
+.Po see the
+.Sy compression
+property for details
+.Pc .
+If the
+.Sy lz4_compress
+feature is active on the sending system, then the receiving system must have
+that feature enabled as well.
+If the
+.Sy large_blocks
+feature is enabled on the sending system but the
+.Fl L
+option is not supplied in conjunction with
+.Fl c ,
+then the data will be decompressed before sending so it can be split into
+smaller block sizes.
+.It Fl i Ar snapshot
+Generate an incremental stream from the first
+.Ar snapshot
+.Pq the incremental source
+to the second
+.Ar snapshot
+.Pq the incremental target .
+The incremental source can be specified as the last component of the snapshot
+name
+.Po the
+.Sy @
+character and following
+.Pc
+and it is assumed to be from the same file system as the incremental target.
+.Pp
+If the destination is a clone, the source may be the origin snapshot, which must
+be fully specified
+.Po for example,
+.Em pool/fs@origin ,
+not just
+.Em @origin
+.Pc .
+.It Fl n, -dryrun
+Do a dry-run
+.Pq Qq No-op
+send.
+Do not generate any actual send data.
+This is useful in conjunction with the
+.Fl v
+or
+.Fl P
+flags to determine what data will be sent.
+In this case, the verbose output will be written to standard output
+.Po contrast with a non-dry-run, where the stream is written to standard output
+and the verbose output goes to standard error
+.Pc .
+.It Fl p, -props
+Include the dataset's properties in the stream.
+This flag is implicit when
+.Fl R
+is specified.
+The receiving system must also support this feature.
+.It Fl v, -verbose
+Print verbose information about the stream package generated.
+This information includes a per-second report of how much data has been sent.
+.Pp
+The format of the stream is committed.
+You will be able to receive your streams on future versions of ZFS .
+.El
+.It Xo
+.Nm
+.Cm send
+.Op Fl Lce
+.Op Fl i Ar snapshot Ns | Ns Ar bookmark
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
+.Xc
+Generate a send stream, which may be of a filesystem, and may be incremental
+from a bookmark.
+If the destination is a filesystem or volume, the pool must be read-only, or the
+filesystem must not be mounted.
+When the stream generated from a filesystem or volume is received, the default
+snapshot name will be
+.Qq --head-- .
+.Bl -tag -width "-L"
+.It Fl L, -large-block
+Generate a stream which may contain blocks larger than 128KB.
+This flag has no effect if the
+.Sy large_blocks
+pool feature is disabled, or if the
+.Sy recordsize
+property of this filesystem has never been set above 128KB.
+The receiving system must have the
+.Sy large_blocks
+pool feature enabled as well.
+See
+.Xr zpool-features 5
+for details on ZFS feature flags and the
+.Sy large_blocks
+feature.
+.It Fl c, -compressed
+Generate a more compact stream by using compressed WRITE records for blocks
+which are compressed on disk and in memory
+.Po see the
+.Sy compression
+property for details
+.Pc .
+If the
+.Sy lz4_compress
+feature is active on the sending system, then the receiving system must have
+that feature enabled as well.
+If the
+.Sy large_blocks
+feature is enabled on the sending system but the
+.Fl L
+option is not supplied in conjunction with
+.Fl c ,
+then the data will be decompressed before sending so it can be split into
+smaller block sizes.
+.It Fl e, -embed
+Generate a more compact stream by using
+.Sy WRITE_EMBEDDED
+records for blocks which are stored more compactly on disk by the
+.Sy embedded_data
+pool feature.
+This flag has no effect if the
+.Sy embedded_data
+feature is disabled.
+The receiving system must have the
+.Sy embedded_data
+feature enabled.
+If the
+.Sy lz4_compress
+feature is active on the sending system, then the receiving system must have
+that feature enabled as well.
+See
+.Xr zpool-features 5
+for details on ZFS feature flags and the
+.Sy embedded_data
+feature.
+.It Fl i Ar snapshot Ns | Ns Ar bookmark
+Generate an incremental send stream.
+The incremental source must be an earlier snapshot in the destination's history.
+It will commonly be an earlier snapshot in the destination's file system, in
+which case it can be specified as the last component of the name
+.Po the
+.Sy #
+or
+.Sy @
+character and following
+.Pc .
+.Pp
+If the incremental target is a clone, the incremental source can be the origin
+snapshot, or an earlier snapshot in the origin's filesystem, or the origin's
+origin, etc.
+.El
+.It Xo
+.Nm
+.Cm send
+.Op Fl Penv
+.Fl t
+.Ar receive_resume_token
+.Xc
+Creates a send stream which resumes an interrupted receive.
+The
+.Ar receive_resume_token
+is the value of this property on the filesystem or volume that was being
+received into.
+See the documentation for
+.Sy zfs receive -s
+for more details.
+.It Xo
+.Nm
+.Cm receive
+.Op Fl Fnsuv
+.Op Fl o Sy origin Ns = Ns Ar snapshot
+.Op Fl o Ar property Ns = Ns Ar value
+.Op Fl x Ar property
+.Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
+.Xc
+.It Xo
+.Nm
+.Cm receive
+.Op Fl Fnsuv
+.Op Fl d Ns | Ns Fl e
+.Op Fl o Sy origin Ns = Ns Ar snapshot
+.Op Fl o Ar property Ns = Ns Ar value
+.Op Fl x Ar property
+.Ar filesystem
+.Xc
+Creates a snapshot whose contents are as specified in the stream provided on
+standard input.
+If a full stream is received, then a new file system is created as well.
+Streams are created using the
+.Nm zfs Cm send
+subcommand, which by default creates a full stream.
+.Nm zfs Cm recv
+can be used as an alias for
+.Nm zfs Cm receive.
+.Pp
+If an incremental stream is received, then the destination file system must
+already exist, and its most recent snapshot must match the incremental stream's
+source.
+For
+.Sy zvols ,
+the destination device link is destroyed and recreated, which means the
+.Sy zvol
+cannot be accessed during the
+.Cm receive
+operation.
+.Pp
+When a snapshot replication package stream that is generated by using the
+.Nm zfs Cm send Fl R
+command is received, any snapshots that do not exist on the sending location are
+destroyed by using the
+.Nm zfs Cm destroy Fl d
+command.
+.Pp
+If
+.Sy Fl o Em property=value
+or
+.Sy Fl x Em property
+is specified, it applies to the effective value of the property throughout
+the entire subtree of replicated datasets. Effective property values will be
+set (
+.Fl o
+) or inherited (
+.Fl x
+) on the topmost in the replicated subtree. In descendant datasets, if the
+property is set by the send stream, it will be overridden by forcing the
+property to be inherited from the top‐most file system. Received properties
+are retained in spite of being overridden and may be restored with
+.Nm zfs Cm inherit Fl S .
+Specifying
+.Sy Fl o Em origin=snapshot
+is a special case because, even if
+.Sy origin
+is a read-only property and cannot be set, it's allowed to receive the send
+stream as a clone of the given snapshot.
+.Pp
+The name of the snapshot
+.Pq and file system, if a full stream is received
+that this subcommand creates depends on the argument type and the use of the
+.Fl d
+or
+.Fl e
+options.
+.Pp
+If the argument is a snapshot name, the specified
+.Ar snapshot
+is created.
+If the argument is a file system or volume name, a snapshot with the same name
+as the sent snapshot is created within the specified
+.Ar filesystem
+or
+.Ar volume .
+If neither of the
+.Fl d
+or
+.Fl e
+options are specified, the provided target snapshot name is used exactly as
+provided.
+.Pp
+The
+.Fl d
+and
+.Fl e
+options cause the file system name of the target snapshot to be determined by
+appending a portion of the sent snapshot's name to the specified target
+.Ar filesystem .
+If the
+.Fl d
+option is specified, all but the first element of the sent snapshot's file
+system path
+.Pq usually the pool name
+is used and any required intermediate file systems within the specified one are
+created.
+If the
+.Fl e
+option is specified, then only the last element of the sent snapshot's file
+system name
+.Pq i.e. the name of the source file system itself
+is used as the target file system name.
+.Bl -tag -width "-F"
+.It Fl F
+Force a rollback of the file system to the most recent snapshot before
+performing the receive operation.
+If receiving an incremental replication stream
+.Po for example, one generated by
+.Nm zfs Cm send Fl R Op Fl i Ns | Ns Fl I
+.Pc ,
+destroy snapshots and file systems that do not exist on the sending side.
+.It Fl d
+Discard the first element of the sent snapshot's file system name, using the
+remaining elements to determine the name of the target file system for the new
+snapshot as described in the paragraph above.
+.It Fl e
+Discard all but the last element of the sent snapshot's file system name, using
+that element to determine the name of the target file system for the new
+snapshot as described in the paragraph above.
+.It Fl n
+Do not actually receive the stream.
+This can be useful in conjunction with the
+.Fl v
+option to verify the name the receive operation would use.
+.It Fl o Sy origin Ns = Ns Ar snapshot
 Forces the stream to be received as a clone of the given snapshot.
 If the stream is a full send stream, this will create the filesystem
-described by the stream as a clone of the specified snapshot. Which
-snapshot was specified will not affect the success or failure of the
-receive, as long as the snapshot does exist.  If the stream is an
-incremental send stream, all the normal verification will be performed.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs receive\fR [\fB-A\fR] \fIfilesystem\fR|\fIvolume\fR
-.ad
-.sp .6
-.RS 4n
-Abort an interrupted \fBzfs receive \fB-s\fR\fR, deleting its saved partially received state.
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs allow\fR \fIfilesystem\fR | \fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Displays permissions that have been delegated on the specified filesystem or volume. See the other forms of \fBzfs allow\fR for more information.
-.sp
-Delegations are supported under Linux with the exception of \fBmount\fR,
-\fBunmount\fR, \fBmountpoint\fR, \fBcanmount\fR, \fBrename\fR, and \fBshare\fR.
-These permissions cannot be delegated because the Linux \fBmount(8)\fR command
-restricts modifications of the global namespace to the root user.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs allow\fR [\fB-ldug\fR] "\fIeveryone\fR"|\fIuser\fR|\fIgroup\fR[,...] \fIperm\fR|@\fIsetname\fR[,...] \fIfilesystem\fR| \fIvolume\fR\fR
-.ad
+described by the stream as a clone of the specified snapshot.
+Which snapshot was specified will not affect the success or failure of the
+receive, as long as the snapshot does exist.
+If the stream is an incremental send stream, all the normal verification will be
+performed.
+.It Fl o Em property=value
+Sets the specified property as if the command
+.Nm zfs Cm set Em property=value
+was invoked immediately before the receive. When receiving a stream from
+.Nm zfs Cm send Fl R ,
+causes the property to be inherited by all descendant datasets, as through
+.Nm zfs Cm inherit Em property
+was run on any descendant datasets that have this property set on the
+sending system.
+.Pp
+Any editable property can be set at receive time. Set-once properties bound
+to the received data, such as
+.Sy normalization
+and
+.Sy casesensitivity ,
+cannot be set at receive time even when the datasets are newly created by
+.Nm zfs Cm receive .
+Additionally both settable properties
+.Sy version
+and
+.Sy volsize
+cannot be set at receive time.
+.Pp
+The
+.Fl o
+option may be specified multiple times, for different properties. An error
+results if the same property is specified in multiple
+.Fl o
+or
+.Fl x
+options.
+.It Fl s
+If the receive is interrupted, save the partially received state, rather
+than deleting it.
+Interruption may be due to premature termination of the stream
+.Po e.g. due to network failure or failure of the remote system
+if the stream is being read over a network connection
+.Pc ,
+a checksum error in the stream, termination of the
+.Nm zfs Cm receive
+process, or unclean shutdown of the system.
+.Pp
+The receive can be resumed with a stream generated by
+.Nm zfs Cm send Fl t Ar token ,
+where the
+.Ar token
+is the value of the
+.Sy receive_resume_token
+property of the filesystem or volume which is received into.
+.Pp
+To use this flag, the storage pool must have the
+.Sy extensible_dataset
+feature enabled.
+See
+.Xr zpool-features 5
+for details on ZFS feature flags.
+.It Fl u
+File system that is associated with the received stream is not mounted.
+.It Fl v
+Print verbose information about the stream and the time required to perform the
+receive operation.
+.It Fl x Em property
+Ensures that the effective value of the specified property after the
+receive is unaffected by the value of that property in the send stream (if any),
+as if the property had been excluded from the send stream.
+.Pp
+If the specified property is not present in the send stream, this option does
+nothing.
+.Pp
+If a received property needs to be overridden, the effective value will be
+set or inherited, depending on whether the property is inheritable or not.
+.Pp
+In the case of an incremental update,
+.Fl x
+leaves any existing local setting or explicit inheritance unchanged.
+.Pp
+All
+.Fl o
+restrictions on set-once and special properties apply equally to
+.Fl x .
+.El
+.It Xo
+.Nm
+.Cm receive
+.Fl A
+.Ar filesystem Ns | Ns Ar volume
+.Xc
+Abort an interrupted
+.Nm zfs Cm receive Fl s ,
+deleting its saved partially received state.
+.It Xo
+.Nm
+.Cm allow
+.Ar filesystem Ns | Ns Ar volume
+.Xc
+Displays permissions that have been delegated on the specified filesystem or
+volume.
+See the other forms of
+.Nm zfs Cm allow
+for more information.
+.Pp
+Delegations are supported under Linux with the exception of
+.Sy mount ,
+.Sy unmount ,
+.Sy mountpoint ,
+.Sy canmount ,
+.Sy rename ,
+and
+.Sy share .
+These permissions cannot be delegated because the Linux
+.Xr mount 8
+command restricts modifications of the global namespace to the root user.
+.It Xo
+.Nm
+.Cm allow
+.Op Fl dglu
+.Ar user Ns | Ns Ar group Ns Oo , Ns Ar user Ns | Ns Ar group Oc Ns ...
+.Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume
 .br
-.na
-\fB\fBzfs allow\fR [\fB-ld\fR] \fB-e\fR \fIperm\fR|@\fIsetname\fR[,...] \fIfilesystem\fR | \fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Delegates \fBZFS\fR administration permission for the file systems to non-privileged users.
-.sp
-.ne 2
-.na
-\fB[\fB-ug\fR] "\fIeveryone\fR"|\fIuser\fR|\fIgroup\fR[,...]\fR
-.ad
-.sp .6
-.RS 4n
-Specifies to whom the permissions are delegated. Multiple entities can be specified as a comma-separated list. If neither of the \fB-ug\fR options are specified, then the argument is interpreted preferentially as the keyword "everyone", then as a user name, and lastly as a group name. To specify a user or group named "everyone", use the \fB-u\fR or \fB-g\fR options. To specify a group with the same name as a user, use the \fB-g\fR options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB[\fB-e\fR] \fIperm\fR|@\fIsetname\fR[,...]\fR
-.ad
-.sp .6
-.RS 4n
-Specifies that the permissions be delegated to "everyone." Multiple permissions may be specified as a comma-separated list. Permission names are the same as \fBZFS\fR subcommand and property names. See the property list below. Property set names, which begin with an at sign (\fB@\fR) , may be specified. See the \fB-s\fR form below for details.
-.RE
-
-.sp
-.ne 2
-.na
-\fB[\fB-ld\fR] \fIfilesystem\fR|\fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Specifies where the permissions are delegated. If neither of the \fB-ld\fR options are specified, or both are, then the permissions are allowed for the file system or volume, and all of its descendents. If only the \fB-l\fR option is used, then is allowed "locally" only for the specified file system. If only the \fB-d\fR option is used, then is allowed only for the descendent file systems.
-.RE
-
-.RE
-
-.sp
-.LP
-Permissions are generally the ability to use a \fBzfs\fR subcommand or change a property. The following permissions are available:
-.sp
-.in +2
-.nf
+.Nm
+.Cm allow
+.Op Fl dl
+.Fl e Ns | Ns Sy everyone
+.Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume
+.Xc
+Delegates ZFS administration permission for the file systems to non-privileged
+users.
+.Bl -tag -width "-d"
+.It Fl d
+Allow only for the descendent file systems.
+.It Fl e Ns | Ns Sy everyone
+Specifies that the permissions be delegated to everyone.
+.It Fl g Ar group Ns Oo , Ns Ar group Oc Ns ...
+Explicitly specify that permissions are delegated to the group.
+.It Fl l
+Allow
+.Qq locally
+only for the specified file system.
+.It Fl u Ar user Ns Oo , Ns Ar user Oc Ns ...
+Explicitly specify that permissions are delegated to the user.
+.It Ar user Ns | Ns Ar group Ns Oo , Ns Ar user Ns | Ns Ar group Oc Ns ...
+Specifies to whom the permissions are delegated.
+Multiple entities can be specified as a comma-separated list.
+If neither of the
+.Fl gu
+options are specified, then the argument is interpreted preferentially as the
+keyword
+.Sy everyone ,
+then as a user name, and lastly as a group name.
+To specify a user or group named
+.Qq everyone ,
+use the
+.Fl g
+or
+.Fl u
+options.
+To specify a group with the same name as a user, use the
+.Fl g
+options.
+.It Xo
+.Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ...
+.Xc
+The permissions to delegate.
+Multiple permissions may be specified as a comma-separated list.
+Permission names are the same as ZFS subcommand and property names.
+See the property list below.
+Property set names, which begin with
+.Sy @ ,
+may be specified.
+See the
+.Fl s
+form below for details.
+.El
+.Pp
+If neither of the
+.Fl dl
+options are specified, or both are, then the permissions are allowed for the
+file system or volume, and all of its descendents.
+.Pp
+Permissions are generally the ability to use a ZFS subcommand or change a ZFS
+property.
+The following permissions are available:
+.Bd -literal
 NAME             TYPE           NOTES
-allow            subcommand     Must also have the permission that is being
-                                allowed
-clone            subcommand     Must also have the 'create' ability and 'mount'
-                                ability in the origin file system
+allow            subcommand     Must also have the permission that is
+                                being allowed
+clone            subcommand     Must also have the 'create' ability and
+                                'mount' ability in the origin file system
 create           subcommand     Must also have the 'mount' ability
 destroy          subcommand     Must also have the 'mount' ability
 diff             subcommand     Allows lookup of paths within a dataset
-                                given an object number, and the ability to
-                                create snapshots necessary to 'zfs diff'.
+                                given an object number, and the ability
+                                to create snapshots necessary to
+                                'zfs diff'.
 mount            subcommand     Allows mount/umount of ZFS datasets
-promote          subcommand     Must also have the 'mount'
-                                and 'promote' ability in the origin file system
-receive          subcommand     Must also have the 'mount' and 'create' ability
+promote          subcommand     Must also have the 'mount' and 'promote'
+                                ability in the origin file system
+receive          subcommand     Must also have the 'mount' and 'create'
+                                ability
 rename           subcommand     Must also have the 'mount' and 'create'
                                 ability in the new parent
 rollback         subcommand     Must also have the 'mount' ability
 send             subcommand
-share            subcommand     Allows sharing file systems over NFS or SMB
-                                protocols
+share            subcommand     Allows sharing file systems over NFS
+                                or SMB protocols
 snapshot         subcommand     Must also have the 'mount' ability
-groupobjquota    other          Allows accessing any groupobjquota@... property
-groupquota       other          Allows accessing any groupquota@... property
-groupobjused     other          Allows reading any groupobjused@... property
+
+groupquota       other          Allows accessing any groupquota@...
+                                property
 groupused        other          Allows reading any groupused@... property
 userprop         other          Allows changing any user property
-userobjquota     other          Allows accessing any userobjquota@... property
-userquota        other          Allows accessing any userquota@... property
-userobjused      other          Allows reading any userobjused@... property
+userquota        other          Allows accessing any userquota@...
+                                property
 userused         other          Allows reading any userused@... property
 
-acltype          property
 aclinherit       property
+acltype          property
 atime            property
 canmount         property
 casesensitivity  property
 checksum         property
 compression      property
 copies           property
-dedup            property
 devices          property
 exec             property
 filesystem_limit property
-logbias          property
-mlslabel         property
 mountpoint       property
 nbmand           property
 normalization    property
@@ -3277,163 +3504,183 @@ volsize          property
 vscan            property
 xattr            property
 zoned            property
-.fi
-.in -2
-.sp
-
-.sp
-.ne 2
-.na
-\fB\fBzfs allow\fR \fB-c\fR \fIperm\fR|@\fIsetname\fR[,...] \fIfilesystem\fR|\fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Sets "create time" permissions. These permissions are granted (locally) to the creator of any newly-created descendent file system.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs allow\fR \fB-s\fR @\fIsetname\fR \fIperm\fR|@\fIsetname\fR[,...] \fIfilesystem\fR|\fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Defines or adds permissions to a permission set. The set can be used by other \fBzfs allow\fR commands for the specified file system and its descendents. Sets are evaluated dynamically, so changes to a set are immediately reflected. Permission sets follow the same naming restrictions as ZFS file systems, but the name must begin with an "at sign" (\fB@\fR), and can be no more than 64 characters long.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs unallow\fR [\fB-rldug\fR] "\fIeveryone\fR"|\fIuser\fR|\fIgroup\fR[,...] [\fIperm\fR|@\fIsetname\fR[, ...]] \fIfilesystem\fR|\fIvolume\fR\fR
-.ad
+.Ed
+.It Xo
+.Nm
+.Cm allow
+.Fl c
+.Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume
+.Xc
+Sets
+.Qq create time
+permissions.
+These permissions are granted
+.Pq locally
+to the creator of any newly-created descendent file system.
+.It Xo
+.Nm
+.Cm allow
+.Fl s No @ Ns Ar setname
+.Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ...
+.Ar filesystem Ns | Ns Ar volume
+.Xc
+Defines or adds permissions to a permission set.
+The set can be used by other
+.Nm zfs Cm allow
+commands for the specified file system and its descendents.
+Sets are evaluated dynamically, so changes to a set are immediately reflected.
+Permission sets follow the same naming restrictions as ZFS file systems, but the
+name must begin with
+.Sy @ ,
+and can be no more than 64 characters long.
+.It Xo
+.Nm
+.Cm unallow
+.Op Fl dglru
+.Ar user Ns | Ns Ar group Ns Oo , Ns Ar user Ns | Ns Ar group Oc Ns ...
+.Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar volume
 .br
-.na
-\fB\fBzfs unallow\fR [\fB-rld\fR] \fB-e\fR [\fIperm\fR|@\fIsetname\fR [,...]] \fIfilesystem\fR|\fIvolume\fR\fR
-.ad
+.Nm
+.Cm unallow
+.Op Fl dlr
+.Fl e Ns | Ns Sy everyone
+.Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar volume
 .br
-.na
-\fB\fBzfs unallow\fR [\fB-r\fR] \fB-c\fR [\fIperm\fR|@\fIsetname\fR[,...]]\fR \fB\fIfilesystem\fR|\fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Removes permissions that were granted with the \fBzfs allow\fR command. No permissions are explicitly denied, so other permissions granted are still in effect. For example, if the permission is granted by an ancestor. If no permissions are specified, then all permissions for the specified \fIuser\fR, \fIgroup\fR, or \fIeveryone\fR are removed. Specifying "everyone" (or using the \fB-e\fR option) only removes the permissions that were granted to "everyone", not all permissions for every user and group. See the \fBzfs allow\fR command for a description of the \fB-ldugec\fR options.
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Nm
+.Cm unallow
+.Op Fl r
+.Fl c
+.Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar volume
+.Xc
+Removes permissions that were granted with the
+.Nm zfs Cm allow
+command.
+No permissions are explicitly denied, so other permissions granted are still in
+effect.
+For example, if the permission is granted by an ancestor.
+If no permissions are specified, then all permissions for the specified
+.Ar user ,
+.Ar group ,
+or
+.Sy everyone
+are removed.
+Specifying
+.Sy everyone
+.Po or using the
+.Fl e
+option
+.Pc
+only removes the permissions that were granted to everyone, not all permissions
+for every user and group.
+See the
+.Nm zfs Cm allow
+command for a description of the
+.Fl ldugec
+options.
+.Bl -tag -width "-r"
+.It Fl r
 Recursively remove the permissions from this file system and all descendents.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs unallow\fR [\fB-r\fR] \fB-s\fR @\fIsetname\fR [\fIperm\fR|@\fIsetname\fR[,...]]\fR \fB\fIfilesystem\fR|\fIvolume\fR\fR
-.ad
-.sp .6
-.RS 4n
-Removes permissions from a permission set. If no permissions are specified, then all permissions are removed, thus removing the set entirely.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs hold\fR [\fB-r\fR] \fItag\fR \fIsnapshot\fR...\fR
-.ad
-.sp .6
-.RS 4n
-Adds a single reference, named with the \fItag\fR argument, to the specified snapshot or snapshots. Each snapshot has its own tag namespace, and tags must be unique within that space.
-.sp
-If a hold exists on a snapshot, attempts to destroy that snapshot by using the \fBzfs destroy\fR command return \fBEBUSY\fR.
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
-Specifies that a hold with the given tag is applied recursively to the snapshots of all descendent file systems.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs holds\fR [\fB-r\fR] \fIsnapshot\fR...\fR
-.ad
-.sp .6
-.RS 4n
+.El
+.It Xo
+.Nm
+.Cm unallow
+.Op Fl r
+.Fl s No @ Ns Ar setname
+.Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
+.Ar setname Oc Ns ... Oc
+.Ar filesystem Ns | Ns Ar volume
+.Xc
+Removes permissions from a permission set.
+If no permissions are specified, then all permissions are removed, thus removing
+the set entirely.
+.It Xo
+.Nm
+.Cm hold
+.Op Fl r
+.Ar tag Ar snapshot Ns ...
+.Xc
+Adds a single reference, named with the
+.Ar tag
+argument, to the specified snapshot or snapshots.
+Each snapshot has its own tag namespace, and tags must be unique within that
+space.
+.Pp
+If a hold exists on a snapshot, attempts to destroy that snapshot by using the
+.Nm zfs Cm destroy
+command return
+.Er EBUSY .
+.Bl -tag -width "-r"
+.It Fl r
+Specifies that a hold with the given tag is applied recursively to the snapshots
+of all descendent file systems.
+.El
+.It Xo
+.Nm
+.Cm holds
+.Op Fl r
+.Ar snapshot Ns ...
+.Xc
 Lists all existing user references for the given snapshot or snapshots.
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
-Lists the holds that are set on the named descendent snapshots, in addition to listing the holds on the named snapshot.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs release\fR [\fB-r\fR] \fItag\fR \fIsnapshot\fR...\fR
-.ad
-.sp .6
-.RS 4n
-Removes a single reference, named with the \fItag\fR argument, from the specified snapshot or snapshots. The tag must already exist for each snapshot.
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.sp .6
-.RS 4n
-Recursively releases a hold with the given tag on the snapshots of all descendent file systems.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzfs diff\fR [\fB-FHt\fR] \fIsnapshot\fR \fIsnapshot\fR|\fIfilesystem\fR
-.ad
-.sp .6
-.RS 4n
+.Bl -tag -width "-r"
+.It Fl r
+Lists the holds that are set on the named descendent snapshots, in addition to
+listing the holds on the named snapshot.
+.El
+.It Xo
+.Nm
+.Cm release
+.Op Fl r
+.Ar tag Ar snapshot Ns ...
+.Xc
+Removes a single reference, named with the
+.Ar tag
+argument, from the specified snapshot or snapshots.
+The tag must already exist for each snapshot.
+If a hold exists on a snapshot, attempts to destroy that snapshot by using the
+.Nm zfs Cm destroy
+command return
+.Er EBUSY .
+.Bl -tag -width "-r"
+.It Fl r
+Recursively releases a hold with the given tag on the snapshots of all
+descendent file systems.
+.El
+.It Xo
+.Nm
+.Cm diff
+.Op Fl FHt
+.Ar snapshot Ar snapshot Ns | Ns Ar filesystem
+.Xc
 Display the difference between a snapshot of a given filesystem and another
 snapshot of that filesystem from a later time or the current contents of the
-filesystem.  The first column is a character indicating the type of change,
-the other columns indicate pathname, new pathname (in case of rename), change
-in link count, and optionally file type and/or change time.
-
+filesystem.
+The first column is a character indicating the type of change, the other columns
+indicate pathname, new pathname
+.Pq in case of rename ,
+change in link count, and optionally file type and/or change time.
 The types of change are:
-.in +2
-.nf
+.Bd -literal
 -       The path has been removed
 +       The path has been created
 M       The path has been modified
 R       The path has been renamed
-.fi
-.in -2
-.sp
-.ne 2
-.na
-\fB-F\fR
-.ad
-.sp .6
-.RS 4n
-Display an indication of the type of file, in a manner similar to the \fB-F\fR
-option of \fBls\fR(1).
-.in +2
-.nf
+.Ed
+.Bl -tag -width "-F"
+.It Fl F
+Display an indication of the type of file, in a manner similar to the
+.Fl
+option of
+.Xr ls 1 .
+.Bd -literal
 B       Block device
 C       Character device
 /       Directory
@@ -3443,132 +3690,103 @@ C       Character device
 P       Event port
 =       Socket
 F       Regular file
-.fi
-.in -2
-.RE
-.sp
-.ne 2
-.na
-\fB-H\fR
-.ad
-.sp .6
-.RS 4n
-Give more parsable tab-separated output, without header lines and without arrows.
-.RE
-.sp
-.ne 2
-.na
-\fB-t\fR
-.ad
-.sp .6
-.RS 4n
+.Ed
+.It Fl H
+Give more parsable tab-separated output, without header lines and without
+arrows.
+.It Fl t
 Display the path's inode change time as the first column of output.
-.RE
-
-.SH EXAMPLES
-.LP
-\fBExample 1 \fRCreating a ZFS File System Hierarchy
-.sp
-.LP
-The following commands create a file system named \fBpool/home\fR and a file system named \fBpool/home/bob\fR. The mount point \fB/export/home\fR is set for the parent file system, and is automatically inherited by the child file system.
-
-.sp
-.in +2
-.nf
-# \fBzfs create pool/home\fR
-# \fBzfs set mountpoint=/export/home pool/home\fR
-# \fBzfs create pool/home/bob\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 2 \fRCreating a ZFS Snapshot
-.sp
-.LP
-The following command creates a snapshot named \fBbackup\fR. This snapshot is mounted on demand in the \fB\&.zfs/snapshot\fR directory at the root of the \fBpool/home/bob\fR file system.
-
-.sp
-.in +2
-.nf
-# \fBzfs snapshot pool/home/bob@backup\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 3 \fRCreating and Destroying Multiple Snapshots
-.sp
-.LP
-The following command creates snapshots named \fBbackup\fR of \fBpool/home\fR and all of its descendent file systems. Each snapshot is mounted on demand in the \fB\&.zfs/snapshot\fR directory at the root of its file system. The second command destroys the newly created snapshots.
-
-.sp
-.in +2
-.nf
-# \fBzfs snapshot -r pool/home@backup\fR
-# \fBzfs destroy -r pool/home@backup\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 4 \fRDisabling and Enabling File System Compression
-.sp
-.LP
-The following command disables the \fBcompression\fR property for all file systems under \fBpool/home\fR. The next command explicitly enables \fBcompression\fR for \fBpool/home/anne\fR.
-
-.sp
-.in +2
-.nf
-# \fBzfs set compression=off pool/home\fR
-# \fBzfs set compression=on pool/home/anne\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 5 \fRListing ZFS Datasets
-.sp
-.LP
-The following command lists all active file systems and volumes in the system. Snapshots are displayed if the pool's \fBlistsnapshots\fR property is \fBon\fR (the default is \fBoff\fR). See \fBzpool\fR(8) for more information on pool properties.
-
-.sp
-.in +2
-.nf
-# \fBzfs list\fR
-   NAME                      USED  AVAIL  REFER  MOUNTPOINT
-   pool                      450K   457G    18K  /pool
-   pool/home                 315K   457G    21K  /export/home
-   pool/home/anne             18K   457G    18K  /export/home/anne
-   pool/home/bob             276K   457G   276K  /export/home/bob
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 6 \fRSetting a Quota on a ZFS File System
-.sp
-.LP
-The following command sets a quota of 50 GiB for \fBpool/home/bob\fR.
-
-.sp
-.in +2
-.nf
-# \fBzfs set quota=50G pool/home/bob\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 7 \fRListing ZFS Properties
-.sp
-.LP
-The following command lists all properties for \fBpool/home/bob\fR.
-
-.sp
-.in +2
-.nf
-# \fBzfs get all pool/home/bob\fR
+.El
+.El
+.Sh EXIT STATUS
+The
+.Nm
+utility exits 0 on success, 1 if an error occurs, and 2 if invalid command line
+options were specified.
+.Sh EXAMPLES
+.Bl -tag -width ""
+.It Sy Example 1 No Creating a ZFS File System Hierarchy
+The following commands create a file system named
+.Em pool/home
+and a file system named
+.Em pool/home/bob .
+The mount point
+.Pa /export/home
+is set for the parent file system, and is automatically inherited by the child
+file system.
+.Bd -literal
+# zfs create pool/home
+# zfs set mountpoint=/export/home pool/home
+# zfs create pool/home/bob
+.Ed
+.It Sy Example 2 No Creating a ZFS Snapshot
+The following command creates a snapshot named
+.Sy yesterday .
+This snapshot is mounted on demand in the
+.Pa .zfs/snapshot
+directory at the root of the
+.Em pool/home/bob
+file system.
+.Bd -literal
+# zfs snapshot pool/home/bob@yesterday
+.Ed
+.It Sy Example 3 No Creating and Destroying Multiple Snapshots
+The following command creates snapshots named
+.Sy yesterday
+of
+.Em pool/home
+and all of its descendent file systems.
+Each snapshot is mounted on demand in the
+.Pa .zfs/snapshot
+directory at the root of its file system.
+The second command destroys the newly created snapshots.
+.Bd -literal
+# zfs snapshot -r pool/home@yesterday
+# zfs destroy -r pool/home@yesterday
+.Ed
+.It Sy Example 4 No Disabling and Enabling File System Compression
+The following command disables the
+.Sy compression
+property for all file systems under
+.Em pool/home .
+The next command explicitly enables
+.Sy compression
+for
+.Em pool/home/anne .
+.Bd -literal
+# zfs set compression=off pool/home
+# zfs set compression=on pool/home/anne
+.Ed
+.It Sy Example 5 No Listing ZFS Datasets
+The following command lists all active file systems and volumes in the system.
+Snapshots are displayed if the
+.Sy listsnaps
+property is
+.Sy on .
+The default is
+.Sy off .
+See
+.Xr zpool 8
+for more information on pool properties.
+.Bd -literal
+# zfs list
+NAME                      USED  AVAIL  REFER  MOUNTPOINT
+pool                      450K   457G    18K  /pool
+pool/home                 315K   457G    21K  /export/home
+pool/home/anne             18K   457G    18K  /export/home/anne
+pool/home/bob             276K   457G   276K  /export/home/bob
+.Ed
+.It Sy Example 6 No Setting a Quota on a ZFS File System
+The following command sets a quota of 50 Gbytes for
+.Em pool/home/bob .
+.Bd -literal
+# zfs set quota=50G pool/home/bob
+.Ed
+.It Sy Example 7 No Listing ZFS Properties
+The following command lists all properties for
+.Em pool/home/bob .
+.Bd -literal
+# zfs get all pool/home/bob
 NAME           PROPERTY              VALUE                  SOURCE
 pool/home/bob  type                  filesystem             -
 pool/home/bob  creation              Tue Jul 21 15:53 2009  -
@@ -3611,340 +3829,250 @@ pool/home/bob  usedbysnapshots       0                      -
 pool/home/bob  usedbydataset         21K                    -
 pool/home/bob  usedbychildren        0                      -
 pool/home/bob  usedbyrefreservation  0                      -
-pool/home/bob  logbias               latency                default
-pool/home/bob  dedup                 off                    default
-pool/home/bob  mlslabel              none                   default
-pool/home/bob  relatime              off                    default
-.fi
-.in -2
-.sp
-
-.sp
-.LP
+.Ed
+.Pp
 The following command gets a single property value.
-
-.sp
-.in +2
-.nf
-# \fBzfs get -H -o value compression pool/home/bob\fR
+.Bd -literal
+# zfs get -H -o value compression pool/home/bob
 on
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-The following command lists all properties with local settings for \fBpool/home/bob\fR.
-
-.sp
-.in +2
-.nf
-# \fBzfs get -r -s local -o name,property,value all pool/home/bob\fR
+.Ed
+The following command lists all properties with local settings for
+.Em pool/home/bob .
+.Bd -literal
+# zfs get -r -s local -o name,property,value all pool/home/bob
 NAME           PROPERTY              VALUE
 pool/home/bob  quota                 20G
 pool/home/bob  compression           on
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 8 \fRRolling Back a ZFS File System
-.sp
-.LP
-The following command reverts the contents of \fBpool/home/anne\fR to the snapshot named \fByesterday\fR, deleting all intermediate snapshots.
-
-.sp
-.in +2
-.nf
-# \fBzfs rollback -r pool/home/anne@yesterday\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 9 \fRCreating a ZFS Clone
-.sp
-.LP
-The following command creates a writable file system whose initial contents are the same as \fBpool/home/bob@yesterday\fR.
-
-.sp
-.in +2
-.nf
-# \fBzfs clone pool/home/bob@yesterday pool/clone\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 10 \fRPromoting a ZFS Clone
-.sp
-.LP
-The following commands illustrate how to test out changes to a file system, and then replace the original file system with the changed one, using clones, clone promotion, and renaming:
-
-.sp
-.in +2
-.nf
-# \fBzfs create pool/project/production\fR
+.Ed
+.It Sy Example 8 No Rolling Back a ZFS File System
+The following command reverts the contents of
+.Em pool/home/anne
+to the snapshot named
+.Sy yesterday ,
+deleting all intermediate snapshots.
+.Bd -literal
+# zfs rollback -r pool/home/anne@yesterday
+.Ed
+.It Sy Example 9 No Creating a ZFS Clone
+The following command creates a writable file system whose initial contents are
+the same as
+.Em pool/home/bob@yesterday .
+.Bd -literal
+# zfs clone pool/home/bob@yesterday pool/clone
+.Ed
+.It Sy Example 10 No Promoting a ZFS Clone
+The following commands illustrate how to test out changes to a file system, and
+then replace the original file system with the changed one, using clones, clone
+promotion, and renaming:
+.Bd -literal
+# zfs create pool/project/production
   populate /pool/project/production with data
-# \fBzfs snapshot pool/project/production@today\fR
-# \fBzfs clone pool/project/production@today pool/project/beta\fR
-make changes to /pool/project/beta and test them
-# \fBzfs promote pool/project/beta\fR
-# \fBzfs rename pool/project/production pool/project/legacy\fR
-# \fBzfs rename pool/project/beta pool/project/production\fR
-once the legacy version is no longer needed, it can be destroyed
-# \fBzfs destroy pool/project/legacy\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 11 \fRInheriting ZFS Properties
-.sp
-.LP
-The following command causes \fBpool/home/bob\fR and \fBpool/home/anne\fR to inherit the \fBchecksum\fR property from their parent.
-
-.sp
-.in +2
-.nf
-# \fBzfs inherit checksum pool/home/bob pool/home/anne\fR
-.fi
-.in -2
-.sp
-.LP
-The following command causes \fBpool/home/bob\fR to revert to the received
-value for the \fBquota\fR property if it exists.
-
-.sp
-.in +2
-.nf
-# \fBzfs inherit -S quota pool/home/bob
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 12 \fRRemotely Replicating ZFS Data
-.sp
-.LP
-The following commands send a full stream and then an incremental stream to a remote machine, restoring them into \fBpoolB/received/fs@a\fRand \fBpoolB/received/fs@b\fR, respectively. \fBpoolB\fR must contain the file system \fBpoolB/received\fR, and must not initially contain \fBpoolB/received/fs\fR.
-
-.sp
-.in +2
-.nf
-# \fBzfs send pool/fs@a | \e\fR
-   \fBssh host zfs receive poolB/received/fs@a\fR
-# \fBzfs send -i a pool/fs@b | ssh host \e\fR
-   \fBzfs receive poolB/received/fs\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 13 \fRUsing the \fBzfs receive\fR \fB-d\fR Option
-.sp
-.LP
-The following command sends a full stream of \fBpoolA/fsA/fsB@snap\fR to a remote machine, receiving it into \fBpoolB/received/fsA/fsB@snap\fR. The \fBfsA/fsB@snap\fR portion of the received snapshot's name is determined from the name of the sent snapshot. \fBpoolB\fR must contain the file system \fBpoolB/received\fR. If \fBpoolB/received/fsA\fR does not exist, it is created as an empty file system.
-
-.sp
-.in +2
-.nf
-# \fBzfs send poolA/fsA/fsB@snap | \e
-   ssh host zfs receive -d poolB/received\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 14 \fRSetting User Properties
-.sp
-.LP
-The following example sets the user-defined \fBcom.example:department\fR property for a dataset.
-
-.sp
-.in +2
-.nf
-# \fBzfs set com.example:department=12345 tank/accounting\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 15 \fRPerforming a Rolling Snapshot
-.sp
-.LP
-The following example shows how to maintain a history of snapshots with a consistent naming scheme. To keep a week's worth of snapshots, the user destroys the oldest snapshot, renames the remaining snapshots, and then creates a new snapshot, as follows:
-
-.sp
-.in +2
-.nf
-# \fBzfs destroy -r pool/users@7daysago\fR
-# \fBzfs rename -r pool/users@6daysago @7daysago\fR
-# \fBzfs rename -r pool/users@5daysago @6daysago\fR
-# \fBzfs rename -r pool/users@4daysago @5daysago\fR
-# \fBzfs rename -r pool/users@3daysago @4daysago\fR
-# \fBzfs rename -r pool/users@2daysago @3daysago\fR
-# \fBzfs rename -r pool/users@yesterday @2daysago\fR
-# \fBzfs rename -r pool/users@today @yesterday\fR
-# \fBzfs snapshot -r pool/users@today\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 16 \fRSetting \fBsharenfs\fR Property Options on a ZFS File System
-.sp
-.LP
-The following commands show how to set \fBsharenfs\fR property options to enable \fBrw\fR access for a set of \fBIP\fR addresses and to enable root access for system \fBneo\fR on the \fBtank/home\fR file system.
-
-.sp
-.in +2
-.nf
-# \fBzfs set sharenfs='rw=@123.123.0.0/16,root=neo' tank/home\fR
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-If you are using \fBDNS\fR for host name resolution, specify the fully qualified hostname.
-
-.sp
-.LP
-If you want to access snapdir through NFS, be sure to add \fBcrossmnt\fR to the options.
-
-.LP
-\fBExample 17 \fRDelegating ZFS Administration Permissions on a ZFS Dataset
-.sp
-The following example shows how to set permissions so that user \fBcindys\fR can create, destroy, mount, and take snapshots on \fBtank/cindys\fR. The permissions on \fBtank/cindys\fR are also displayed.
-
-.sp
-.in +2
-.nf
-# \fBzfs allow cindys create,destroy,mount,snapshot tank/cindys\fR
-# \fBzfs allow tank/cindys\fR
--------------------------------------------------------------
-Local+Descendent permissions on (tank/cindys)
-          user cindys create,destroy,mount,snapshot
--------------------------------------------------------------
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-Because the \fBtank/cindys\fR mount point permission is set to 755 by default, user \fBcindys\fR will be unable to mount file systems under \fBtank/cindys\fR. Set an \fBACL\fR similar to the following syntax to provide mount point access:
-.sp
-.in +2
-.nf
-# \fBchmod A+user:cindys:add_subdirectory:allow /tank/cindys\fR
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 18 \fRDelegating Create Time Permissions on a ZFS Dataset
-.sp
-.LP
-The following example shows how to grant anyone in the group \fBstaff\fR to create file systems in \fBtank/users\fR. This syntax also allows staff members to destroy their own file systems, but not destroy anyone else's file system. The permissions on \fBtank/users\fR are also displayed.
-
-.sp
-.in +2
-.nf
-# \fBzfs allow staff create,mount tank/users\fR
-# \fBzfs allow -c destroy tank/users\fR
-# \fBzfs allow tank/users\fR
--------------------------------------------------------------
-Create time permissions on (tank/users)
-          create,destroy
-Local+Descendent permissions on (tank/users)
-          group staff create,mount
--------------------------------------------------------------
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 19 \fRDefining and Granting a Permission Set on a ZFS Dataset
-.sp
-.LP
-The following example shows how to define and grant a permission set on the \fBtank/users\fR file system. The permissions on \fBtank/users\fR are also displayed.
-
-.sp
-.in +2
-.nf
-# \fBzfs allow -s @pset create,destroy,snapshot,mount tank/users\fR
-# \fBzfs allow staff @pset tank/users\fR
-# \fBzfs allow tank/users\fR
--------------------------------------------------------------
-Permission sets on (tank/users)
+# zfs snapshot pool/project/production@today
+# zfs clone pool/project/production@today pool/project/beta
+  make changes to /pool/project/beta and test them
+# zfs promote pool/project/beta
+# zfs rename pool/project/production pool/project/legacy
+# zfs rename pool/project/beta pool/project/production
+  once the legacy version is no longer needed, it can be destroyed
+# zfs destroy pool/project/legacy
+.Ed
+.It Sy Example 11 No Inheriting ZFS Properties
+The following command causes
+.Em pool/home/bob
+and
+.Em pool/home/anne
+to inherit the
+.Sy checksum
+property from their parent.
+.Bd -literal
+# zfs inherit checksum pool/home/bob pool/home/anne
+.Ed
+.It Sy Example 12 No Remotely Replicating ZFS Data
+The following commands send a full stream and then an incremental stream to a
+remote machine, restoring them into
+.Em poolB/received/fs@a
+and
+.Em poolB/received/fs@b ,
+respectively.
+.Em poolB
+must contain the file system
+.Em poolB/received ,
+and must not initially contain
+.Em poolB/received/fs .
+.Bd -literal
+# zfs send pool/fs@a | \e
+  ssh host zfs receive poolB/received/fs@a
+# zfs send -i a pool/fs@b | \e
+  ssh host zfs receive poolB/received/fs
+.Ed
+.It Sy Example 13 No Using the zfs receive -d Option
+The following command sends a full stream of
+.Em poolA/fsA/fsB@snap
+to a remote machine, receiving it into
+.Em poolB/received/fsA/fsB@snap .
+The
+.Em fsA/fsB@snap
+portion of the received snapshot's name is determined from the name of the sent
+snapshot.
+.Em poolB
+must contain the file system
+.Em poolB/received .
+If
+.Em poolB/received/fsA
+does not exist, it is created as an empty file system.
+.Bd -literal
+# zfs send poolA/fsA/fsB@snap | \e
+  ssh host zfs receive -d poolB/received
+.Ed
+.It Sy Example 14 No Setting User Properties
+The following example sets the user-defined
+.Sy com.example:department
+property for a dataset.
+.Bd -literal
+# zfs set com.example:department=12345 tank/accounting
+.Ed
+.It Sy Example 15 No Performing a Rolling Snapshot
+The following example shows how to maintain a history of snapshots with a
+consistent naming scheme.
+To keep a week's worth of snapshots, the user destroys the oldest snapshot,
+renames the remaining snapshots, and then creates a new snapshot, as follows:
+.Bd -literal
+# zfs destroy -r pool/users@7daysago
+# zfs rename -r pool/users@6daysago @7daysago
+# zfs rename -r pool/users@5daysago @6daysago
+# zfs rename -r pool/users@yesterday @5daysago
+# zfs rename -r pool/users@yesterday @4daysago
+# zfs rename -r pool/users@yesterday @3daysago
+# zfs rename -r pool/users@yesterday @2daysago
+# zfs rename -r pool/users@today @yesterday
+# zfs snapshot -r pool/users@today
+.Ed
+.It Sy Example 16 No Setting sharenfs Property Options on a ZFS File System
+The following commands show how to set
+.Sy sharenfs
+property options to enable
+.Sy rw
+access for a set of
+.Sy IP
+addresses and to enable root access for system
+.Sy neo
+on the
+.Em tank/home
+file system.
+.Bd -literal
+# zfs set sharenfs='rw=@123.123.0.0/16,root=neo' tank/home
+.Ed
+.Pp
+If you are using
+.Sy DNS
+for host name resolution, specify the fully qualified hostname.
+.It Sy Example 17 No Delegating ZFS Administration Permissions on a ZFS Dataset
+The following example shows how to set permissions so that user
+.Sy cindys
+can create, destroy, mount, and take snapshots on
+.Em tank/cindys .
+The permissions on
+.Em tank/cindys
+are also displayed.
+.Bd -literal
+# zfs allow cindys create,destroy,mount,snapshot tank/cindys
+# zfs allow tank/cindys
+---- Permissions on tank/cindys --------------------------------------
+Local+Descendent permissions:
+        user cindys create,destroy,mount,snapshot
+.Ed
+.Pp
+Because the
+.Em tank/cindys
+mount point permission is set to 755 by default, user
+.Sy cindys
+will be unable to mount file systems under
+.Em tank/cindys .
+Add an ACE similar to the following syntax to provide mount point access:
+.Bd -literal
+# chmod A+user:cindys:add_subdirectory:allow /tank/cindys
+.Ed
+.It Sy Example 18 No Delegating Create Time Permissions on a ZFS Dataset
+The following example shows how to grant anyone in the group
+.Sy staff
+to create file systems in
+.Em tank/users .
+This syntax also allows staff members to destroy their own file systems, but not
+destroy anyone else's file system.
+The permissions on
+.Em tank/users
+are also displayed.
+.Bd -literal
+# zfs allow staff create,mount tank/users
+# zfs allow -c destroy tank/users
+# zfs allow tank/users
+---- Permissions on tank/users ---------------------------------------
+Permission sets:
+        destroy
+Local+Descendent permissions:
+        group staff create,mount
+.Ed
+.It Sy Example 19 No Defining and Granting a Permission Set on a ZFS Dataset
+The following example shows how to define and grant a permission set on the
+.Em tank/users
+file system.
+The permissions on
+.Em tank/users
+are also displayed.
+.Bd -literal
+# zfs allow -s @pset create,destroy,snapshot,mount tank/users
+# zfs allow staff @pset tank/users
+# zfs allow tank/users
+---- Permissions on tank/users ---------------------------------------
+Permission sets:
         @pset create,destroy,mount,snapshot
-Create time permissions on (tank/users)
-        create,destroy
-Local+Descendent permissions on (tank/users)
-        group staff @pset,create,mount
--------------------------------------------------------------
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 20 \fRDelegating Property Permissions on a ZFS Dataset
-.sp
-.LP
-The following example shows to grant the ability to set quotas and reservations on the \fBusers/home\fR file system. The permissions on \fBusers/home\fR are also displayed.
-
-.sp
-.in +2
-.nf
-# \fBzfs allow cindys quota,reservation users/home\fR
-# \fBzfs allow users/home\fR
--------------------------------------------------------------
-Local+Descendent permissions on (users/home)
+Local+Descendent permissions:
+        group staff @pset
+.Ed
+.It Sy Example 20 No Delegating Property Permissions on a ZFS Dataset
+The following example shows to grant the ability to set quotas and reservations
+on the
+.Em users/home
+file system.
+The permissions on
+.Em users/home
+are also displayed.
+.Bd -literal
+# zfs allow cindys quota,reservation users/home
+# zfs allow users/home
+---- Permissions on users/home ---------------------------------------
+Local+Descendent permissions:
         user cindys quota,reservation
--------------------------------------------------------------
-cindys% \fBzfs set quota=10G users/home/marks\fR
-cindys% \fBzfs get quota users/home/marks\fR
-NAME              PROPERTY  VALUE             SOURCE
-users/home/marks  quota     10G               local
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 21 \fRRemoving ZFS Delegated Permissions on a ZFS Dataset
-.sp
-.LP
-The following example shows how to remove the snapshot permission from the \fBstaff\fR group on the \fBtank/users\fR file system. The permissions on \fBtank/users\fR are also displayed.
-
-.sp
-.in +2
-.nf
-# \fBzfs unallow staff snapshot tank/users\fR
-# \fBzfs allow tank/users\fR
--------------------------------------------------------------
-Permission sets on (tank/users)
+cindys% zfs set quota=10G users/home/marks
+cindys% zfs get quota users/home/marks
+NAME              PROPERTY  VALUE  SOURCE
+users/home/marks  quota     10G    local
+.Ed
+.It Sy Example 21 No Removing ZFS Delegated Permissions on a ZFS Dataset
+The following example shows how to remove the snapshot permission from the
+.Sy staff
+group on the
+.Em tank/users
+file system.
+The permissions on
+.Em tank/users
+are also displayed.
+.Bd -literal
+# zfs unallow staff snapshot tank/users
+# zfs allow tank/users
+---- Permissions on tank/users ---------------------------------------
+Permission sets:
         @pset create,destroy,mount,snapshot
-Create time permissions on (tank/users)
-        create,destroy
-Local+Descendent permissions on (tank/users)
-        group staff @pset,create,mount
--------------------------------------------------------------
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 22\fR Showing the differences between a snapshot and a ZFS Dataset
-.sp
-.LP
+Local+Descendent permissions:
+        group staff @pset
+.Ed
+.It Sy Example 22 No Showing the differences between a snapshot and a ZFS Dataset
 The following example shows how to see what has changed between a prior
-snapshot of a ZFS Dataset and its current state.  The \fB-F\fR option is used
-to indicate type information for the files affected.
-
-.sp
-.in +2
-.nf
+snapshot of a ZFS dataset and its current state.
+The
+.Fl F
+option is used to indicate type information for the files affected.
+.Bd -literal
 # zfs diff -F tank/test@before tank/test
 M       /       /tank/test/
 M       F       /tank/test/linked      (+1)
@@ -3952,65 +4080,60 @@ R       F       /tank/test/oldname -> /tank/test/newname
 -       F       /tank/test/deleted
 +       F       /tank/test/created
 M       F       /tank/test/modified
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 23\fR Creating a bookmark
-.sp
-.LP
-The following example create a bookmark to a snapshot. This bookmark can then
-be used instead of snapshot in send streams.
-
-.sp
-.in +2
-.nf
+.Ed
+.It Sy Example 23 No Creating a bookmark
+The following example create a bookmark to a snapshot. This bookmark
+can then be used instead of snapshot in send streams.
+.Bd -literal
 # zfs bookmark rpool@snapshot rpool#bookmark
-.fi
-.in -2
-.sp
-
-.SH "ENVIRONMENT VARIABLES"
-.TP
-.B "ZFS_ABORT
-Cause \fBzfs\fR to dump core on exit for the purposes of running \fB::findleaks\fR.
-
-.SH EXIT STATUS
-.LP
-The following exit values are returned:
-.sp
-.ne 2
-.na
-\fB\fB0\fR\fR
-.ad
-.sp .6
-.RS 4n
-Successful completion.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB1\fR\fR
-.ad
-.sp .6
-.RS 4n
-An error occurred.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB2\fR\fR
-.ad
-.sp .6
-.RS 4n
-Invalid command line options were specified.
-.RE
-
-.SH SEE ALSO
-.LP
-\fBchmod\fR(2), \fBfsync\fR(2), \fBgzip\fR(1), \fBls\fR(1), \fBmount\fR(8), \fBopen\fR(2), \fBreaddir\fR(3), \fBssh\fR(1), \fBstat\fR(2), \fBwrite\fR(2), \fBzpool\fR(8), \fBzfs-module-parameters\fR(5)
-.sp
-On Solaris: \fBdfstab(4)\fR, \fBiscsitadm(1M)\fR, \fBmount(1M)\fR, \fBshare(1M)\fR, \fBsharemgr(1M)\fR, \fBunshare(1M)\fR
+.Ed
+.It Sy Example 24 No Setting sharesmb Property Options on a ZFS File System
+The following example show how to share SMB filesystem through ZFS. Note that
+that a user and his/her password must be given.
+.Bd -literal
+# smbmount //127.0.0.1/share_tmp /mnt/tmp \\
+  -o user=workgroup/turbo,password=obrut,uid=1000
+.Ed
+.Pp
+Minimal
+.Em /etc/samba/smb.conf
+configuration required:
+.Pp
+Samba will need to listen to 'localhost' (127.0.0.1) for the ZFS utilities to
+communicate with Samba. This is the default behavior for most Linux
+distributions.
+.Pp
+Samba must be able to authenticate a user. This can be done in a number of
+ways, depending on if using the system password file, LDAP or the Samba
+specific smbpasswd file. How to do this is outside the scope of this manual.
+Please refer to the
+.Xr smb.conf 5
+man page for more information.
+.Pp
+See the
+.Sy USERSHARE section
+of the
+.Xr smb.conf 5
+man page for all configuration options in case you need to modify any options
+to the share afterwards. Do note that any changes done with the
+.Xr net 8
+command will be undone if the share is ever unshared (such as at a reboot etc).
+.El
+.Sh INTERFACE STABILITY
+.Sy Committed .
+.Sh SEE ALSO
+.Xr gzip 1 ,
+.Xr ssh 1 ,
+.Xr mount 8 ,
+.Xr zpool 8 ,
+.Xr selinux 8 ,
+.Xr chmod 2 ,
+.Xr stat 2 ,
+.Xr write 2 ,
+.Xr fsync 2 ,
+.Xr attr 1 ,
+.Xr acl 5 ,
+.Xr exports 5 ,
+.Xr exportfs 8 ,
+.Xr net 8 ,
+.Xr attributes 5


### PR DESCRIPTION
### Description

* Fixed some typos
* Additional description for some commands arguments
* Text reworked to be in sync with OpenZFS
* Added Linux as .Os type

### Motivation and Context

Synchronize the man pages with those found in OpenZFS in order to minimize conflicts.

### How Has This Been Tested?

Proofreading.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.