### PR TITLE
Use SET_ERROR for constant non-zero return codes

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6187,7 +6187,7 @@ arc_kstat_update(kstat_t *ksp, int rw)
 	arc_stats_t *as = ksp->ks_data;
 
 	if (rw == KSTAT_WRITE) {
-		return (EACCES);
+		return (SET_ERROR(EACCES));
 	} else {
 		arc_kstat_update_state(arc_anon,
 		    &as->arcstat_anon_size,

--- a/module/zfs/blkptr.c
+++ b/module/zfs/blkptr.c
@@ -137,7 +137,7 @@ decode_embedded_bp(const blkptr_t *bp, void *buf, int buflen)
 	psize = BPE_GET_PSIZE(bp);
 
 	if (lsize > buflen)
-		return (ENOSPC);
+		return (SET_ERROR(ENOSPC));
 	ASSERT3U(lsize, ==, buflen);
 
 	if (BP_GET_COMPRESS(bp) != ZIO_COMPRESS_OFF) {

--- a/module/zfs/dbuf_stats.c
+++ b/module/zfs/dbuf_stats.c
@@ -143,7 +143,7 @@ dbuf_stats_hash_table_data(char *buf, size_t size, void *data)
 		 * to be called with a larger scratch buffers.
 		 */
 		if (size < 512) {
-			error = ENOMEM;
+			error = SET_ERROR(ENOMEM);
 			break;
 		}
 

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -370,7 +370,7 @@ dump_write_embedded(dmu_sendarg_t *dsp, uint64_t object, uint64_t offset,
 
 	if (dsp->dsa_pending_op != PENDING_NONE) {
 		if (dump_record(dsp, NULL, 0) != 0)
-			return (EINTR);
+			return (SET_ERROR(EINTR));
 		dsp->dsa_pending_op = PENDING_NONE;
 	}
 
@@ -390,7 +390,7 @@ dump_write_embedded(dmu_sendarg_t *dsp, uint64_t object, uint64_t offset,
 	decode_embedded_bp_compressed(bp, buf);
 
 	if (dump_record(dsp, buf, P2ROUNDUP(drrw->drr_psize, 8)) != 0)
-		return (EINTR);
+		return (SET_ERROR(EINTR));
 	return (0);
 }
 
@@ -2380,15 +2380,15 @@ receive_write_embedded(struct receive_writer_arg *rwa,
 	int err;
 
 	if (drrwe->drr_offset + drrwe->drr_length < drrwe->drr_offset)
-		return (EINVAL);
+		return (SET_ERROR(EINVAL));
 
 	if (drrwe->drr_psize > BPE_PAYLOAD_SIZE)
-		return (EINVAL);
+		return (SET_ERROR(EINVAL));
 
 	if (drrwe->drr_etype >= NUM_BP_EMBEDDED_TYPES)
-		return (EINVAL);
+		return (SET_ERROR(EINVAL));
 	if (drrwe->drr_compression >= ZIO_COMPRESS_FUNCTIONS)
-		return (EINVAL);
+		return (SET_ERROR(EINVAL));
 
 	tx = dmu_tx_create(rwa->os);
 

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -888,7 +888,7 @@ dmu_tx_try_assign(dmu_tx_t *tx, txg_how_t txg_how)
 	    dsl_pool_need_dirty_delay(tx->tx_pool)) {
 		tx->tx_wait_dirty = B_TRUE;
 		DMU_TX_STAT_BUMP(dmu_tx_dirty_delay);
-		return (ERESTART);
+		return (SET_ERROR(ERESTART));
 	}
 
 	tx->tx_txg = txg_hold_open(tx->tx_pool, &tx->tx_txgh);

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1288,11 +1288,11 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 
 	if ((flag & DNODE_MUST_BE_FREE) && !dnode_is_free(db, idx, slots)) {
 		dbuf_rele(db, FTAG);
-		return (ENOSPC);
+		return (SET_ERROR(ENOSPC));
 	} else if ((flag & DNODE_MUST_BE_ALLOCATED) &&
 	    !dnode_is_allocated(db, idx)) {
 		dbuf_rele(db, FTAG);
-		return (ENOENT);
+		return (SET_ERROR(ENOENT));
 	}
 
 	dnh = &children_dnodes->dnc_children[idx];
@@ -1308,7 +1308,7 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 		mutex_exit(&dn->dn_mtx);
 		zrl_remove(&dnh->dnh_zrlock);
 		dbuf_rele(db, FTAG);
-		return (type == DMU_OT_NONE ? ENOENT : EEXIST);
+		return (SET_ERROR(type == DMU_OT_NONE ? ENOENT : EEXIST));
 	}
 	if (refcount_add(&dn->dn_holds, tag) == 1)
 		dbuf_add_ref(db, dnh);

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -871,7 +871,7 @@ dsl_props_set_check(void *arg, dmu_tx_t *tx)
 			    SPA_VERSION_STMF_PROP ?
 			    ZAP_OLDMAXVALUELEN : ZAP_MAXVALUELEN)) {
 				dsl_dataset_rele(ds, FTAG);
-				return (E2BIG);
+				return (SET_ERROR(E2BIG));
 			}
 		}
 	}

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -157,7 +157,7 @@ dsl_scan_init(dsl_pool_t *dp, uint64_t txg)
 				    scn->scn_async_destroying) {
 					spa->spa_errata =
 					    ZPOOL_ERRATA_ZOL_2094_ASYNC_DESTROY;
-					return (EOVERFLOW);
+					return (SET_ERROR(EOVERFLOW));
 				}
 
 				bcopy(zaptmp, &scn->scn_phys,
@@ -2081,7 +2081,7 @@ dsl_scan(dsl_pool_t *dp, pool_scan_func_t func)
 		int err = dsl_scrub_set_pause_resume(scn->scn_dp,
 		    POOL_SCRUB_NORMAL);
 		if (err == 0)
-			return (ECANCELED);
+			return (SET_ERROR(ECANCELED));
 
 		return (SET_ERROR(err));
 	}

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -578,7 +578,7 @@ zfs_zevent_minor_to_state(minor_t minor, zfs_zevent_t **ze)
 {
 	*ze = zfsdev_get_state(minor, ZST_ZEVENT);
 	if (*ze == NULL)
-		return (EBADF);
+		return (SET_ERROR(EBADF));
 
 	return (0);
 }
