### PR TITLE
Fix 'zpool clear' on readonly pools

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -6144,7 +6144,7 @@ zfs_ioctl_init(void)
 	    zfs_secpolicy_config, B_TRUE, POOL_CHECK_NONE);
 
 	zfs_ioctl_register_pool(ZFS_IOC_CLEAR, zfs_ioc_clear,
-	    zfs_secpolicy_config, B_TRUE, POOL_CHECK_NONE);
+	    zfs_secpolicy_config, B_TRUE, POOL_CHECK_READONLY);
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_REOPEN, zfs_ioc_pool_reopen,
 	    zfs_secpolicy_config, B_TRUE, POOL_CHECK_SUSPENDED);
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -200,7 +200,8 @@ tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
 tests = ['zpool_attach_001_neg', 'attach-o_ashift']
 
 [tests/functional/cli_root/zpool_clear]
-tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg']
+tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg',
+    'zpool_clear_readonly']
 
 [tests/functional/cli_root/zpool_create]
 tests = ['zpool_create_001_pos', 'zpool_create_002_pos',

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/Makefile.am
@@ -5,4 +5,5 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	zpool_clear_001_pos.ksh \
 	zpool_clear_002_neg.ksh \
-	zpool_clear_003_neg.ksh
+	zpool_clear_003_neg.ksh \
+	zpool_clear_readonly.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_readonly.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_readonly.ksh
@@ -1,0 +1,71 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_clear/zpool_clear.cfg
+
+#
+# DESCRIPTION:
+# Verify 'zpool clear' cannot be used on readonly pools.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Export the pool and import it readonly.
+# 3. Verify 'zpool clear' on the pool (and each device) returns an error.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	destroy_pool $TESTPOOL1
+	rm -f $TESTDIR/file.*
+}
+
+log_assert "Verify 'zpool clear' cannot be used on readonly pools."
+log_onexit cleanup
+
+# 1. Create a pool.
+log_must truncate -s $FILESIZE $TESTDIR/file.{1,2,3}
+log_must zpool create $TESTPOOL1 raidz $TESTDIR/file.*
+
+# 2. Export the pool and import it readonly.
+log_must zpool export $TESTPOOL1
+log_must zpool import -d $TESTDIR -o readonly=on $TESTPOOL1
+if [[ "$(get_pool_prop readonly $TESTPOOL1)" != 'on' ]]; then
+	log_fail "Pool $TESTPOOL1 was not imported readonly."
+fi
+
+# 3. Verify 'zpool clear' on the pool (and each device) returns an error.
+log_mustnot zpool clear $TESTPOOL1
+for i in {1..3}; do
+	# Device must be online
+	log_must check_state $TESTPOOL1 $TESTDIR/file.$i 'online'
+	# Device cannot be cleared if the pool was imported readonly
+	log_mustnot zpool clear $TESTPOOL1 $TESTDIR/file.$i
+done
+
+log_pass "'zpool clear' fails on readonly pools as expected."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

