### PR TITLE
Pool classes no explicit mirror requirement

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -73,7 +73,8 @@
 	zio_checksum_table[(idx)].ci_name : "UNKNOWN")
 #define	ZDB_OT_TYPE(idx) ((idx) < DMU_OT_NUMTYPES ? (idx) :		\
 	(((idx) == DMU_OTN_ZAP_DATA || (idx) == DMU_OTN_ZAP_METADATA) ?	\
-	DMU_OT_ZAP_OTHER : DMU_OT_NUMTYPES))
+	DMU_OT_ZAP_OTHER : (idx) == DMU_OTN_UINT64_METADATA ?		\
+	DMU_OT_UINT64_OTHER : DMU_OT_NUMTYPES))
 
 static char *
 zdb_ot_name(dmu_object_type_t type)
@@ -278,6 +279,23 @@ dump_history_offsets(objset_t *os, uint64_t object, void *data, size_t size)
 	    (u_longlong_t)shp->sh_records_lost);
 }
 
+/* ARGSUSED */
+static void
+dump_space_map_header(objset_t *os, uint64_t object, void *data, size_t size)
+{
+	space_map_phys_t *smp = data;
+
+	if (smp == NULL)
+		return;
+
+	(void) printf("\n\t%14s:    %10llu\n", "smp_object",
+	    (u_longlong_t)smp->smp_object);
+	(void) printf("\t%14s:    %10llu\n", "smp_objsize",
+	    (u_longlong_t)smp->smp_objsize);
+	(void) printf("\t%14s:    %10llu\n", "smp_alloc",
+	    (u_longlong_t)smp->smp_alloc);
+}
+
 static void
 zdb_nicenum(uint64_t num, char *buf)
 {
@@ -403,6 +421,24 @@ dump_uint8(objset_t *os, uint64_t object, void *data, size_t size)
 static void
 dump_uint64(objset_t *os, uint64_t object, void *data, size_t size)
 {
+	if (size == 0) {
+		dmu_object_info_t doi;
+		uint64_t off, val;
+
+		VERIFY0(dmu_object_info(os, object, &doi));
+
+		for (off = 0; off < doi.doi_max_offset; off += sizeof (val)) {
+			if (dmu_read(os, object, off, sizeof (val), &val,
+			    DMU_READ_PREFETCH) == 0) {
+				(void) printf("\t[%d]: %llu\n", (int)off >> 3,
+				    (u_longlong_t)val);
+				if (((off >> 3) & 0x03ULL) == 0x03)
+					printf("\n");
+			} else {
+				break;
+			}
+		}
+	}
 }
 
 /*ARGSUSED*/
@@ -772,6 +808,58 @@ dump_metaslab_stats(metaslab_t *msp)
 	dump_histogram(rt->rt_histogram, RANGE_TREE_HISTOGRAM_SIZE, 0);
 }
 
+const char alloc_stars[] = "*********************************";
+
+static void
+dump_allocation_line(const char *name, uint64_t value, uint64_t total)
+{
+	if (dump_opt['P']) {
+		(void) printf("\t\t%11s: %10llu\n", name, (u_longlong_t)value);
+	} else {
+		int index, width = sizeof (alloc_stars) - 1;
+
+		index = width - ((width * value) / total);
+		(void) printf("\t\t%11s: %5.1f%%  %s\n", name,
+		    100.0 * value / total, &alloc_stars[index]);
+	}
+}
+
+static void
+dump_allocation_info(objset_t *mos, uint64_t obj, uint64_t id, uint64_t total)
+{
+	ms_alloc_phys_t ms_alloc;
+	uint64_t generic = total;
+	char number[32];
+
+	if (obj == 0)
+		return;
+
+	VERIFY0(dmu_read(mos, obj, id * sizeof (ms_alloc_phys_t),
+	    sizeof (ms_alloc_phys_t), &ms_alloc, DMU_READ_PREFETCH));
+
+	if (ms_alloc.ms_alloc_metadata == 0 &&
+	    ms_alloc.ms_alloc_smallblks == 0 &&
+	    ms_alloc.ms_alloc_dedup == 0)
+		return;
+
+	zdb_nicenum(total, number);
+
+	(void) printf("\n\tAllocation Summary:%*s%s allocated\n",
+	    dump_opt['P'] ? 7 : 10, "", number);
+
+	generic -= ms_alloc.ms_alloc_metadata;
+	dump_allocation_line("metadata", ms_alloc.ms_alloc_metadata, total);
+
+	generic -= ms_alloc.ms_alloc_smallblks;
+	dump_allocation_line("smallblks", ms_alloc.ms_alloc_smallblks, total);
+
+	generic -= ms_alloc.ms_alloc_dedup;
+	dump_allocation_line("dedup", ms_alloc.ms_alloc_dedup, total);
+
+	dump_allocation_line("generic", generic, total);
+	(void) printf("\n");
+}
+
 static void
 dump_metaslab(metaslab_t *msp)
 {
@@ -779,13 +867,27 @@ dump_metaslab(metaslab_t *msp)
 	spa_t *spa = vd->vdev_spa;
 	space_map_t *sm = msp->ms_sm;
 	char freebuf[32];
+	const char *group = "";
+
+	/* segregated vdevs have multiple groups */
+	if (vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE) {
+		if (space_map_object(sm) == 0)
+			group = "  ----  ";
+		else if (msp->ms_group == vd->vdev_mg)
+			group = "normal";
+		else if (msp->ms_group == vd->vdev_log_mg)
+			group = "log data";
+		else if (msp->ms_group == vd->vdev_special_mg)
+			group = "special";
+	}
 
 	zdb_nicenum(msp->ms_size - space_map_allocated(sm), freebuf);
 
 	(void) printf(
-	    "\tmetaslab %6llu   offset %12llx   spacemap %6llu   free    %5s\n",
+	    "\tmetaslab %6llu   offset %12llx   spacemap %6llu   free   "
+	    "%5s%10s\n",
 	    (u_longlong_t)msp->ms_id, (u_longlong_t)msp->ms_start,
-	    (u_longlong_t)space_map_object(sm), freebuf);
+	    (u_longlong_t)space_map_object(sm), freebuf, group);
 
 	if (dump_opt['m'] > 2 && !dump_opt['L']) {
 		mutex_enter(&msp->ms_lock);
@@ -811,6 +913,15 @@ dump_metaslab(metaslab_t *msp)
 		    SPACE_MAP_HISTOGRAM_SIZE, sm->sm_shift);
 	}
 
+	if (dump_opt['m'] > 1 && sm != NULL &&
+	    spa_feature_is_active(spa, SPA_FEATURE_ALLOCATION_CLASSES)) {
+		/*
+		 * For particiating metaslabs, there is additional alloc info
+		 */
+		dump_allocation_info(spa->spa_meta_objset, vd->vdev_ms_extra,
+		    msp->ms_id, space_map_allocated(sm));
+	}
+
 	if (dump_opt['d'] > 5 || dump_opt['m'] > 3) {
 		ASSERT(msp->ms_size == (1ULL << vd->vdev_ms_shift));
 
@@ -818,18 +929,35 @@ dump_metaslab(metaslab_t *msp)
 		dump_spacemap(spa->spa_meta_objset, msp->ms_sm);
 		mutex_exit(&msp->ms_lock);
 	}
+	if (dump_opt['m'] > 1 && sm != NULL) {
+		(void) printf("\t%15s   %19s   %15s   %12s\n",
+		    "---------------", "-------------------",
+		    "---------------", "------------");
+	}
 }
 
 static void
 print_vdev_metaslab_header(vdev_t *vd)
 {
-	(void) printf("\tvdev %10llu\n\t%-10s%5llu   %-19s   %-15s   %-10s\n",
-	    (u_longlong_t)vd->vdev_id,
+	vdev_alloc_bias_t alloc_bias = vd->vdev_alloc_bias;
+	const char *bias_str;
+
+	bias_str = (alloc_bias == VDEV_BIAS_LOG || vd->vdev_islog) ?
+	    VDEV_ALLOC_BIAS_LOG :
+	    (alloc_bias == VDEV_BIAS_SPECIAL) ? VDEV_ALLOC_BIAS_SPECIAL :
+	    (alloc_bias == VDEV_BIAS_SEGREGATE) ? VDEV_ALLOC_BIAS_SEGREGATE :
+	    vd->vdev_islog ? "log" : "";
+
+	(void) printf("\tvdev %10llu   %s\n"
+	    "\t%-10s%5llu   %-19s   %-15s   %-12s  %-8s\n",
+	    (u_longlong_t)vd->vdev_id, bias_str,
 	    "metaslabs", (u_longlong_t)vd->vdev_ms_count,
-	    "offset", "spacemap", "free");
-	(void) printf("\t%15s   %19s   %15s   %10s\n",
+	    "offset", "spacemap", "free",
+	    (alloc_bias == VDEV_BIAS_SEGREGATE) ? "class" : "");
+	(void) printf("\t%15s   %19s   %15s   %12s  %8s\n",
 	    "---------------", "-------------------",
-	    "---------------", "-------------");
+	    "---------------", "------------",
+	    (alloc_bias == VDEV_BIAS_SEGREGATE) ? "--------" : "");
 }
 
 static void
