### PR TITLE
Fix 'zpool clear' on suspended pools

### DIFF
--- a/TEST
+++ b/TEST
@@ -4,24 +4,24 @@
 #TEST_PREPARE_WATCHDOG="no"
 
 ### SPLAT
-#TEST_SPLAT_SKIP="yes"
+TEST_SPLAT_SKIP="yes"
 #TEST_SPLAT_OPTIONS="-acvx"
 
 ### ztest
-#TEST_ZTEST_SKIP="yes"
+TEST_ZTEST_SKIP="yes"
 #TEST_ZTEST_TIMEOUT=1800
 #TEST_ZTEST_DIR="/var/tmp/"
 #TEST_ZTEST_OPTIONS="-V"
 
 ### zimport
-#TEST_ZIMPORT_SKIP="yes"
+TEST_ZIMPORT_SKIP="yes"
 #TEST_ZIMPORT_DIR="/var/tmp/zimport"
 #TEST_ZIMPORT_VERSIONS="master installed"
 #TEST_ZIMPORT_POOLS="zol-0.6.1 zol-0.6.2 master installed"
 #TEST_ZIMPORT_OPTIONS="-c"
 
 ### xfstests
-#TEST_XFSTESTS_SKIP="yes"
+TEST_XFSTESTS_SKIP="yes"
 #TEST_XFSTESTS_URL="https://github.com/behlendorf/xfstests/archive/"
 #TEST_XFSTESTS_VER="zfs.tar.gz"
 #TEST_XFSTESTS_POOL="tank"
@@ -33,10 +33,10 @@
 #TEST_ZFSTESTS_SKIP="yes"
 #TEST_ZFSTESTS_DISKS="vdb vdc vdd"
 #TEST_ZFSTESTS_DISKSIZE="8G"
-#TEST_ZFSTESTS_RUNFILE="linux.run"
+TEST_ZFSTESTS_RUNFILE="zpool_suspended.run"
 
 ### zfsstress
-#TEST_ZFSSTRESS_SKIP="yes"
+TEST_ZFSSTRESS_SKIP="yes"
 #TEST_ZFSSTRESS_URL="https://github.com/nedbass/zfsstress/archive/"
 #TEST_ZFSSTRESS_VER="master.tar.gz"
 #TEST_ZFSSTRESS_RUNTIME=300

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4946,7 +4946,7 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 
 	vdev_clear(spa, vd);
 
