### PR TITLE
zio_dva_throttle_done() should conditionally accept zinjected ZIOs

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3661,7 +3661,8 @@ zio_dva_throttle_done(zio_t *zio)
 	ASSERT3U(zio->io_child_type, ==, ZIO_CHILD_VDEV);
 	ASSERT(vd != NULL);
 	ASSERT3P(vd, ==, vd->vdev_top);
-	ASSERT(!(zio->io_flags & (ZIO_FLAG_IO_REPAIR | ZIO_FLAG_IO_RETRY)));
+	ASSERT(zio_injection_enabled || !(zio->io_flags & ZIO_FLAG_IO_RETRY));
+	ASSERT(!(zio->io_flags & ZIO_FLAG_IO_REPAIR));
 	ASSERT(zio->io_flags & ZIO_FLAG_IO_ALLOCATING);
 	ASSERT(!(lio->io_flags & ZIO_FLAG_IO_REWRITE));
 	ASSERT(!(lio->io_orig_flags & ZIO_FLAG_NODATA));


### PR DESCRIPTION
#6383)

zinject enables ZIO_FLAG_IO_RETRY to ensure FMA events are generated. These ZIOs
could have ZIO_FLAG_IO_ALOCATING set. Hence, conditionally allow such ZIOs in
zio_dva_throttle_done() and do not fail the ASSERT() for ZIO_FLAG_IO_RETRY.

Signed-off-by: Sanjeev Bagewadi <sanjeev.bagewadi@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

If fault injection is enabled, the ZIO_FLAG_IO_RETRY could be set by
zio_handle_device_injection() to generate the FMA events and update
stats. Hence, ignore the flag and process such zios.

A better fix would be to add another flag in the zio_t to indicate
that the zio is failed because of a zinject rule. However, considering the
fact that we do this in debug bits, we could do with the crude check using the
global flag zio_injection_enabled which is set to 1 when zinject records are added.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If zinject faults are enabled, it fails the ZIOs and adds the ZIO_FLAG_IO_RETRY flag to ensure that FMA events are raised. And we could have ZIOs with ZIO_FLAG_IO_ALLOCATING enabled. However, for such IOs in the zio_done() when zio_dva_throttle_done() we hit the ASSERT() for ZIO_FLAG_IO_RETRY. We could apply the ASSERT() only if zinject is not enabled.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Ran internal tests which do the following \:
- zinject -a -d /dev/sdad -e io testpool -T all
- Generate IO to the testpool (by issuing some writes e.g.: cp -R /usr/lib /testpool/dir1)

Without the fix this would have resulted in a panic (one-debug builds). Ensured that with the fix no panic was seen.

NOTE : The cp command ensures that we have ALLOCATING ZIOs generated.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.