@@ -1882,7 +2010,7 @@ static object_viewer_t *object_viewer[DMU_OT_NUMTYPES + 1] = {
 	dump_packed_nvlist,	/* packed nvlist size		*/
 	dump_none,		/* bpobj			*/
 	dump_bpobj,		/* bpobj header			*/
-	dump_none,		/* SPA space map header		*/
+	dump_space_map_header,	/* SPA space map header		*/
 	dump_none,		/* SPA space map		*/
 	dump_none,		/* ZIL intent log		*/
 	dump_dnode,		/* DMU dnode			*/
@@ -2858,6 +2986,7 @@ typedef struct zdb_blkstats {
 	uint64_t zb_count;
 	uint64_t zb_gangs;
 	uint64_t zb_ditto_samevdev;
+	uint64_t zb_ditto_same_ms;
 	uint64_t zb_psize_histogram[PSIZE_HISTO_SIZE];
 } zdb_blkstats_t;
 
@@ -2894,6 +3023,16 @@ typedef struct zdb_cb {
 	spa_t		*zcb_spa;
 } zdb_cb_t;
 
+/* test if two DVA offsets from same vdev are within the same metaslab */
+static boolean_t
+same_metaslab(spa_t *spa, uint64_t vdev, uint64_t off1, uint64_t off2)
+{
+	vdev_t *vd = vdev_lookup_top(spa, vdev);
+	uint64_t ms_shift = vd->vdev_ms_shift;
+
+	return ((off1 >> ms_shift) == (off2 >> ms_shift));
+}
+
 static void
 zdb_count_block(zdb_cb_t *zcb, zilog_t *zilog, const blkptr_t *bp,
     dmu_object_type_t type)
@@ -2905,6 +3044,8 @@ zdb_count_block(zdb_cb_t *zcb, zilog_t *zilog, const blkptr_t *bp,
 
 	if (zilog && zil_bp_tree_add(zilog, bp) != 0)
 		return;
+
+	spa_config_enter(zcb->zcb_spa, SCL_CONFIG, FTAG, RW_READER);
 
 	for (i = 0; i < 4; i++) {
 		int l = (i < 2) ? BP_GET_LEVEL(bp) : ZB_TOTAL;
@@ -2931,8 +3072,15 @@ zdb_count_block(zdb_cb_t *zcb, zilog_t *zilog, const blkptr_t *bp,
 		switch (BP_GET_NDVAS(bp)) {
 		case 2:
 			if (DVA_GET_VDEV(&bp->blk_dva[0]) ==
-			    DVA_GET_VDEV(&bp->blk_dva[1]))
+			    DVA_GET_VDEV(&bp->blk_dva[1])) {
 				zb->zb_ditto_samevdev++;
+
+				if (same_metaslab(zcb->zcb_spa,
+				    DVA_GET_VDEV(&bp->blk_dva[0]),
+				    DVA_GET_OFFSET(&bp->blk_dva[0]),
+				    DVA_GET_OFFSET(&bp->blk_dva[1])))
+					zb->zb_ditto_same_ms++;
+			}
 			break;
 		case 3:
 			equal = (DVA_GET_VDEV(&bp->blk_dva[0]) ==
@@ -2941,12 +3089,37 @@ zdb_count_block(zdb_cb_t *zcb, zilog_t *zilog, const blkptr_t *bp,
 			    DVA_GET_VDEV(&bp->blk_dva[2])) +
 			    (DVA_GET_VDEV(&bp->blk_dva[1]) ==
 			    DVA_GET_VDEV(&bp->blk_dva[2]));
-			if (equal != 0)
+			if (equal != 0) {
 				zb->zb_ditto_samevdev++;
+
+				if (DVA_GET_VDEV(&bp->blk_dva[0]) ==
+				    DVA_GET_VDEV(&bp->blk_dva[1]) &&
+				    same_metaslab(zcb->zcb_spa,
+				    DVA_GET_VDEV(&bp->blk_dva[0]),
+				    DVA_GET_OFFSET(&bp->blk_dva[0]),
+				    DVA_GET_OFFSET(&bp->blk_dva[1])))
+					zb->zb_ditto_same_ms++;
+				else if (DVA_GET_VDEV(&bp->blk_dva[0]) ==
+				    DVA_GET_VDEV(&bp->blk_dva[2]) &&
+				    same_metaslab(zcb->zcb_spa,
+				    DVA_GET_VDEV(&bp->blk_dva[0]),
+				    DVA_GET_OFFSET(&bp->blk_dva[0]),
+				    DVA_GET_OFFSET(&bp->blk_dva[2])))
+					zb->zb_ditto_same_ms++;
+				else if (DVA_GET_VDEV(&bp->blk_dva[1]) ==
+				    DVA_GET_VDEV(&bp->blk_dva[2]) &&
+				    same_metaslab(zcb->zcb_spa,
+				    DVA_GET_VDEV(&bp->blk_dva[1]),
+				    DVA_GET_OFFSET(&bp->blk_dva[1]),
+				    DVA_GET_OFFSET(&bp->blk_dva[2])))
+					zb->zb_ditto_same_ms++;
+			}
 			break;
 		}
 
 	}
+
+	spa_config_exit(zcb->zcb_spa, SCL_CONFIG, FTAG);
 
 	if (BP_IS_EMBEDDED(bp)) {
 		zcb->zcb_embedded_blocks[BPE_GET_ETYPE(bp)]++;
@@ -3182,9 +3355,12 @@ zdb_leak_init(spa_t *spa, zdb_cb_t *zcb)
 		for (c = 0; c < rvd->vdev_children; c++) {
 			vdev_t *vd = rvd->vdev_child[c];
 			ASSERTV(metaslab_group_t *mg = vd->vdev_mg);
+
 			for (m = 0; m < vd->vdev_ms_count; m++) {
 				metaslab_t *msp = vd->vdev_ms[m];
-				ASSERT3P(msp->ms_group, ==, mg);
+
+				ASSERT(msp->ms_group == mg ||
+				    vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE);
 				mutex_enter(&msp->ms_lock);
 				metaslab_unload(msp);
 
@@ -3241,9 +3417,12 @@ zdb_leak_fini(spa_t *spa)
 		for (c = 0; c < rvd->vdev_children; c++) {
 			vdev_t *vd = rvd->vdev_child[c];
 			ASSERTV(metaslab_group_t *mg = vd->vdev_mg);
+
 			for (m = 0; m < vd->vdev_ms_count; m++) {
 				metaslab_t *msp = vd->vdev_ms[m];
-				ASSERT3P(mg, ==, msp->ms_group);
+
+				ASSERT(mg == msp->ms_group ||
+				    vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE);
 				mutex_enter(&msp->ms_lock);
 
 				/*
@@ -3331,6 +3510,7 @@ dump_block_stats(spa_t *spa)
 		flags |= TRAVERSE_PREFETCH_DATA;
 
 	zcb.zcb_totalasize = metaslab_class_get_alloc(spa_normal_class(spa));
+	zcb.zcb_totalasize += metaslab_class_get_alloc(spa_special_class(spa));
 	zcb.zcb_start = zcb.zcb_lastprint = gethrtime();
 	zcb.zcb_haderrors |= traverse_pool(spa, 0, flags, zdb_blkptr_cb, &zcb);
 
@@ -3369,7 +3549,9 @@ dump_block_stats(spa_t *spa)
 	norm_alloc = metaslab_class_get_alloc(spa_normal_class(spa));
 	norm_space = metaslab_class_get_space(spa_normal_class(spa));
 
-	total_alloc = norm_alloc + metaslab_class_get_alloc(spa_log_class(spa));
+	total_alloc = norm_alloc +
+	    metaslab_class_get_alloc(spa_log_class(spa)) +
+	    metaslab_class_get_alloc(spa_special_class(spa));
 	total_found = tzb->zb_asize - zcb.zcb_dedup_asize;
 
 	if (total_found == total_alloc) {
@@ -3390,30 +3572,38 @@ dump_block_stats(spa_t *spa)
 		return (2);
 
 	(void) printf("\n");
-	(void) printf("\tbp count:      %10llu\n",
+	(void) printf("\t%-16s %14llu\n", "bp count:",
 	    (u_longlong_t)tzb->zb_count);
-	(void) printf("\tganged count:  %10llu\n",
+	(void) printf("\t%-16s %14llu\n", "ganged count:",
 	    (longlong_t)tzb->zb_gangs);
-	(void) printf("\tbp logical:    %10llu      avg: %6llu\n",
+	(void) printf("\t%-16s %14llu      avg: %6llu\n", "bp logical:",
 	    (u_longlong_t)tzb->zb_lsize,
 	    (u_longlong_t)(tzb->zb_lsize / tzb->zb_count));
-	(void) printf("\tbp physical:   %10llu      avg:"
-	    " %6llu     compression: %6.2f\n",
-	    (u_longlong_t)tzb->zb_psize,
+	(void) printf("\t%-16s %14llu      avg: %6llu     compression: %6.2f\n",
+	    "bp physical:", (u_longlong_t)tzb->zb_psize,
 	    (u_longlong_t)(tzb->zb_psize / tzb->zb_count),
 	    (double)tzb->zb_lsize / tzb->zb_psize);
-	(void) printf("\tbp allocated:  %10llu      avg:"
-	    " %6llu     compression: %6.2f\n",
-	    (u_longlong_t)tzb->zb_asize,
+	(void) printf("\t%-16s %14llu      avg: %6llu     compression: %6.2f\n",
+	    "bp allocated:", (u_longlong_t)tzb->zb_asize,
 	    (u_longlong_t)(tzb->zb_asize / tzb->zb_count),
 	    (double)tzb->zb_lsize / tzb->zb_asize);
-	(void) printf("\tbp deduped:    %10llu    ref>1:"
-	    " %6llu   deduplication: %6.2f\n",
-	    (u_longlong_t)zcb.zcb_dedup_asize,
+	(void) printf("\t%-16s %14llu    ref>1: %6llu   deduplication: %6.2f\n",
+	    "bp deduped:", (u_longlong_t)zcb.zcb_dedup_asize,
 	    (u_longlong_t)zcb.zcb_dedup_blocks,
 	    (double)zcb.zcb_dedup_asize / tzb->zb_asize + 1.0);
-	(void) printf("\tSPA allocated: %10llu     used: %5.2f%%\n",
+	(void) printf("\t%-16s %14llu     used: %5.2f%%\n", "Normal class:",
 	    (u_longlong_t)norm_alloc, 100.0 * norm_alloc / norm_space);
+
+	if (spa_special_class(spa)->mc_rotor != NULL) {
+		uint64_t alloc = metaslab_class_get_alloc(
+		    spa_special_class(spa));
+		uint64_t space = metaslab_class_get_space(
+		    spa_special_class(spa));
+
+		(void) printf("\t%-16s %14llu     used: %5.2f%%\n",
+		    "Special class", (u_longlong_t)alloc,
+		    100.0 * alloc / space);
+	}
 
 	for (i = 0; i < NUM_BP_EMBEDDED_TYPES; i++) {
 		if (zcb.zcb_embedded_blocks[i] == 0)
@@ -3435,6 +3625,10 @@ dump_block_stats(spa_t *spa)
 	if (tzb->zb_ditto_samevdev != 0) {
 		(void) printf("\tDittoed blocks on same vdev: %llu\n",
 		    (longlong_t)tzb->zb_ditto_samevdev);
+	}
+	if (tzb->zb_ditto_same_ms != 0) {
+		(void) printf("\tDittoed blocks in same metaslab: %llu\n",
+		    (longlong_t)tzb->zb_ditto_same_ms);
 	}
 
 	if (dump_opt['b'] >= 2) {

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -28,6 +28,7 @@
  * Copyright (c) 2013 by Prasad Joshi (sTec). All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>.
  * Copyright (c) 2017 Datto Inc.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <assert.h>
@@ -328,7 +329,7 @@ get_usage(zpool_help_t idx)
 	case HELP_LABELCLEAR:
 		return (gettext("\tlabelclear [-f] <vdev>\n"));
 	case HELP_LIST:
-		return (gettext("\tlist [-gHLpPv] [-o property[,...]] "
+		return (gettext("\tlist [-CgHLpPv] [-o property[,...]] "
 		    "[-T d|u] [pool] ... [interval [count]]\n"));
 	case HELP_OFFLINE:
 		return (gettext("\toffline [-f] [-t] <pool> <device> ...\n"));
@@ -380,7 +381,7 @@ print_prop_cb(int prop, void *cb)
 {
 	FILE *fp = cb;
 
-	(void) fprintf(fp, "\t%-15s  ", zpool_prop_to_name(prop));
+	(void) fprintf(fp, "\t%-19s  ", zpool_prop_to_name(prop));
 
 	if (zpool_prop_readonly(prop))
 		(void) fprintf(fp, "  NO   ");
@@ -432,14 +433,14 @@ usage(boolean_t requested)
 		(void) fprintf(fp,
 		    gettext("\nthe following properties are supported:\n"));
 
-		(void) fprintf(fp, "\n\t%-15s  %s   %s\n\n",
+		(void) fprintf(fp, "\n\t%-19s  %s   %s\n\n",
 		    "PROPERTY", "EDIT", "VALUES");
 
 		/* Iterate over all properties */
 		(void) zprop_iter(print_prop_cb, fp, B_FALSE, B_TRUE,
 		    ZFS_TYPE_POOL);
 
-		(void) fprintf(fp, "\t%-15s   ", "feature@...");
+		(void) fprintf(fp, "\t%-19s   ", "feature@...");
 		(void) fprintf(fp, "YES   disabled | enabled | active\n");
 
 		(void) fprintf(fp, gettext("\nThe feature@ properties must be "
@@ -457,7 +458,10 @@ usage(boolean_t requested)
 	exit(requested ? 0 : 2);
 }
 
-void
+/*
+ * print a pool vdev config for dry runs
+ */
+static void
 print_vdev_tree(zpool_handle_t *zhp, const char *name, nvlist_t *nv, int indent,
     boolean_t print_logs, int name_flags)
 {
@@ -722,8 +726,9 @@ zpool_do_add(int argc, char **argv)
 
 		/* print original main pool and new tree */
 		print_vdev_tree(zhp, poolname, poolnvroot, 0, B_FALSE,
-		    name_flags);
-		print_vdev_tree(zhp, NULL, nvroot, 0, B_FALSE, name_flags);
+		    name_flags | VDEV_NAME_TYPE_ID | VDEV_NAME_ALLOC_BIAS);
+		print_vdev_tree(zhp, NULL, nvroot, 0, B_FALSE,
+		    name_flags | VDEV_NAME_ALLOC_BIAS);
 
 		/* Do the same for the logs */
 		if (num_logs(poolnvroot) > 0) {
@@ -1232,7 +1237,9 @@ zpool_do_create(int argc, char **argv)
 		(void) printf(gettext("would create '%s' with the "
 		    "following layout:\n\n"), poolname);
 
-		print_vdev_tree(NULL, poolname, nvroot, 0, B_FALSE, 0);
+		print_vdev_tree(NULL, poolname, nvroot, 0, B_FALSE,
+		    VDEV_NAME_ALLOC_BIAS);
+
 		if (num_logs(nvroot) > 0)
 			print_vdev_tree(NULL, "logs", nvroot, 0, B_TRUE, 0);
 
@@ -1906,6 +1913,8 @@ print_logs(zpool_handle_t *zhp, status_cbdata_t *cb, nvlist_t *nv)
 {
 	uint_t c, children;
 	nvlist_t **child;
+
+	assert(zhp != NULL || !cb->cb_verbose);
 
 	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN, &child,
 	    &children) != 0)
@@ -3615,7 +3624,7 @@ print_iostat_default(vdev_stat_t *vs, iostat_cbdata_t *cb, double scale)
  *
  * Returns the number of stat lines printed.
  */
-unsigned int
+static unsigned int
 print_vdev_stats(zpool_handle_t *zhp, const char *name, nvlist_t *oldnv,
     nvlist_t *newnv, iostat_cbdata_t *cb, int depth)
 {
@@ -3749,7 +3758,7 @@ children:
 			continue;
 
 		vname = zpool_vdev_name(g_zfs, zhp, newchild[c],
-		    cb->cb_name_flags);
+		    cb->cb_name_flags | VDEV_NAME_ALLOC_BIAS);
 		ret += print_vdev_stats(zhp, vname, oldnv ? oldchild[c] : NULL,
 		    newchild[c], cb, depth + 2);
 		free(vname);
@@ -3904,7 +3913,7 @@ get_namewidth(zpool_handle_t *zhp, void *data)
 		else
 			cb->cb_namewidth = MAX(poolname_len,
 			    max_width(zhp, nvroot, 0, cb->cb_namewidth,
-			    cb->cb_name_flags));
+			    cb->cb_name_flags | VDEV_NAME_ALLOC_BIAS));
 	}
 	/*
 	 * The width must be at least 10, but may be as large as the
@@ -4722,7 +4731,11 @@ typedef struct list_cbdata {
 	boolean_t	cb_scripted;
 	zprop_list_t	*cb_proplist;
 	boolean_t	cb_literal;
+	boolean_t	cb_category;
 } list_cbdata_t;
+
+#define	CATEGORY_NAME_WIDTH	14
+
 
 /*
  * Given a list of columns to display, output appropriate headers for each one.
@@ -4736,6 +4749,20 @@ print_header(list_cbdata_t *cb)
 	boolean_t first = B_TRUE;
 	boolean_t right_justify;
 	size_t width = 0;
+
+	if (cb->cb_category) {
+		const char *fmt;
+
+		(void) printf("%-*s  ", CATEGORY_NAME_WIDTH, "NAME");
+		if (cb->cb_literal)
+			fmt = "%-11s  %-11s  %-11s  %-11s\n";
+		else
+			fmt = "%-5s  %-5s  %-5s  %-8s\n";
+		(void) printf(fmt, "SIZE", "ALLOC", "FREE", "CAPACITY");
+		(void) printf("%-*s  ", CATEGORY_NAME_WIDTH, "--------------");
+		(void) printf(fmt, "-----", "-----", "-----", "--------");
+		return;
+	}
 
 	for (; pl != NULL; pl = pl->pl_next) {
 		width = pl->pl_width;
@@ -4778,7 +4805,7 @@ print_header(list_cbdata_t *cb)
 
 /*
  * Given a pool and a list of properties, print out all the properties according
- * to the described layout.
+ * to the described layout. Used by zpool_do_list().
  */
 static void
 print_pool(zpool_handle_t *zhp, list_cbdata_t *cb)
@@ -4873,12 +4900,14 @@ print_one_column(zpool_prop_t prop, uint64_t value, boolean_t scripted,
 		}
 		break;
 	case ZPOOL_PROP_CAPACITY:
+		/* by convention capacity value is 100x for more precision */
 		if (format == ZFS_NICENUM_RAW)
 			(void) snprintf(propval, sizeof (propval), "%llu",
-			    (unsigned long long)value);
+			    (unsigned long long)value / 100);
 		else
-			(void) snprintf(propval, sizeof (propval), "%llu%%",
-			    (unsigned long long)value);
+			(void) snprintf(propval, sizeof (propval),
+			    value < 1000 ? "%1.2f%%" : value < 10000 ?
+			    "%2.1f%%" : "%3.0f%%", value / 100.0);
 		break;
 	default:
 		zfs_nicenum_format(value, propval, sizeof (propval), format);
@@ -4893,6 +4922,10 @@ print_one_column(zpool_prop_t prop, uint64_t value, boolean_t scripted,
 		(void) printf("  %*s", (int)width, propval);
 }
 
+/*
+ * print static default line per vdev
+ * not compatible with '-o' <proplist> option
+ */
 void
 print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
     list_cbdata_t *cb, int depth)
@@ -4946,7 +4979,7 @@ print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		    (vs->vs_fragmentation != ZFS_FRAG_INVALID && toplevel),
 		    format);
 		cap = (vs->vs_space == 0) ? 0 :
-		    (vs->vs_alloc * 100 / vs->vs_space);
+		    (vs->vs_alloc * 10000 / vs->vs_space);
 		print_one_column(ZPOOL_PROP_CAPACITY, cap, scripted, toplevel,
 		    format);
 		(void) printf("\n");
@@ -4970,7 +5003,7 @@ print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		}
 
 		vname = zpool_vdev_name(g_zfs, zhp, child[c],
-		    cb->cb_name_flags);
+		    cb->cb_name_flags | VDEV_NAME_ALLOC_BIAS);
 		print_list_stats(zhp, vname, child[c], cb, depth + 2);
 		free(vname);
 	}
@@ -5014,6 +5047,99 @@ print_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 	}
 }
 
+void
+print_category_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
+    list_cbdata_t *cb, int depth)
+{
+	nvlist_t **child;
+	vdev_stat_t *vs;
+	uint_t c, children;
+	boolean_t scripted = cb->cb_scripted;
+	char *bias = NULL, *type = "";
+
+	if (nvlist_lookup_uint64_array(nv, ZPOOL_CONFIG_VDEV_STATS,
+	    (uint64_t **)&vs, &c) != 0)
+		return;
+
+	(void) nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS, &bias);
+	(void) nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE, &type);
+
+	if (name != NULL &&
+	    (bias != NULL || strcmp(type, VDEV_TYPE_ROOT) == 0)) {
+		uint64_t space, alloc, capacity;
+		enum zfs_nicenum_format format;
+		boolean_t virtual, hascap = B_TRUE;
+
+		if (cb->cb_literal)
+			format = ZFS_NICENUM_RAW;
+		else
+			format = ZFS_NICENUM_1024;
+
+		if (scripted)
+			(void) printf("\t%s", name);
+		else if (strlen(name) + depth > cb->cb_namewidth)
+			(void) printf("%*s%s", depth, "", name);
+		else
+			(void) printf("%*s%s%*s", depth, "", name,
+			    (int)(cb->cb_namewidth - strlen(name) - depth), "");
+
+		if (strcmp(name, "normal") == 0) {
+			space = vs->vs_normal_assigned;
+			alloc = vs->vs_alloc - vs->vs_special_alloc;
+			virtual = B_TRUE;
+		} else if (strcmp(name, "special") == 0) {
+			space = vs->vs_special_assigned;
+			alloc = vs->vs_special_alloc;
+			virtual = B_TRUE;
+		} else if (strcmp(name, "unassigned") == 0) {
+			uint64_t assigned = vs->vs_normal_assigned +
+			    vs->vs_special_assigned;
+			if (vs->vs_space > assigned)
+				space = vs->vs_space - assigned;
+			else
+				space = 0;
+			alloc = 0;
+			virtual = B_TRUE;
+			hascap = B_FALSE;
+		} else {
+			space = vs->vs_space;
+			alloc = vs->vs_alloc;
+			virtual = B_FALSE;
+		}
+		print_one_column(ZPOOL_PROP_SIZE, space, scripted, B_TRUE,
+		    format);
+		print_one_column(ZPOOL_PROP_ALLOCATED, alloc, scripted, B_TRUE,
+		    format);
+		print_one_column(ZPOOL_PROP_FREE, space - alloc, scripted,
+		    B_TRUE, format);
+		capacity = (space == 0) ? 0 : (alloc * 10000 / space);
+		print_one_column(ZPOOL_PROP_CAPACITY, capacity, scripted,
+		    hascap, ZFS_NICENUM_1024);
+		(void) printf("\n");
+
+		char *bias;
+		if (!virtual &&
+		    nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &bias) == 0 &&
+		    strcmp(bias, VDEV_ALLOC_BIAS_SEGREGATE) == 0) {
+			print_category_stats(zhp, "normal", nv, cb, depth + 2);
+			print_category_stats(zhp, "special", nv, cb, depth + 2);
+			print_category_stats(zhp, "unassigned", nv, cb,
+			    depth + 2);
+		}
+	}
+
+	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN,
+	    &child, &children) != 0)
+		return;
+
+	for (c = 0; c < children; c++) {
+		char *vname = zpool_vdev_name(g_zfs, zhp, child[c],
+		    cb->cb_name_flags);
+		print_category_stats(zhp, vname, child[c], cb, depth + 2);
+		free(vname);
+	}
+}
 
 /*
  * Generic callback function to list a pool.
@@ -5027,20 +5153,35 @@ list_callback(zpool_handle_t *zhp, void *data)
 
 	config = zpool_get_config(zhp, NULL);
 
-	print_pool(zhp, cbp);
-	if (!cbp->cb_verbose)
+	if (cbp->cb_verbose || cbp->cb_category) {
+		config = zpool_get_config(zhp, NULL);
+
+		verify(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
+		    &nvroot) == 0);
+	}
+
+	if (cbp->cb_category) {
+		print_category_stats(zhp, zpool_get_name(zhp), nvroot, cbp, 0);
 		return (0);
 
-	verify(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
-	    &nvroot) == 0);
-	print_list_stats(zhp, NULL, nvroot, cbp, 0);
+	}
+
+	if (cbp->cb_verbose)
+		cbp->cb_namewidth = max_width(zhp, nvroot, 0, 0,
+		    cbp->cb_name_flags | VDEV_NAME_ALLOC_BIAS);
+
+	print_pool(zhp, cbp);
+
+	if (cbp->cb_verbose)
+		print_list_stats(zhp, NULL, nvroot, cbp, 0);
 
 	return (0);
 }
 
 /*
- * zpool list [-gHLpP] [-o prop[,prop]*] [-T d|u] [pool] ... [interval [count]]
+ * zpool list [-CgHLpP] [-o prop[,prop]*] [-T d|u] [pool] ... [interval [count]]
  *
+ *	-C	Diplay the list of block allocations by category
  *	-g	Display guid for individual vdev name.
  *	-H	Scripted mode.  Don't display headers, and separate properties
  *		by a single tab.
@@ -5064,6 +5205,7 @@ zpool_do_list(int argc, char **argv)
 	static char default_props[] =
 	    "name,size,allocated,free,expandsize,fragmentation,capacity,"
 	    "dedupratio,health,altroot";
+	static char category_props[] = "name,size,allocated";
 	char *props = default_props;
 	float interval = 0;
 	unsigned long count = 0;
@@ -5071,8 +5213,15 @@ zpool_do_list(int argc, char **argv)
 	boolean_t first = B_TRUE;
 
 	/* check options */
