### PR TITLE
Provide function for Linux version in test suite

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -40,6 +40,29 @@ if [ -n "$STF_PATH" ]; then
 	PATH="$STF_PATH"
 fi
 
+# Linux kernel version comparison function
+#
+# $1 Linux version ("4.10", "2.6.32") or blank for installed Linux version
+#
+# Used for comparison: if [ $(linux_version) -ge $(linux_version "2.6.32") ]
+#
+function linux_version
+{
+	typeset ver="$1"
+
+	[[ -z "$ver" ]] && ver=$(uname -r | grep -Eo "^[0-9]+\.[0-9]+\.[0-9]+")
+
+	typeset version=$(echo $ver | cut -d '.' -f 1)
+	typeset major=$(echo $ver | cut -d '.' -f 2)
+	typeset minor=$(echo $ver | cut -d '.' -f 3)
+
+	[[ -z "$version" ]] && version=0
+	[[ -z "$major" ]] && major=0
+	[[ -z "$minor" ]] && minor=0
+
+	echo $((version * 10000 + major * 100 + minor))
+}
+
 # Determine if this is a Linux test system
 #
 # Return 0 if platform Linux, 1 if otherwise

--- a/tests/zfs-tests/include/properties.shlib
+++ b/tests/zfs-tests/include/properties.shlib
@@ -91,8 +91,17 @@ function get_rand_large_recsize
 #
 # Functions to toggle on/off properties
 #
-typeset -a binary_props=('atime' 'devices' 'exec' 'nbmand' 'readonly' 'setuid'
-    'xattr' 'zoned')
+typeset -a binary_props=('atime' 'devices' 'exec' 'readonly' 'setuid' 'xattr'
+    'zoned')
+
+if is_linux; then
+	# Only older kernels support non-blocking mandatory locks
+	if [[ $(linux_version) -lt $(linux_version "4.4") ]]; then
+		binary_props+=('nbmand')
+	fi
+else
+	binary_props+=('nbmand')
+fi
 
 function toggle_prop
 {

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/mountpoint_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/mountpoint_003_pos.ksh
@@ -67,11 +67,15 @@ if is_linux; then
 	set -A args \
 	"nodev"		"dev"	\
 	"noexec"	"exec"	\
-	"mand"		"nomand"	\
 	"ro"		"rw"	\
 	"nosuid"	"suid"	\
 	"xattr"		"noxattr"	\
 	"atime"		"noatime"
+
+	# Only older kernels support non-blocking mandatory locks
+	if [[ $(linux_version) -lt $(linux_version "4.4") ]]; then
+		args+=("mand" "nomand")
+	fi
 else
 	set -A args \
 	"devices"	"/devices/"	"nodevices"	"/nodevices/"	\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Provide a function to determine if the currently installed
Linux kernel is at least a specific major.minor version.
Update mountpoint_003_pos and properties.shlib in the test
suite to only allow mandatory lock testing on Linux kernel
versions lower than 4.4.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#6347 
#6346 

### How Has This Been Tested?
Tested by running the test suite on VMs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
