### PR TITLE
Minor fixes in zpool iostat -c documentation

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1456,7 +1456,7 @@ values, use the
 .Fl p
 flag.
 .Bl -tag -width Ds
-.It Fl c Op Ar SCRIPT1 , Ar SCRIPT2 ...
+.It Fl c Op Ar SCRIPT1 Ns Oo , Ns Ar SCRIPT2 Oc Ns ...
 Run a script (or scripts) on each vdev and include the output as a new column
 in the
 .Nm zpool Cm iostat
@@ -1470,8 +1470,8 @@ ZPOOL_SCRIPTS_PATH environment variable. A privileged user can run
 if they have the ZPOOL_SCRIPTS_AS_ROOT
 environment variable set. If a script requires the use of a privileged
 command, like
-.Xr smartctl 8
-, then it's recommended you allow the user access to it in
+.Xr smartctl 8 ,
+then it's recommended you allow the user access to it in
 .Pa /etc/sudoers
 or add the user to the
 .Pa /etc/sudoers.d/zfs
@@ -1481,8 +1481,8 @@ If
 .Fl c
 is passed without a script name, it prints a list of all scripts.
 .Fl c
-also sets verbose mode (
-.Fl c ).
+also sets verbose mode
+.No ( Ns Fl v Ns No ).
 .Pp
 Script output should be in the form of "name=value". The column name is
 set to "name" and the value is set to "value". Multiple lines can be
@@ -1912,7 +1912,7 @@ and automatically import it.
 .It Xo
 .Nm
 .Cm status
-.Op Fl c Op Ar SCRIPT1 , Ar SCRIPT2 ...
+.Op Fl c Op Ar SCRIPT1 Ns Oo , Ns Ar SCRIPT2 Oc Ns ...
 .Op Fl gLPvxD
 .Op Fl T Sy u Ns | Ns Sy d
 .Oo Ar pool Oc Ns ...
@@ -1931,7 +1931,7 @@ and the estimated time to completion.
 Both of these are only approximate, because the amount of data in the pool and
 the other workloads on the system can change.
 .Bl -tag -width Ds
-.It Fl c Op Ar SCRIPT1 , Ar SCRIPT2 ...
+.It Fl c Op Ar SCRIPT1 Ns Oo , Ns Ar SCRIPT2 Oc Ns ...
 Run a script (or scripts) on each vdev and include the output as a new column
 in the
 .Nm zpool Cm status
@@ -2322,11 +2322,11 @@ by setting
 .El
 .Bl -tag -width "ZPOOL_SCRIPTS_AS_ROOT"
 .It Ev ZPOOL_SCRIPTS_AS_ROOT
-Allow a privilaged user to run the
+Allow a privileged user to run the
 .Nm zpool status/iostat
 with the
 .Fl c
-option.  Normally, only unprivilaged users are allowed to run
+option.  Normally, only unprivileged users are allowed to run
 .Fl c .
 .El
 .Bl -tag -width "ZPOOL_SCRIPTS_PATH"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
- Use nested [] notation to denote optional script list elements
- Fix space before comma after smarctl(8)
- Fix typo and formatting error in reference to -v option
- Fix spelling errors

### Motivation and Context
Minor documentation cleanup.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Visual inspection with `nroff -man man/man8/zpool.8 | less`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
