### PR TITLE
Fix range locking in ZIL commit codepath

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -2145,6 +2145,7 @@ ztest_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 	if (buf != NULL) {	/* immediate write */
 		zgd_private->z_rl = ztest_range_lock(zd, object, offset, size,
 		    RL_READER);
+		zgd->zgd_rl = zgd_private->z_rl->z_rl;
 
 		error = dmu_read(os, object, offset, size, buf,
 		    DMU_READ_NO_PREFETCH);
@@ -2160,6 +2161,7 @@ ztest_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 
 		zgd_private->z_rl = ztest_range_lock(zd, object, offset, size,
 		    RL_READER);
+		zgd->zgd_rl = zgd_private->z_rl->z_rl;
 
 		error = dmu_buf_hold(os, object, offset, zgd, &db,
 		    DMU_READ_NO_PREFETCH);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -49,6 +49,7 @@
 #include <sys/zfeature.h>
 #include <sys/abd.h>
 #include <sys/trace_dmu.h>
+#include <sys/zfs_rlock.h>
 #ifdef _KERNEL
 #include <sys/vmsystm.h>
 #include <sys/zfs_znode.h>
@@ -1814,6 +1815,11 @@ dmu_sync(zio_t *pio, uint64_t txg, dmu_sync_cb_t *done, zgd_t *zgd)
 
 	ASSERT(pio != NULL);
 	ASSERT(txg != 0);
+
+	/* dbuf is within the locked range */
+	ASSERT3U(db->db.db_offset, >=, zgd->zgd_rl->r_off);
+	ASSERT3U(db->db.db_offset + db->db.db_size, <=,
+	    zgd->zgd_rl->r_off + zgd->zgd_rl->r_len);
 
 	SET_BOOKMARK(&zb, ds->ds_object,
 	    db->db.db_object, db->db_level, db->db_blkid);

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1050,7 +1050,7 @@ zfs_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 	} else { /* indirect write */
 		/*
 		 * Have to lock the whole block to ensure when it's
-		 * written out and it's checksum is being calculated
+		 * written out and its checksum is being calculated
 		 * that no one can change the data. We need to re-check
 		 * blocksize after we get the lock in case it's changed!
 		 */

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -594,7 +594,7 @@ tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 [tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
     'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos',
-    'zvol_misc_snapdev', 'zvol_misc_volmode']
+    'zvol_misc_snapdev', 'zvol_misc_volmode', 'zvol_misc_zil']
 
 [tests/functional/zvol/zvol_swap]
 tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/Makefile.am
@@ -10,4 +10,5 @@ dist_pkgdata_SCRIPTS = \
 	zvol_misc_005_neg.ksh \
 	zvol_misc_006_pos.ksh \
 	zvol_misc_snapdev.ksh \
-	zvol_misc_volmode.ksh
+	zvol_misc_volmode.ksh \
+	zvol_misc_zil.ksh

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_zil.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_zil.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/zvol/zvol_common.shlib
+. $STF_SUITE/tests/functional/zvol/zvol_misc/zvol_misc_common.kshlib
+
+#
+# DESCRIPTION:
+# Verify ZIL functionality on ZVOLs
+#
+# STRATEGY:
+# 1. Create a ZVOLs with various combination of "logbias" and "sync" values
+# 2. Write data to ZVOL device node
+# 3. Verify we don't trigger any issue like the one reported in #6238
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	datasetexists $ZVOL && log_must_busy zfs destroy $ZVOL
+	udev_wait
+}
+
+log_assert "Verify ZIL functionality on ZVOLs"
+log_onexit cleanup
+
+ZVOL="$TESTPOOL/vol"
+ZDEV="$ZVOL_DEVDIR/$ZVOL"
+typeset -a logbias_prop_vals=('latency' 'throughput')
+typeset -a sync_prop_vals=('standard' 'always' 'disabled')
+
+for logbias in ${logbias_prop_vals[@]}; do
+	for sync in ${sync_prop_vals[@]}; do
+		# 1. Create a ZVOL with logbias=throughput and sync=always
+		log_must zfs create -V $VOLSIZE -b 128K -o sync=$sync \
+		    -o logbias=$logbias $ZVOL
+
+		# 2. Write data to its device node
+		for i in {1..50}; do
+			dd if=/dev/zero of=$ZDEV bs=8k count=1 &
+		done
+
+		# 3. Verify we don't trigger any issue
+		log_must wait
+		log_must_busy zfs destroy $ZVOL
+	done
+done
+
+log_pass "ZIL functionality works on ZVOLs"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
I'm trying to reproduce the issue described in #6238 reliably so we can add a new test case when it's fixed.

This PR will be updated with a proper fix when the code is ready.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Investigate #6238
Also #6315 and #6356 seems to be duplicates of the same issue.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Local QEMU/KVM hypervisor with ZVOLs used directly (VirtIO) and exported via ISCSI. This need more investigation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
