### PR TITLE
Add a a function in the libzfs library that allows for requesting all properties

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -502,6 +502,7 @@ extern uint64_t zfs_prop_get_int(zfs_handle_t *, zfs_prop_t);
 extern int zfs_prop_inherit(zfs_handle_t *, const char *, boolean_t);
 extern const char *zfs_prop_values(zfs_prop_t);
 extern int zfs_prop_is_string(zfs_prop_t prop);
+extern nvlist_t *zfs_get_all_props(zfs_handle_t *);
 extern nvlist_t *zfs_get_user_props(zfs_handle_t *);
 extern nvlist_t *zfs_get_recvd_props(zfs_handle_t *);
 extern nvlist_t *zfs_get_clones_nvl(zfs_handle_t *);

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -64,6 +64,7 @@
 #include "zfs_namecheck.h"
 #include "zfs_prop.h"
 #include "libzfs_impl.h"
+#include "libzfs.h"
 #include "zfs_deleg.h"
 
 static int userquota_propname_decode(const char *propname, boolean_t zoned,
@@ -4351,6 +4352,21 @@ error:
 		changelist_free(cl);
 	}
 	return (ret);
+}
+
+nvlist_t *
+zfs_get_all_props(zfs_handle_t *zhp)
+{
+	return (zhp->zfs_props);
+}
+
+nvlist_t *
+zfs_get_recvd_props(zfs_handle_t *zhp)
+{
+	if (zhp->zfs_recvd_props == NULL)
+		if (get_recvd_props_ioctl(zhp) != 0)
+			return (NULL);
+	return (zhp->zfs_recvd_props);
 }
 
 nvlist_t *


### PR DESCRIPTION
### Description

It would be useful to have a function in the libzfs library that allows for requesting all properties just like the [zfs_get_user_props() function](https://github.com/zfsonlinux/zfs/blob/27ef66ef19020dcdcda7b6f64a2f92cac9674565/lib/libzfs/libzfs_dataset.c#L4240-#L4244). From what I can tell it should be as simple as a call returning `zhp->zfs_props`.

### Motivation and Context

Right now when attempting to be a consumer of the libzfs library there is a lot involved when trying to query all properties from a dataset. It is easy to get all user properties with `zfs_get_user_props(zfs_handle_t *)`, and I propose adding a similar function to access all properties.

I would basically like an easy way to get an nvlist of all the properties in a dataset.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