@@ -591,7 +591,7 @@ zfs_zevent_fd_hold(int fd, minor_t *minorp, zfs_zevent_t **ze)
 
 	fp = getf(fd);
 	if (fp == NULL)
-		return (EBADF);
+		return (SET_ERROR(EBADF));
 
 	error = zfsdev_getminor(fp->f_file, minorp);
 	if (error == 0)

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -533,7 +533,7 @@ __vdev_disk_physio(struct block_device *bdev, zio_t *zio,
 retry:
 	dr = vdev_disk_dio_alloc(bio_count);
 	if (dr == NULL)
-		return (ENOMEM);
+		return (SET_ERROR(ENOMEM));
 
 	if (zio && !(zio->io_flags & (ZIO_FLAG_IO_RETRY | ZIO_FLAG_TRYHARD)))
 		bio_set_flags_failfast(bdev, &flags);
@@ -574,7 +574,7 @@ retry:
 		    BIO_MAX_PAGES));
 		if (unlikely(dr->dr_bio[i] == NULL)) {
 			vdev_disk_dio_free(dr);
-			return (ENOMEM);
+			return (SET_ERROR(ENOMEM));
 		}
 
 		/* Matching put called by vdev_disk_physio_completion */
@@ -645,12 +645,12 @@ vdev_disk_io_flush(struct block_device *bdev, zio_t *zio)
 
 	q = bdev_get_queue(bdev);
 	if (!q)
-		return (ENXIO);
+		return (SET_ERROR(ENXIO));
 
 	bio = bio_alloc(GFP_NOIO, 0);
 	/* bio_alloc() with __GFP_WAIT never returns NULL */
 	if (unlikely(bio == NULL))
-		return (ENOMEM);
+		return (SET_ERROR(ENOMEM));
 
 	bio->bi_end_io = vdev_disk_io_flush_completion;
 	bio->bi_private = zio;

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -944,7 +944,7 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 		nvlist_free(label);
 		abd_free(vp_abd);
 		/* EFAULT means nvlist_pack ran out of room */
-		return (error == EFAULT ? ENAMETOOLONG : EINVAL);
+		return (SET_ERROR(error == EFAULT ? ENAMETOOLONG : EINVAL));
 	}
 
 	/*

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -525,7 +525,7 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	 * already be freed, so this should be perfectly fine.
 	 */
 	if (blkid == 0)
