### PR TITLE
Restrict zpool iostat/status -c to search path

### DIFF
--- a/cmd/zpool/zpool_iter.c
+++ b/cmd/zpool/zpool_iter.c
@@ -565,6 +565,9 @@ vdev_run_cmd_thread(void *cb_cmd_data)
 		char *dir = NULL, *sp, *sprest;
 		char fullpath[MAXPATHLEN];
 
+		if (strchr(cmd, '/') != NULL)
+			continue;
+
 		sp = zpool_get_cmd_search_path();
 		if (sp == NULL)
 			continue;

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1464,7 +1464,8 @@ output. Users can run any script found in their
 .Pa ~/.zpool.d
 directory or from the system
 .Pa /etc/zfs/zpool.d
-directory. The default search path can be overridden by setting the
+directory. Script names containing the slash (/) character are not allowed.
+The default search path can be overridden by setting the
 ZPOOL_SCRIPTS_PATH environment variable. A privileged user can run
 .Fl c
 if they have the ZPOOL_SCRIPTS_AS_ROOT


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
`zpool iostat/status -c` is supposed to be restricted
by its search path, but currently isn't. To prevent
arbitrary scripts from being executed, disallow
'~' and '/' from command names.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, it is possible to execute arbitrary scripts by using relative paths
or referring to subdirectories. (ex. `zpool status -c ../../../cmd`). See #6353.
Note, I'm continuing to allow `.` because someone may actually want
extensions. `.` seems to only be dangerous when combined with `/`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Manually tested on a VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