-	while ((c = getopt(argc, argv, ":gHLo:pPT:v")) != -1) {
+	while ((c = getopt(argc, argv, ":CgHLo:pPT:v")) != -1) {
 		switch (c) {
+		case 'C':
+			cb.cb_category = B_TRUE;
+			props = category_props;
+			cb.cb_name_flags |= VDEV_NAME_TYPE_ID;
+			cb.cb_namewidth = CATEGORY_NAME_WIDTH;
+			cb.cb_verbose = B_TRUE;
+			break;
 		case 'g':
 			cb.cb_name_flags |= VDEV_NAME_GUID;
 			break;
@@ -5096,6 +5245,7 @@ zpool_do_list(int argc, char **argv)
 			break;
 		case 'v':
 			cb.cb_verbose = B_TRUE;
+			cb.cb_namewidth = 8;	/* 8 until precalc is avail */
 			break;
 		case ':':
 			(void) fprintf(stderr, gettext("missing argument for "
@@ -6467,7 +6617,8 @@ status_callback(zpool_handle_t *zhp, void *data)
 		print_scan_status(ps);
 
 		cbp->cb_namewidth = max_width(zhp, nvroot, 0, 0,
-		    cbp->cb_name_flags | VDEV_NAME_TYPE_ID);
+		    cbp->cb_name_flags | VDEV_NAME_TYPE_ID |
+		    VDEV_NAME_ALLOC_BIAS);
 		if (cbp->cb_namewidth < 10)
 			cbp->cb_namewidth = 10;
 
@@ -6480,8 +6631,11 @@ status_callback(zpool_handle_t *zhp, void *data)
 			print_cmd_columns(cbp->vcdl, 0);
 
 		printf("\n");
+
+		cbp->cb_name_flags |= VDEV_NAME_ALLOC_BIAS;
 		print_status_config(zhp, cbp, zpool_get_name(zhp), nvroot, 0,
 		    B_FALSE);
+		cbp->cb_name_flags &= ~VDEV_NAME_ALLOC_BIAS;
 
 		if (num_logs(nvroot) > 0)
 			print_logs(zhp, cbp, nvroot);

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, 2015 by Delphix. All rights reserved.
- * Copyright (c) 2016 Intel Corporation.
+ * Copyright (c) 2017 Intel Corporation.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>.
  */
 
@@ -682,6 +682,9 @@ make_leaf_vdev(nvlist_t *props, const char *arg, uint64_t is_log)
 	verify(nvlist_add_string(vdev, ZPOOL_CONFIG_PATH, path) == 0);
 	verify(nvlist_add_string(vdev, ZPOOL_CONFIG_TYPE, type) == 0);
 	verify(nvlist_add_uint64(vdev, ZPOOL_CONFIG_IS_LOG, is_log) == 0);
+	if (is_log)
+		verify(nvlist_add_string(vdev, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    VDEV_ALLOC_BIAS_LOG) == 0);
 	if (strcmp(type, VDEV_TYPE_DISK) == 0)
 		verify(nvlist_add_uint64(vdev, ZPOOL_CONFIG_WHOLE_DISK,
 		    (uint64_t)wholedisk) == 0);
@@ -740,6 +743,9 @@ make_leaf_vdev(nvlist_t *props, const char *arg, uint64_t is_log)
  *
  * 	Otherwise, make sure that the current spec (if there is one) and the new
  * 	spec have consistent replication levels.
+ *
+ *	If there is no current spec (create), make sure new spec has at least
+ *	one general purpose vdev.
  */
 typedef struct replication_level {
 	char *zprl_type;
@@ -775,7 +781,7 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 	nvlist_t **child;
 	uint_t c, children;
 	nvlist_t *nv;
-	char *type;
+	char *type, *alloc_bias;
 	replication_level_t lastrep = {0};
 	replication_level_t rep;
 	replication_level_t *ret;
@@ -798,6 +804,9 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 		 */
 		(void) nvlist_lookup_uint64(nv, ZPOOL_CONFIG_IS_LOG, &is_log);
 		if (is_log)
+			continue;
+		if (nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &alloc_bias) == 0)
 			continue;
 
 		verify(nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE,
@@ -959,7 +968,7 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 		/*
 		 * At this point, we have the replication of the last toplevel
 		 * vdev in 'rep'.  Compare it to 'lastrep' to see if its
-		 * different.
+		 * different. Skip checks involving dedicated top-level vdevs.
 		 */
 		if (lastrep.zprl_type != NULL) {
 			if (is_raidz_mirror(&lastrep, &rep, &raidz, &mirror) ||
@@ -1458,6 +1467,12 @@ is_grouping(const char *type, int *mindev, int *maxdev)
 		return (VDEV_TYPE_LOG);
 	}
 
+	if (strcmp(type, VDEV_ALLOC_BIAS_SPECIAL) == 0) {
+		if (mindev != NULL)
+			*mindev = 2;
+		return (type);
+	}
+
 	if (strcmp(type, "cache") == 0) {
 		if (mindev != NULL)
 			*mindev = 1;
@@ -1465,6 +1480,19 @@ is_grouping(const char *type, int *mindev, int *maxdev)
 	}
 
 	return (NULL);
+}
+
+static boolean_t
+segregate_prop_active(nvlist_t *props, zpool_prop_t prop)
+{
+	char *str;
+
+	if (props != NULL &&
+	    nvlist_lookup_string(props, zpool_prop_to_name(prop), &str) == 0 &&
+	    strcmp(str, "on") == 0) {
+		return (B_TRUE);
+	}
+	return (B_FALSE);
 }
 
 /*
@@ -1479,7 +1507,7 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 	nvlist_t *nvroot, *nv, **top, **spares, **l2cache;
 	int t, toplevels, mindev, maxdev, nspares, nlogs, nl2cache;
 	const char *type;
-	uint64_t is_log;
+	uint64_t is_log, is_special;
 	boolean_t seen_logs;
 
 	top = NULL;
@@ -1489,7 +1517,7 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 	nspares = 0;
 	nlogs = 0;
 	nl2cache = 0;
-	is_log = B_FALSE;
+	is_log = is_special = B_FALSE;
 	seen_logs = B_FALSE;
 	nvroot = NULL;
 
@@ -1512,7 +1540,7 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 					    "specified only once\n"));
 					goto spec_out;
 				}
-				is_log = B_FALSE;
+				is_log = is_special = B_FALSE;
 			}
 
 			if (strcmp(type, VDEV_TYPE_LOG) == 0) {
@@ -1523,14 +1551,44 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 					    "specified only once\n"));
 					goto spec_out;
 				}
+				if (segregate_prop_active(props,
+				    ZPOOL_PROP_SEGREGATE_LOG)) {
+					(void) fprintf(stderr,
+					    gettext("invalid vdev specified: "
+					    "'%s' was already specified by "
+					    "'%s' property\n"),
+					    VDEV_TYPE_LOG, zpool_prop_to_name(
+					    ZPOOL_PROP_SEGREGATE_LOG));
+					goto spec_out;
+				}
 				seen_logs = B_TRUE;
 				is_log = B_TRUE;
+				is_special = B_FALSE;
 				argc--;
 				argv++;
 				/*
 				 * A log is not a real grouping device.
 				 * We just set is_log and continue.
 				 */
+				continue;
+			}
+
+			if (strcmp(type, VDEV_ALLOC_BIAS_SPECIAL) == 0) {
+				if (segregate_prop_active(props,
+				    ZPOOL_PROP_SEGREGATE_SPECIAL)) {
+					(void) fprintf(stderr,
+					    gettext("invalid vdev specified: "
+					    "'%s' was already specified by "
+					    "'%s' property\n"),
+					    VDEV_ALLOC_BIAS_SPECIAL,
+					    zpool_prop_to_name(
+					    ZPOOL_PROP_SEGREGATE_SPECIAL));
+					goto spec_out;
+				}
+				is_special = B_TRUE;
+				is_log = B_FALSE;
+				argc--;
+				argv++;
 				continue;
 			}
 
@@ -1542,15 +1600,16 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 					    "specified only once\n"));
 					goto spec_out;
 				}
-				is_log = B_FALSE;
+				is_log = is_special = B_FALSE;
 			}
 
-			if (is_log) {
+			if (is_log || is_special) {
 				if (strcmp(type, VDEV_TYPE_MIRROR) != 0) {
 					(void) fprintf(stderr,
 					    gettext("invalid vdev "
-					    "specification: unsupported 'log' "
-					    "device: %s\n"), type);
+					    "specification: unsupported '%s' "
+					    "device: %s\n"), is_log ? "log" :
+					    "special", type);
 					goto spec_out;
 				}
 				nlogs++;
@@ -1613,6 +1672,15 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 				    type) == 0);
 				verify(nvlist_add_uint64(nv,
 				    ZPOOL_CONFIG_IS_LOG, is_log) == 0);
+				if (is_log)
+					verify(nvlist_add_string(nv,
+					    ZPOOL_CONFIG_ALLOCATION_BIAS,
+					    VDEV_ALLOC_BIAS_LOG) == 0);
+				if (is_special) {
+					verify(nvlist_add_string(nv,
+					    ZPOOL_CONFIG_ALLOCATION_BIAS,
+					    VDEV_ALLOC_BIAS_SPECIAL) == 0);
+				}
 				if (strcmp(type, VDEV_TYPE_RAIDZ) == 0) {
 					verify(nvlist_add_uint64(nv,
 					    ZPOOL_CONFIG_NPARITY,
@@ -1637,6 +1705,12 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 
 			if (is_log)
 				nlogs++;
+			if (is_special) {
+				(void) fprintf(stderr,
+				    gettext("invalid vdev specification: "
+				    "special expects mirror\n"));
+				goto spec_out;
+			}
 			argc--;
 			argv++;
 		}
@@ -1737,6 +1811,30 @@ split_mirror_vdev(zpool_handle_t *zhp, char *newname, nvlist_t *props,
 	return (newroot);
 }
 
+static int
+num_normal_vdevs(nvlist_t *nvroot)
+{
+	nvlist_t **top;
+	uint_t t, toplevels, normal = 0;
+
+	verify(nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
+	    &top, &toplevels) == 0);
+
+	for (t = 0; t < toplevels; t++) {
+		uint64_t log = B_FALSE;
+
+		(void) nvlist_lookup_uint64(top[t], ZPOOL_CONFIG_IS_LOG, &log);
+		if (log)
+			continue;
+		if (nvlist_exists(top[t], ZPOOL_CONFIG_ALLOCATION_BIAS))
+			continue;
+
+		normal++;
+	}
+
+	return (normal);
+}
+
 /*
  * Get and validate the contents of the given vdev specification.  This ensures
  * that the nvlist returned is well-formed, that all the devices exist, and that
@@ -1785,6 +1883,16 @@ make_root_vdev(zpool_handle_t *zhp, nvlist_t *props, int force, int check_rep,
 	 * catch changes against the existing replication level.
 	 */
 	if (check_rep && check_replication(poolconfig, newroot) != 0) {
+		nvlist_free(newroot);
+		return (NULL);
+	}
+
+	/*
+	 * On pool create the new vdev spec must have one normal vdev.
+	 */
+	if (poolconfig == NULL && num_normal_vdevs(newroot) == 0) {
+		vdev_error(gettext("at least one general top-level vdev must "
+		    "be specified\n"));
 		nvlist_free(newroot);
 		return (NULL);
 	}

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 /*
@@ -146,6 +147,12 @@ typedef struct ztest_shared_hdr {
 
 static ztest_shared_hdr_t *ztest_shared_hdr;
 
+enum ztest_class_state {
+	ZTEST_VDEV_CLASS_OFF,
+	ZTEST_VDEV_CLASS_ON,
+	ZTEST_VDEV_CLASS_RND
+};
+
 typedef struct ztest_shared_opts {
 	char zo_pool[ZFS_MAX_DATASET_NAME_LEN];
 	char zo_dir[ZFS_MAX_DATASET_NAME_LEN];
@@ -167,6 +174,8 @@ typedef struct ztest_shared_opts {
 	uint64_t zo_time;
 	uint64_t zo_maxloops;
 	uint64_t zo_metaslab_gang_bang;
+	int zo_dedicated_vdevs;
+	int zo_segregated_vdevs;
 	int zo_mmp_test;
 } ztest_shared_opts_t;
 
@@ -190,7 +199,9 @@ static const ztest_shared_opts_t ztest_opts_defaults = {
 	.zo_init = 1,
 	.zo_time = 300,			/* 5 minutes */
 	.zo_maxloops = 50,		/* max loops during spa_freeze() */
-	.zo_metaslab_gang_bang = 32 << 10
+	.zo_metaslab_gang_bang = 32 << 10,
+	.zo_dedicated_vdevs = ZTEST_VDEV_CLASS_RND,
+	.zo_segregated_vdevs = ZTEST_VDEV_CLASS_RND
 };
 
 extern uint64_t metaslab_gang_bang;
@@ -332,6 +343,7 @@ ztest_func_t ztest_dsl_dataset_promote_busy;
 ztest_func_t ztest_vdev_attach_detach;
 ztest_func_t ztest_vdev_LUN_growth;
 ztest_func_t ztest_vdev_add_remove;
+ztest_func_t ztest_vdev_class_add;
 ztest_func_t ztest_vdev_aux_add_remove;
 ztest_func_t ztest_split_pool;
 ztest_func_t ztest_reguid;
@@ -383,6 +395,7 @@ ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_vdev_attach_detach, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_vdev_LUN_growth, 1, &zopt_rarely),
 	ZTI_INIT(ztest_vdev_add_remove, 1, &ztest_opts.zo_vdevtime),
+	ZTI_INIT(ztest_vdev_class_add, 1, &ztest_opts.zo_vdevtime),
 	ZTI_INIT(ztest_vdev_aux_add_remove, 1, &ztest_opts.zo_vdevtime),
 	ZTI_INIT(ztest_fletcher, 1, &zopt_rarely),
 	ZTI_INIT(ztest_fletcher_incr, 1, &zopt_rarely),
@@ -633,6 +646,8 @@ usage(boolean_t requested)
 	    "\t[-F freezeloops (default: %llu)] max loops in spa_freeze()\n"
 	    "\t[-P passtime (default: %llu sec)] time per pass\n"
 	    "\t[-B alt_ztest (default: <none>)] alternate ztest path\n"
+	    "\t[-C vdev class state (default: random)] "
+	    "dedicated|segregated=on|off|random\n"
 	    "\t[-o variable=value] ... set global variable to an unsigned\n"
 	    "\t    32-bit integer value\n"
 	    "\t[-h] (print help)\n"
@@ -657,6 +672,48 @@ usage(boolean_t requested)
 	exit(requested ? 0 : 1);
 }
 
+
+static void
+ztest_parse_name_value(const char *input, ztest_shared_opts_t *zo)
+{
+	char name[32];
+	char *value;
+	int state = ZTEST_VDEV_CLASS_RND;
+
+	(void) strlcpy(name, input, sizeof (name));
+
+	value = strchr(name, '=');
+	if (value == NULL) {
+		(void) fprintf(stderr, "missing value in property=value "
+		    "'-C' argument (%s)\n", input);
+		usage(B_FALSE);
+	}
+	*(value) = '\0';
+	value++;
+
+	if (strcmp(value, "on") == 0) {
+		state = ZTEST_VDEV_CLASS_ON;
+	} else if (strcmp(value, "off") == 0) {
+		state = ZTEST_VDEV_CLASS_OFF;
+	} else if (strcmp(value, "random") == 0) {
+		state = ZTEST_VDEV_CLASS_RND;
+	} else {
+		(void) fprintf(stderr, "invalid property value '%s'\n", value);
+		usage(B_FALSE);
+	}
+
+	if (strcmp(name, "dedicated") == 0) {
+		zo->zo_dedicated_vdevs = state;
+	} else if (strcmp(name, "segregated") == 0) {
+		zo->zo_segregated_vdevs = state;
+	} else {
+		(void) fprintf(stderr, "invalid proeprty name '%s'\n", name);
+		usage(B_FALSE);
+	}
+	if (zo->zo_verbose >= 3)
+		(void) printf("%s vdev state is '%s'\n", name, value);
+}
+
 static void
 process_options(int argc, char **argv)
 {
@@ -670,7 +727,7 @@ process_options(int argc, char **argv)
 	bcopy(&ztest_opts_defaults, zo, sizeof (*zo));
 
 	while ((opt = getopt(argc, argv,
-	    "v:s:a:m:r:R:d:t:g:i:k:p:f:MVET:P:hF:B:o:")) != EOF) {
+	    "v:s:a:m:r:R:d:t:g:i:k:p:f:MVET:P:hF:B:C:o:")) != EOF) {
 		value = 0;
 		switch (opt) {
 		case 'v':
@@ -760,6 +817,9 @@ process_options(int argc, char **argv)
 			break;
 		case 'B':
 			(void) strlcpy(altdir, optarg, sizeof (altdir));
+			break;
+		case 'C':
+			ztest_parse_name_value(optarg, zo);
 			break;
 		case 'o':
 			if (set_global_var(optarg) != 0)
@@ -985,12 +1045,15 @@ make_vdev_mirror(char *path, char *aux, char *pool, size_t size,
 
 static nvlist_t *
 make_vdev_root(char *path, char *aux, char *pool, size_t size, uint64_t ashift,
-    int log, int r, int m, int t)
+    const char *classes, int r, int m, int t)
 {
 	nvlist_t *root, **child;
 	int c;
+	boolean_t log;
 
 	ASSERT(t > 0);
+
+	log = (classes != NULL && strcmp(classes, "log") == 0);
 
 	child = umem_alloc(t * sizeof (nvlist_t *), UMEM_NOFAIL);
 
@@ -999,6 +1062,12 @@ make_vdev_root(char *path, char *aux, char *pool, size_t size, uint64_t ashift,
 		    r, m);
 		VERIFY(nvlist_add_uint64(child[c], ZPOOL_CONFIG_IS_LOG,
 		    log) == 0);
+
+		if (classes != NULL && classes[0] != '\0') {
+			ASSERT(m > 1 || log);   /* expecting a mirror */
+			VERIFY(nvlist_add_string(child[c],
+			    ZPOOL_CONFIG_ALLOCATION_BIAS, classes) == 0);
+		}
 	}
 
 	VERIFY(nvlist_alloc(&root, NV_UNIQUE_NAME, 0) == 0);
@@ -1038,6 +1107,8 @@ ztest_random_spa_version(uint64_t initial_version)
 static int
 ztest_random_blocksize(void)
 {
+	ASSERT(ztest_spa->spa_max_ashift != 0);
+
 	/*
 	 * Choose a block size >= the ashift.
 	 * If the SPA supports new MAXBLOCKSIZE, test up to 1MB blocks.
@@ -2632,7 +2703,7 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Attempt to create using a bad file.
 	 */
-	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, 0, 0, 0, 1);
+	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, NULL, 0, 0,  1);
 	VERIFY3U(ENOENT, ==,
 	    spa_create("ztest_bad_file", nvroot, NULL, NULL));
 	nvlist_free(nvroot);
@@ -2640,7 +2711,7 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Attempt to create using a bad mirror.
 	 */
-	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, 0, 0, 2, 1);
+	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, NULL, 0, 2, 1);
 	VERIFY3U(ENOENT, ==,
 	    spa_create("ztest_bad_mirror", nvroot, NULL, NULL));
 	nvlist_free(nvroot);
