### PR TITLE
Add corruption failure option to zinject(8)

### DIFF
--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -589,6 +589,8 @@ extern int zio_clear_fault(int id);
 extern void zio_handle_panic_injection(spa_t *spa, char *tag, uint64_t type);
 extern int zio_handle_fault_injection(zio_t *zio, int error);
 extern int zio_handle_device_injection(vdev_t *vd, zio_t *zio, int error);
+extern int zio_handle_device_injections(vdev_t *vd, zio_t *zio, int err1,
+    int err2);
 extern int zio_handle_label_injection(zio_t *zio, int error);
 extern void zio_handle_ignored_writes(zio_t *zio);
 extern hrtime_t zio_handle_io_delay(zio_t *zio);

--- a/man/man8/zinject.8
+++ b/man/man8/zinject.8
@@ -108,6 +108,7 @@ A vdev specified by path or GUID.
 .BI "\-e" " device_error"
 Specify
 .BR "checksum" " for an ECKSUM error,"
+.BR "corrupt" " to flip a bit in the data after a read,"
 .BR "dtl" " for an ECHILD error,"
 .BR "io" " for an EIO error where reopening the device will succeed, or"
 .BR "nxio" " for an ENXIO error where reopening the device will fail."

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3308,8 +3308,8 @@ zio_vdev_io_done(zio_t *zio)
 			vdev_cache_write(zio);
 
 		if (zio_injection_enabled && zio->io_error == 0)
-			zio->io_error = zio_handle_device_injection(vd,
-			    zio, EIO);
+			zio->io_error = zio_handle_device_injections(vd, zio,
+			    EIO, EILSEQ);
 
 		if (zio_injection_enabled && zio->io_error == 0)
 			zio->io_error = zio_handle_label_injection(zio, EIO);

--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -271,9 +271,24 @@ zio_handle_label_injection(zio_t *zio, int error)
 	return (ret);
 }
 
+/*ARGSUSED*/
+static int
+zio_inject_bitflip_cb(void *data, size_t len, void *private)
+{
+	ASSERTV(zio_t *zio = private);
+	uint8_t *buffer = data;
+	uint_t byte = spa_get_random(len);
 
-int
-zio_handle_device_injection(vdev_t *vd, zio_t *zio, int error)
+	ASSERT(zio->io_type == ZIO_TYPE_READ);
+
+	/* flip a single random bit in an abd data buffer */
+	buffer[byte] ^= 1 << spa_get_random(8);
+
+	return (1);	/* stop after first flip */
+}
+
+static int
+zio_handle_device_injection_impl(vdev_t *vd, zio_t *zio, int err1, int err2)
 {
 	inject_handler_t *handler;
 	int ret = 0;
@@ -311,7 +326,8 @@ zio_handle_device_injection(vdev_t *vd, zio_t *zio, int error)
 			    handler->zi_record.zi_iotype != zio->io_type)
 				continue;
 
