### PR TITLE
ZTS: replace su commands by run_user function

### DIFF
--- a/tests/zfs-tests/tests/functional/acl/posix/posix_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/acl/posix/posix_001_pos.ksh
@@ -48,21 +48,21 @@ log_assert "Verify acltype=posixacl works on file"
 # Test access to FILE
 log_note "Testing access to FILE"
 log_must touch $TESTDIR/file.0
-log_must setfacl -m g:zfsgrp:rw $TESTDIR/file.0
-getfacl $TESTDIR/file.0 2> /dev/null | egrep -q "^group:zfsgrp:rw-$"
+log_must setfacl -m g:$ZFS_ACL_STAFF_GROUP:rw $TESTDIR/file.0
+getfacl $TESTDIR/file.0 2> /dev/null | egrep -q "^group:$ZFS_ACL_STAFF_GROUP:rw-$"
 if [ "$?" -eq "0" ]; then
 	# Should be able to write to file
-	log_must su staff1 -c "echo \"echo test > /dev/null\" > $TESTDIR/file.0"
+	log_must user_run $ZFS_ACL_STAFF1 "echo 'echo test > /dev/null' > $TESTDIR/file.0"
 
 	# Should NOT be able to create new file
-	log_mustnot su staff1 -c "touch $TESTDIR/file.1"
+	log_mustnot user_run $ZFS_ACL_STAFF1 "touch $TESTDIR/file.1"
 
 	# Root should be able to run file, but not user
 	chmod +x $TESTDIR/file.0
 	log_must $TESTDIR/file.0
-	log_mustnot su staff1 -c $TESTDIR/file.0
+	log_mustnot user_run $ZFS_ACL_STAFF1 $TESTDIR/file.0
 
 	log_pass "POSIX ACL mode works on files"
 else
-	log_fail "Group 'zfsgrp' does not have 'rw' as specified"
+	log_fail "Group '$ZFS_ACL_STAFF_GROUP' does not have 'rw' as specified"
 fi

--- a/tests/zfs-tests/tests/functional/acl/posix/posix_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/acl/posix/posix_002_pos.ksh
@@ -47,16 +47,16 @@ log_assert "Verify acltype=posixacl works on directory"
 # Test access to DIRECTORY
 log_note "Testing access to DIRECTORY"
 log_must mkdir $TESTDIR/dir.0
-log_must setfacl -m g:zfsgrp:wx $TESTDIR/dir.0
-getfacl $TESTDIR/dir.0 2> /dev/null | egrep -q "^group:zfsgrp:-wx$"
+log_must setfacl -m g:$ZFS_ACL_STAFF_GROUP:wx $TESTDIR/dir.0
+getfacl $TESTDIR/dir.0 2> /dev/null | egrep -q "^group:$ZFS_ACL_STAFF_GROUP:-wx$"
 if [ "$?" -eq "0" ]; then
 	# Should be able to create file in directory
-	log_must su staff1 -c "touch $TESTDIR/dir.0/file.0"
+	log_must user_run $ZFS_ACL_STAFF1 "touch $TESTDIR/dir.0/file.0"
 
 	# Should NOT be able to list files in directory
-	log_mustnot su staff1 -c "ls -l $TESTDIR/dir.0"
+	log_mustnot user_run $ZFS_ACL_STAFF1 "ls -l $TESTDIR/dir.0"
 
 	log_pass "POSIX ACL mode works on directories"
 else
-	log_fail "Group 'zfsgrp' does not have 'rwx' as specified"
+	log_fail "Group '$ZFS_ACL_STAFF_GROUP' does not have 'rwx' as specified"
 fi

--- a/tests/zfs-tests/tests/functional/acl/posix/posix_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/acl/posix/posix_003_pos.ksh
@@ -37,25 +37,25 @@ verify_runnable "both"
 log_assert "Verify regular and default POSIX ACLs survive  remount"
 
 typeset output=/tmp/zfs-posixacl.$$