@@ -2650,7 +2721,7 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	 * what's in the nvroot; we should fail with EEXIST.
 	 */
 	(void) rw_rdlock(&ztest_name_lock);
-	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, 0, 0, 0, 1);
+	nvroot = make_vdev_root("/dev/bogus", NULL, NULL, 0, 0, NULL, 0, 0, 1);
 	VERIFY3U(EEXIST, ==, spa_create(zo->zo_pool, nvroot, NULL, NULL));
 	nvlist_free(nvroot);
 	VERIFY3U(0, ==, spa_open(zo->zo_pool, &spa, FTAG));
@@ -2682,7 +2753,7 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 	(void) spa_destroy(name);
 
 	nvroot = make_vdev_root(NULL, NULL, name, ztest_opts.zo_vdev_size, 0,
-	    0, ztest_opts.zo_raidz, ztest_opts.zo_mirrors, 1);
+	    NULL, ztest_opts.zo_raidz, ztest_opts.zo_mirrors, 1);
 
 	/*
 	 * If we're configuring a RAIDZ device then make sure that the
@@ -2800,10 +2871,16 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 	 * If we have slogs then remove them 1/4 of the time.
 	 */
 	if (spa_has_slogs(spa) && ztest_random(4) == 0) {
+		metaslab_group_t *mg;
+
 		/*
-		 * Grab the guid from the head of the log class rotor.
+		 * find the first real slog in log allocation class
 		 */
-		guid = spa_log_class(spa)->mc_rotor->mg_vd->vdev_guid;
+		mg =  spa_log_class(spa)->mc_rotor;
+		while (!mg->mg_vd->vdev_islog)
+			mg = mg->mg_next;
+
+		guid = mg->mg_vd->vdev_guid;
 
 		spa_config_exit(spa, SCL_VDEV, FTAG);
 
@@ -2825,12 +2902,13 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 		spa_config_exit(spa, SCL_VDEV, FTAG);
 
 		/*
-		 * Make 1/4 of the devices be log devices.
+		 * Make 1/4 of the devices be log devices unless
+		 * segregated logs are requested for the pool.
 		 */
 		nvroot = make_vdev_root(NULL, NULL, NULL,
 		    ztest_opts.zo_vdev_size, 0,
-		    ztest_random(4) == 0, ztest_opts.zo_raidz,
-		    zs->zs_mirrors, 1);
+		    (ztest_random(4) == 0 && spa->spa_segregate_log == 0) ?
+		    "log" : NULL, ztest_opts.zo_raidz, zs->zs_mirrors, 1);
 
 		error = spa_vdev_add(spa, nvroot);
 		nvlist_free(nvroot);
@@ -2842,6 +2920,69 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 	}
 
 	mutex_exit(&ztest_vdev_lock);
+}
+
+/* ARGSUSED */
+void
+ztest_vdev_class_add(ztest_ds_t *zd, uint64_t id)
+{
+	ztest_shared_t *zs = ztest_shared;
+	spa_t *spa = ztest_spa;
+	const char *class = VDEV_ALLOC_BIAS_SPECIAL;
+	uint64_t leaves;
+	nvlist_t *nvroot;
+	int error;
+
+	/*
+	 * By default add a dedicated vdev 50% of the time
+	 */
+	if ((ztest_opts.zo_dedicated_vdevs == ZTEST_VDEV_CLASS_OFF) ||
+	    (ztest_opts.zo_dedicated_vdevs == ZTEST_VDEV_CLASS_RND &&
+	    ztest_random(2) == 0)) {
+		return;
+	}
+
+	mutex_enter(&ztest_vdev_lock);
+
+	/* Only test with mirrors */
+	if (zs->zs_mirrors < 2) {
+		mutex_exit(&ztest_vdev_lock);
+		return;
+	}
+
+	/* requires feature@allocation_classes */
+	if (!spa_feature_is_enabled(spa, SPA_FEATURE_ALLOCATION_CLASSES)) {
+		mutex_exit(&ztest_vdev_lock);
+		return;
+	}
+
+	/* Skip when pool is using segregated VDEVs */
+	if (spa->spa_segregate_special) {
+		mutex_exit(&ztest_vdev_lock);
+		return;
+	}
+
+	leaves = MAX(zs->zs_mirrors + zs->zs_splits, 1) * ztest_opts.zo_raidz;
+
+	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
+	ztest_shared->zs_vdev_next_leaf = find_vdev_hole(spa) * leaves;
+	spa_config_exit(spa, SCL_VDEV, FTAG);
+
+	nvroot = make_vdev_root(NULL, NULL, NULL, ztest_opts.zo_vdev_size, 0,
+	    class, ztest_opts.zo_raidz, zs->zs_mirrors, 1);
+
+	error = spa_vdev_add(spa, nvroot);
+	nvlist_free(nvroot);
+
+	if (error == ENOSPC)
+		ztest_record_enospc("spa_vdev_add");
+	else if (error != 0)
+		fatal(0, "spa_vdev_add() = %d", error);
+
+	mutex_exit(&ztest_vdev_lock);
+
+	if (ztest_opts.zo_verbose >= 3)
+		(void) printf("Added a dedicated %s mirrored vdev\n", class);
 }
 
 /*
@@ -2910,7 +3051,7 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 		 * Add a new device.
 		 */
 		nvlist_t *nvroot = make_vdev_root(NULL, aux, NULL,
-		    (ztest_opts.zo_vdev_size * 5) / 4, 0, 0, 0, 0, 1);
+		    (ztest_opts.zo_vdev_size * 5) / 4, 0, NULL, 0, 0, 1);
 		error = spa_vdev_add(spa, nvroot);
 		if (error != 0)
 			fatal(0, "spa_vdev_add(%p) = %d", nvroot, error);
@@ -3088,11 +3229,15 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	 * Locate this vdev.
 	 */
 	oldvd = rvd->vdev_child[top];
+
+	/* pick a child from the mirror */
 	if (zs->zs_mirrors >= 1) {
 		ASSERT(oldvd->vdev_ops == &vdev_mirror_ops);
 		ASSERT(oldvd->vdev_children >= zs->zs_mirrors);
 		oldvd = oldvd->vdev_child[leaf / ztest_opts.zo_raidz];
 	}
+
+	/* pick a child out of the raidz group */
 	if (ztest_opts.zo_raidz > 1) {
 		ASSERT(oldvd->vdev_ops == &vdev_raidz_ops);
 		ASSERT(oldvd->vdev_children == ztest_opts.zo_raidz);
@@ -3189,7 +3334,7 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	 * Build the nvlist describing newpath.
 	 */
 	root = make_vdev_root(newpath, NULL, NULL, newvd == NULL ? newsize : 0,
-	    ashift, 0, 0, 0, 1);
+	    ashift, NULL, 0, 0, 1);
 
 	error = spa_vdev_attach(spa, oldguid, root, replacing);
 
@@ -3383,7 +3528,10 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 		return;
 	}
 	ASSERT(psize > 0);
-	newsize = psize + psize / 8;
+	if (vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE)
+		newsize = psize + MAX(psize / 4, SPA_MAXBLOCKSIZE);
+	else
+		newsize = psize + MAX(psize / 8, SPA_MAXBLOCKSIZE);
 	ASSERT3U(newsize, >, psize);
 
 	if (ztest_opts.zo_verbose >= 6) {
@@ -6576,12 +6724,30 @@ print_time(hrtime_t t, char *timebuf)
 		(void) sprintf(timebuf, "%llus", s);
 }
 
+#define	SEGREGATE_MINDEVSIZE	(256ULL << 20)		/* 256M minimum size */
+
 static nvlist_t *
 make_random_props(void)
 {
 	nvlist_t *props;
 
 	VERIFY(nvlist_alloc(&props, NV_UNIQUE_NAME, 0) == 0);
+
+	/* With mirror or raidz configs, use segregation 20% of the time */
+	if (ztest_opts.zo_vdev_size >= SEGREGATE_MINDEVSIZE &&
+	    (ztest_opts.zo_raidz > 1 || ztest_opts.zo_mirrors > 1)) {
+		if ((ztest_opts.zo_segregated_vdevs == ZTEST_VDEV_CLASS_ON) ||
+		    (ztest_opts.zo_segregated_vdevs == ZTEST_VDEV_CLASS_RND &&
+		    ztest_random(5) == 0)) {
+			fnvlist_add_uint64(props, "segregate_log", 1);
+			fnvlist_add_uint64(props, "segregate_special", 1);
+
+			if (ztest_opts.zo_verbose >= 3)
+				(void) printf("Adding segregate props to pool "
+				    "'%s'\n", ztest_opts.zo_pool);
+		}
+	}
+
 	if (ztest_random(2) == 0)
 		return (props);
 	VERIFY(nvlist_add_uint64(props, "autoreplace", 1) == 0);
@@ -6663,7 +6829,7 @@ ztest_init(ztest_shared_t *zs)
 	zs->zs_splits = 0;
 	zs->zs_mirrors = ztest_opts.zo_mirrors;
 	nvroot = make_vdev_root(NULL, NULL, NULL, ztest_opts.zo_vdev_size, 0,
-	    0, ztest_opts.zo_raidz, zs->zs_mirrors, 1);
+	    NULL, ztest_opts.zo_raidz, zs->zs_mirrors, 1);
 	props = make_random_props();
 	for (i = 0; i < SPA_FEATURES; i++) {
 		char *buf;
@@ -6672,6 +6838,7 @@ ztest_init(ztest_shared_t *zs)
 		VERIFY3U(0, ==, nvlist_add_uint64(props, buf, 0));
 		free(buf);
 	}
+
 	VERIFY3U(0, ==, spa_create(ztest_opts.zo_pool, nvroot, props, NULL));
 	nvlist_free(nvroot);
 	nvlist_free(props);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -24,7 +24,7 @@
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
- * Copyright (c) 2016, Intel Corporation.
+ * Copyright (c) 2016, 2017, Intel Corporation.
  * Copyright 2016 Nexenta Systems, Inc.
  * Copyright (c) 2017 Datto Inc.
  */
