### PR TITLE
Clang fixes

### DIFF
--- a/module/icp/asm-x86_64/sha2/sha256_impl.S
+++ b/module/icp/asm-x86_64/sha2/sha256_impl.S
@@ -100,12 +100,12 @@ ENTRY_NP(SHA256TransformBlocks)
 	mov	%rdx,16*4+2*8(%rsp)		# save end pointer, "3rd" arg
 	mov	%rbp,16*4+3*8(%rsp)		# save copy of %rsp
 
-	/.picmeup %rbp
-	/ The .picmeup pseudo-directive, from perlasm/x86_64_xlate.pl, puts
-	/ the address of the "next" instruction into the target register
-	/ (%rbp).  This generates these 2 instructions:
+	#.picmeup %rbp
+	# The .picmeup pseudo-directive, from perlasm/x86_64_xlate.pl, puts
+	# the address of the "next" instruction into the target register
+	# (%rbp).  This generates these 2 instructions:
 	lea	.Llea(%rip),%rbp
-	/nop	/ .picmeup generates a nop for mod 8 alignment--not needed here
+	#nop	# .picmeup generates a nop for mod 8 alignment--not needed here
 
 .Llea:
 	lea	K256-.(%rbp),%rbp

--- a/module/icp/asm-x86_64/sha2/sha512_impl.S
+++ b/module/icp/asm-x86_64/sha2/sha512_impl.S
@@ -101,12 +101,12 @@ ENTRY_NP(SHA512TransformBlocks)
 	mov	%rdx,16*8+2*8(%rsp)		# save end pointer, "3rd" arg
 	mov	%rbp,16*8+3*8(%rsp)		# save copy of %rsp
 
-	/.picmeup %rbp
-	/ The .picmeup pseudo-directive, from perlasm/x86_64_xlate.pl, puts
-	/ the address of the "next" instruction into the target register
-	/ (%rbp).  This generates these 2 instructions:
+	#.picmeup %rbp
+	# The .picmeup pseudo-directive, from perlasm/x86_64_xlate.pl, puts
+	# the address of the "next" instruction into the target register
+	# (%rbp).  This generates these 2 instructions:
 	lea	.Llea(%rip),%rbp
-	/nop	/ .picmeup generates a nop for mod 8 alignment--not needed here
+	#nop	# .picmeup generates a nop for mod 8 alignment--not needed here
 
 .Llea:
 	lea	K512-.(%rbp),%rbp


### PR DESCRIPTION
Clang doesn't support `/` as comment in assembly, this patch replace
them with `#`

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Replace comment symbol `/` with `#`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves building errors with clang
```
../../module/icp/asm-x86_64/sha2/sha256_impl.S:103:2: error: unexpected token at start of statement
 /.picmeup %rbp
 ^
../../module/icp/asm-x86_64/sha2/sha256_impl.S:104:2: error: unexpected token at start of statement
 / The .picmeup pseudo-directive, from perlasm/x86_64_xlate.pl, puts
 ^
../../module/icp/asm-x86_64/sha2/sha256_impl.S:105:2: error: unexpected token at start of statement
 / the address of the "next" instruction into the target register
 ^
../../module/icp/asm-x86_64/sha2/sha256_impl.S:106:2: error: unexpected token at start of statement
 / (%rbp). This generates these 2 instructions:
 ^
../../module/icp/asm-x86_64/sha2/sha256_impl.S:108:2: error: unexpected token at start of statement
 /nop / .picmeup generates a nop for mod 8 alignment--not needed here
 ^
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Built with clang

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