Illumos 4080 (https://github.com/zfsonlinux/zfs/commit/ac72fac3eaa569902cad88053167f7d74e7fe7e4) inadvertently allows `zpool clear` on readonly pools: fix this by reintroducing a check (POOL_CHECK_READONLY) in `zfs_ioc_clear()` registration code.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On Debug kernels `zpool clear` triggers a VERIFY() in `vdev_state_dirty()`.

This is reproducible on both ZoL:

```
[  260.819805] VERIFY(spa_writeable(spa)) failed
[  260.820679] PANIC at vdev.c:3379:vdev_state_dirty()
[  260.821559] Showing stack for process 2461
[  260.822267] CPU: 3 PID: 2461 Comm: zpool Tainted: P           OE   4.6.4 #1
[  260.823510] Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
[  260.825546]  0000000000000286 000000000f5b544a ffffffff81315815 ffffffffc0776d70
[  260.829043]  ffff88002932bd68 ffffffffc018d9df 0000000000000000 ffff880000000028
[  260.832862]  ffff88002932bd78 ffff88002932bd18 7328594649524556 65746972775f6170
[  260.835167] Call Trace:
[  260.835571]  [<ffffffff81315815>] ? dump_stack+0x5c/0x77
[  260.837485]  [<ffffffffc018d9df>] ? spl_panic+0xbf/0xf0 [spl]
[  260.839528]  [<ffffffffc0646aff>] ? vdev_validate+0x2bf/0x2e0 [zfs]
[  260.841646]  [<ffffffffc0645517>] ? vdev_state_dirty+0x107/0x140 [zfs]
[  260.844783]  [<ffffffffc06477a4>] ? vdev_clear+0x1a4/0x280 [zfs]
[  260.846802]  [<ffffffffc064767c>] ? vdev_clear+0x7c/0x280 [zfs]
[  260.848796]  [<ffffffffc064767c>] ? vdev_clear+0x7c/0x280 [zfs]
[  260.850806]  [<ffffffffc0676676>] ? zfs_ioc_clear+0x166/0x290 [zfs]
[  260.852891]  [<ffffffffc067a1b7>] ? zfsdev_ioctl+0x627/0x740 [zfs]
[  260.854835]  [<ffffffff811b04f2>] ? vma_merge+0x202/0x320
[  260.855620]  [<ffffffff812086f9>] ? do_vfs_ioctl+0x99/0x5d0
[  260.857492]  [<ffffffff811b1b8d>] ? do_brk+0x1dd/0x2c0
[  260.859310]  [<ffffffff81208ca6>] ? SyS_ioctl+0x76/0x90
[  260.861219]  [<ffffffff815cc1b6>] ? system_call_fast_compare_end+0xc/0x96
```

and Illumos:

```
> ::status
debugging crash dump vmcore.1 (64-bit) from openindiana
operating system: 5.11 master-0-g8dcfe5e5a1 (i86pc)
image uuid: 49f26dc4-a94a-6177-c9d4-b1ca68f101e3
panic message: assertion failed: spa_writeable(spa), file: ../../common/fs/zfs/vdev.c, line: 3110
dump content: kernel pages only
> ::stack
vpanic()
0xfffffffffbdfed08()
vdev_state_dirty+0x100(ffffff04e130ac80)
vdev_clear+0x1d8(ffffff04e19fa000, ffffff04e1309f80)
vdev_clear+0xa6(ffffff04e19fa000, ffffff04e130ac80)
vdev_clear+0xa6(ffffff04e19fa000, 0)
zfs_ioc_clear+0x11a(ffffff04e1c50000)
zfsdev_ioctl+0x50f(10e00000000, 5a21, 8042b48, 100003, ffffff04c6b7b0e8, ffffff001436ae58)
cdev_ioctl+0x39(10e00000000, 5a21, 8042b48, 100003, ffffff04c6b7b0e8, ffffff001436ae58)
spec_ioctl+0x60(ffffff04c44e5800, 5a21, 8042b48, 100003, ffffff04c6b7b0e8, ffffff001436ae58)
fop_ioctl+0x55(ffffff04c44e5800, 5a21, 8042b48, 100003, ffffff04c6b7b0e8, ffffff001436ae58)
ioctl+0x9b(3, 5a21, 8042b48)
_sys_sysenter_post_swapgs+0x237()
> ffffff04e130ac80::print vdev_t vdev_spa->spa_mode
vdev_spa->spa_mode = 0x1
> ffffff04e130ac80::print vdev_t vdev_cant_write   
vdev_cant_write = 0 (0)
> 
```

Non-Debug kernels drive on and clear the pool: i don't think this is the intended behaviour, we shouldn't be allowed to clear readonly pools.

To be honest i'm not entirely convinced this fix is complete: it's not yet clear to me how we managed to have a readonly SPA with, at least, one writable VDEV. This issue cannot be reproduced on single-device and stripe pools, only mirror and raidz are affected. The writable device seems to be a non-leaf VDEV in every failure.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Test added to the ZTS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