@@ -431,6 +431,7 @@ typedef enum {
 	VDEV_NAME_GUID		= 1 << 1,
 	VDEV_NAME_FOLLOW_LINKS	= 1 << 2,
 	VDEV_NAME_TYPE_ID	= 1 << 3,
+	VDEV_NAME_ALLOC_BIAS	= 1 << 4	/* top-level only */
 } vdev_name_t;
 
 extern char *zpool_vdev_name(libzfs_handle_t *, zpool_handle_t *, nvlist_t *,

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -26,6 +26,7 @@
  * Copyright 2014 HybridCluster. All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -120,6 +121,12 @@ typedef enum dmu_object_byteswap {
 	((ot) & DMU_OT_METADATA) : \
 	dmu_ot[(int)(ot)].ot_metadata)
 
+#define	DMU_OT_IS_DDT(ot) \
+	((ot) == DMU_OT_DDT_ZAP || (ot) == DMU_OT_DDT_STATS)
+
+#define	DMU_OT_IS_ZIL(ot) \
+	((ot) == DMU_OT_INTENT_LOG)
+
 /*
  * These object types use bp_fill != 1 for their L0 bp's. Therefore they can't
  * have their data embedded (i.e. use a BP_IS_EMBEDDED() bp), because bp_fill
@@ -206,7 +213,7 @@ typedef enum dmu_object_type {
 	 * values.
 	 *
 	 * The DMU_OTN_* types do not have entries in the dmu_ot table,
-	 * use the DMU_OT_IS_METDATA() and DMU_OT_BYTESWAP() macros instead
+	 * use the DMU_OT_IS_METADATA() and DMU_OT_BYTESWAP() macros instead
 	 * of indexing into dmu_ot directly (this works for both DMU_OT_* types
 	 * and DMU_OTN_* types).
 	 */

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -26,6 +26,7 @@
  * Copyright (c) 2013, 2017 Joyent, Inc. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright (c) 2017 Datto Inc.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -224,6 +225,9 @@ typedef enum {
 	ZPOOL_PROP_TNAME,
 	ZPOOL_PROP_MAXDNODESIZE,
 	ZPOOL_PROP_MULTIHOST,
+	ZPOOL_PROP_SEGREGATE_LOG,
+	ZPOOL_PROP_SEGREGATE_SPECIAL,
+	ZPOOL_PROP_SMALLBLKCEILING,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -299,6 +303,7 @@ const char *zpool_prop_to_name(zpool_prop_t);
 const char *zpool_prop_default_string(zpool_prop_t);
 uint64_t zpool_prop_default_numeric(zpool_prop_t);
 boolean_t zpool_prop_readonly(zpool_prop_t);
+boolean_t zpool_prop_setonce(zfs_prop_t);
 boolean_t zpool_prop_feature(const char *);
 boolean_t zpool_prop_unsupported(const char *);
 int zpool_prop_index_to_string(zpool_prop_t, uint64_t, const char **);
@@ -656,6 +661,7 @@ typedef struct zpool_rewind_policy {
 #define	ZPOOL_CONFIG_MMP_TXG		"mmp_txg"	/* not stored on disk */
 #define	ZPOOL_CONFIG_MMP_HOSTNAME	"mmp_hostname"	/* not stored on disk */
 #define	ZPOOL_CONFIG_MMP_HOSTID		"mmp_hostid"	/* not stored on disk */
+#define	ZPOOL_CONFIG_ALLOCATION_BIAS	"alloc_bias"	/* not stored on disk */
 
 /*
  * The persistent vdev state is stored as separate values rather than a single
@@ -692,6 +698,19 @@ typedef struct zpool_rewind_policy {
 #define	VDEV_TYPE_SPARE			"spare"
 #define	VDEV_TYPE_LOG			"log"
 #define	VDEV_TYPE_L2CACHE		"l2cache"
+
+/* vdev metaslab allocation bias */
+#define	VDEV_ALLOC_BIAS_LOG		"log"
+#define	VDEV_ALLOC_BIAS_SPECIAL		"special"
+#define	VDEV_ALLOC_BIAS_SEGREGATE	"segregate"
+
+/* VDEV_TOP_ZAP_* are used in top-level vdev ZAP objects. */
+#define	VDEV_TOP_ZAP_ALLOCATION_BIAS \
+	"com.intel:allocation_bias"
+#define	VDEV_TOP_ZAP_ALLOCATION_BIRTH \
+	"com.intel:allocation_birth"
+#define	VDEV_TOP_ZAP_METASLAB_INFO_OBJ \
+	"com.intel:metaslab_info_obj"
 
 /*
  * This is needed in userland to report the minimum necessary device size.
@@ -881,6 +900,9 @@ typedef struct vdev_stat {
 	uint64_t	vs_scan_processed;	/* scan processed bytes	*/
 	uint64_t	vs_fragmentation;	/* device fragmentation */
 
+	uint64_t	vs_normal_assigned;	/* ms assigned space	*/
+	uint64_t	vs_special_assigned;	/* ms assigned space	*/
+	uint64_t	vs_special_alloc;	/* special allocated	*/
 } vdev_stat_t;
 
 /*

--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_METASLAB_H
@@ -65,6 +66,15 @@ uint64_t metaslab_block_maxsize(metaslab_t *);
 #define	METASLAB_DONT_THROTTLE		0x10
 #define	METASLAB_FASTWRITE		0x20
 
+typedef enum metaslab_block_category {
+	MS_CATEGORY_REGULAR,	/* regular file data */
+	MS_CATEGORY_LOG,	/* log data */
+	MS_CATEGORY_METADATA,	/* metadata */
+	MS_CATEGORY_DEDUP,	/* dedup block */
+	MS_CATEGORY_SMALL	/* small block */
+} metaslab_block_category_t;
+
+
 int metaslab_alloc(spa_t *, metaslab_class_t *, uint64_t,
     blkptr_t *, int, uint64_t, blkptr_t *, int, zio_alloc_list_t *, zio_t *);
 void metaslab_free(spa_t *, const blkptr_t *, uint64_t, boolean_t);
@@ -78,6 +88,9 @@ void metaslab_alloc_trace_fini(void);
 void metaslab_trace_init(zio_alloc_list_t *);
 void metaslab_trace_fini(zio_alloc_list_t *);
 
+void metaslab_class_stat_init(void);
+void metaslab_class_stat_fini(void);
+
 metaslab_class_t *metaslab_class_create(spa_t *, metaslab_ops_t *);
 void metaslab_class_destroy(metaslab_class_t *);
 int metaslab_class_validate(metaslab_class_t *);
@@ -88,8 +101,6 @@ boolean_t metaslab_class_throttle_reserve(metaslab_class_t *, int,
     zio_t *, int);
 void metaslab_class_throttle_unreserve(metaslab_class_t *, int, zio_t *);
 
-void metaslab_class_space_update(metaslab_class_t *, int64_t, int64_t,
-    int64_t, int64_t);
 uint64_t metaslab_class_get_alloc(metaslab_class_t *);
 uint64_t metaslab_class_get_space(metaslab_class_t *);
 uint64_t metaslab_class_get_dspace(metaslab_class_t *);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -27,6 +27,7 @@
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2017 Joyent, Inc.
  * Copyright (c) 2017 Datto Inc.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_SPA_H
@@ -822,6 +823,10 @@ extern uint64_t spa_version(spa_t *spa);
 extern boolean_t spa_deflate(spa_t *spa);
 extern metaslab_class_t *spa_normal_class(spa_t *spa);
 extern metaslab_class_t *spa_log_class(spa_t *spa);
+extern metaslab_class_t *spa_special_class(spa_t *spa);
+extern metaslab_class_t *spa_preferred_class(spa_t *spa, uint64_t size,
+    dmu_object_type_t objtype, int level);
+
 extern void spa_evicting_os_register(spa_t *, objset_t *os);
 extern void spa_evicting_os_deregister(spa_t *, objset_t *os);
 extern void spa_evicting_os_wait(spa_t *spa);
@@ -915,6 +920,7 @@ extern int spa_prop_set(spa_t *spa, nvlist_t *nvp);
 extern int spa_prop_get(spa_t *spa, nvlist_t **nvp);
 extern void spa_prop_clear_bootfs(spa_t *spa, uint64_t obj, dmu_tx_t *tx);
 extern void spa_configfile_set(spa_t *, nvlist_t *, boolean_t);
+extern void spa_sync_smallblk_ceiling(spa_t *spa, dmu_tx_t *tx);
 
 /* asynchronous event notification */
 extern void spa_event_notify(spa_t *spa, vdev_t *vdev, nvlist_t *hist_nvl,

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -26,6 +26,7 @@
  * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2016 Actifio, Inc. All rights reserved.
  * Copyright (c) 2017 Datto Inc.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_SPA_IMPL_H
@@ -148,6 +149,7 @@ struct spa {
 	boolean_t	spa_is_initializing;	/* true while opening pool */
 	metaslab_class_t *spa_normal_class;	/* normal data class */
 	metaslab_class_t *spa_log_class;	/* intent log data class */
+	metaslab_class_t *spa_special_class;	/* special allocation class */
 	uint64_t	spa_first_txg;		/* first txg after spa_open() */
 	uint64_t	spa_final_txg;		/* txg of export/destroy */
 	uint64_t	spa_freeze_txg;		/* freeze pool at this txg */
@@ -247,6 +249,7 @@ struct spa {
 	uint64_t	spa_dedup_ditto;	/* dedup ditto threshold */
 	uint64_t	spa_dedup_checksum;	/* default dedup checksum */
 	uint64_t	spa_dspace;		/* dspace in normal class */
+	uint64_t	spa_smallblk_ceiling;	/* largest block in special */
 	kmutex_t	spa_vdev_top_lock;	/* dueling offline/remove */
 	kmutex_t	spa_proc_lock;		/* protects spa_proc* */
 	kcondvar_t	spa_proc_cv;		/* spa_proc_state transitions */
@@ -254,6 +257,8 @@ struct spa {
 	proc_t		*spa_proc;		/* "zpool-poolname" process */
 	uint64_t	spa_did;		/* if procp != p0, did of t1 */
 	boolean_t	spa_autoreplace;	/* autoreplace set in open */
+	boolean_t	spa_segregate_log;	/* segregate vdev log data */
+	boolean_t	spa_segregate_special;	/* segregate vdev small+meta */
 	int		spa_vdev_locks;		/* locks grabbed */
 	uint64_t	spa_creation_version;	/* version at pool creation */
 	uint64_t	spa_prev_software_version; /* See ub_software_version */

--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _SYS_VDEV_H
@@ -95,8 +96,10 @@ extern void vdev_propagate_state(vdev_t *vd);
 extern void vdev_set_state(vdev_t *vd, boolean_t isopen, vdev_state_t state,
     vdev_aux_t aux);
 
-extern void vdev_space_update(vdev_t *vd,
+extern void vdev_space_update(vdev_t *vd, metaslab_class_t *mc,
     int64_t alloc_delta, int64_t defer_delta, int64_t space_delta);
+
+extern int64_t vdev_deflated_space(vdev_t *vd, int64_t space);
 
 extern uint64_t vdev_psize_to_asize(vdev_t *vd, uint64_t psize);
 

--- a/include/zfeature_common.h
+++ b/include/zfeature_common.h
@@ -23,6 +23,7 @@
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifndef _ZFEATURE_COMMON_H
@@ -57,6 +58,7 @@ typedef enum spa_feature {
 	SPA_FEATURE_SKEIN,
 	SPA_FEATURE_EDONR,
 	SPA_FEATURE_USEROBJ_ACCOUNTING,
+	SPA_FEATURE_ALLOCATION_CLASSES,
 	SPA_FEATURES
 } spa_feature_t;
 

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -25,6 +25,7 @@
  * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  * Copyright (c) 2017 Datto Inc.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <ctype.h>
@@ -504,7 +505,8 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			goto error;
 		}
 
-		if (zpool_prop_readonly(prop)) {
+		if (zpool_prop_readonly(prop) &&
+		    !(flags.create && zpool_prop_setonce(prop))) {
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "'%s' "
 			    "is readonly"), propname);
 			(void) zfs_error(hdl, EZFS_PROPREADONLY, errbuf);
@@ -3559,6 +3561,7 @@ zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
 	uint64_t value;
 	char buf[PATH_BUF_LEN];
 	char tmpbuf[PATH_BUF_LEN];
+	char altbuf[PATH_BUF_LEN];
 
 	env = getenv("ZPOOL_VDEV_NAME_PATH");
 	if (env && (strtoul(env, NULL, 0) > 0 ||
@@ -3667,6 +3670,19 @@ zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
 			(void) snprintf(buf, sizeof (buf), "%s%llu", path,
 			    (u_longlong_t)value);
 			path = buf;
+		}
+
+		/*
+		 * if requested add classes info for top-level vdevs
+		 */
+		if ((name_flags & VDEV_NAME_GUID) == 0 &&
+		    (name_flags & VDEV_NAME_ALLOC_BIAS) &&
+		    nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &type) == 0 &&
+		    strcmp(type, VDEV_ALLOC_BIAS_SEGREGATE) != 0) {
+			(void) snprintf(altbuf, sizeof (altbuf), "%s:%s",
+			    type, path);
+			path = altbuf;
 		}
 
 		/*

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -3658,6 +3658,19 @@ zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
 		    == 0 && value && !(name_flags & VDEV_NAME_PATH)) {
 			return (zfs_strip_partition(path));
 		}
+
+		/*
+		 * if requested add classes info for top-level vdevs
+		 */
+		if ((name_flags & VDEV_NAME_GUID) == 0 &&
+		    (name_flags & VDEV_NAME_ALLOC_BIAS) &&
+		    nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &type) == 0 &&
+		    strcmp(type, VDEV_ALLOC_BIAS_SEGREGATE) != 0) {
+			(void) snprintf(altbuf, sizeof (altbuf), "%s:%s",
+			    type, path);
+			path = altbuf;
+		}
 	} else {
 		verify(nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE, &path) == 0);
 

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <sys/zio.h>
@@ -51,6 +52,8 @@ zpool_prop_get_table(void)
 void
 zpool_prop_init(void)
 {
+	zprop_desc_t *prop_tbl = zpool_prop_get_table();
+
 	static zprop_index_t boolean_table[] = {
 		{ "off",	0},
 		{ "on",		1},
@@ -138,6 +141,18 @@ zpool_prop_init(void)
 	    PROP_ONETIME, ZFS_TYPE_POOL, "TNAME");
 	zprop_register_hidden(ZPOOL_PROP_MAXDNODESIZE, "maxdnodesize",
 	    PROP_TYPE_NUMBER, PROP_READONLY, ZFS_TYPE_POOL, "MAXDNODESIZE");
+	zprop_register_hidden(ZPOOL_PROP_SMALLBLKCEILING, "smallblkceiling",
+	    PROP_TYPE_NUMBER, PROP_ONETIME, ZFS_TYPE_POOL, "SMALLBLKCEILING");
+
+	/* hidden boolean properties */
+	zprop_register_index(ZPOOL_PROP_SEGREGATE_LOG,
+	    "segregate_log", 0, PROP_ONETIME, ZFS_TYPE_POOL, "on",
+	    "SEGREGATE_LOG", boolean_table);
+	prop_tbl[ZPOOL_PROP_SEGREGATE_LOG].pd_visible = B_FALSE;
+	zprop_register_index(ZPOOL_PROP_SEGREGATE_SPECIAL,
+	    "segregate_special", 0, PROP_ONETIME, ZFS_TYPE_POOL, "on",
+	    "SEGREGATE_SPECIAL", boolean_table);
+	prop_tbl[ZPOOL_PROP_SEGREGATE_SPECIAL].pd_visible = B_FALSE;
 }
 
 /*
@@ -168,7 +183,18 @@ zpool_prop_get_type(zpool_prop_t prop)
 boolean_t
 zpool_prop_readonly(zpool_prop_t prop)
 {
-	return (zpool_prop_table[prop].pd_attr == PROP_READONLY);
+
+	return (zpool_prop_table[prop].pd_attr == PROP_READONLY ||
+	    zpool_prop_table[prop].pd_attr == PROP_ONETIME);
+}
+
+/*
+ * Returns TRUE if the property is only allowed to be set once.
+ */
+boolean_t
+zpool_prop_setonce(zfs_prop_t prop)
+{
+	return (zpool_prop_table[prop].pd_attr == PROP_ONETIME);
 }
 
 const char *

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2994,7 +2994,7 @@ arc_hdr_l2hdr_destroy(arc_buf_hdr_t *hdr)
 	ARCSTAT_INCR(arcstat_l2_psize, -psize);
 	ARCSTAT_INCR(arcstat_l2_lsize, -HDR_GET_LSIZE(hdr));
 
-	vdev_space_update(dev->l2ad_vdev, -psize, 0, 0);
+	vdev_space_update(dev->l2ad_vdev, NULL, -psize, 0, 0);
 
 	(void) refcount_remove_many(&dev->l2ad_alloc, psize, hdr);
 	arc_hdr_clear_flags(hdr, ARC_FLAG_HAS_L2HDR);
@@ -7030,7 +7030,7 @@ top:
 	kmem_cache_free(hdr_l2only_cache, head);
 	mutex_exit(&dev->l2ad_mtx);
 
-	vdev_space_update(dev->l2ad_vdev, -bytes_dropped, 0, 0);
+	vdev_space_update(dev->l2ad_vdev, NULL, -bytes_dropped, 0, 0);
 
 	l2arc_do_free_on_write();
 
@@ -7498,7 +7498,7 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
 	ARCSTAT_INCR(arcstat_l2_write_bytes, write_psize);
 	ARCSTAT_INCR(arcstat_l2_lsize, write_lsize);
 	ARCSTAT_INCR(arcstat_l2_psize, write_psize);
-	vdev_space_update(dev->l2ad_vdev, write_psize, 0, 0);
+	vdev_space_update(dev->l2ad_vdev, NULL, write_psize, 0, 0);
 
 	/*
 	 * Bump device hand to the device start if it is approaching the end.
@@ -7664,7 +7664,7 @@ l2arc_add_vdev(spa_t *spa, vdev_t *vd)
 	list_create(&adddev->l2ad_buflist, sizeof (arc_buf_hdr_t),
 	    offsetof(arc_buf_hdr_t, b_l2hdr.b_l2node));
 
-	vdev_space_update(vd, 0, 0, adddev->l2ad_end - adddev->l2ad_hand);
+	vdev_space_update(vd, NULL, 0, 0, adddev->l2ad_end - adddev->l2ad_hand);
 	refcount_create(&adddev->l2ad_alloc);
 
 	/*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -31,6 +31,7 @@
  * Copyright (c) 2016 Actifio, Inc. All rights reserved.
  * Copyright (c) 2017 Datto Inc.
  * Copyright 2017 Joyent, Inc.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 /*
@@ -218,8 +219,12 @@ spa_prop_get_config(spa_t *spa, nvlist_t **nvp)
 	ASSERT(MUTEX_HELD(&spa->spa_props_lock));
 
 	if (rvd != NULL) {
-		alloc = metaslab_class_get_alloc(spa_normal_class(spa));
-		size = metaslab_class_get_space(spa_normal_class(spa));
+		alloc = metaslab_class_get_alloc(mc);
+		alloc += metaslab_class_get_alloc(spa_special_class(spa));
+
+		size = metaslab_class_get_space(mc);
+		size += metaslab_class_get_space(spa_special_class(spa));
+
 		spa_prop_add_list(*nvp, ZPOOL_PROP_NAME, spa_name(spa), 0, src);
 		spa_prop_add_list(*nvp, ZPOOL_PROP_SIZE, NULL, size, src);
 		spa_prop_add_list(*nvp, ZPOOL_PROP_ALLOCATED, NULL, alloc, src);
@@ -500,6 +505,14 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 			if (!error && !spa_get_hostid())
 				error = SET_ERROR(ENOTSUP);
 
+			break;
+
+		case ZPOOL_PROP_SEGREGATE_LOG:
+		case ZPOOL_PROP_SEGREGATE_SPECIAL:
+			/* set-once that can only be enabled */
+			error = nvpair_value_uint64(elem, &intval);
+			if (!error && intval != 1)
+				error = SET_ERROR(EINVAL);
 			break;
 
 		case ZPOOL_PROP_BOOTFS:
@@ -1111,6 +1124,7 @@ spa_activate(spa_t *spa, int mode)
 
 	spa->spa_normal_class = metaslab_class_create(spa, zfs_metaslab_ops);
 	spa->spa_log_class = metaslab_class_create(spa, zfs_metaslab_ops);
+	spa->spa_special_class = metaslab_class_create(spa, zfs_metaslab_ops);
 
 	/* Try to create a covering process */
 	mutex_enter(&spa->spa_proc_lock);
@@ -1236,6 +1250,9 @@ spa_deactivate(spa_t *spa)
 	metaslab_class_destroy(spa->spa_log_class);
 	spa->spa_log_class = NULL;
 
+	metaslab_class_destroy(spa->spa_special_class);
+	spa->spa_special_class = NULL;
+
 	/*
 	 * If this was part of an import or the open otherwise failed, we may
 	 * still have errors left in the queues.  Empty them just in case.
@@ -1359,6 +1376,19 @@ spa_unload(spa_t *spa)
 
 	if (spa->spa_mmp.mmp_thread)
 		mmp_thread_stop(spa);
+
+	/*
+	 * Even though vdev_free() also calls vdev_metaslab_fini, we need
+	 * to call it earlier, before we wait for async i/o to complete.
+	 * This ensures that there is no async metaslab prefetching, by
+	 * calling taskq_wait(mg_taskq).
+	 */
+	if (spa->spa_root_vdev != NULL) {
+		spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
+		for (c = 0; c < spa->spa_root_vdev->vdev_children; c++)
+			vdev_metaslab_fini(spa->spa_root_vdev->vdev_child[c]);
+		spa_config_exit(spa, SCL_ALL, FTAG);
+	}
 
 	/*
 	 * Wait for any outstanding async I/O to complete.
@@ -2338,6 +2368,50 @@ vdev_count_verify_zaps(vdev_t *vd)
 #endif
 
 /*
+ * Transfer the vdev top zap keys from mos-config into config
+ */
+static void
+spa_config_transfer_topzap(nvlist_t *config, nvlist_t *mos)
+{
+	nvlist_t *ctree, *mtree;
+	nvlist_t **c_child, **m_child;
+	uint_t c, c_max, m_max, count;
+
+	if (!nvlist_exists(mos, ZPOOL_CONFIG_HAS_PER_VDEV_ZAPS))
+		return;
+
+	VERIFY0(nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE, &ctree));
+	VERIFY0(nvlist_lookup_nvlist(mos, ZPOOL_CONFIG_VDEV_TREE, &mtree));
+
+	/*
+	 * scan through all the top level vdevs to transfer top zap
+	 */
+	if (nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE, &ctree) != 0 ||
+	    nvlist_lookup_nvlist_array(ctree, ZPOOL_CONFIG_CHILDREN, &c_child,
+	    &c_max) != 0) {
+		return;
+	}
+	if (nvlist_lookup_nvlist(mos, ZPOOL_CONFIG_VDEV_TREE, &mtree) != 0 ||
+	    nvlist_lookup_nvlist_array(mtree, ZPOOL_CONFIG_CHILDREN, &m_child,
+	    &m_max) != 0) {
+		return;
+	}
+	count = MIN(c_max, m_max);
+
+	for (c = 0; c < count; c++) {
+		uint64_t top_zap;
+
+		/* transfer missing top zap */
+		if (nvlist_lookup_uint64(m_child[c], ZPOOL_CONFIG_VDEV_TOP_ZAP,
+		    &top_zap) == 0) {
+			VERIFY0(nvlist_add_uint64(c_child[c],
+			    ZPOOL_CONFIG_VDEV_TOP_ZAP, top_zap));
+		}
+	}
+	fnvlist_add_boolean(config, ZPOOL_CONFIG_HAS_PER_VDEV_ZAPS);
+}
+
+/*
  * Determine whether the activity check is required.
  */
 static boolean_t
@@ -2526,6 +2600,32 @@ out:
 		nvlist_free(mmp_label);
 
 	return (error);
+}
+
+void
+spa_segregated_prop_get(spa_t *spa, nvlist_t *props)
+{
+	uint64_t segregate_log = 0;
+	uint64_t segregate_special = 0;
+
+	if (props != NULL) {
+		/* Create case is passed as a property */
+		(void) nvlist_lookup_uint64(props,
+		    zpool_prop_to_name(ZPOOL_PROP_SEGREGATE_LOG),
+		    &segregate_log);
+		(void) nvlist_lookup_uint64(props,
+		    zpool_prop_to_name(ZPOOL_PROP_SEGREGATE_SPECIAL),
+		    &segregate_special);
+	} else {
+		/* Import case comes from property zap */
+		spa_prop_find(spa, ZPOOL_PROP_SEGREGATE_LOG,
+		    &segregate_log);
+		spa_prop_find(spa, ZPOOL_PROP_SEGREGATE_SPECIAL,
+		    &segregate_special);
+	}
+
+	spa->spa_segregate_log = (segregate_log == 1);
+	spa->spa_segregate_special = (segregate_special == 1);
 }
 
 /*
@@ -2917,6 +3017,37 @@ spa_load_impl(spa_t *spa, uint64_t pool_guid, nvlist_t *config,
 		spa_activate(spa, orig_mode);
 
 		return (spa_load(spa, state, SPA_IMPORT_EXISTING, B_TRUE));
+
+	} else if (!nvlist_exists(config, ZPOOL_CONFIG_HAS_PER_VDEV_ZAPS)) {
+		/*
+		 * The current config is missing vdev zaps. The top vdev
+		 * zap is required before vdev metaslabs are initialized
+		 * for both dRAID and the special allocation class.
+		 *
+		 * Note that we cannot just replace the config with the
+		 * mos config since the passed in config may also contain
+		 * vdev path updates that need to be picked up.
+		 */
+		nvlist_t *mos;
+
+		if (load_nvlist(spa, spa->spa_config_object, &mos) == 0) {
+			if (nvlist_exists(mos,
+			    ZPOOL_CONFIG_HAS_PER_VDEV_ZAPS)) {
+				spa_config_transfer_topzap(config, mos);
+				nvlist_free(mos);
+
+				spa_unload(spa);
+				spa_deactivate(spa);
+				spa_activate(spa, orig_mode);
+
+				error = spa_load(spa, state,
+				    SPA_IMPORT_EXISTING, B_TRUE);
+				if (error == 0)
+					spa_async_suspend(spa);
+				return (error);
+			}
+			nvlist_free(mos);
+		}
 	}
 
 	/* Grab the checksum salt from the MOS. */
