### PR TITLE
Add zgenhostid utility script and package with utilities

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,3 +1,3 @@
 SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest zpios
 SUBDIRS += mount_zfs fsck_zfs zvol_id vdev_id arcstat dbufstat zed
-SUBDIRS += arc_summary raidz_test
+SUBDIRS += arc_summary raidz_test zgenhostid

--- a/cmd/zgenhostid/Makefile.am
+++ b/cmd/zgenhostid/Makefile.am
@@ -1,0 +1,1 @@
+dist_bin_SCRIPTS = zgenhostid

--- a/cmd/zgenhostid/zgenhostid
+++ b/cmd/zgenhostid/zgenhostid
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Emulate genhostid(1) available on RHEL/CENTOS, for use on distros
+# which do not provide that utility.
+#
+# Usage:
+#    zgenhostid
+#    zgenhostid <value>
+#
+# If /etc/hostid already exists and is size > 0, the script exits immediately
+# and changes nothing.  Unlike genhostid, this generates an error message.
+#
+# The first form generates a random hostid and stores it in /etc/hostid.
+# The second form checks that the provided value is between 0x1 and 0xFFFFFFFF
+# and if so, stores it in /etc/hostid.  This form is not supported by
+# genhostid(1).
+
+hostid_file=/etc/hostid
+
+function usage {
+	echo "$0 [value]"
+	echo "If $hostid_file is not present, store a hostid in it." >&2
+	echo "The optional value must be an 8-digit hex number between" >&2
+	echo "1 and 2^32-1.  If no value is provided, a random one will" >&2
+	echo "be generated.  The value must be unique among your systems." >&2
+}
+
+# hostid(1) ignores contents of /etc/hostid if size < 4 bytes.  It would
+# be better if this checked size >= 4 bytes but it the method must be
+# widely portable.
+if [ -s $hostid_file ]; then
+	echo "$hostid_file already exists.  No change made." >&2
+	exit 1
+fi
+
+if [ -n "$1" ]; then
+	host_id=$1
+else
+	# $RANDOM goes from 0..32k-1
+	number=$((((RANDOM % 4) * 32768 + RANDOM) * 32768 + RANDOM))
+	host_id=$(printf "%08x" $number)
+fi
+
+if egrep -o '^0{8}$' <<< $host_id >/dev/null 2>&1; then
+	usage
+	exit 2
+fi
+
+if ! egrep -o '^[a-fA-F0-9]{8}$' <<< $host_id >/dev/null 2>&1; then
+	usage
+	exit 3
+fi
+
+a=${host_id:6:2}
+b=${host_id:4:2}
+c=${host_id:2:2}
+d=${host_id:0:2}
+
+echo -ne \\x$a\\x$b\\x$c\\x$d > $hostid_file
+
+exit 0

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2177,7 +2177,7 @@ show_import(nvlist_t *config)
 			break;
 		case ZPOOL_STATUS_HOSTID_REQUIRED:
 			(void) printf(gettext(" action: Set a unique system "
-			    "hostid with the genhostid(1) command.\n"));
+			    "hostid with the zgenhostid(8) command.\n"));
 			break;
 		default:
 			(void) printf(gettext(" action: The pool cannot be "
@@ -2304,7 +2304,7 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 			(void) fprintf(stderr, gettext("Cannot import '%s': "
 			    "pool has the multihost property on and the\n"
 			    "system's hostid is not set. Set a unique hostid "
-			    "with the genhostid(1) command.\n"), name);
+			    "with the zgenhostid(8) command.\n"), name);
 		} else {
 			char *hostname = "<unknown>";
 			uint64_t timestamp = 0;

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ AC_CONFIG_FILES([
 	cmd/arc_summary/Makefile
 	cmd/zed/Makefile
 	cmd/raidz_test/Makefile
+	cmd/zgenhostid/Makefile
 	contrib/Makefile
 	contrib/bash_completion.d/Makefile
 	contrib/dracut/Makefile

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -1865,7 +1865,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 					    "the multihost property on and "
 					    "the\nsystem's hostid is not set. "
 					    "Set a unique system hostid with "
-					    "the genhostid(1) command.\n"));
+					    "the zgenhostid(8) command.\n"));
 				}
 
 				(void) zfs_error_aux(hdl, aux);

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -4,6 +4,7 @@ dist_man_MANS = \
 	vdev_id.8 \
 	zdb.8 \
 	zfs.8 \
+	zgenhostid.8
 	zinject.8 \
 	zpool.8 \
 	zstreamdump.8