-typeset acl_str1="^group:${ZFS_ACL_STAFF_GROUP}:-wx$"
-typeset acl_str2="^default:group:${ZFS_ACL_STAFF_GROUP}:-wx$"
-typeset ACLDIR="${TESTDIR}/dir.1"
+typeset acl_str1="^group:$ZFS_ACL_STAFF_GROUP:-wx$"
+typeset acl_str2="^default:group:$ZFS_ACL_STAFF_GROUP:-wx$"
+typeset ACLDIR="$TESTDIR/dir.1"
 
 log_note "Testing access to DIRECTORY"
 log_must mkdir $ACLDIR
-log_must setfacl -m g:${ZFS_ACL_STAFF_GROUP}:wx $ACLDIR
-log_must setfacl -d -m g:${ZFS_ACL_STAFF_GROUP}:wx $ACLDIR
-getfacl $ACLDIR 2> /dev/null | egrep -q "${acl_str1}"
+log_must setfacl -m g:$ZFS_ACL_STAFF_GROUP:wx $ACLDIR
+log_must setfacl -d -m g:$ZFS_ACL_STAFF_GROUP:wx $ACLDIR
+getfacl $ACLDIR 2> /dev/null | egrep -q "$acl_str1"
 if [ "$?" -eq "0" ]; then
-	getfacl $ACLDIR 2> /dev/null | egrep -q "${acl_str2}"
+	getfacl $ACLDIR 2> /dev/null | egrep -q "$acl_str2"
 fi
 
 if [ "$?" -eq "0" ]; then
 	log_must zfs unmount $TESTPOOL/$TESTFS
 	log_must zfs mount $TESTPOOL/$TESTFS
-	log_must eval 'getfacl $ACLDIR 2> /dev/null | egrep -q "${acl_str1}"'
-	log_must eval 'getfacl $ACLDIR 2> /dev/null | egrep -q "${acl_str2}"'
+	log_must eval "getfacl $ACLDIR 2> /dev/null | egrep -q \"$acl_str1\""
+	log_must eval "getfacl $ACLDIR 2> /dev/null | egrep -q \"$acl_str2\""
 	log_pass "POSIX ACLs survive remount"
 else
-	log_fail "Group '${ZFS_ACL_STAFF_GROUP}' does not have 'rwx'"
+	log_fail "Group '$ZFS_ACL_STAFF_GROUP' does not have 'rwx'"
 fi

--- a/tests/zfs-tests/tests/functional/history/history_common.kshlib
+++ b/tests/zfs-tests/tests/functional/history/history_common.kshlib
@@ -74,7 +74,7 @@ function run_and_verify
 	if [[ $user == "root" ]]; then
 		log_must eval "$fullcmd"
 	else
-		log_must su $user -c "eval $fullcmd"
+		log_must user_run $user "$fullcmd"
 	fi
 	zpool history $flags $pool > $TMP_HISTORY 2>/dev/null
 	diff $OLD_HISTORY $TMP_HISTORY | grep "^> " | sed 's/^> //g' \

--- a/tests/zfs-tests/tests/functional/privilege/privilege_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/privilege_001_pos.ksh
@@ -66,30 +66,30 @@ log_assert "The RBAC profile \"ZFS Storage Management\" works"
 ZFS_USER=$(cat /tmp/zfs-privs-test-user.txt)
 
 # the user shouldn't be able to do anything initially
-log_mustnot su $ZFS_USER -c "zpool create $TESTPOOL $DISKS"
-log_mustnot su $ZFS_USER -c "pfexec zpool create $TESTPOOL $DISKS"
+log_mustnot user_run $ZFS_USER "zpool create $TESTPOOL $DISKS"
+log_mustnot user_run $ZFS_USER "pfexec zpool create $TESTPOOL $DISKS"
 
 # the first time we assign the profile, we insist it should work
 log_must usermod -P "ZFS Storage Management" $ZFS_USER
-log_must su $ZFS_USER -c "pfexec zpool create -f $TESTPOOL $DISKS"
+log_must user_run $ZFS_USER "pfexec zpool create -f $TESTPOOL $DISKS"
 
 # ensure the user can't create a filesystem with this profile
