### PR TITLE
Disable rsend_024_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
@@ -36,8 +36,8 @@
 verify_runnable "both"
 
 # See issue: https://github.com/zfsonlinux/zfs/issues/5665
-if is_32bit; then
-	log_unsupported "Test case fails on 32-bit systems"
+if is_linux; then
+	log_unsupported "Test case hangs frequently."
 fi
 
 log_assert "Verify resumability of a full ZFS send/receive with the source " \


### PR DESCRIPTION
The test case frequently hangs on buildbot TEST builders. Disable it for now.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
