### PR TITLE
zpool import -P to specify device path

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -316,14 +316,14 @@ get_usage(zpool_help_t idx)
 		return (gettext("\thistory [-il] [<pool>] ...\n"));
 	case HELP_IMPORT:
 		return (gettext("\timport [-d dir] [-D]\n"
-		    "\timport [-d dir | -c cachefile] [-F [-n]] [-l] "
-		    "<pool | id>\n"
+		    "\timport [-d dir | -c cachefile | -P device] [-F [-n]] "
+		    "[-l] <pool | id>\n"
 		    "\timport [-o mntopts] [-o property=value] ... \n"
-		    "\t    [-d dir | -c cachefile] [-D] [-l] [-f] [-m] [-N] "
-		    "[-R root] [-F [-n]] -a\n"
+		    "\t    [-d dir | -c cachefile | -P device] [-D] [-l] "
+		    "[-f] [-m] [-N] [-R root] [-F [-n]] -a\n"
 		    "\timport [-o mntopts] [-o property=value] ... \n"
-		    "\t    [-d dir | -c cachefile] [-D] [-l] [-f] [-m] [-N] "
-		    "[-R root] [-F [-n]]\n"
+		    "\t    [-d dir | -c cachefile | -P device] [-D] [-l] "
+		    "[-f] [-m] [-N] [-R root] [-F [-n]]\n"
 		    "\t    <pool | id> [newpool]\n"));
 	case HELP_IOSTAT:
 		return (gettext("\tiostat [[[-c [script1,script2,...]"
@@ -2372,15 +2372,37 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 	return (ret);
 }
 
+/* Helper function for adding searchdirs entry in import -d | -P */
+static void
+searchdir_add(char ***searchdirs, int *nsearch, char *dir)
+{
+	char **olddirs = *searchdirs;
+	int n = *nsearch;
+
+	if (olddirs == NULL) {
+		*searchdirs = safe_malloc(sizeof (char *));
+	} else {
+		*searchdirs = safe_malloc((n+1) * sizeof (char *));
+		bcopy(olddirs, *searchdirs, n * sizeof (char *));
+		free(olddirs);
+	}
+	(*searchdirs)[n++] = dir;
+	*nsearch = n;
+}
+
 /*
  * zpool import [-d dir] [-D]
  *       import [-o mntopts] [-o prop=value] ... [-R root] [-D] [-l]
- *              [-d dir | -c cachefile] [-f] -a
+ *              [-d dir | -c cachefile | -P <dev>...] [-f] -a
  *       import [-o mntopts] [-o prop=value] ... [-R root] [-D] [-l]
- *              [-d dir | -c cachefile] [-f] [-n] [-F] <pool | id> [newpool]
+ *              [-d dir | -c cachefile | -P <dev>...] [-f] [-n] [-F]
+ *              <pool | id> [newpool]
  *
  *	 -c	Read pool information from a cachefile instead of searching
  *		devices.
+ *
+ *	 -P	Import by specifying device path instead of searching. Specify
+ *		multiple devices by using multiple -P
  *
  *       -d	Scan in a specific directory, other than /dev/.  More than
  *		one directory can be specified using multiple '-d' options.
@@ -2448,13 +2470,14 @@ zpool_do_import(int argc, char **argv)
 	boolean_t do_rewind = B_FALSE;
 	boolean_t xtreme_rewind = B_FALSE;
 	boolean_t do_scan = B_FALSE;
+	boolean_t do_path = B_FALSE;
 	uint64_t pool_state, txg = -1ULL;
 	char *cachefile = NULL;
 	importargs_t idata = { 0 };
 	char *endptr;
 
 	/* check options */
-	while ((c = getopt(argc, argv, ":aCc:d:DEfFlmnNo:R:stT:VX")) != -1) {
+	while ((c = getopt(argc, argv, ":aCc:P:d:DEfFlmnNo:R:stT:VX")) != -1) {
 		switch (c) {
 		case 'a':
 			do_all = B_TRUE;
@@ -2462,18 +2485,24 @@ zpool_do_import(int argc, char **argv)
 		case 'c':
 			cachefile = optarg;
 			break;
-		case 'd':
-			if (searchdirs == NULL) {
-				searchdirs = safe_malloc(sizeof (char *));
-			} else {
-				char **tmp = safe_malloc((nsearch + 1) *
-				    sizeof (char *));
-				bcopy(searchdirs, tmp, nsearch *
-				    sizeof (char *));
-				free(searchdirs);
-				searchdirs = tmp;
+		case 'P':
+			if (searchdirs != NULL && do_path == B_FALSE) {
+				(void) fprintf(stderr,
+				    gettext("cannot mix -d and -P\n"));
+				err = 1;
+				goto error;
 			}
-			searchdirs[nsearch++] = optarg;
+			do_path = B_TRUE;
+			searchdir_add(&searchdirs, &nsearch, optarg);
+			break;
+		case 'd':
+			if (do_path) {
+				(void) fprintf(stderr,
+				    gettext("cannot mix -d and -P\n"));
+				err = 1;
+				goto error;
+			}
+			searchdir_add(&searchdirs, &nsearch, optarg);
 			break;
 		case 'D':
 			do_destroyed = B_TRUE;
@@ -2679,6 +2708,7 @@ zpool_do_import(int argc, char **argv)
 	idata.guid = searchguid;
 	idata.cachefile = cachefile;
 	idata.scan = do_scan;
+	idata.fullpaths = do_path;
 
 	pools = zpool_search_import(g_zfs, &idata);
 

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -409,6 +409,7 @@ typedef struct importargs {
 	int unique : 1;		/* does 'poolname' already exist?	*/
 	int exists : 1;		/* set on return if pool already exists	*/
 	int scan : 1;		/* prefer scanning to libblkid cache    */
+	int fullpaths : 1;	/* use specified device paths		*/
 } importargs_t;
 
 extern nvlist_t *zpool_search_import(libzfs_handle_t *, importargs_t *);

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -87,13 +87,13 @@
 .Nm
 .Cm import
 .Op Fl D
-.Op Fl d Ar dir
+.Op Fl d Ar dir Ns | Ns Fl P Ar device
 .Nm
 .Cm import
 .Fl a
 .Op Fl DflmN
 .Op Fl F Oo Fl n Oc Oo Fl T Oc Oo Fl X Oc
-.Op Fl c Ar cachefile Ns | Ns Fl d Ar dir
+.Op Fl c Ar cachefile Ns | Ns Fl d Ar dir Ns | Ns Fl P Ar device
 .Op Fl o Ar mntopts
 .Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
 .Op Fl R Ar root
@@ -101,7 +101,7 @@
 .Cm import
 .Op Fl Dflm
 .Op Fl F Oo Fl n Oc Oo Fl T Oc Oo Fl X Oc
-.Op Fl c Ar cachefile Ns | Ns Fl d Ar dir
+.Op Fl c Ar cachefile Ns | Ns Fl d Ar dir Ns | Ns Fl P Ar device
 .Op Fl o Ar mntopts
 .Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
 .Op Fl R Ar root
@@ -1141,7 +1141,7 @@ performed.
 .Nm
 .Cm import
 .Op Fl D
-.Op Fl d Ar dir
+.Op Fl d Ar dir Ns | Ns Fl P Ar device
 .Xc
 Lists pools available to import.
 If the
@@ -1178,6 +1178,15 @@ Searches for devices or files in
 The
 .Fl d
 option can be specified multiple times.
+.It Fl P Ar device
+Use the specified
+.Ar device ,
+instead of searching. The
+.Fl P
+option can be specified multiple times.
+This option is incompatible with the
+.Fl d
+option.
 .It Fl D
 Lists destroyed pools only.
 .El
@@ -1187,7 +1196,7 @@ Lists destroyed pools only.
 .Fl a
 .Op Fl DflmN
 .Op Fl F Oo Fl n Oc Oo Fl T Oc Oo Fl X Oc
-.Op Fl c Ar cachefile Ns | Ns Fl d Ar dir
+.Op Fl c Ar cachefile Ns | Ns Fl d Ar dir Ns | Ns Fl P Ar device
 .Op Fl o Ar mntopts
 .Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
 .Op Fl R Ar root
@@ -1221,6 +1230,15 @@ The
 option can be specified multiple times.
 This option is incompatible with the
 .Fl c
+option.
+.It Fl P Ar device
+Use the specified
+.Ar device ,
+instead of searching. The
+.Fl P
+option can be specified multiple times.
+This option is incompatible with the
+.Fl d
 option.
 .It Fl D
 Imports destroyed pools only.
@@ -1308,7 +1326,7 @@ health of your pool and should only be used as a last resort.
 .Cm import
 .Op Fl Dflm
 .Op Fl F Oo Fl n Oc Oo Fl t Oc Oo Fl T Oc Oo Fl X Oc
-.Op Fl c Ar cachefile Ns | Ns Fl d Ar dir
+.Op Fl c Ar cachefile Ns | Ns Fl d Ar dir Ns | Ns Fl P Ar device
 .Op Fl o Ar mntopts
 .Oo Fl o Ar property Ns = Ns Ar value Oc Ns ...
 .Op Fl R Ar root
@@ -1350,6 +1368,15 @@ The
 option can be specified multiple times.
 This option is incompatible with the
 .Fl c
+option.
+.It Fl P Ar device
+Use the specified
+.Ar device ,
+instead of searching. The
+.Fl P
+option can be specified multiple times.
+This option is incompatible with the
+.Fl d
 option.
 .It Fl D
 Imports destroyed pool.


### PR DESCRIPTION
When we know which devices have the pool we are looking for, sometime
it's better if we can directly pass those device paths to zpool import
instead of letting it to search through all unrelated stuff, which might
take a lot of time if you have hundreds of disks.

This patch add an option -P <path> to zpool import. You can have
multiple pairs of -P <path>, and zpool import will only search through
those devices. For example:

    zpool import -P /dev/sda -P /dev/sdb

Note this option conflicts with -d, you cannot simultaneously have both
-P and -d options.

Signed-off-by: Chunwei Chen <david.chen@osnexus.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
