### PR TITLE
B MMP minor tweaks

### DIFF
--- a/cmd/zhack/zhack.c
+++ b/cmd/zhack/zhack.c
@@ -151,7 +151,8 @@ zhack_import(char *target, boolean_t readonly)
 	}
 
 	zfeature_checks_disable = B_TRUE;
-	error = spa_import(target, config, props, ZFS_IMPORT_NORMAL);
+	error = spa_import(target, config, props,
+	    (readonly ?  ZFS_IMPORT_SKIP_MMP : ZFS_IMPORT_NORMAL));
 	zfeature_checks_disable = B_FALSE;
 	if (error == EEXIST)
 		error = 0;

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2653,18 +2653,18 @@ spa_load_impl(spa_t *spa, uint64_t pool_guid, nvlist_t *config,
 	 */
 	activity_check = spa_activity_check_required(spa, ub, config);
 	if (activity_check) {
-		error = spa_activity_check(spa, ub, config);
-		if (error) {
-			nvlist_free(label);
-			return (error);
-		}
-
 		if (ub->ub_mmp_magic == MMP_MAGIC && ub->ub_mmp_delay &&
 		    spa_get_hostid() == 0) {
 			nvlist_free(label);
 			fnvlist_add_uint64(spa->spa_load_info,
 			    ZPOOL_CONFIG_MMP_STATE, MMP_STATE_NO_HOSTID);
 			return (spa_vdev_err(rvd, VDEV_AUX_ACTIVE, EREMOTEIO));
+		}
+
+		error = spa_activity_check(spa, ub, config);
+		if (error) {
+			nvlist_free(label);
+			return (error);
 		}
 
 		fnvlist_add_uint64(spa->spa_load_info,

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3325,7 +3325,7 @@ zio_vdev_io_done(zio_t *zio)
 
 	ops->vdev_op_io_done(zio);
 
-	if (unexpected_error && zio->io_waiter != NULL)
+	if (unexpected_error)
 		VERIFY(vdev_probe(vd, zio) == NULL);
 
 	return (ZIO_PIPELINE_CONTINUE);

--- a/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
@@ -28,7 +28,7 @@
 #	4. Verify multihost=off and hostid allowed (no activity check)
 #	5. Verify multihost=on and hostids match (no activity check)
 #	6. Verify multihost=on and hostids differ (activity check)
-#	7. Verify multihost=on and hostid zero fails (activity check)
+#	7. Verify multihost=on and hostid zero fails (no activity check)
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -85,11 +85,11 @@ log_must mmp_set_hostid $HOSTID2
 log_mustnot import_activity_check $TESTPOOL ""
 log_must import_activity_check $TESTPOOL "-f"
 
-# 7. Verify multihost=on and hostid zero fails (activity check)
+# 7. Verify multihost=on and hostid zero fails (no activity check)
 log_must zpool export -F $TESTPOOL
 log_must mmp_clear_hostid
 MMP_IMPORTED_MSG="Set the system hostid"
 log_must check_pool_import $TESTPOOL "-f" "action" $MMP_IMPORTED_MSG
-log_mustnot import_activity_check $TESTPOOL "-f"
+log_mustnot import_no_activity_check $TESTPOOL "-f"
 
 log_pass "multihost=on|off inactive pool activity checks passed"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Detect the conditions for MMP_STATE_NO_HOSTID before performing the activity check and return immediately.  Performing the activity check in this situation is unnecessary (the results do not change the message passed to the user).

Add the ZFS_IMPORT_SKIP_MMP flag when zhack performs a readonly import for the `feature stat` subcommand, as is done for zdb.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Hand testing and ran the mmp zfs-tests locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
