### PR TITLE
Fix chattr_001_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/chattr/chattr_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/chattr/chattr_001_pos.ksh
@@ -65,11 +65,11 @@ log_must chattr -i $TESTDIR/writable
 log_must chattr +i $TESTDIR/immutable
 log_must chattr +a $TESTDIR/append
 
-log_must echo test > $TESTDIR/writable
-log_must echo test >> $TESTDIR/writable
-log_mustnot echo test > $TESTDIR/immutable
-log_mustnot echo test >> $TESTDIR/immutable
-log_mustnot echo test > $TESTDIR/append
-log_must echo test >> $TESTDIR/append
+log_must eval "echo test > $TESTDIR/writable"
+log_must eval "echo test >> $TESTDIR/writable"
+log_mustnot eval "echo test > $TESTDIR/immutable"
+log_mustnot eval "echo test >> $TESTDIR/immutable"
+log_mustnot eval "echo test > $TESTDIR/append"
+log_must eval "echo test >> $TESTDIR/append"
 
 log_pass "chattr works as expected"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Commands should be `eval()`ed if they involve a shell redirection, otherwise we end up writing log_* functions messages to the output.
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

On Gentoo (which apparently ships a newer ksh version compared to debian/centos/illumos) the test fails because we check the return value of `echo test` (which is 0) with `log_mustnot` and then try to write the output of said log function to `$TESTDIR/immutable`, which of course fails.

This test should always fail, probably: maybe ksh in the BB has some kind of bug and doesn't catch this issue? According to my build slaves these are the version used:

Debian8
```
root@debian:~# ksh --version
  version         sh (AT&T Research) 93u+ 2012-08-01
```

CentOS7
```
[root@centos ~]# ksh --version
  version         sh (AT&T Research) 93u+ 2012-08-01
```

Gentoo ships "93.20140625" and "93.20160110" (!?)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #6300

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Fixed ZTS script run manually

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
