### PR TITLE
Disable mount(8) canonical paths in do_mount()

### DIFF
--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -11,7 +11,6 @@ Before=local-fs.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@sbindir@/zfs mount -a
-WorkingDirectory=-/sbin/
 
 [Install]
 WantedBy=zfs-share.service

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -345,8 +345,9 @@ zfs_is_mountable(zfs_handle_t *zhp, char *buf, size_t buflen,
 static int
 do_mount(const char *src, const char *mntpt, char *opts)
 {
-	char *argv[8] = {
+	char *argv[9] = {
 	    "/bin/mount",
+	    "--no-canonicalize",
 	    "-t", MNTTYPE_ZFS,
 	    "-o", opts,
 	    (char *)src,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
By default the `mount(8)` command, as invoked by `zfs mount`, will try to resolve any path parameter in its canonical form: this could lead to mount failures when the cwd contains a symlink having the same name of the dataset being mounted.

Fix this by explicitly disabling `mount(8)` path canonicalization.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/1791
Maybe fix https://github.com/zfsonlinux/zfs/issues/6429: i don't have a reproducer to verify this could solve the issue addressed in https://github.com/zfsonlinux/zfs/commit/d32d25c5c26c8d1e254bc0fcb8a8ae059e95cebc. If it does we could revert that change to the unit file since the systemd version used in CentOS7 does not (yet) support it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested manually, will probably need to add/modify something in `tests/zfs-tests/tests/functional/cli_root/zfs_mount`.
This PR is mostly just to propose a possible fix for https://github.com/zfsonlinux/zfs/issues/6429.

```
root@linux:~# POOLNAME="wipefs"
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# #
root@linux:~# cd /sbin
root@linux:/sbin# ls -l $POOLNAME
-rwxr-xr-x 1 root root 27144 Mar 30  2015 wipefs
root@linux:/sbin# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:/sbin# zpool destroy $POOLNAME
root@linux:/sbin# rm -f $TMPDIR/zpool.dat
root@linux:/sbin# fallocate -l 64m $TMPDIR/zpool.dat
root@linux:/sbin# strace -f -s 1024 -e trace=execve,mount zpool create $POOLNAME $TMPDIR/zpool.dat
execve("/usr/sbin/zpool", ["zpool", "create", "wipefs", "/var/tmp/zpool.dat"], [/* 14 vars */]) = 0
Process 3715 attached
[pid  3715] execve("/bin/mount", ["/bin/mount", "--no-canonicalize", "-t", "zfs", "-o", "defaults,atime,strictatime,dev,exec,rw,suid,nomand,zfsutil", "wipefs", "/wipefs"], [/* 14 vars */]) = 0
Process 3716 attached
[pid  3716] execve("/sbin/mount.zfs", ["/sbin/mount.zfs", "wipefs", "/wipefs", "-o", "rw,strictatime,zfsutil"], [/* 10 vars */]) = 0
[pid  3716] mount("wipefs", "/wipefs", "zfs", MS_STRICTATIME, "rw,strictatime,zfsutil,mntpoint=/wipefs") = 0
[pid  3716] +++ exited with 0 +++
[pid  3715] --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=3716, si_uid=0, si_status=0, si_utime=0, si_stime=0} ---
[pid  3715] +++ exited with 0 +++
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=3715, si_uid=0, si_status=0, si_utime=0, si_stime=0} ---
+++ exited with 0 +++
root@linux:/sbin# #
root@linux:/sbin# mount -t zfs # what!?
/sbin/wipefs on /wipefs type zfs (rw,xattr,noacl)
root@linux:/sbin# 
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