-		return (ENOENT);
+		return (SET_ERROR(ENOENT));
 
 	dn = dmu_buf_dnode_enter(zap->zap_dbuf);
 	err = dmu_buf_hold_by_dnode(dn,
@@ -767,7 +767,7 @@ fzap_checksize(uint64_t integer_size, uint64_t num_integers)
 	}
 
 	if (integer_size * num_integers > ZAP_MAXVALUELEN)
-		return (E2BIG);
+		return (SET_ERROR(E2BIG));
 
 	return (0);
 }

--- a/module/zfs/zap_leaf.c
+++ b/module/zfs/zap_leaf.c
@@ -589,7 +589,7 @@ zap_entry_create(zap_leaf_t *l, zap_name_t *zn, uint32_t cd,
 	numchunks = 1 + ZAP_LEAF_ARRAY_NCHUNKS(zn->zn_key_orig_numints *
 	    zn->zn_key_intlen) + ZAP_LEAF_ARRAY_NCHUNKS(valuelen);
 	if (numchunks > ZAP_LEAF_NUMCHUNKS(l))
-		return (E2BIG);
+		return (SET_ERROR(E2BIG));
 
 	if (cd == ZAP_NEED_CD) {
 		/* find the lowest unused cd */

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -308,7 +308,7 @@ zfsctl_snapshot_rename(char *old_snapname, char *new_snapname)
 
 	se = zfsctl_snapshot_find_by_name(old_snapname);
 	if (se == NULL)
-		return (ENOENT);
+		return (SET_ERROR(ENOENT));
 
 	zfsctl_snapshot_remove(se);
 	strfree(se->se_name);
@@ -751,7 +751,7 @@ zfsctl_snapshot_path_objset(zfsvfs_t *zfsvfs, uint64_t objsetid,
 	int error = 0;
 
 	if (zfsvfs->z_vfs->vfs_mntpoint == NULL)
-		return (ENOENT);
+		return (SET_ERROR(ENOENT));
 
 	cookie = spl_fstrans_mark();
 	snapname = kmem_alloc(ZFS_MAX_DATASET_NAME_LEN, KM_SLEEP);
@@ -856,7 +856,7 @@ zfsctl_snapdir_rename(struct inode *sdip, char *snm,
 	int error;
 
 	if (!zfs_admin_snapshot)
-		return (EACCES);
+		return (SET_ERROR(EACCES));
 
 	ZFS_ENTER(zfsvfs);
 
@@ -933,7 +933,7 @@ zfsctl_snapdir_remove(struct inode *dip, char *name, cred_t *cr, int flags)
 	int error;
 
 	if (!zfs_admin_snapshot)
-		return (EACCES);
+		return (SET_ERROR(EACCES));
 
 	ZFS_ENTER(zfsvfs);
 
@@ -982,7 +982,7 @@ zfsctl_snapdir_mkdir(struct inode *dip, char *dirname, vattr_t *vap,
 	int error;
 
 	if (!zfs_admin_snapshot)
-		return (EACCES);
+		return (SET_ERROR(EACCES));
 
 	dsname = kmem_alloc(ZFS_MAX_DATASET_NAME_LEN, KM_SLEEP);
 
@@ -1029,7 +1029,7 @@ zfsctl_snapshot_unmount(char *snapname, int flags)
 	rw_enter(&zfs_snapshot_lock, RW_READER);
 	if ((se = zfsctl_snapshot_find_by_name(snapname)) == NULL) {
 		rw_exit(&zfs_snapshot_lock);
-		return (ENOENT);
+		return (SET_ERROR(ENOENT));
 	}
 	rw_exit(&zfs_snapshot_lock);
 
@@ -1070,7 +1070,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	struct path spath;
 
 	if (ip == NULL)
-		return (EISDIR);
+		return (SET_ERROR(EISDIR));
 
 	zfsvfs = ITOZSB(ip);
 	ZFS_ENTER(zfsvfs);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -595,7 +595,7 @@ out_check:
 		return (PRIV_POLICY(cr, needed_priv, B_FALSE, EPERM, NULL));
 	return (0);
 #else
-	return (ENOTSUP);
+	return (SET_ERROR(ENOTSUP));
 #endif /* HAVE_MLSLABEL */
 }
 
@@ -3652,7 +3652,7 @@ zfs_ioc_destroy(zfs_cmd_t *zc)
 			if (err == 0)
 				err = dsl_destroy_head(zc->zc_name);
 			else if (err == ENOENT)
-				err = EEXIST;
+				err = SET_ERROR(EEXIST);
 		}
 	}
 
@@ -6313,7 +6313,7 @@ zfsdev_getminor(struct file *filp, minor_t *minorp)
 
 	fpd = filp->private_data;
 	if (fpd == NULL)
-		return (EBADF);
+		return (SET_ERROR(EBADF));
 
 	mutex_enter(&zfsdev_state_lock);
 
@@ -6331,7 +6331,7 @@ zfsdev_getminor(struct file *filp, minor_t *minorp)
 
 	mutex_exit(&zfsdev_state_lock);
 
-	return (EBADF);
+	return (SET_ERROR(EBADF));
 }
 
 /*

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -229,7 +229,7 @@ zfs_sa_set_xattr(znode_t *zp)
 
 	error = nvlist_size(zp->z_xattr_cached, &size, NV_ENCODE_XDR);
 	if ((error == 0) && (size > SA_ATTR_MAX_LEN))
-		error = EFBIG;
+		error = SET_ERROR(EFBIG);
 	if (error)
 		goto out;
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2735,12 +2735,12 @@ zfs_setattr(struct inode *ip, vattr_t *vap, int flags, cred_t *cr)
 	if ((zp->z_pflags & ZFS_IMMUTABLE) &&
 	    ((mask & (ATTR_SIZE|ATTR_UID|ATTR_GID|ATTR_MTIME|ATTR_MODE)) ||
 	    ((mask & ATTR_XVATTR) && XVA_ISSET_REQ(xvap, XAT_CREATETIME)))) {
-		err = EPERM;
+		err = SET_ERROR(EPERM);
 		goto out3;
 	}
 
 	if ((mask & ATTR_SIZE) && (zp->z_pflags & ZFS_READONLY)) {
-		err = EPERM;
+		err = SET_ERROR(EPERM);
 		goto out3;
 	}
 
@@ -2755,7 +2755,7 @@ zfs_setattr(struct inode *ip, vattr_t *vap, int flags, cred_t *cr)
 		    TIMESPEC_OVERFLOW(&vap->va_atime)) ||
 		    ((mask & ATTR_MTIME) &&
 		    TIMESPEC_OVERFLOW(&vap->va_mtime))) {
-			err = EOVERFLOW;
+			err = SET_ERROR(EOVERFLOW);
 			goto out3;
 		}
 	}
@@ -2766,7 +2766,7 @@ top:
 
 	/* Can this be moved to before the top label? */
 	if (zfs_is_readonly(zfsvfs)) {
-		err = EROFS;
+		err = SET_ERROR(EROFS);
 		goto out3;
 	}
 
@@ -2927,7 +2927,7 @@ top:
 
 		if (XVA_ISSET_REQ(xvap, XAT_REPARSE)) {
 			mutex_exit(&zp->z_lock);
-			err = EPERM;
+			err = SET_ERROR(EPERM);
 			goto out3;
 		}
 
@@ -2997,7 +2997,7 @@ top:
 			    zfs_fuid_overquota(zfsvfs, B_FALSE, new_kuid)) {
 				if (attrzp)
 					iput(ZTOI(attrzp));
-				err = EDQUOT;
+				err = SET_ERROR(EDQUOT);
 				goto out2;
 			}
 		}
@@ -3009,7 +3009,7 @@ top:
 			    zfs_fuid_overquota(zfsvfs, B_TRUE, new_kgid)) {
 				if (attrzp)
 					iput(ZTOI(attrzp));
-				err = EDQUOT;
+				err = SET_ERROR(EDQUOT);
 				goto out2;
 			}
 		}

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -2013,7 +2013,7 @@ zfs_obj_to_pobj(objset_t *osp, sa_handle_t *hdl, sa_attr_type_t *sa_table,
 	 * Otherwise the parent must be a directory.
 	 */
 	if (!*is_xattrdir && !S_ISDIR(parent_mode))
-		return (EINVAL);
+		return (SET_ERROR(EINVAL));
 
 	*pobjp = parent;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Update many return statements to follow the ZFS coding convention
of using the SET_ERROR macro when returing a hard-coded non-zero
value from a function. This aids debugging by recording the error
codes in the debug log.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve debugging facilities.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Buildbot.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