--- a/man/man8/zgenhostid.8
+++ b/man/man8/zgenhostid.8
@@ -1,0 +1,38 @@
+.TH zgenhostid 8
+.SH NAME
+zgenhostid \- generate and store a hostid in /etc/hostid
+.SH SYNOPSIS
+.LP
+.nf
+\fBzgenhostid\fR [hostid]
+.fi
+.SH DESCRIPTION
+If \fB/etc/hostid\fR does not exist, create it and store a hostid in
+it.  If the user provides \fBhostid\fR on the command line, store that value.
+Otherwise, randomly generate a value to store.
+
+This emulates the \fBgenhostid(1)\fR utility, and is provided for users on
+SUSE which does not include the utility.
+
+.SH OPTIONS
+.TP
+\fBhostid\fR
+Specifies the value to be placed in \fB/etc/hostid\fR.  It must be a
+number with a value between 1 and 2^32-1.  This value \fBmust\fR be
+unique among your systems.  It must be expressed in hexadecimal and be
+exactly 8 digits long.
+.SH EXAMPLES
+.TP
+zgenhostid
+Generate a random hostid and store it
+.TP
+zgenhostid $(hostid)
+Record the libc-generated hostid in /etc/hostid
+.TP
+zgenhostid deadbeef
+Record a custom hostid (0xdeadbeef) in /etc/hostid
+.SH SEE ALSO
+.LP
+\fBspl-module-parameters\fR(5)
+\fBgenhostid\fR(1)
+\fBhostid\fR(1)

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -732,7 +732,7 @@ in the
 man page.  In order to enable this property each host must set a unique hostid.
 See
 .Xr genhostid 1
-and
+.Xr zgenhostid 8
 .Xr spl-module-paramters 5
 for additional details.  The default value is
 .Sy off .

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -141,6 +141,7 @@ export ZFS_FILES='zdb
     arcstat.py
     dbufstat.py
     zed
+    zgenhostid
     zstreamdump'
 
 export ZFSTEST_FILES='chg_usr_exec

--- a/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -79,12 +79,7 @@ function mmp_set_hostid
 {
 	typeset hostid=$1
 
-	a=${hostid:6:2}
-	b=${hostid:4:2}
-	c=${hostid:2:2}
-	d=${hostid:0:2}
-
-	printf "\\x$a\\x$b\\x$c\\x$d" >$HOSTID_FILE
+	zgenhostid $1
 
 	if [ $(hostid) != "$hostid" ]; then
 		return 1
@@ -107,10 +102,12 @@ function mmp_pool_create # pool dir
 	log_must mkdir -p $dir
 	log_must truncate -s $MINVDEVSIZE $dir/vdev1 $dir/vdev2
 
+	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $HOSTID1
 	log_must zpool create -f $pool mirror $dir/vdev1 $dir/vdev2
 	log_must zpool set multihost=on $pool
 	log_must zpool export $pool
+	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $HOSTID2
 
 	log_note "Starting ztest in the background as hostid $HOSTID1"
@@ -146,6 +143,7 @@ function mmp_pool_set_hostid # pool hostid
 	typeset pool=$1
 	typeset hostid=$2
 
+	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $hostid
 	log_must zpool export $pool
 	log_must zpool import $pool

--- a/tests/zfs-tests/tests/functional/mmp/mmp_active_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_active_import.ksh
@@ -86,6 +86,7 @@ log_must mmp_set_hostid $HOSTID1
 MMP_IMPORTED_MSG="The pool can be imported"
 log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "action" $MMP_IMPORTED_MSG
 
+log_must mmp_clear_hostid
 log_must mmp_set_hostid $HOSTID2
 MMP_IMPORTED_MSG="The pool was last accessed by another system."
 log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "status" $MMP_IMPORTED_MSG

--- a/tests/zfs-tests/tests/functional/mmp/mmp_exported_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_exported_import.ksh
@@ -62,6 +62,7 @@ done
 for opt in "" "-f"; do
 	log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
 	log_must zpool export $TESTPOOL
+	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $HOSTID2
 	log_must import_no_activity_check $TESTPOOL $opt
 done
@@ -87,6 +88,7 @@ done
 for opt in "" "-f"; do
 	log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
 	log_must zpool export $TESTPOOL
+	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $HOSTID2
 	log_must import_no_activity_check $TESTPOOL $opt
 done

--- a/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
@@ -60,6 +60,7 @@ done
 
 # 3. Verify multihost=off and hostids differ (no activity check)
 log_must zpool export -F $TESTPOOL
+log_must mmp_clear_hostid
 log_must mmp_set_hostid $HOSTID2
 log_mustnot import_no_activity_check $TESTPOOL ""
 log_must import_no_activity_check $TESTPOOL "-f"
@@ -81,6 +82,7 @@ done
 
 # 6. Verify multihost=on and hostids differ (activity check)
 log_must zpool export -F $TESTPOOL
+log_must mmp_clear_hostid
 log_must mmp_set_hostid $HOSTID2
 log_mustnot import_activity_check $TESTPOOL ""
 log_must import_activity_check $TESTPOOL "-f"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
This commit adds a script modeled after genhostid(1).

Zgenhostid checks for an /etc/hostid file; if it does not exist, it
creates one and stores a value.  If the user has provided a hostid as an
argument, that value is used.  Otherwise, a random hostid is generated
and stored.

This differs from the CENTOS 6/7 versions of genhostid, which overwrite
the /etc/hostid file even though their manpages state otherwise.

Add a man page. The one for genhostid is in (1), but I put zgenhostid in
(8) because I believe it's more appropriate.

Modified mmp tests to use zgenhostid to set the hostid instead of using
the spl_hostid module parameter.  zgenhostid will not replace an
existing /etc/hostid file, so new mmp_clear_hostid calls are required.

Fixes #6358

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Turning the multihost property on requires that a hostid be set to allow
ZFS to determine when a foreign system is attemping to import a pool.
The error message instructing the user to set a hostid refers to
genhostid(1).

Genhostid(1) is not available on SUSE Linux.  

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