@@ -3073,6 +3204,10 @@ spa_load_impl(spa_t *spa, uint64_t pool_guid, nvlist_t *config,
 		    &spa->spa_dedup_ditto);
 
 		spa->spa_autoreplace = (autoreplace != 0);
+
+		spa_segregated_prop_get(spa, NULL);
+		spa_prop_find(spa, ZPOOL_PROP_SMALLBLKCEILING,
+		    &spa->spa_smallblk_ceiling);
 	}
 
 	/*
@@ -3996,7 +4131,8 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	char *poolname;
 	nvlist_t *nvl;
 
-	if (nvlist_lookup_string(props, "tname", &poolname) != 0)
+	if (props == NULL ||
+	    nvlist_lookup_string(props, "tname", &poolname) != 0)
 		poolname = (char *)pool;
 
 	/*
@@ -4045,6 +4181,13 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	}
 	ASSERT(SPA_VERSION_IS_SUPPORTED(version));
 
+	/* examine segregation props before instantiating vdevs */
+	if (props != NULL)
+		spa_segregated_prop_get(spa, props);
+
+	if (spa->spa_segregate_special)
+		spa->spa_smallblk_ceiling = MS_SPECIAL_SMALLBLK_CEILING;
+
 	spa->spa_first_txg = txg;
 	spa->spa_uberblock.ub_txg = txg - 1;
 	spa->spa_uberblock.ub_version = version;
@@ -4080,8 +4223,10 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	    (error = spa_validate_aux(spa, nvroot, txg,
 	    VDEV_ALLOC_ADD)) == 0) {
 		for (c = 0; c < rvd->vdev_children; c++) {
-			vdev_metaslab_set_size(rvd->vdev_child[c]);
-			vdev_expand(rvd->vdev_child[c], txg);
+			vdev_t *vd = rvd->vdev_child[c];
+
+			vdev_metaslab_set_size(vd);
+			vdev_expand(vd, txg);
 		}
 	}
 
@@ -4211,6 +4356,15 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	if (props != NULL) {
 		spa_configfile_set(spa, props, B_FALSE);
 		spa_sync_props(props, tx);
+	}
+
+	/*
+	 * Set-once segregate properties activate the segregated vdev feature
+	 */
+	if ((spa->spa_segregate_log || spa->spa_segregate_special) &&
+	    spa_feature_is_enabled(spa, SPA_FEATURE_ALLOCATION_CLASSES)) {
+		spa_feature_incr(spa, SPA_FEATURE_ALLOCATION_CLASSES, tx);
+		spa_sync_smallblk_ceiling(spa, tx);
 	}
 
 	dmu_tx_commit(tx);
@@ -5071,6 +5225,14 @@ spa_vdev_detach(spa_t *spa, uint64_t guid, uint64_t pguid, int replace_done)
 	ASSERT(pvd->vdev_children >= 2);
 
 	/*
+	 * If dedicated class, then it must remain mirrored
+	 */
+	if (pvd->vdev_alloc_bias == VDEV_BIAS_SPECIAL) {
+		if (pvd->vdev_children <= 2) {
+			return (spa_vdev_exit(spa, NULL, txg, ENOTSUP));
+		}
+	}
+	/*
 	 * If we are detaching the second disk from a replacing vdev, then
 	 * check to see if we changed the original vdev's path to have "/old"
 	 * at the end in spa_vdev_attach().  If so, undo that change now.
@@ -5310,6 +5472,7 @@ spa_vdev_split_mirror(spa_t *spa, char *newname, nvlist_t *config,
 	/* then, loop over each vdev and validate it */
 	for (c = 0; c < children; c++) {
 		uint64_t is_hole = 0;
+		vdev_alloc_bias_t alloc_bias;
 
 		(void) nvlist_lookup_uint64(child[c], ZPOOL_CONFIG_IS_HOLE,
 		    &is_hole);
@@ -5322,6 +5485,15 @@ spa_vdev_split_mirror(spa_t *spa, char *newname, nvlist_t *config,
 				error = SET_ERROR(EINVAL);
 				break;
 			}
+		}
+
+		/* disallow splitting for allocation classes */
+		alloc_bias = spa->spa_root_vdev->vdev_child[c]->vdev_alloc_bias;
+		if (alloc_bias == VDEV_BIAS_SPECIAL) {
+			cmn_err(CE_NOTE, "%s pool split with allocation "
+			    "classes not allowed", spa_name(spa));
+			error = SET_ERROR(EINVAL);
+			break;
 		}
 
 		/* which disk is going to be split? */
@@ -6087,8 +6259,12 @@ spa_async_thread(spa_t *spa)
 
 		mutex_enter(&spa_namespace_lock);
 		old_space = metaslab_class_get_space(spa_normal_class(spa));
+		old_space += metaslab_class_get_space(spa_special_class(spa));
+
 		spa_config_update(spa, SPA_CONFIG_UPDATE_POOL);
+
 		new_space = metaslab_class_get_space(spa_normal_class(spa));
+		new_space += metaslab_class_get_space(spa_special_class(spa));
 		mutex_exit(&spa_namespace_lock);
 
 		/*
@@ -6641,6 +6817,23 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 	}
 
 	mutex_exit(&spa->spa_props_lock);
+}
+
+/*
+ * Save off the small block ceiling required for special class
+ */
+void
+spa_sync_smallblk_ceiling(spa_t *spa, dmu_tx_t *tx)
+{
+	ASSERT(spa->spa_smallblk_ceiling != 0);
+
+	/* Save off the small block ceiling we'll be using */
+	nvlist_t *ceiling = fnvlist_alloc();
+	fnvlist_add_uint64(ceiling,
+	    zpool_prop_to_name(ZPOOL_PROP_SMALLBLKCEILING),
+	    spa->spa_smallblk_ceiling);
+	spa_sync_props(ceiling, tx);
+	nvlist_free(ceiling);
 }
 
 /*

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -5225,14 +5225,6 @@ spa_vdev_detach(spa_t *spa, uint64_t guid, uint64_t pguid, int replace_done)
 	ASSERT(pvd->vdev_children >= 2);
 
 	/*
-	 * If dedicated class, then it must remain mirrored
-	 */
-	if (pvd->vdev_alloc_bias == VDEV_BIAS_SPECIAL) {
-		if (pvd->vdev_children <= 2) {
-			return (spa_vdev_exit(spa, NULL, txg, ENOTSUP));
-		}
-	}
-	/*
 	 * If we are detaching the second disk from a replacing vdev, then
 	 * check to see if we changed the original vdev's path to have "/old"
 	 * at the end in spa_vdev_attach().  If so, undo that change now.
@@ -5472,7 +5464,6 @@ spa_vdev_split_mirror(spa_t *spa, char *newname, nvlist_t *config,
 	/* then, loop over each vdev and validate it */
 	for (c = 0; c < children; c++) {
 		uint64_t is_hole = 0;
-		vdev_alloc_bias_t alloc_bias;
 
 		(void) nvlist_lookup_uint64(child[c], ZPOOL_CONFIG_IS_HOLE,
 		    &is_hole);
@@ -5485,15 +5476,6 @@ spa_vdev_split_mirror(spa_t *spa, char *newname, nvlist_t *config,
 				error = SET_ERROR(EINVAL);
 				break;
 			}
-		}
-
-		/* disallow splitting for allocation classes */
-		alloc_bias = spa->spa_root_vdev->vdev_child[c]->vdev_alloc_bias;
-		if (alloc_bias == VDEV_BIAS_SPECIAL) {
-			cmn_err(CE_NOTE, "%s pool split with allocation "
-			    "classes not allowed", spa_name(spa));
-			error = SET_ERROR(EINVAL);
-			break;
 		}
 
 		/* which disk is going to be split? */

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -513,11 +513,6 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 
 		if (nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
 		    &bias) == 0) {
-			/* dedicated vdevs are expected to be mirrored */
-			if (ops != &vdev_mirror_ops && strcmp(bias,
-			    VDEV_ALLOC_BIAS_LOG) != 0) {
-				return (SET_ERROR(ENOTSUP));
-			}
 			alloc_bias = vdev_derive_alloc_bias(bias);
 
 			/* Disallow a dedicated bias if already segregating */

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Toomas Soome <tsoome@me.com>
  * Copyright 2017 Joyent, Inc.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <sys/zfs_context.h>
@@ -86,6 +87,25 @@ vdev_getops(const char *type)
 			break;
 
 	return (ops);
+}
+
+/*
+ * Derive the enumerated alloction bias from string input.
+ * String origin is either the per-vdev zap or zpool(1M).
+ */
+static vdev_alloc_bias_t
+vdev_derive_alloc_bias(const char *bias)
+{
+	vdev_alloc_bias_t alloc_bias = VDEV_BIAS_NONE;
+
+	if (strcmp(bias, VDEV_ALLOC_BIAS_LOG) == 0)
+		alloc_bias = VDEV_BIAS_LOG;
+	else if (strcmp(bias, VDEV_ALLOC_BIAS_SPECIAL) == 0)
+		alloc_bias = VDEV_BIAS_SPECIAL;
+	else if (strcmp(bias, VDEV_ALLOC_BIAS_SEGREGATE) == 0)
+		alloc_bias = VDEV_BIAS_SEGREGATE;
+
+	return (alloc_bias);
 }
 
 /*
@@ -397,6 +417,8 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	vdev_t *vd;
 	char *tmp = NULL;
 	int rc;
+	vdev_alloc_bias_t alloc_bias = VDEV_BIAS_NONE;
+	boolean_t top_level = (parent && !parent->vdev_parent);
 
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
 
@@ -483,10 +505,58 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	}
 	ASSERT(nparity != -1ULL);
 
+	/*
+	 * If creating a top-level vdev, check for allocation classes input
+	 */
+	if (top_level && alloctype == VDEV_ALLOC_ADD) {
+		char *bias;
+
+		if (nvlist_lookup_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &bias) == 0) {
+			/* dedicated vdevs are expected to be mirrored */
+			if (ops != &vdev_mirror_ops && strcmp(bias,
+			    VDEV_ALLOC_BIAS_LOG) != 0) {
+				return (SET_ERROR(ENOTSUP));
+			}
+			alloc_bias = vdev_derive_alloc_bias(bias);
+
+			/* Disallow a dedicated bias if already segregating */
+			if ((alloc_bias == VDEV_BIAS_LOG &&
+			    spa->spa_segregate_log) ||
+			    (alloc_bias == VDEV_BIAS_SPECIAL &&
+			    spa->spa_segregate_special)) {
+				return (SET_ERROR(EINVAL));
+			}
+			/* spa_vdev_add() expects feature to be enabled */
+			if (spa->spa_load_state != SPA_LOAD_CREATE &&
+			    !spa_feature_is_enabled(spa,
+			    SPA_FEATURE_ALLOCATION_CLASSES)) {
+				cmn_err(CE_WARN, "pool '%s' adding a %s class "
+				    "VDEV requires feature@allocation_classes",
+				    spa_name(spa), bias);
+				return (SET_ERROR(EINVAL));
+			}
+			if (alloc_bias == VDEV_BIAS_SPECIAL &&
+			    spa->spa_smallblk_ceiling == 0) {
+				spa->spa_smallblk_ceiling =
+				    MS_SPECIAL_SMALLBLK_CEILING;
+			}
+		}
+
+		if (alloc_bias == VDEV_BIAS_NONE && !islog) {
+			if (spa->spa_segregate_log ||
+			    spa->spa_segregate_special) {
+				alloc_bias = VDEV_BIAS_SEGREGATE;
+			}
+		}
+	}
+
 	vd = vdev_alloc_common(spa, id, guid, ops);
 
 	vd->vdev_islog = islog;
 	vd->vdev_nparity = nparity;
+	if (top_level && alloc_bias != VDEV_BIAS_NONE)
+		vd->vdev_alloc_bias = alloc_bias;
 
 	if (nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &vd->vdev_path) == 0)
 		vd->vdev_path = spa_strdup(vd->vdev_path);
@@ -545,7 +615,7 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	/*
 	 * If we're a top-level vdev, try to load the allocation parameters.
 	 */
