### PR TITLE
Enforce request limits on zvols

### DIFF
--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -139,6 +139,12 @@ blk_queue_set_read_ahead(struct request_queue *q, unsigned long ra_pages)
 #endif
 }
 
+static inline unsigned long
+blk_queue_nr_requests(struct request_queue *q)
+{
+	return (q->nr_requests);
+}
+
 #ifndef HAVE_GET_DISK_RO
 static inline int
 get_disk_ro(struct gendisk *disk)

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -131,6 +131,10 @@ struct zvol_state {
 	kmutex_t		zv_state_lock;	/* protects zvol_state_t */
 	atomic_t		zv_suspend_ref;	/* refcount for suspend */
 	krwlock_t		zv_suspend_lock;	/* suspend lock */
+	kcondvar_t		zv_write_cv;	/* write queue wait */
+	unsigned long		zv_writes;	/* in-flight writes */
+	kcondvar_t		zv_read_cv;	/* read queue wait */
+	unsigned long		zv_reads;	/* in-flight reads */
 };
 
 typedef enum {
@@ -786,6 +790,11 @@ zvol_write(void *arg)
 	generic_end_io_acct(WRITE, &zv->zv_disk->part0, start_jif);
 	BIO_END_IO(bio, -error);
 	kmem_free(zvr, sizeof (zv_request_t));
+
+	mutex_enter(&zv->zv_state_lock);
+	zv->zv_writes--;
+	cv_signal(&zv->zv_write_cv);
+	mutex_exit(&zv->zv_state_lock);
 }
 
 /*
@@ -873,6 +882,11 @@ unlock:
 	generic_end_io_acct(WRITE, &zv->zv_disk->part0, start_jif);
 	BIO_END_IO(bio, -error);
 	kmem_free(zvr, sizeof (zv_request_t));
+
+	mutex_enter(&zv->zv_state_lock);
+	zv->zv_writes--;
+	cv_signal(&zv->zv_write_cv);
+	mutex_exit(&zv->zv_state_lock);
 }
 
 static void
@@ -914,6 +928,11 @@ zvol_read(void *arg)
 	generic_end_io_acct(READ, &zv->zv_disk->part0, start_jif);
 	BIO_END_IO(bio, -error);
 	kmem_free(zvr, sizeof (zv_request_t));
+
+	mutex_enter(&zv->zv_state_lock);
+	zv->zv_reads--;
+	cv_signal(&zv->zv_read_cv);
+	mutex_exit(&zv->zv_state_lock);
 }
 
 static MAKE_REQUEST_FN_RET
@@ -962,6 +981,12 @@ zvol_request(struct request_queue *q, struct bio *bio)
 			goto out;
 		}
 
+		mutex_enter(&zv->zv_state_lock);
+		while (zv->zv_writes >= blk_queue_nr_requests(zv->zv_queue))
+			cv_wait(&zv->zv_write_cv, &zv->zv_state_lock);
+		zv->zv_writes++;
+		mutex_exit(&zv->zv_state_lock);
+
 		zvr = kmem_alloc(sizeof (zv_request_t), KM_SLEEP);
 		zvr->zv = zv;
 		zvr->bio = bio;
@@ -994,6 +1019,12 @@ zvol_request(struct request_queue *q, struct bio *bio)
 				zvol_write(zvr);
 		}
 	} else {
+		mutex_enter(&zv->zv_state_lock);
+		while (zv->zv_reads >= blk_queue_nr_requests(zv->zv_queue))
+			cv_wait(&zv->zv_read_cv, &zv->zv_state_lock);
+		zv->zv_reads++;
+		mutex_exit(&zv->zv_state_lock);
+
 		zvr = kmem_alloc(sizeof (zv_request_t), KM_SLEEP);
 		zvr->zv = zv;
 		zvr->bio = bio;
@@ -1655,6 +1686,10 @@ zvol_alloc(dev_t dev, const char *name)
 	list_link_init(&zv->zv_next);
 
 	mutex_init(&zv->zv_state_lock, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&zv->zv_write_cv, NULL, CV_DEFAULT, NULL);
+	cv_init(&zv->zv_read_cv, NULL, CV_DEFAULT, NULL);
+	zv->zv_reads = 0;
+	zv->zv_writes = 0;
 
 	zv->zv_queue = blk_alloc_queue(GFP_ATOMIC);
 	if (zv->zv_queue == NULL)
@@ -1741,7 +1776,12 @@ zvol_free(void *arg)
 
 	ida_simple_remove(&zvol_ida, MINOR(zv->zv_dev) >> ZVOL_MINOR_BITS);
 
+	ASSERT0(zv->zv_reads);
+	ASSERT0(zv->zv_writes);
+
 	mutex_destroy(&zv->zv_state_lock);
+	cv_destroy(&zv->zv_write_cv);
+	cv_destroy(&zv->zv_read_cv);
 
 	kmem_free(zv, sizeof (zvol_state_t));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
Currently, zvols do not handle heavy random IO
workloads. zvols should limit the number of outstanding
in-flight IO requests. This should improve performance.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#6127 
#6278 

### How Has This Been Tested?
Builds on my VM. Buildbot will help me test. Hoping to test on hardware soon.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
