### PR TITLE
Fix volmode=none property behavior at import time

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1603,6 +1603,9 @@ zvol_alloc(dev_t dev, const char *name)
 	if (volmode == ZFS_VOLMODE_DEFAULT)
 		volmode = zvol_volmode;
 
+	if (volmode == ZFS_VOLMODE_NONE)
+		return (NULL);
+
 	zv = kmem_zalloc(sizeof (zvol_state_t), KM_SLEEP);
 
 	list_link_init(&zv->zv_next);

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3425,7 +3425,7 @@ function swap_setup
 	typeset swapdev=$1
 
 	if is_linux; then
-		log_must mkswap $swapdev > /dev/null 2>&1
+		log_must eval "mkswap $swapdev > /dev/null 2>&1"
 		log_must swapon $swapdev
 	else
 	        log_must swap -a $swapdev


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
At import time `spa_import()` calls `zvol_create_minors()` directly: with the current implementation we have no way to avoid device node creation when `volmode=none`.

Fix this by enforcing `volmode=none` directly in `zvol_alloc()`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I encountered this issue importing an old USB disk used to backup virtual machines: i set `volmode=none` on the root dataset but subsequent imports were still creating device nodes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
I've updated the ZTS script `tests/functional/zvol/zvol_misc/zvol_misc_volmode.ksh`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
