### PR TITLE
Prevent calls to dh_shlibdeps

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -38,9 +38,24 @@ if CONFIG_USER
 	pkg7=$${name}-test-$${version}.$${arch}.rpm; \
 	pkg8=$${name}-dracut-$${version}.$${arch}.rpm; \
 	pkg9=$${name}-initramfs-$${version}.$${arch}.rpm; \
+## Arguments need to be passed to dh_shlibdeps. Alien provides no mechanism
+## to do this, so we install a shim onto the path which calls the real
+## dh_shlibdeps with the required arguments.
+	path_prepend=`mktemp -d /tmp/intercept.XXX`; \
+	echo "#$(SHELL)" > $${path_prepend}/dh_shlibdeps; \
+	echo "`which dh_shlibdeps` -- \
+	 -xlibuutil1linux -xlibnvpair1linux -xlibzfs2linux -xlibzpool2linux" \
+	 >> $${path_prepend}/dh_shlibdeps; \
+## These -x arguments are passed to dpkg-shlibdeps, which exclude the
+## Debianized packages from the auto-generated dependencies of the new debs,
+## which should NOT be mixed with the alien-generated debs created here
+	chmod +x $${path_prepend}/dh_shlibdeps; \
+	env PATH=$${path_prepend}:$${PATH} \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb \
 	    $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
-	    $$pkg8 $$pkg9;
+	    $$pkg8 $$pkg9; \
+	$(RM) $${path_prepend}/dh_shlibdeps; \
+	rmdir $${path_prepend}; \
 	$(RM) $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
 	    $$pkg8 $$pkg9;
 endif


### PR DESCRIPTION
Avoid calling dh_shlibdeps by hacking the PATH variable. A temporary directory and a softlink to /bin/true are created. This directory is pre-pended to the PATH when the call to `alien` is made. Therefore, instead of `alien` calling the real dh_shlibdeps, it simply gets a null output from true. Consequently, no library dependencies are generated, avoiding the incorrect ones that can be generated if other packages are installed.

This bugfix avoids zfsonlinux/zfs#6106 .

This patch, and its companion for SPL, have been built, installed, loaded kernel module. A pool, filesystem and test file have been created. I have no reason to believe this minor change could possibly affect anything beyond loading issues.

I don't know what the policy on Makefile styles is. rmdir may need to be replaced with $(RMDIR).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
