### PR TITLE
vdev_id: implement slot numbering by port id

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -237,7 +237,7 @@ sas_handler() {
 
 	PHY=`ls -d $port_dir/phy* 2>/dev/null | head -1 | awk -F: '{print $NF}'`
 	if [ -z "$PHY" ] ; then
-		return
+		PHY=0
 	fi
 	PORT=$(( $PHY / $PHYS_PER_PORT ))
 
@@ -261,6 +261,10 @@ sas_handler() {
 		;;
 	"phy")
 		SLOT=`cat $end_device_dir/phy_identifier 2>/dev/null`
+		;;
+	"port")
+		d=$(eval echo \${$i})
+		SLOT=`echo $d | sed -e 's/^.*://'`
 		;;
 	"id")
 		i=$(($i + 1))

--- a/man/man5/vdev_id.conf.5
+++ b/man/man5/vdev_id.conf.5
@@ -90,13 +90,15 @@ internally uses this value to determine which HBA or switch port a
 device is connected to.  The default is 4.
 
 .TP
-\fIslot\fR <bay|phy|id|lun>
+\fIslot\fR <bay|phy|port|id|lun>
 Specifies from which element of a SAS identifier the slot number is
 taken.  The default is bay.
 
 \fIbay\fR - read the slot number from the bay identifier.
 
 \fIphy\fR - read the slot number from the phy identifier.
+
+\fIport\fR - use the SAS port as the slot number.
 
 \fIid\fR - use the scsi id as the slot number.
 


### PR DESCRIPTION
### Description
With HPE hardware and hpsa-driven SAS adapters, only a single phy is
reported, but no individual per-port phys (ie. no `phy*` entry below
`port_dir`), which breaks topology detection in the current sas_handler
code. Instead, slot information can be derived directly from the port
number. This change implements a new slot keyword `port` similar to
`id` and `lun`, and assumes a default phy/port of 0 if no individual
phy entry can be found.

### Motivation and Context
This change allows to use `vdev_id` and its `sas_direct` topology with
current HPE JBODs such as Dxxxx and Apollo 45xx. Currently, this is not
possible due to the check for `phy*` below `port_dir`.

### How Has This Been Tested?
Tested with HPE Apollo 45xx, D3xxx and D6xxx JBODs on systems running RHEL 7.3, hpsa 3.4.14 and 3.4.18.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
