### PR TITLE
OpenZFS 8491 - uberblock on-disk padding to reserve space for smoothl…

### DIFF
--- a/include/sys/uberblock_impl.h
+++ b/include/sys/uberblock_impl.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_UBERBLOCK_IMPL_H
@@ -60,6 +61,7 @@ struct uberblock {
 	uint64_t	ub_mmp_magic;	/* MMP_MAGIC			*/
 	uint64_t	ub_mmp_delay;	/* nanosec since last MMP write	*/
 	uint64_t	ub_mmp_seq;	/* reserved for sequence number	*/
+	uint64_t	ub_checkpoint_txg;
 };
 
 #ifdef	__cplusplus


### PR DESCRIPTION
…y merging zpool checkpoint & MMP in ZFS

The zpool checkpoint feature in DxOS added a new field in the uberblock.
The Multi-Modifier Protection Pull Request from ZoL adds three new fields
in the uberblock (Reference: https://github.com/zfsonlinux/zfs/pull/6279).
As these two changes come from two different sources and once upstreamed
and deployed will introduce an incompatibility with each other we want
to upstream a change that will reserve the padding for both of them so
integration goes smoothly and everyone gets both features.

Porting Notes: Preserved MMP comments in uberblock struct.

Authored by: Serapheim Dimitropoulos <serapheim@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed by: Olaf Faaland <faaland1@llnl.gov>
Approved by: Gordon Ross <gwr@nexenta.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/8491
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/d84fa5f
