### PR TITLE
dracut: make module-setup.sh shebang explicit

### DIFF
--- a/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
+++ b/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 get_devtype() {
   local typ

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 check() {
 	# We depend on udev-rules being loaded


### PR DESCRIPTION
the script is full of bashisms, which trigger warnings on systems which are not using bash as default /bin/sh (like Debian and a lot of its derivates, which use dash).

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>

### Description & Motivation and Context
see commit message - the current shebangs produce linter warnings when building Debian packages.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
