### PR TITLE
Allow larger SPA names in stats

### DIFF
--- a/lib/libspl/include/sys/kstat.h
+++ b/lib/libspl/include/sys/kstat.h
@@ -59,7 +59,7 @@ typedef int	kid_t;		/* unique kstat id */
  *	kcid = ioctl(kd, KSTAT_IOC_WRITE, kstat_t *);
  */
 
-#define	KSTAT_STRLEN	31	/* 30 chars + NULL; must be 16 * n - 1 */
+#define	KSTAT_STRLEN	255	/* 254 chars + NULL; must be 16 * n - 1 */
 
 /*
  * The generic kstat header

--- a/module/icp/spi/kcf_spi.c
+++ b/module/icp/spi/kcf_spi.c
@@ -111,7 +111,7 @@ int
 crypto_register_provider(crypto_provider_info_t *info,
     crypto_kcf_provider_handle_t *handle)
 {
-	char ks_name[KSTAT_STRLEN];
+	char *ks_name;
 
 	kcf_provider_desc_t *prov_desc = NULL;
 	int ret = CRYPTO_ARGUMENTS_BAD;
@@ -238,12 +238,12 @@ crypto_register_provider(crypto_provider_info_t *info,
 		 * This kstat is deleted, when the provider unregisters.
 		 */
 		if (prov_desc->pd_prov_type == CRYPTO_SW_PROVIDER) {
-			(void) snprintf(ks_name, KSTAT_STRLEN, "%s_%s",
+			ks_name = kmem_asprintf("%s_%s",
 			    "NONAME", "provider_stats");
 		} else {
-			(void) snprintf(ks_name, KSTAT_STRLEN, "%s_%d_%u_%s",
-			    "NONAME", 0,
-			    prov_desc->pd_prov_id, "provider_stats");
+			ks_name = kmem_asprintf("%s_%d_%u_%s",
+			    "NONAME", 0, prov_desc->pd_prov_id,
+			    "provider_stats");
 		}
 
 		prov_desc->pd_kstat = kstat_create("kcf", 0, ks_name, "crypto",
@@ -261,6 +261,7 @@ crypto_register_provider(crypto_provider_info_t *info,
 			prov_desc->pd_kstat->ks_update = kcf_prov_kstat_update;
 			kstat_install(prov_desc->pd_kstat);
 		}
+		strfree(ks_name);
 	}
 
 	if (prov_desc->pd_prov_type == CRYPTO_HW_PROVIDER)

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -142,7 +142,7 @@ static void
 spa_read_history_init(spa_t *spa)
 {
 	spa_stats_history_t *ssh = &spa->spa_stats.read_history;
-	char name[KSTAT_STRLEN];
+	char *name;
 	kstat_t *ksp;
 
 	mutex_init(&ssh->lock, NULL, MUTEX_DEFAULT, NULL);
@@ -153,7 +153,7 @@ spa_read_history_init(spa_t *spa)
 	ssh->size = 0;
 	ssh->private = NULL;
 
-	(void) snprintf(name, KSTAT_STRLEN, "zfs/%s", spa_name(spa));
+	name = kmem_asprintf("zfs/%s", spa_name(spa));
 
 	ksp = kstat_create(name, 0, "reads", "misc",
 	    KSTAT_TYPE_RAW, 0, KSTAT_FLAG_VIRTUAL);
@@ -168,6 +168,7 @@ spa_read_history_init(spa_t *spa)
 		    spa_read_history_data, spa_read_history_addr);
 		kstat_install(ksp);
 	}
+	strfree(name);
 }
 
 static void
@@ -365,7 +366,7 @@ static void
 spa_txg_history_init(spa_t *spa)
 {
 	spa_stats_history_t *ssh = &spa->spa_stats.txg_history;
-	char name[KSTAT_STRLEN];
+	char *name;
 	kstat_t *ksp;
 
 	mutex_init(&ssh->lock, NULL, MUTEX_DEFAULT, NULL);
@@ -376,7 +377,7 @@ spa_txg_history_init(spa_t *spa)
 	ssh->size = 0;
 	ssh->private = NULL;
 
-	(void) snprintf(name, KSTAT_STRLEN, "zfs/%s", spa_name(spa));
+	name = kmem_asprintf("zfs/%s", spa_name(spa));
 
 	ksp = kstat_create(name, 0, "txgs", "misc",
 	    KSTAT_TYPE_RAW, 0, KSTAT_FLAG_VIRTUAL);
@@ -391,6 +392,7 @@ spa_txg_history_init(spa_t *spa)
 		    spa_txg_history_data, spa_txg_history_addr);
 		kstat_install(ksp);
 	}
+	strfree(name);
 }
 
 static void