-	if (parent && !parent->vdev_parent &&
+	if (top_level &&
 	    (alloctype == VDEV_ALLOC_LOAD || alloctype == VDEV_ALLOC_SPLIT)) {
 		(void) nvlist_lookup_uint64(nv, ZPOOL_CONFIG_METASLAB_ARRAY,
 		    &vd->vdev_ms_array);
@@ -561,13 +631,12 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 		ASSERT0(vd->vdev_top_zap);
 	}
 
-	if (parent && !parent->vdev_parent && alloctype != VDEV_ALLOC_ATTACH) {
+	if (top_level && alloctype != VDEV_ALLOC_ATTACH) {
 		ASSERT(alloctype == VDEV_ALLOC_LOAD ||
 		    alloctype == VDEV_ALLOC_ADD ||
 		    alloctype == VDEV_ALLOC_SPLIT ||
 		    alloctype == VDEV_ALLOC_ROOTPOOL);
-		vd->vdev_mg = metaslab_group_create(islog ?
-		    spa_log_class(spa) : spa_normal_class(spa), vd);
+		/* Note: metaslab_group_create() is now deferred */
 	}
 
 	if (vd->vdev_ops->vdev_op_leaf &&
@@ -678,6 +747,10 @@ vdev_free(vdev_t *vd)
 	if (vd->vdev_mg != NULL) {
 		vdev_metaslab_fini(vd);
 		metaslab_group_destroy(vd->vdev_mg);
+		if (vd->vdev_log_mg != NULL)
+			metaslab_group_destroy(vd->vdev_log_mg);
+		if (vd->vdev_special_mg != NULL)
+			metaslab_group_destroy(vd->vdev_special_mg);
 	}
 
 	ASSERT0(vd->vdev_stat.vs_space);
@@ -706,7 +779,6 @@ vdev_free(vdev_t *vd)
 
 	if (vd->vdev_enc_sysfs_path)
 		spa_strfree(vd->vdev_enc_sysfs_path);
-
 	if (vd->vdev_fru)
 		spa_strfree(vd->vdev_fru);
 
@@ -757,23 +829,38 @@ vdev_top_transfer(vdev_t *svd, vdev_t *tvd)
 	tvd->vdev_ms_array = svd->vdev_ms_array;
 	tvd->vdev_ms_shift = svd->vdev_ms_shift;
 	tvd->vdev_ms_count = svd->vdev_ms_count;
+	tvd->vdev_ms_extra = svd->vdev_ms_extra;
 	tvd->vdev_top_zap = svd->vdev_top_zap;
 
 	svd->vdev_ms_array = 0;
 	svd->vdev_ms_shift = 0;
 	svd->vdev_ms_count = 0;
+	svd->vdev_ms_extra = 0;
 	svd->vdev_top_zap = 0;
 
 	if (tvd->vdev_mg)
 		ASSERT3P(tvd->vdev_mg, ==, svd->vdev_mg);
 	tvd->vdev_mg = svd->vdev_mg;
+	tvd->vdev_log_mg = svd->vdev_log_mg;
+	tvd->vdev_special_mg = svd->vdev_special_mg;
 	tvd->vdev_ms = svd->vdev_ms;
 
 	svd->vdev_mg = NULL;
+	svd->vdev_log_mg = NULL;
+	svd->vdev_special_mg = NULL;
 	svd->vdev_ms = NULL;
 
 	if (tvd->vdev_mg != NULL)
 		tvd->vdev_mg->mg_vd = tvd;
+	if (tvd->vdev_log_mg != NULL)
+		tvd->vdev_log_mg->mg_vd = tvd;
+	if (tvd->vdev_special_mg != NULL)
+		tvd->vdev_special_mg->mg_vd = tvd;
+
+	tvd->vdev_alloc_bias = svd->vdev_alloc_bias;
+	tvd->vdev_alloc_bias_birth = svd->vdev_alloc_bias_birth;
+	svd->vdev_alloc_bias = VDEV_BIAS_NONE;
+	svd->vdev_alloc_bias_birth = 0;
 
 	tvd->vdev_stat.vs_alloc = svd->vdev_stat.vs_alloc;
 	tvd->vdev_stat.vs_space = svd->vdev_stat.vs_space;
@@ -910,6 +997,63 @@ vdev_remove_parent(vdev_t *cvd)
 	vdev_free(mvd);
 }
 
+static void
+vdev_metaslab_group_create(vdev_t *vd)
+{
+	spa_t *spa = vd->vdev_spa;
+
+	/*
+	 * metaslab_group_create was delayed until allocation bias was available
+	 */
+	if (vd->vdev_mg == NULL) {
+		metaslab_class_t *mc;
+
+		if (vd->vdev_islog && vd->vdev_alloc_bias == VDEV_BIAS_NONE)
+			vd->vdev_alloc_bias = VDEV_BIAS_LOG;
+
+		ASSERT3U(vd->vdev_islog, ==,
+		    (vd->vdev_alloc_bias == VDEV_BIAS_LOG));
+
+		switch (vd->vdev_alloc_bias) {
+		case VDEV_BIAS_LOG:
+			mc = spa_log_class(spa);
+			break;
+		case VDEV_BIAS_SPECIAL:
+			mc = spa_special_class(spa);
+			break;
+		case VDEV_BIAS_SEGREGATE:
+			/* Segregate allocations into multiple groups */
+			if (spa->spa_segregate_log) {
+				vd->vdev_log_mg = metaslab_group_create(
+				    spa_log_class(spa), vd);
+			}
+			if (spa->spa_segregate_special) {
+				vd->vdev_special_mg = metaslab_group_create(
+				    spa_special_class(spa), vd);
+			}
+			mc = spa_normal_class(spa);
+			break;
+		default:
+			mc = spa_normal_class(spa);
+		}
+
+		vd->vdev_mg = metaslab_group_create(mc, vd);
+
+		/*
+		 * The spa ashift values currently only reflect the
+		 * general vdev classes. Class destination is late
+		 * binding so ashift checking had to wait until now
+		 */
+		if (vd->vdev_top == vd && vd->vdev_ashift != 0 &&
+		    mc == spa_normal_class(spa) && vd->vdev_aux == NULL) {
+			if (vd->vdev_ashift > spa->spa_max_ashift)
+				spa->spa_max_ashift = vd->vdev_ashift;
+			if (vd->vdev_ashift < spa->spa_min_ashift)
+				spa->spa_min_ashift = vd->vdev_ashift;
+		}
+	}
+}
+
 int
 vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 {
@@ -920,6 +1064,7 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 	uint64_t newc = vd->vdev_asize >> vd->vdev_ms_shift;
 	metaslab_t **mspp;
 	int error;
+	boolean_t expanding = (oldc != 0);
 
 	ASSERT(txg == 0 || spa_config_held(spa, SCL_ALLOC, RW_WRITER));
 
@@ -930,6 +1075,11 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 		return (0);
 
 	ASSERT(!vd->vdev_ishole);
+
+	if (vd->vdev_alloc_bias > VDEV_BIAS_LOG &&
+	    vd->vdev_alloc_bias_birth == 0) {
+		vd->vdev_alloc_bias_birth = txg;
+	}
 
 	/*
 	 * Compute the raidz-deflation ratio.  Note, we hard-code
@@ -944,7 +1094,7 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 
 	mspp = vmem_zalloc(newc * sizeof (*mspp), KM_SLEEP);
 
-	if (oldc != 0) {
+	if (expanding) {
 		bcopy(vd->vdev_ms, mspp, oldc * sizeof (*mspp));
 		vmem_free(vd->vdev_ms, oldc * sizeof (*mspp));
 	}
@@ -954,6 +1104,7 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 
 	for (m = oldc; m < newc; m++) {
 		uint64_t object = 0;
+		metaslab_group_t *mg = vd->vdev_mg;
 
 		if (txg == 0) {
 			error = dmu_read(mos, vd->vdev_ms_array,
@@ -961,12 +1112,35 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 			    DMU_READ_PREFETCH);
 			if (error)
 				return (error);
+
+			/*
+			 * Segregated vdevs only instantiate assigned metaslabs
+			 * in the first pass over the metaslab array.
+			 */
+			if (vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE &&
+			    !expanding && object == 0)
+				continue;
 		}
 
-		error = metaslab_init(vd->vdev_mg, m, object, txg,
-		    &(vd->vdev_ms[m]));
+		error = metaslab_init(mg, m, object, txg, &(vd->vdev_ms[m]));
 		if (error)
 			return (error);
+	}
+
+	/*
+	 * Segregated vdevs take a second pass which now has activation context
+	 */
+	if (vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE && !expanding) {
+		for (m = oldc; m < newc; m++) {
+			metaslab_group_t *mg = vd->vdev_mg;
+
+			if (vd->vdev_ms[m] != NULL)
+				continue;
+
+			error = metaslab_init(mg, m, 0, txg, &(vd->vdev_ms[m]));
+			if (error)
+				return (error);
+		}
 	}
 
 	if (txg == 0)
@@ -977,8 +1151,13 @@ vdev_metaslab_init(vdev_t *vd, uint64_t txg)
 	 * the metaslabs since we want to ensure that no new
 	 * allocations are performed on this device.
 	 */
-	if (oldc == 0 && !vd->vdev_removing)
+	if (!expanding && !vd->vdev_removing) {
 		metaslab_group_activate(vd->vdev_mg);
+		if (vd->vdev_log_mg)
+			metaslab_group_activate(vd->vdev_log_mg);
+		if (vd->vdev_special_mg)
+			metaslab_group_activate(vd->vdev_special_mg);
+	}
 
 	if (txg == 0)
 		spa_config_exit(spa, SCL_ALLOC, FTAG);
@@ -994,6 +1173,11 @@ vdev_metaslab_fini(vdev_t *vd)
 
 	if (vd->vdev_ms != NULL) {
 		metaslab_group_passivate(vd->vdev_mg);
+		if (vd->vdev_log_mg != NULL)
+			metaslab_group_passivate(vd->vdev_log_mg);
+		if (vd->vdev_special_mg != NULL)
+			metaslab_group_passivate(vd->vdev_special_mg);
+
 		for (m = 0; m < count; m++) {
 			metaslab_t *msp = vd->vdev_ms[m];
 
@@ -1436,9 +1620,14 @@ vdev_open(vdev_t *vd)
 
 	/*
 	 * Track the min and max ashift values for normal data devices.
+	 *
+	 * DJB - TBD these should perhaps be tracked per allocation class
+	 * (e.g. spa_min_ashift is used to round up post compression buffers)
 	 */
 	if (vd->vdev_top == vd && vd->vdev_ashift != 0 &&
-	    !vd->vdev_islog && vd->vdev_aux == NULL) {
+	    (vd->vdev_alloc_bias == VDEV_BIAS_NONE ||
+	    vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE) &&
+	    vd->vdev_aux == NULL) {
 		if (vd->vdev_ashift > spa->spa_max_ashift)
 			spa->spa_max_ashift = vd->vdev_ashift;
 		if (vd->vdev_ashift < spa->spa_min_ashift)
@@ -1724,8 +1913,11 @@ vdev_metaslab_set_size(vdev_t *vd)
 	/*
 	 * Aim for roughly metaslabs_per_vdev (default 200) metaslabs per vdev.
 	 */
+	uint64_t min_shift = (vd->vdev_nparity > 0) ? SPA_MAXBLOCKSHIFT + 2 :
+	    SPA_MAXBLOCKSHIFT;
+
 	vd->vdev_ms_shift = highbit64(vd->vdev_asize / metaslabs_per_vdev);
-	vd->vdev_ms_shift = MAX(vd->vdev_ms_shift, SPA_MAXBLOCKSHIFT);
+	vd->vdev_ms_shift = MAX(vd->vdev_ms_shift, min_shift);
 }
 
 void
@@ -2087,6 +2279,36 @@ vdev_dtl_load(vdev_t *vd)
 	return (error);
 }
 
+static void
+vdev_zap_add_allocation_bias(vdev_t *vd, dmu_tx_t *tx)
+{
+	spa_t *spa = vd->vdev_spa;
+	objset_t *mos = spa->spa_meta_objset;
+	vdev_alloc_bias_t alloc_bias = vd->vdev_alloc_bias;
+	const char *string;
+
+	ASSERT(alloc_bias != VDEV_BIAS_NONE);
+
+	string =
+	    (alloc_bias == VDEV_BIAS_LOG) ? VDEV_ALLOC_BIAS_LOG :
+	    (alloc_bias == VDEV_BIAS_SPECIAL) ? VDEV_ALLOC_BIAS_SPECIAL :
+	    (alloc_bias == VDEV_BIAS_SEGREGATE) ? VDEV_ALLOC_BIAS_SEGREGATE :
+	    NULL;
+
+	ASSERT(string != NULL);
+	VERIFY0(zap_add(mos, vd->vdev_top_zap, VDEV_TOP_ZAP_ALLOCATION_BIAS,
+	    1, strlen(string) + 1, string, tx));
+
+	if (alloc_bias != VDEV_BIAS_LOG) {
+		ASSERT(spa_feature_is_enabled(spa,
+		    SPA_FEATURE_ALLOCATION_CLASSES));
+		if (alloc_bias == VDEV_BIAS_SPECIAL &&
+		    !spa_feature_is_active(spa, SPA_FEATURE_ALLOCATION_CLASSES))
+			spa_sync_smallblk_ceiling(spa, tx);
+		spa_feature_incr(spa, SPA_FEATURE_ALLOCATION_CLASSES, tx);
+	}
+}
+
 void
 vdev_destroy_unlink_zap(vdev_t *vd, uint64_t zapobj, dmu_tx_t *tx)
 {
@@ -2125,8 +2347,11 @@ vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx)
 		}
 		if (vd == vd->vdev_top && vd->vdev_top_zap == 0) {
 			vd->vdev_top_zap = vdev_create_link_zap(vd, tx);
+			if (vd->vdev_alloc_bias != VDEV_BIAS_NONE)
+				vdev_zap_add_allocation_bias(vd, tx);
 		}
 	}
+
 	for (i = 0; i < vd->vdev_children; i++) {
 		vdev_construct_zaps(vd->vdev_child[i], tx);
 	}
@@ -2307,11 +2532,64 @@ vdev_load(vdev_t *vd)
 	/*
 	 * If this is a top-level vdev, initialize its metaslabs.
 	 */
-	if (vd == vd->vdev_top && !vd->vdev_ishole &&
-	    (vd->vdev_ashift == 0 || vd->vdev_asize == 0 ||
-	    vdev_metaslab_init(vd, 0) != 0))
-		vdev_set_state(vd, B_FALSE, VDEV_STATE_CANT_OPEN,
-		    VDEV_AUX_CORRUPT_DATA);
+	if (vd == vd->vdev_top && !vd->vdev_ishole) {
+		/*
+		 * On spa_load path, grab the allocation bias from our zap
+		 */
+		if (vd->vdev_top_zap != 0) {
+			spa_t *spa = vd->vdev_spa;
+			char bias_str[64];
+			uint64_t value;
+			int err;
+
+			if (zap_lookup(spa->spa_meta_objset, vd->vdev_top_zap,
+			    VDEV_TOP_ZAP_ALLOCATION_BIAS, 1, sizeof (bias_str),
+			    bias_str) == 0) {
+				ASSERT(vd->vdev_alloc_bias == VDEV_BIAS_NONE);
+				vd->vdev_alloc_bias =
+				    vdev_derive_alloc_bias(bias_str);
+			}
+
+			err = zap_lookup(spa->spa_meta_objset, vd->vdev_top_zap,
+			    VDEV_TOP_ZAP_METASLAB_INFO_OBJ, sizeof (uint64_t),
+			    1, &value);
+			if (err == 0) {
+				ASSERT0(vd->vdev_ms_extra);
+				vd->vdev_ms_extra = value;
+			} else if (vd->vdev_alloc_bias > VDEV_BIAS_LOG) {
+				cmn_err(CE_WARN, "vdev_load: vd-%llu, bias %s "
+				    "missing '%s', err %d", vd->vdev_id,
+				    bias_str, VDEV_TOP_ZAP_METASLAB_INFO_OBJ,
+				    err);
+			}
+
+			err = zap_lookup(spa->spa_meta_objset, vd->vdev_top_zap,
+			    VDEV_TOP_ZAP_ALLOCATION_BIRTH, sizeof (uint64_t), 1,
+			    &value);
+			if (err == 0) {
+				ASSERT0(vd->vdev_alloc_bias_birth);
+				vd->vdev_alloc_bias_birth = value;
+			} else if (vd->vdev_alloc_bias > VDEV_BIAS_LOG) {
+				cmn_err(CE_WARN, "vdev_load: vd-%llu, bias %s "
+				    "missing '%s', err %d", vd->vdev_id,
+				    bias_str, VDEV_TOP_ZAP_ALLOCATION_BIRTH,
+				    err);
+			}
+		} else if (vd->vdev_spa->spa_segregate_special) {
+			/* not expected but seen with zdb */
+			cmn_err(CE_WARN, "vdev_load: vd-%llu top zap object "
+			    "missing (segregation requested)", vd->vdev_id);
+		}
+
+		vdev_metaslab_group_create(vd);
+
+		if (vd->vdev_ashift == 0 || vd->vdev_asize == 0 ||
+		    vdev_metaslab_init(vd, 0) != 0) {
+			vdev_set_state(vd, B_FALSE, VDEV_STATE_CANT_OPEN,
+			    VDEV_AUX_CORRUPT_DATA);
+		}
+	}
+
 	/*
 	 * If this is a leaf vdev, load its DTL.
 	 */
@@ -2362,6 +2640,24 @@ vdev_validate_aux(vdev_t *vd)
 	return (0);
 }
 
+static void
+vdev_metaslab_histogram_verify(vdev_t *vd)
+{
+	metaslab_group_t *mg = vd->vdev_mg;
+
+	metaslab_group_histogram_verify(mg);
+	metaslab_class_histogram_verify(mg->mg_class);
+
+	if ((mg = vd->vdev_log_mg) != NULL) {
+		metaslab_group_histogram_verify(mg);
+		metaslab_class_histogram_verify(mg->mg_class);
+	}
+	if ((mg = vd->vdev_special_mg) != NULL) {
+		metaslab_group_histogram_verify(mg);
+		metaslab_class_histogram_verify(mg->mg_class);
+	}
+}
+
 void
 vdev_remove(vdev_t *vd, uint64_t txg)
 {
@@ -2375,10 +2671,7 @@ vdev_remove(vdev_t *vd, uint64_t txg)
 	ASSERT3U(txg, ==, spa_syncing_txg(spa));
 
 	if (vd->vdev_ms != NULL) {
-		metaslab_group_t *mg = vd->vdev_mg;
-
-		metaslab_group_histogram_verify(mg);
-		metaslab_class_histogram_verify(mg->mg_class);
+		vdev_metaslab_histogram_verify(vd);
 
 		for (m = 0; m < vd->vdev_ms_count; m++) {
 			metaslab_t *msp = vd->vdev_ms[m];
@@ -2394,7 +2687,7 @@ vdev_remove(vdev_t *vd, uint64_t txg)
 			 * here so that we ensure that the metaslab group
 			 * and metaslab class are up-to-date.
 			 */
-			metaslab_group_histogram_remove(mg, msp);
+			metaslab_group_histogram_remove(msp->ms_group, msp);
 
 			VERIFY0(space_map_allocated(msp->ms_sm));
 			space_map_free(msp->ms_sm, tx);
@@ -2403,11 +2696,15 @@ vdev_remove(vdev_t *vd, uint64_t txg)
 			mutex_exit(&msp->ms_lock);
 		}
 
-		metaslab_group_histogram_verify(mg);
-		metaslab_class_histogram_verify(mg->mg_class);
-		for (i = 0; i < RANGE_TREE_HISTOGRAM_SIZE; i++)
-			ASSERT0(mg->mg_histogram[i]);
+		vdev_metaslab_histogram_verify(vd);
 
+		for (i = 0; i < RANGE_TREE_HISTOGRAM_SIZE; i++) {
+			ASSERT0(vd->vdev_mg->mg_histogram[i]);
+			if (vd->vdev_log_mg != NULL)
+				ASSERT0(vd->vdev_log_mg->mg_histogram[i]);
+			if (vd->vdev_special_mg != NULL)
+				ASSERT0(vd->vdev_special_mg->mg_histogram[i]);
+		}
 	}
 
 	if (vd->vdev_ms_array) {
@@ -2426,15 +2723,29 @@ void
 vdev_sync_done(vdev_t *vd, uint64_t txg)
 {
 	metaslab_t *msp;
-	boolean_t reassess = !txg_list_empty(&vd->vdev_ms_list, TXG_CLEAN(txg));
+	boolean_t dirty_primary = B_FALSE;
+	boolean_t dirty_log = B_FALSE;
+	boolean_t dirty_meta = B_FALSE;
 
 	ASSERT(!vd->vdev_ishole);
 
-	while ((msp = txg_list_remove(&vd->vdev_ms_list, TXG_CLEAN(txg))))
+	while ((msp = txg_list_remove(&vd->vdev_ms_list, TXG_CLEAN(txg)))) {
 		metaslab_sync_done(msp, txg);
 
-	if (reassess)
+		if (msp->ms_group == vd->vdev_mg)
+			dirty_primary = B_TRUE;
+		else if (msp->ms_group == vd->vdev_log_mg)
+			dirty_log = B_TRUE;
+		else if (msp->ms_group == vd->vdev_special_mg)
+			dirty_meta = B_TRUE;
+	}
+
+	if (dirty_primary)
 		metaslab_sync_reassess(vd->vdev_mg);
+	if (dirty_log)
+		metaslab_sync_reassess(vd->vdev_log_mg);
+	if (dirty_meta)
+		metaslab_sync_reassess(vd->vdev_special_mg);
 }
 
 void
@@ -2454,6 +2765,45 @@ vdev_sync(vdev_t *vd, uint64_t txg)
 		    DMU_OT_OBJECT_ARRAY, 0, DMU_OT_NONE, 0, tx);
 		ASSERT(vd->vdev_ms_array != 0);
 		vdev_config_dirty(vd);
+		dmu_tx_commit(tx);
+	}
+
+	if (vd->vdev_alloc_bias > VDEV_BIAS_LOG && vd->vdev_ms_extra == 0 &&
+	    vd->vdev_ms_shift != 0) {
+		int blocksize, err;
+
+		ASSERT(vd->vdev_top_zap != 0);
+
+		blocksize = vd->vdev_ms_count * sizeof (ms_alloc_phys_t);
+		blocksize = P2ROUNDUP(blocksize, SPA_MINBLOCKSIZE);
+		blocksize = MIN(blocksize, SPA_OLD_MAXBLOCKSIZE);
+
+		tx = dmu_tx_create_assigned(spa->spa_dsl_pool, txg);
+		vd->vdev_ms_extra = dmu_object_alloc(spa->spa_meta_objset,
+		    DMU_OTN_UINT64_METADATA, blocksize, DMU_OT_NONE, 0, tx);
+		ASSERT(vd->vdev_ms_extra != 0);
+
+		err = zap_add(spa->spa_meta_objset, vd->vdev_top_zap,
+		    VDEV_TOP_ZAP_METASLAB_INFO_OBJ, sizeof (uint64_t), 1,
+		    &vd->vdev_ms_extra, tx);
+		if (err)
+			cmn_err(CE_PANIC, "vd-%llu failed to add ms_extra obj "
+			    "%llu to zap, err %d, txg %llu", vd->vdev_id,
+			    vd->vdev_ms_extra, err, txg);
+
+		if (vd->vdev_alloc_bias_birth == 0) {
+			vd->vdev_alloc_bias_birth = txg;
+			cmn_err(CE_WARN, "vdev_sync: vd-%llu, forcing "
+			    "alloc_bias_birth to %llu", vd->vdev_id, txg);
+		}
+		err = zap_add(spa->spa_meta_objset, vd->vdev_top_zap,
+		    VDEV_TOP_ZAP_ALLOCATION_BIRTH, sizeof (uint64_t), 1,
+		    &vd->vdev_alloc_bias_birth, tx);
+		if (err)
+			cmn_err(CE_PANIC, "vd-%llu failed to add alloc birth "
+			    "%llu to zap, err %d, txg %llu", vd->vdev_id,
+			    vd->vdev_alloc_bias_birth, err, txg);
+
 		dmu_tx_commit(tx);
 	}
 
