### PR TITLE
dracut: Install commands required for vdev_id

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -52,6 +52,8 @@ install() {
 	fi
 	dracut_install @sbindir@/mount.zfs
 	dracut_install @udevdir@/vdev_id
+	dracut_install awk
+	dracut_install head
 	dracut_install @udevdir@/zvol_id
 	inst_hook cmdline 95 "${moddir}/parse-zfs.sh"
 	if [ -n "$systemdutildir" ] ; then


### PR DESCRIPTION
The vdev_id script requires awk, grep, and head.  Use dracut_install to
ensure that these commands are available in the initrd environment.
References #6443

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
The [vdev_id](/zfsonlinux/zfs/blob/master/cmd/vdev_id/vdev_id) script requires the external commands `awk`, `grep`, and `head`.  The previous version of the dracut ZFS module only used `dracut_install` to install `grep` explicitly, but not `awk` and `head`.  I added `dracut_install` lines for these two commands.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without `awk` and `head`, the creation of device links in /dev/disk/by-vdev fails.  This means that a root pool making use of these device names is not imported automatically.

<!--- If it fixes an open issue, please link to the issue here. -->
[#6443](/zfsonlinux/zfs/issues/6443)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I created new initramfs images in the standard way, then checked for the presence of the commands with

```
% sudo lsinitrd /boot/initramfs-4.11.9-200.fc25.x86_64.img | grep -E 'awk|grep|head'                      
lrwxrwxrwx   1 root     root            4 Nov  7  2016 usr/bin/awk -> gawk
-rwxr-xr-x   1 root     root       659184 Nov  7  2016 usr/bin/gawk
-rwxr-xr-x   1 root     root       166320 Nov  7  2016 usr/bin/grep
-rwxr-xr-x   1 root     root        44960 Nov  7  2016 usr/bin/head
```

<!--- Include details of your testing environment, and the tests you ran to -->
Test done on Gentoo 2017-08-01 x86_64 and Fedora 26 x86_64

<!--- see how your change affects other areas of the code, etc. -->
The size if the initramfs image grows, especially `gawk` is not a small file.  On my Fedora 26 installation, this is about 3 percent.

<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
