### PR TITLE
On failure tests-runner should do non-zero exit

### DIFF
--- a/tests/test-runner/cmd/test-runner.py
+++ b/tests/test-runner/cmd/test-runner.py
@@ -13,6 +13,7 @@
 
 #
 # Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+# Copyright (c) 2017 Datto Inc.
 #
 
 import ConfigParser
@@ -702,7 +703,7 @@ class TestRun(object):
 
     def summary(self):
         if Result.total is 0:
-            return
+            return 2
 
         print '\nResults Summary'
         for key in Result.runresults.keys():
@@ -715,6 +716,10 @@ class TestRun(object):
         print 'Percent passed:\t%.1f%%' % ((float(Result.runresults['PASS']) /
                                             float(Result.total)) * 100)
         print 'Log directory:\t%s' % self.outputdir
+
+        if Result.runresults['FAIL'] > 0:
+            return 1
+        return 0
 
 
 def verify_file(pathname):
@@ -871,8 +876,7 @@ def main():
 
     testrun.complete_outputdirs()
     testrun.run(options)
-    testrun.summary()
-    exit(0)
+    exit(testrun.summary())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On failure, tests-runner should do non-zero exit

### Description
<!--- Describe your changes in detail -->
Right now test runner will always exit(0).
It's helpful to have zfs-tests.sh provide different
exit values to the shell depending on if everything passed or not.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With this change we can use common shell commands to run tests until failure:
`time while ./scripts/zfs-tests.sh -v -r some_runfile.run; do sleep 1; done`
Will only stop running when a failure has occured.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Running some runfiles and checking output as well as $?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
