### PR TITLE
Only record zio->io_delay on reads and writes

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3278,9 +3278,9 @@ zio_vdev_io_start(zio_t *zio)
 			zio_interrupt(zio);
 			return (ZIO_PIPELINE_STOP);
 		}
+		zio->io_delay = gethrtime();
 	}
 
-	zio->io_delay = gethrtime();
 	vd->vdev_ops->vdev_op_io_start(zio);
 	return (ZIO_PIPELINE_STOP);
 }


### PR DESCRIPTION
### Description
While investigating https://github.com/zfsonlinux/zfs/issues/6425 I noticed that ioctl ZIOs were not setting `zio->io_delay` correctly.  They would set the start time in `zio_vdev_io_start()`, but never set the end time in `zio_vdev_io_done()`, since ioctls skip it and go straight to `zio_done()`.  This was causing spurious "delayed IO" events to appear, which would eventually get rate-limited and displayed as "Missed events" messages in zed.

To get around the problem, this patch only sets `zio->io_delay` for read and write ZIOs, since that's all we care about anyway.

### Motivation and Context
Fixes https://github.com/zfsonlinux/zfs/issues/6425

### How Has This Been Tested?
Tested by doing a bunch of `zfs set` calls in a tight loop.  Saw the the "Missed events" messages go away with the patch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