-			if (handler->zi_record.zi_error == error) {
+			if (handler->zi_record.zi_error == err1 ||
+			    handler->zi_record.zi_error == err2) {
 				/*
 				 * limit error injection if requested
 				 */
@@ -322,7 +338,7 @@ zio_handle_device_injection(vdev_t *vd, zio_t *zio, int error)
 				 * For a failed open, pretend like the device
 				 * has gone away.
 				 */
-				if (error == ENXIO)
+				if (err1 == ENXIO)
 					vd->vdev_stat.vs_aux =
 					    VDEV_AUX_OPEN_FAILED;
 
@@ -335,7 +351,21 @@ zio_handle_device_injection(vdev_t *vd, zio_t *zio, int error)
 				    zio != NULL)
 					zio->io_flags |= ZIO_FLAG_IO_RETRY;
 
-				ret = error;
+				/*
+				 * EILSEQ means flip a bit after a read
+				 */
+				if (handler->zi_record.zi_error == EILSEQ) {
+					if (zio == NULL)
+						break;
+
+					/* locate buffer data and flip a bit */
+					(void) abd_iterate_func(zio->io_abd, 0,
+					    zio->io_size, zio_inject_bitflip_cb,
+					    zio);
+					break;
+				}
+
+				ret = handler->zi_record.zi_error;
 				break;
 			}
 			if (handler->zi_record.zi_error == ENXIO) {
@@ -348,6 +378,18 @@ zio_handle_device_injection(vdev_t *vd, zio_t *zio, int error)
 	rw_exit(&inject_lock);
 
 	return (ret);
+}
+
+int
+zio_handle_device_injection(vdev_t *vd, zio_t *zio, int error)
+{
+	return (zio_handle_device_injection_impl(vd, zio, error, INT_MAX));
+}
+
+int
+zio_handle_device_injections(vdev_t *vd, zio_t *zio, int err1, int err2)
+{
+	return (zio_handle_device_injection_impl(vd, zio, err1, err2));
 }
 
 /*


### PR DESCRIPTION
### Description
Added a _-e 'corrupt'_ option for device error injection that will flip a bit in the data after a read operation.

### Motivation and Context
This change is useful for generating checksum errors at the device layer (in a mirror config for example). It is also used to validate the diagnosis of checksum errors from the zfs diagnosis engine.

### How Has This Been Tested?
A sample validation session is as follows:
```
-sh-4.2$ sudo zpool import flipper
-sh-4.2$ zpool status flipper
  pool: flipper
 state: ONLINE
  scan: none requested
config:

        NAME                        STATE     READ WRITE CKSUM
        flipper                     ONLINE       0     0     0
          mirror-0                  ONLINE       0     0     0
            wwn-0x55cd2e404c033fac  ONLINE       0     0     0
            wwn-0x55cd2e404c033da3  ONLINE       0     0     0

errors: No known data errors

-sh-4.2$ sudo zinject -d wwn-0x55cd2e404c033da3 -e corrupt -T read -f 1 flipper
Added handler 1 with the following properties:
  pool: flipper
  vdev: 4f2dafb5cf366e50
-sh-4.2$ sudo cp -r /flipper/src-1 /var/tmp/scratch/
-sh-4.2$ zpool status flipper
  pool: flipper
 state: ONLINE
status: One or more devices has experienced an unrecoverable error.  An
        attempt was made to correct the error.  Applications are unaffected.
action: Determine if the device needs to be replaced, and clear the errors
        using 'zpool clear' or replace the device with 'zpool replace'.
   see: http://zfsonlinux.org/msg/ZFS-8000-9P
  scan: none requested
config:

        NAME                        STATE     READ WRITE CKSUM
        flipper                     ONLINE       0     0     0
          mirror-0                  ONLINE       0     0     0
            wwn-0x55cd2e404c033fac  ONLINE       0     0     0
            wwn-0x55cd2e404c033da3  ONLINE       0     0    18

errors: No known data errors

-sh-4.2$ sudo zpool events
TIME                           CLASS
Jul 13 2017 17:23:22.586271081 sysevent.fs.zfs.pool_import
Jul 13 2017 17:23:22.588271085 sysevent.fs.zfs.history_event
Jul 13 2017 17:23:22.662271236 sysevent.fs.zfs.config_sync
Jul 13 2017 17:27:02.759718892 ereport.fs.zfs.checksum
Jul 13 2017 17:27:03.303719998 ereport.fs.zfs.checksum
Jul 13 2017 17:27:03.592720586 ereport.fs.zfs.checksum
Jul 13 2017 17:27:03.632720667 ereport.fs.zfs.checksum
Jul 13 2017 17:27:03.776720960 ereport.fs.zfs.checksum
Jul 13 2017 17:27:04.267721958 ereport.fs.zfs.checksum
Jul 13 2017 17:27:04.535722503 ereport.fs.zfs.checksum
Jul 13 2017 17:27:05.159723772 ereport.fs.zfs.checksum
Jul 13 2017 17:27:05.559724586 ereport.fs.zfs.checksum
Jul 13 2017 17:27:05.749724972 ereport.fs.zfs.checksum
Jul 13 2017 17:27:06.038725560 ereport.fs.zfs.checksum
Jul 13 2017 17:27:06.429726355 ereport.fs.zfs.checksum
Jul 13 2017 17:27:06.614726731 ereport.fs.zfs.checksum
Jul 13 2017 17:27:06.669726843 ereport.fs.zfs.checksum
Jul 13 2017 17:27:07.531728596 ereport.fs.zfs.checksum
Jul 13 2017 17:27:07.706728952 ereport.fs.zfs.checksum
Jul 13 2017 17:27:09.378732352 ereport.fs.zfs.checksum
Jul 13 2017 17:27:12.425738548 ereport.fs.zfs.checksum
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
