### PR TITLE
mmp_on_uberblocks: Use kstat for uberblock counts

### DIFF
--- a/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -182,3 +182,19 @@ function import_activity_check # pool opts
 
 	return $rc
 }
+
+function clear_mmp_history
+{
+	log_must set_tunable64 zfs_multihost_history $MMP_HISTORY_OFF
+	log_must set_tunable64 zfs_multihost_history $MMP_HISTORY
+}
+
+function count_uberblocks # pool duration
+{
+	typeset pool=$1
+	typeset -i duration=$2
+	typeset hist_path="/proc/spl/kstat/zfs/$pool/multihost"
+
+	log_must sleep $duration
+	echo $(cat "$hist_path" | sed '1,2d' | wc -l)
+}

--- a/tests/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh
@@ -24,8 +24,8 @@
 # STRATEGY:
 #	1. Set zfs_txg_timeout to large value
 #	2. Create a zpool
-#	3. Find the current "best" uberblock
-#	4. Loop for 10 seconds, increment counter for each change in UB
+#	3. Clear multihost history
+#	4. Sleep, then collect count of uberblocks written
 #	5. If number of changes seen is less than min threshold, then fail
 #	6. If number of changes seen is more than max threshold, then fail
 #
@@ -37,12 +37,15 @@
 verify_runnable "both"
 
 UBER_CHANGES=0
+EXPECTED=$(($(echo $DISKS | wc -w) * 10))
+FUDGE=$((EXPECTED * 20 / 100))
+MIN=$((EXPECTED - FUDGE))
+MAX=$((EXPECTED + FUDGE))
 
 function cleanup
 {
 	default_cleanup_noexit
 	set_tunable64 zfs_txg_timeout $TXG_TIMEOUT_DEFAULT
-	log_must rm -f $PREV_UBER $CURR_UBER
 	log_must mmp_clear_hostid
 }
 
@@ -52,28 +55,19 @@ log_onexit cleanup
 log_must set_tunable64 zfs_txg_timeout $TXG_TIMEOUT_LONG
 log_must mmp_set_hostid $HOSTID1
 
-default_setup_noexit $DISK
+default_setup_noexit "$DISKS"
 log_must zpool set multihost=on $TESTPOOL
-
-log_must zdb -u $TESTPOOL > $PREV_UBER
-
-SECONDS=0
-while [[ $SECONDS -le 10 ]]; do
-	log_must zdb -u $TESTPOOL > $CURR_UBER
-	if ! diff -u "$CURR_UBER" "$PREV_UBER"; then
-		(( UBER_CHANGES = UBER_CHANGES + 1 ))
-		log_must mv "$CURR_UBER" "$PREV_UBER"
-	fi
-done
+clear_mmp_history
+UBER_CHANGES=$(count_uberblocks $TESTPOOL 10)
 
 log_note "Uberblock changed $UBER_CHANGES times"
 
-if [[ $UBER_CHANGES -lt 8 ]]; then
-	log_fail "Fewer uberblock writes occured than expected (10)"
+if [ $UBER_CHANGES -lt $MIN ]; then
+	log_fail "Fewer uberblock writes occured than expected ($EXPECTED)"
 fi
 
-if [[ $UBER_CHANGES -gt 12 ]]; then
-	log_fail "More uberblock writes occured than expected (10)"
+if [ $UBER_CHANGES -gt $MAX ]; then
+	log_fail "More uberblock writes occured than expected ($EXPECTED)"
 fi
 
 log_pass "Ensure MMP uberblocks update at the correct interval passed"

--- a/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
@@ -53,14 +53,11 @@ log_must mmp_set_hostid $HOSTID1
 default_setup_noexit $DISK
 log_must zpool set multihost=on $TESTPOOL
 
-prev_count=$(wc -l /proc/spl/kstat/zfs/$TESTPOOL/multihost | cut -f1 -d' ')
+clear_mmp_history
 log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_DEFAULT
+uber_count=$(count_uberblocks $TESTPOOL 1)
 
-# slight delay to allow time for the mmp write to complete
-sleep 1
-curr_count=$(wc -l /proc/spl/kstat/zfs/$TESTPOOL/multihost | cut -f1 -d' ')
-
-if [ $curr_count -eq $prev_count ]; then
+if [ $uber_count -eq 0 ]; then
 	log_fail "mmp writes did not start when zfs_multihost_interval reduced"
 fi
 

--- a/tests/zfs-tests/tests/functional/mmp/mmp_write_uberblocks.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_write_uberblocks.ksh
@@ -48,12 +48,10 @@ log_must mmp_set_hostid $HOSTID1
 default_mirror_setup_noexit $DISKS
 log_must zpool set multihost=on $TESTPOOL
 log_must zinject -d ${DISK[0]} -e io -T write -f 50 $TESTPOOL -L uber
+clear_mmp_history
+uber_count=$(count_uberblocks $TESTPOOL 3)
 
-prev_count=$(wc -l /proc/spl/kstat/zfs/$TESTPOOL/multihost | cut -f1 -d' ')
-log_must sleep 3
-curr_count=$(wc -l /proc/spl/kstat/zfs/$TESTPOOL/multihost | cut -f1 -d' ')
-
-if [ $curr_count -eq $prev_count ]; then
+if [ $uber_count -eq 0 ]; then
 	log_fail "mmp writes did not occur when uberblock IO errors injected"
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Use kstat to get a more accurate count of uberblock updates.
Using a loop with zdb can potentially miss some uberblocks.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `mmp_on_uberblocks` test case occasionally fails because uberblock changes are lower than expected. Using kstat should provide more consistent uberblock change counts.

#6407

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Locally on a CentOS 7 VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.