-log_mustnot su $ZFS_USER -c "zfs create $TESTPOOL/fs"
+log_mustnot user_run $ZFS_USER "zfs create $TESTPOOL/fs"
 
 # add ZFS File System Management profile, and try to create a fs
 log_must usermod -P "ZFS File System Management" $ZFS_USER
-log_must su $ZFS_USER -c "pfexec zfs create $TESTPOOL/fs"
+log_must user_run $ZFS_USER "pfexec zfs create $TESTPOOL/fs"
 
 # revoke File System Management profile
 usermod -P, $ZFS_USER
 usermod -P "ZFS Storage Management" $ZFS_USER
 
 # ensure the user can destroy pools
-log_mustnot su $ZFS_USER -c "zpool destroy $TESTPOOL"
-log_must su $ZFS_USER -c "pfexec zpool destroy $TESTPOOL"
+log_mustnot user_run $ZFS_USER "zpool destroy $TESTPOOL"
+log_must user_run $ZFS_USER "pfexec zpool destroy $TESTPOOL"
 
 # revoke Storage Management profile
 usermod -P, $ZFS_USER
-log_mustnot su $ZFS_USER -c "pfexec zpool create -f $TESTPOOL $DISKS"
+log_mustnot user_run $ZFS_USER "pfexec zpool create -f $TESTPOOL $DISKS"
 
 log_pass "The RBAC profile \"ZFS Storage Management\" works"

--- a/tests/zfs-tests/tests/functional/privilege/privilege_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/privilege_002_pos.ksh
@@ -77,29 +77,29 @@ else
 fi
 
 # A user shouldn't be able to create filesystems
-log_mustnot su $ZFS_USER -c "zfs create $DATASET/zfsprivfs"
+log_mustnot user_run $ZFS_USER "zfs create $DATASET/zfsprivfs"
 
 # Insist this invocation of usermod works
 log_must usermod -P "ZFS File System Management" $ZFS_USER
 
 # Now try to create file systems as the user
-log_mustnot su $ZFS_USER -c "zfs create $DATASET/zfsprivfs"
-log_must su $ZFS_USER -c "pfexec zfs create $DATASET/zfsprivfs"
+log_mustnot user_run $ZFS_USER "zfs create $DATASET/zfsprivfs"
+log_must user_run $ZFS_USER "pfexec zfs create $DATASET/zfsprivfs"
 
 # Ensure the user can't do anything to pools in this state:
-log_mustnot su $ZFS_USER -c "zpool destroy $DATASET"
-log_mustnot su $ZFS_USER -c "pfexec zpool destroy $DATASET"
+log_mustnot user_run $ZFS_USER "zpool destroy $DATASET"
+log_mustnot user_run $ZFS_USER "pfexec zpool destroy $DATASET"
 
 # revoke File System Management profile
 usermod -P, $ZFS_USER
 
 # Ensure the user can't create more filesystems
-log_mustnot su $ZFS_USER -c "zfs create $DATASET/zfsprivfs2"
-log_mustnot su $ZFS_USER -c "pfexec zfs create $DATASET/zfsprivfs2"
+log_mustnot user_run $ZFS_USER "zfs create $DATASET/zfsprivfs2"
+log_mustnot user_run $ZFS_USER "pfexec zfs create $DATASET/zfsprivfs2"
 
 # assign the profile again and destroy the fs.
 usermod -P "ZFS File System Management" $ZFS_USER
-log_must su $ZFS_USER -c "pfexec zfs destroy $DATASET/zfsprivfs"
+log_must user_run $ZFS_USER "pfexec zfs destroy $DATASET/zfsprivfs"
 usermod -P, $ZFS_USER
 
 log_pass "The RBAC profile \"ZFS File System Management\" works"


### PR DESCRIPTION
It's needed for PATH variable to be passed into su.

Signed-off-by: George Melikov <mail@gmelikov.ru>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