@@ -598,7 +600,7 @@ static void
 spa_tx_assign_init(spa_t *spa)
 {
 	spa_stats_history_t *ssh = &spa->spa_stats.tx_assign_histogram;
-	char name[KSTAT_STRLEN];
+	char *name;
 	kstat_named_t *ks;
 	kstat_t *ksp;
 	int i;
@@ -609,7 +611,7 @@ spa_tx_assign_init(spa_t *spa)
 	ssh->size = ssh->count * sizeof (kstat_named_t);
 	ssh->private = kmem_alloc(ssh->size, KM_SLEEP);
 
-	(void) snprintf(name, KSTAT_STRLEN, "zfs/%s", spa_name(spa));
+	name = kmem_asprintf("zfs/%s", spa_name(spa));
 
 	for (i = 0; i < ssh->count; i++) {
 		ks = &((kstat_named_t *)ssh->private)[i];
@@ -632,6 +634,7 @@ spa_tx_assign_init(spa_t *spa)
 		ksp->ks_update = spa_tx_assign_update;
 		kstat_install(ksp);
 	}
+	strfree(name);
 }
 
 static void
@@ -678,12 +681,12 @@ static void
 spa_io_history_init(spa_t *spa)
 {
 	spa_stats_history_t *ssh = &spa->spa_stats.io_history;
-	char name[KSTAT_STRLEN];
+	char *name;
 	kstat_t *ksp;
 
 	mutex_init(&ssh->lock, NULL, MUTEX_DEFAULT, NULL);
 
-	(void) snprintf(name, KSTAT_STRLEN, "zfs/%s", spa_name(spa));
+	name = kmem_asprintf("zfs/%s", spa_name(spa));
 
 	ksp = kstat_create(name, 0, "io", "disk", KSTAT_TYPE_IO, 1, 0);
 	ssh->kstat = ksp;
@@ -694,6 +697,7 @@ spa_io_history_init(spa_t *spa)
 		ksp->ks_update = spa_io_history_update;
 		kstat_install(ksp);
 	}
+	strfree(name);
 }
 
 static void
@@ -806,7 +810,7 @@ static void
 spa_mmp_history_init(spa_t *spa)
 {
 	spa_stats_history_t *ssh = &spa->spa_stats.mmp_history;
-	char name[KSTAT_STRLEN];
+	char *name;
 	kstat_t *ksp;
 
 	mutex_init(&ssh->lock, NULL, MUTEX_DEFAULT, NULL);
@@ -817,7 +821,7 @@ spa_mmp_history_init(spa_t *spa)
 	ssh->size = 0;
 	ssh->private = NULL;
 
-	(void) snprintf(name, KSTAT_STRLEN, "zfs/%s", spa_name(spa));
+	name = kmem_asprintf("zfs/%s", spa_name(spa));
 
 	ksp = kstat_create(name, 0, "multihost", "misc",
 	    KSTAT_TYPE_RAW, 0, KSTAT_FLAG_VIRTUAL);
@@ -832,6 +836,7 @@ spa_mmp_history_init(spa_t *spa)
 		    spa_mmp_history_data, spa_mmp_history_addr);
 		kstat_install(ksp);
 	}
+	strfree(name);
 }
 
 static void


### PR DESCRIPTION
Signed-off-by: gaurkuma <gauravk.18@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
The pool name can be 256 chars long. Today, in /proc/spl/kstat/zfs/<pool name> the name is limited to < 32 characters. This change is to allow bigger pool names. 
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves two main problems:
1. In a system, with several pools each having a large pool name, there is a possibility of having the first 31 characters of  "zfs/\<pool name\>" same, in which case, we will loose stats for all the pools except one. 
2. Same is applicable for pool/pools running on different VMs in a cluster, and upon failover, when the pool is moved from one VM to another, the name clash due to same initial characters can lead to losing the stats. 

Pool name can be constructed in different ways. It can be any random name or a combination of some strings appended to some UUID etc. For e.g. we have the following pools in one of our nodes:

VM:~$ sudo zpool list
NAME                                                                                      SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
zpool-ABCD-WT-e1c0d782-ca7f-4916-bf68-8fc0650a1172-023c8d8c-baa0-4cbb-b26a-bcc6eb502ccf  39.8T  98.5G  39.7T         -     0%     0%  162.82x  ONLINE  -
zpool-ABCD-WT-e1c0d782-ca7f-4916-bf68-8fc0650a1172-4986f9c6-5603-4fac-aae7-f0e0319af2a9  39.8T  94.3G  39.7T         -     0%     0%  162.06x  ONLINE  -
zpool-ABCD-WT-e1c0d782-ca7f-4916-bf68-8fc0650a1172-85eef403-6d5b-455f-87a6-22aafc396a39  39.8T  96.7G  39.7T         -     0%     0%  162.49x  ONLINE  -
zpool-ABCD-WT-e1c0d782-ca7f-4916-bf68-8fc0650a1172-fb64fbb7-d4fb-4087-8278-c92d5a41f2d6  39.8T  98.3G  39.7T         -     0%     0%  161.72x  ONLINE  -
zpool-ABCD-WT-e1c0d782-ca7f-4916-bf68-8fc0650a1172-fd66d34a-43c1-44de-8970-5e659863b235  39.8T   174G  39.6T         -     0%     0%  236.73x  ONLINE  -

In the above example, the first few characters are same across all the pools.
 
SPL Changes: https://github.com/zfsonlinux/spl/pull/641

<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
As in the above multi-pool scenario, we need to have stats for each of the pool under /proc/spl/kstats/zfs/
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