@@ -2866,6 +3216,12 @@ boolean_t
 vdev_allocatable(vdev_t *vd)
 {
 	uint64_t state = vd->vdev_state;
+	boolean_t mg_initialized = vd->vdev_mg->mg_initialized;
+
+	if ((vd->vdev_log_mg && !vd->vdev_log_mg->mg_initialized) ||
+	    (vd->vdev_special_mg && !vd->vdev_special_mg->mg_initialized)) {
+		mg_initialized = B_FALSE;
+	}
 
 	/*
 	 * We currently allow allocations from vdevs which may be in the
@@ -2877,7 +3233,7 @@ vdev_allocatable(vdev_t *vd)
 	 */
 	return (!(state < VDEV_STATE_DEGRADED && state != VDEV_STATE_CLOSED) &&
 	    !vd->vdev_cant_write && !vd->vdev_ishole &&
-	    vd->vdev_mg->mg_initialized);
+	    mg_initialized);
 }
 
 boolean_t
@@ -2895,6 +3251,24 @@ vdev_accessible(vdev_t *vd, zio_t *zio)
 		return (!vd->vdev_cant_write);
 
 	return (B_TRUE);
+}
+
+metaslab_group_t *
+vdev_get_mg(vdev_t *vd, metaslab_class_t *mc)
+{
+	spa_t *spa = vd->vdev_spa;
+	metaslab_group_t *mg = vd->vdev_mg;
+
+	if (vd->vdev_alloc_bias == VDEV_BIAS_SEGREGATE) {
+		if (mc == spa_log_class(spa) && vd->vdev_log_mg != NULL) {
+			mg = vd->vdev_log_mg;
+		} else if (mc == spa_special_class(spa) &&
+		    vd->vdev_special_mg != NULL) {
+			mg = vd->vdev_special_mg;
+		}
+	}
+
+	return (mg);
 }
 
 static void
@@ -3020,7 +3394,8 @@ vdev_get_stats_ex(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 		vs->vs_esize = vd->vdev_max_asize - vd->vdev_asize;
 		if (vd->vdev_aux == NULL && vd == vd->vdev_top &&
 		    !vd->vdev_ishole) {
-			vs->vs_fragmentation = vd->vdev_mg->mg_fragmentation;
+			vs->vs_fragmentation = (vd->vdev_mg != NULL) ?
+			    vd->vdev_mg->mg_fragmentation : 0;
 		}
 	}
 
@@ -3225,19 +3600,26 @@ vdev_stat_update(zio_t *zio, uint64_t psize)
 	}
 }
 
+int64_t
+vdev_deflated_space(vdev_t *vd, int64_t space)
+{
+	ASSERT((space & (SPA_MINBLOCKSIZE-1)) == 0);
+	ASSERT(vd->vdev_deflate_ratio != 0 || vd->vdev_isl2cache);
+
+	return ((space >> SPA_MINBLOCKSHIFT) * vd->vdev_deflate_ratio);
+}
+
 /*
- * Update the in-core space usage stats for this vdev, its metaslab class,
- * and the root vdev.
+ * Update the in-core space usage stats for this vdev and the root vdev.
  */
 void
-vdev_space_update(vdev_t *vd, int64_t alloc_delta, int64_t defer_delta,
-    int64_t space_delta)
+vdev_space_update(vdev_t *vd, metaslab_class_t *mc, int64_t alloc_delta,
+    int64_t defer_delta, int64_t space_delta)
 {
-	int64_t dspace_delta = space_delta;
+	int64_t dspace_delta;
 	spa_t *spa = vd->vdev_spa;
 	vdev_t *rvd = spa->spa_root_vdev;
-	metaslab_group_t *mg = vd->vdev_mg;
-	metaslab_class_t *mc = mg ? mg->mg_class : NULL;
+	boolean_t special = (mc == spa_special_class(vd->vdev_spa));
 
 	ASSERT(vd == vd->vdev_top);
 
@@ -3247,32 +3629,76 @@ vdev_space_update(vdev_t *vd, int64_t alloc_delta, int64_t defer_delta,
 	 * because the root vdev's psize-to-asize is simply the max of its
 	 * childrens', thus not accurate enough for us.
 	 */
-	ASSERT((dspace_delta & (SPA_MINBLOCKSIZE-1)) == 0);
-	ASSERT(vd->vdev_deflate_ratio != 0 || vd->vdev_isl2cache);
-	dspace_delta = (dspace_delta >> SPA_MINBLOCKSHIFT) *
-	    vd->vdev_deflate_ratio;
+	dspace_delta = vdev_deflated_space(vd, space_delta);
 
 	mutex_enter(&vd->vdev_stat_lock);
 	vd->vdev_stat.vs_alloc += alloc_delta;
 	vd->vdev_stat.vs_space += space_delta;
 	vd->vdev_stat.vs_dspace += dspace_delta;
+	if (special)
+		vd->vdev_stat.vs_special_alloc += alloc_delta;
 	mutex_exit(&vd->vdev_stat_lock);
 
-	if (mc == spa_normal_class(spa)) {
+	/* every class but log contributes to root space stats */
+	if (vd->vdev_mg != NULL && !vd->vdev_islog) {
 		mutex_enter(&rvd->vdev_stat_lock);
 		rvd->vdev_stat.vs_alloc += alloc_delta;
 		rvd->vdev_stat.vs_space += space_delta;
 		rvd->vdev_stat.vs_dspace += dspace_delta;
+		if (special)
+			rvd->vdev_stat.vs_special_alloc += alloc_delta;
 		mutex_exit(&rvd->vdev_stat_lock);
 	}
+	/* Note: metaslab_class_space_update moved to metaslab_space_update */
+}
 
-	if (mc != NULL) {
-		ASSERT(rvd == vd->vdev_parent);
-		ASSERT(vd->vdev_ms_count != 0);
+/*
+ * propagate metaslab block category changes to vdev state
+ * called from: metaslab_init, metaslab_fini, and metaslab_sync
+ */
+void
+vdev_category_space_update(vdev_t *vd, int64_t normal_assigned_delta,
+    int64_t special_assigned_delta)
+{
+	vdev_t *rvd = vd->vdev_spa->spa_root_vdev;
 
-		metaslab_class_space_update(mc,
-		    alloc_delta, defer_delta, space_delta, dspace_delta);
+	ASSERT(vd == vd->vdev_top);
+
+	mutex_enter(&vd->vdev_stat_lock);
+	vd->vdev_stat.vs_normal_assigned += normal_assigned_delta;
+	vd->vdev_stat.vs_special_assigned += special_assigned_delta;
+	mutex_exit(&vd->vdev_stat_lock);
+
+	mutex_enter(&rvd->vdev_stat_lock);
+	rvd->vdev_stat.vs_normal_assigned += normal_assigned_delta;
+	rvd->vdev_stat.vs_special_assigned += special_assigned_delta;
+	mutex_exit(&rvd->vdev_stat_lock);
+}
+
+#define	VDEV_MS_METADATA_RESERVE	10
+
+boolean_t
+vdev_category_space_full(spa_t *spa, metaslab_block_category_t category,
+    uint64_t request)
+{
+	metaslab_class_t *mc;
+	uint64_t space = 0, alloc = 0;
+
+	if (category == MS_CATEGORY_SMALL) {
+		mc = spa_special_class(spa);
+		space = metaslab_class_get_space(mc);
+		/* Maintain a reserve for metadata */
+		space = (space * (100 - VDEV_MS_METADATA_RESERVE)) / 100;
+		alloc = metaslab_class_get_alloc(mc) + request;
 	}
+
+	if (category == MS_CATEGORY_REGULAR) {
+		mc = spa_normal_class(spa);
+		space = metaslab_class_get_space(mc);
+		alloc = metaslab_class_get_alloc(mc) + request;
+	}
+
+	return (alloc > space);
 }
 
 /*
@@ -3701,6 +4127,7 @@ vdev_expand(vdev_t *vd, uint64_t txg)
 	ASSERT(spa_config_held(vd->vdev_spa, SCL_ALL, RW_WRITER) == SCL_ALL);
 
 	if ((vd->vdev_asize >> vd->vdev_ms_shift) > vd->vdev_ms_count) {
+		vdev_metaslab_group_create(vd);
 		VERIFY(vdev_metaslab_init(vd, txg) == 0);
 		vdev_config_dirty(vd);
 	}

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 /*
@@ -428,6 +429,28 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 		if (vd->vdev_removing)
 			fnvlist_add_uint64(nv, ZPOOL_CONFIG_REMOVING,
 			    vd->vdev_removing);
+
+		/* zpool command expects alloc class data */
+		if (getstats && vd->vdev_alloc_bias != VDEV_BIAS_NONE) {
+			const char *bias = NULL;
+
+			switch (vd->vdev_alloc_bias) {
+			case VDEV_BIAS_LOG:
+				bias = VDEV_ALLOC_BIAS_LOG;
+				break;
+			case VDEV_BIAS_SPECIAL:
+				bias = VDEV_ALLOC_BIAS_SPECIAL;
+				break;
+			case VDEV_BIAS_SEGREGATE:
+				bias = VDEV_ALLOC_BIAS_SEGREGATE;
+				break;
+			default:
+				ASSERT3U(vd->vdev_alloc_bias, ==,
+				    VDEV_BIAS_NONE);
+			}
+			fnvlist_add_string(nv, ZPOOL_CONFIG_ALLOCATION_BIAS,
+			    bias);
+		}
 	}
 
 	if (vd->vdev_dtl_sm != NULL) {

--- a/module/zfs/zfeature_common.c
+++ b/module/zfs/zfeature_common.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2014, Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #ifdef _KERNEL
@@ -317,5 +318,12 @@ zpool_feature_init(void)
 	    "User/Group object accounting.",
 	    ZFEATURE_FLAG_READONLY_COMPAT | ZFEATURE_FLAG_PER_DATASET,
 	    userobj_accounting_deps);
+	}
+
+	{
+	zfeature_register(SPA_FEATURE_ALLOCATION_CLASSES,
+	    "com.intel:allocation_classes", "allocation_classes",
+	    "Support for separate allocation classes.",
+	    ZFEATURE_FLAG_READONLY_COMPAT, NULL);
 	}
 }

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation.
  */
 
 #include <sys/sysmacros.h>
@@ -57,7 +58,11 @@ const char *zio_type_name[ZIO_TYPES] = {
 	"z_null", "z_rd", "z_wr", "z_fr", "z_cl", "z_ioctl"
 };
 
+#ifdef ZPOOL_CONFIG_ALLOCATION_BIAS
+int zio_dva_throttle_enabled = B_FALSE;  /* not compatible with alloc classes */
+#else
 int zio_dva_throttle_enabled = B_TRUE;
+#endif
 
 /*
  * ==========================================================================
@@ -1399,7 +1404,7 @@ zio_write_compress(zio_t *zio)
 		zio->io_pipeline = zio->io_orig_pipeline;
 
 	} else {
-		ASSERT3U(psize, !=, 0);
+		VERIFY3U(psize, !=, 0);
 
 	}
 
@@ -1415,7 +1420,8 @@ zio_write_compress(zio_t *zio)
 	    BP_GET_PSIZE(bp) == psize &&
 	    pass >= zfs_sync_pass_rewrite) {
 		enum zio_stage gang_stages = zio->io_pipeline & ZIO_GANG_STAGES;
-		ASSERT(psize != 0);
+
+		VERIFY3U(psize, !=, 0);
 		zio->io_pipeline = ZIO_REWRITE_PIPELINE | gang_stages;
 		zio->io_flags |= ZIO_FLAG_IO_REWRITE;
 	} else {
@@ -2287,7 +2293,7 @@ static int
 zio_write_gang_block(zio_t *pio)
 {
 	spa_t *spa = pio->io_spa;
-	metaslab_class_t *mc = spa_normal_class(spa);
+	metaslab_class_t *mc;
 	blkptr_t *bp = pio->io_bp;
 	zio_t *gio = pio->io_gang_leader;
 	zio_t *zio;
@@ -2301,8 +2307,10 @@ zio_write_gang_block(zio_t *pio)
 	int gbh_copies = MIN(copies + 1, spa_max_replication(spa));
 	zio_prop_t zp;
 	int g, error;
-
 	int flags = METASLAB_HINTBP_FAVOR | METASLAB_GANG_HEADER;
+
+	mc = spa_preferred_class(spa, SPA_GANGBLOCKSIZE, BP_GET_TYPE(bp), 0);
+
 	if (pio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 		ASSERT(pio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
 		ASSERT(!(pio->io_flags & ZIO_FLAG_NODATA));
@@ -3009,7 +3017,7 @@ static int
 zio_dva_allocate(zio_t *zio)
 {
 	spa_t *spa = zio->io_spa;
-	metaslab_class_t *mc = spa_normal_class(spa);
+	metaslab_class_t *mc;
 	blkptr_t *bp = zio->io_bp;
 	int error;
 	int flags = 0;
@@ -3033,9 +3041,23 @@ zio_dva_allocate(zio_t *zio)
 	if (zio->io_priority == ZIO_PRIORITY_ASYNC_WRITE)
 		flags |= METASLAB_ASYNC_ALLOC;
 
+	/* locate an appropriate allocation class */
+	mc = spa_preferred_class(spa, zio->io_size, zio->io_prop.zp_type,
+	    zio->io_prop.zp_level);
+
 	error = metaslab_alloc(spa, mc, zio->io_size, bp,
 	    zio->io_prop.zp_copies, zio->io_txg, NULL, flags,
 	    &zio->io_alloc_list, zio);
+
+	/*
+	 * Fallback to spa_normal_class when a dedicated class is full
+	 */
+	if (error == ENOSPC && mc != spa_normal_class(spa)) {
+		mc = spa_normal_class(spa);
+		error = metaslab_alloc(spa, mc, zio->io_size, bp,
+		    zio->io_prop.zp_copies, zio->io_txg, NULL, flags,
+		    &zio->io_alloc_list, zio);
+	}
 
 	if (error != 0) {
 		spa_dbgmsg(spa, "%s: metaslab allocation failure: zio %p, "
@@ -3106,6 +3128,15 @@ zio_alloc_zil(spa_t *spa, uint64_t txg, blkptr_t *new_bp, uint64_t size,
 	ASSERT(txg > spa_syncing_txg(spa));
 
 	metaslab_trace_init(&io_alloc_list);
+
+	/*
+	 * Block pointer fields are useful to metaslabs for stats and debugging.
+	 * Fill in the obvious ones before calling into metaslab_alloc().
+	 */
+	BP_SET_TYPE(new_bp, DMU_OT_INTENT_LOG);
+	BP_SET_PSIZE(new_bp, size);
+	BP_SET_LEVEL(new_bp, 0);
+
 	error = metaslab_alloc(spa, spa_log_class(spa), size, new_bp, 1,
 	    txg, NULL, METASLAB_FASTWRITE, &io_alloc_list, NULL);
 	if (error == 0) {

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -78,5 +78,6 @@ if is_linux; then
 	    "ashift"
 	    "feature@large_dnode"
 	    "feature@userobj_accounting"
+	    "feature@allocation_classes"
 	)
 fi


### PR DESCRIPTION
Please ignore this as a usual PR.
Used to test a commit that removes the mirror requirement for special pool allocation class.  When working, would be suggested to be squashed into #5182 