-	(void) spa_vdev_state_exit(spa, spa->spa_root_vdev, 0);
+	(void) spa_vdev_state_exit(spa, NULL, 0);
 
 	/*
 	 * Resume any suspended I/Os.

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -201,7 +201,7 @@ tests = ['zpool_attach_001_neg', 'attach-o_ashift']
 
 [tests/functional/cli_root/zpool_clear]
 tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg',
-    'zpool_clear_readonly']
+    'zpool_clear_readonly', 'zpool_clear_suspended']
 
 [tests/functional/cli_root/zpool_create]
 tests = ['zpool_create_001_pos', 'zpool_create_002_pos',

--- a/tests/runfiles/zpool_suspended.run
+++ b/tests/runfiles/zpool_suspended.run
@@ -1,0 +1,33 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+[DEFAULT]
+pre = setup
+quiet = False
+pre_user = root
+user = root
+timeout = 600
+post_user = root
+post = cleanup
+outputdir = /var/tmp/test_results
+
+[tests/functional/cli_root/zpool_clear]
+tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg',
+    'zpool_clear_readonly', 'zpool_clear_suspended', 'zpool_clear_suspended',
+    'zpool_clear_suspended', 'zpool_clear_suspended', 'zpool_clear_suspended',
+    'zpool_clear_suspended', 'zpool_clear_suspended', 'zpool_clear_suspended',
+    'zpool_clear_suspended', 'zpool_clear_suspended', 'zpool_clear_suspended',
+    'zpool_clear_suspended', 'zpool_clear_suspended', 'zpool_clear_suspended',
+    'zpool_clear_suspended', 'zpool_clear_suspended', 'zpool_clear_suspended']
+
+[tests/functional/cli_root/zpool_offline]
+tests = ['zpool_offline_001_pos', 'zpool_offline_002_neg', 'zpool_offline_003_pos']
+

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/Makefile.am
@@ -6,4 +6,5 @@ dist_pkgdata_SCRIPTS = \
 	zpool_clear_001_pos.ksh \
 	zpool_clear_002_neg.ksh \
 	zpool_clear_003_neg.ksh \
-	zpool_clear_readonly.ksh
+	zpool_clear_readonly.ksh \
+	zpool_clear_suspended.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_suspended.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_suspended.ksh
@@ -1,0 +1,104 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_clear/zpool_clear.cfg
+
+#
+# DESCRIPTION:
+# Verify 'zpool clear' works on suspended pools.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Suspend the pool.
+# 3. Verify various operations fail on a suspended pool.
+# 4. Verify we can 'zpool clear' the suspended pool.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must zinject -c all
+	destroy_pool $TESTPOOL1
+	rm -f $TESTDIR/file.*
+}
+
+#
+# Wait $pool to be suspended
+#
+function wait_pool_suspended # pool
+{
+	typeset poolname="$1"
+
+	for i in {1..3}; do
+		check_pool_status "$poolname" "state" "UNAVAIL" && return 0
+		sleep 1
+	done
+	return 1
+}
+
+log_assert "Verify 'zpool clear' works on suspended pools."
+log_onexit cleanup
+
+typeset status
+typeset -i scrub_pid
+typeset -i retval
+
+# 1. Create a pool.
+log_must truncate -s $FILESIZE $TESTDIR/file.{1,2,3}
+log_must zpool create $TESTPOOL1 raidz $TESTDIR/file.*
+
+# 2. Suspend the pool
+# 2.1 zinject read errors on every device
+for i in {1..3}; do
+	log_must zinject -d $TESTDIR/file.$i -e nxio -T read $TESTPOOL1
+done
+# 2.2 scrub the pool
+zpool scrub $TESTPOOL1 &
+scrub_pid=$!
+# 2.3 verify the pool is suspended
+log_must wait_pool_suspended $TESTPOOL1
+
+# 3. Verify various operations fail on a suspended pool.
+log_mustnot zpool set comment="No I/O on suspended pools" $TESTPOOL1
+log_mustnot zpool reopen $TESTPOOL1
+log_mustnot zpool scrub $TESTPOOL1
+
+# 4. Verify we can 'zpool clear' the suspended pool.
+log_must zinject -c all
+log_must zpool clear $TESTPOOL1
+status="$(get_pool_prop health $TESTPOOL1)"
+if [[ "$status" != 'ONLINE' ]]; then
+	log_fail "Pool $TESTPOOL1 is not ONLINE ($status)"
+fi
+wait $scrub_pid
+retval=$?
+if [[ $retval -ne 0 ]]; then
+	log_fail "'zpool scrub' exit status is not 0 ($retval)"
+fi
+
+log_pass "'zpool clear' works on suspended pools."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

`zpool clear` should be able to resume I/O on suspended, but otherwise healty, pools.

4a283c7 accidentally introduced a new codepath where we call `txg_wait_synced()` on the suspended pool before we had the chance to resume I/O via `zio_resume()`: this results in the `zpool clear` command to hang indefinitely waiting for a TXG that cannot be synced.

Fix this by avoiding the call to `txg_wait_synced()`.

**EDIT**: the new test case is racy because, even if from userland (`zpool status`|`zpool get health`) the pool status is reported as `UNAVAIL`, when we go to `zpool set comment="$something"` the sanity checks in the IOCTL dispatch code don't detect the pool as suspended (`spa_suspended(spa)` in `pool_status_check()`), so we get to call `zfs_ioc_pool_set_props()` on a pool _that is about to become suspended_ (next TXG will not be synced)

```bash
# 2.3 verify the pool is suspended
log_must wait_pool_suspended $TESTPOOL1 <-- pool is reported as "UNAVAIL"

# 3. Verify various operations fail on a suspended pool.
log_mustnot zpool set comment="No I/O on suspended pools" $TESTPOOL1 <-- !spa_suspended(spa)
```

```
INFO: task zpool:6556 blocked for more than 120 seconds.
      Tainted: P           -- ------------    2.6.32-696.6.3.el6.x86_64 #1
"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
zpool         D 0000000000000000     0  6556   6313 0x00000080
 ffff88018f76bb88 0000000000000082 ffff88018f76bb28 0000000000000060
 ffffffffa043c4b0 0000000000000060 0000000000000000 000000000000c210
 0000000000000000 0000000000400000 ffff8800ad8c85f8 ffff88018f76bfd8
Call Trace:
 [<ffffffff810a6b7e>] ? prepare_to_wait_exclusive+0x4e/0x80
 [<ffffffffa03540fd>] cv_wait_common+0x15d/0x2b0 [spl]
 [<ffffffff810a6930>] ? autoremove_wake_function+0x0/0x40
 [<ffffffffa0528bb2>] ? rrw_held+0x82/0x100 [zfs]
 [<ffffffffa03542a5>] __cv_wait+0x15/0x20 [spl]
 [<ffffffffa054d10f>] txg_wait_synced+0x11f/0x1f0 [zfs]
 [<ffffffffa051830a>] dsl_sync_task+0x16a/0x250 [zfs]
 [<ffffffffa0535be0>] ? spa_sync_props+0x0/0x6b0 [zfs]
 [<ffffffffa0517f60>] ? dsl_null_checkfunc+0x0/0x10 [zfs]
 [<ffffffffa0535be0>] ? spa_sync_props+0x0/0x6b0 [zfs]
 [<ffffffffa0536677>] spa_prop_set+0x127/0x1b0 [zfs]
 [<ffffffffa05888b2>] zfs_ioc_pool_set_props+0xc2/0x1e0 [zfs]
 [<ffffffffa058ad04>] zfsdev_ioctl+0x4d4/0x540 [zfs]
 [<ffffffff810521c4>] ? __do_page_fault+0x1f4/0x500
 [<ffffffff811af832>] vfs_ioctl+0x22/0xa0
 [<ffffffff811af9d4>] do_vfs_ioctl+0x84/0x580
 [<ffffffff811aff51>] sys_ioctl+0x81/0xa0
 [<ffffffff8100b0d2>] system_call_fastpath+0x16/0x1b
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before 4a283c7 we were able to call `zio_resume()` and resume I/O on a suspended pool:

```
 -> zfs_ioc_clear
   -> spa_lookup
   <- spa_lookup
   -> spa_lookup
   <- spa_lookup
   -> spa_vdev_state_enter
   <- spa_vdev_state_enter
   -> vdev_clear
     -> vdev_clear
     <- vdev_clear
   <- vdev_clear
   -> spa_vdev_state_exit
   <- spa_vdev_state_exit
   -> zio_resume
   <- zio_resume
 <- zfs_ioc_clear
```

Trying to `zpool clear` a suspended pool with current HEAD hangs:

```
  -> zfs_ioc_clear
    -> spa_lookup
    <- spa_lookup
    -> spa_lookup
    <- spa_lookup
    -> spa_vdev_state_enter
    <- spa_vdev_state_enter
    -> vdev_clear
      -> vdev_clear
      <- vdev_clear
    <- vdev_clear
    -> spa_vdev_state_exit
      -> txg_wait_synced <--- doesn't return because we cannot sync any txg while I/O is suspended
```

```
root@linux:~# cat /proc/`pgrep -f 'zpool clear'`/stack
[<ffffffffc0141ac4>] cv_wait_common+0x154/0x2b0 [spl]
[<ffffffffc0141c35>] __cv_wait+0x15/0x20 [spl]
[<ffffffffc037c2dc>] txg_wait_synced+0x10c/0x1e0 [zfs]
[<ffffffffc0375a41>] spa_vdev_state_exit+0xa1/0x1e0 [zfs]
[<ffffffffc03b6110>] zfs_ioc_clear+0x180/0x2a0 [zfs]
[<ffffffffc03b9e35>] zfsdev_ioctl+0x635/0x750 [zfs]
[<ffffffff8121b44d>] do_vfs_ioctl+0x9d/0x5b0
[<ffffffff8121b9d9>] SyS_ioctl+0x79/0x90
[<ffffffff81834536>] system_call_fast_compare_end+0xc/0x96
[<ffffffffffffffff>] 0xffffffffffffffff
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Test case added to ZTS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.