### PR TITLE
Reschedule processes on error.

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1358,6 +1358,8 @@ out_mutex:
 	mutex_exit(&zv->zv_state_lock);
 	if (drop_suspend)
 		rw_exit(&zv->zv_suspend_lock);
+	if (error)
+		schedule();
 
 	return (SET_ERROR(error));
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
On the single core machine the system may hang when the ```spa_namespare_lock``` acquisition fails in the ```zvol_first_open``` function. It returns ```ERESTARTSYS``` error what causes the endless loop in ```__blkdev_get``` function.

### Motivation and Context
Solves system hang on single core machines.

### How Has This Been Tested?
On KVM single core virtual machine following test has been run:
```
zpool create p0 sdb
for i in `seq 1 100`; do zfs create -s -V10G p0/zvi${1}; done
zpool export p0
zpool import p0
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
