### PR TITLE
Fix autoconf detection of super_setup_bdi_name

### DIFF
--- a/config/kernel-bdi.m4
+++ b/config/kernel-bdi.m4
@@ -11,8 +11,9 @@ AC_DEFUN([ZFS_AC_KERNEL_BDI], [
 		struct super_block sb;
 	], [
 		char *name = "bdi";
+		atomic_long_t zfs_bdi_seq;
 		int error __attribute__((unused)) =
-		    super_setup_bdi_name(&sb, name);
+		    super_setup_bdi_name(&sb, "%.28s-%ld", name, atomic_long_inc_return(&zfs_bdi_seq));
 	], [super_setup_bdi_name], [fs/super.c], [
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_SUPER_SETUP_BDI_NAME, 1,


### PR DESCRIPTION
The previous autoconf test for the presence of super_setup_bdi_name()
uses an invocation with an incorrect type signature, producing a
warning by the compiler when the test is run. This gets elevated to an
error when compiling with -Werror=format-security, causing autoconf to
falsely infer super_setup_bdi_name() is not present. This updates the
testing code to match the invocation used in
include/linux/vfs_compat.h.

Signed-off-by: Justin Bedo <cu@cua0.org>

### Description
Updates the autoconf test for super_setup_bdi_name() to the same form used in include/linux/vfs_compat.h.

### Motivation and Context
Previous test calls super_setup_bdi_name() with incorrect types, generating a warning. If promoting warnings to errors (-Werror) then this causes the test to incorrectly fail, preventing a successful build.

### How Has This Been Tested?
Change was tested on nixos against kernel 4.12. Autoconf correctly detects super_setup_bdi_name after application of this patch, and ZFS subsequently builds successfully.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
