### PR TITLE
Fix remounting snapshots read-write

### DIFF
--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -1763,7 +1763,14 @@ zfs_remount(struct super_block *sb, int *flags, zfs_mnt_t *zm)
 {
 	zfsvfs_t *zfsvfs = sb->s_fs_info;
 	vfs_t *vfsp;
+	boolean_t issnap = dmu_objset_is_snapshot(zfsvfs->z_os);
 	int error;
+
+	if ((issnap || !spa_writeable(dmu_objset_spa(zfsvfs->z_os))) &&
+	    !(*flags & MS_RDONLY)) {
+		*flags |= MS_RDONLY;
+		return (EROFS);
+	}
 
 	error = zfsvfs_parse_options(zm->mnt_data, &vfsp);
 	if (error)
@@ -1774,7 +1781,8 @@ zfs_remount(struct super_block *sb, int *flags, zfs_mnt_t *zm)
 
 	vfsp->vfs_data = zfsvfs;
 	zfsvfs->z_vfs = vfsp;
-	(void) zfs_register_callbacks(vfsp);
+	if (!issnap)
+		(void) zfs_register_callbacks(vfsp);
 
 	return (error);
 }

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -119,7 +119,7 @@ tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_004_pos', 'zfs_mount_005_pos', 'zfs_mount_007_pos',
     'zfs_mount_008_pos', 'zfs_mount_009_neg', 'zfs_mount_010_neg',
     'zfs_mount_011_neg', 'zfs_mount_012_neg', 'zfs_mount_all_001_pos',
-    'zfs_mount_encrypted']
+    'zfs_mount_encrypted', 'zfs_mount_remount']
 
 [tests/functional/cli_root/zfs_promote]
 tests = ['zfs_promote_001_pos', 'zfs_promote_002_pos', 'zfs_promote_003_pos',

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/Makefile.am
@@ -17,4 +17,5 @@ dist_pkgdata_SCRIPTS = \
 	zfs_mount_011_neg.ksh \
 	zfs_mount_012_neg.ksh \
 	zfs_mount_encrypted.ksh \
-	zfs_mount_all_001_pos.ksh
+	zfs_mount_all_001_pos.ksh \
+	zfs_mount_remount.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_remount.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_remount.ksh
@@ -1,0 +1,144 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_mount/zfs_mount.kshlib
+
+#
+# DESCRIPTION:
+# Verify remount functionality, expecially on readonly objects.
+#
+# STRATEGY:
+# 1. Prepare a filesystem and a snapshot
+# 2. Verify we can (re)mount the dataset readonly/read-write
+# 3. Verify we can mount the snapshot and it's mounted readonly
+# 4. Verify we can't remount it read-write
+# 5. Re-import the pool readonly
+# 6. Verify we can't remount its filesystem read-write
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zpool export $TESTPOOL
+	log_must zpool import $TESTPOOL
+	snapexists $TESTSNAP && log_must zfs destroy $TESTSNAP
+	[[ -d $MNTPSNAP ]] && log_must rmdir $MNTPSNAP
+	return 0
+}
+
+#
+# Verify the $filesystem is mounted readonly
+# This is preferred over "log_mustnot touch $fs" because we actually want to
+# verify the error returned is EROFS
+#
+function readonlyfs # filesystem
+{
+	typeset filesystem="$1"
+
+	file_write -o create -f $filesystem/file.dat
+	ret=$?
+	if [[ $ret != 30 ]]; then
+		log_fail "Writing to $filesystem did not return EROFS ($ret)."
+	fi
+}
+
+#
+# Verify $dataset is mounted with $option
+#
+function checkmount # dataset option
+{
+	typeset dataset="$1"
+	typeset option="$2"
+
+	options="$(awk -v ds="$dataset" '$1 == ds { print $4 }' /proc/mounts)"
+	if [[ "$options" == '' ]]; then
+		log_fail "Dataset $dataset is not mounted"
+	elif [[ ! -z "${options##*$option*}" ]]; then
+		log_fail "Dataset $dataset is not mounted with expected "\
+		    "option $option ($options)"
+	else
+		log_note "Dataset $dataset is mounted with option $option"
+	fi
+}
+
+log_assert "Verify remount functionality on both filesystem and snapshots"
+
+log_onexit cleanup
+
+# 1. Prepare a filesystem and a snapshot
+TESTFS=$TESTPOOL/$TESTFS
+TESTSNAP="$TESTFS@snap"
+datasetexists $TESTFS || log_must zfs create $TESTFS
+snapexists $TESTSNAP || log_must zfs snapshot $TESTSNAP
+log_must zfs set readonly=off $TESTFS
+MNTPFS="$(get_prop mountpoint $TESTFS)"
+MNTPSNAP="$TESTDIR/zfs_snap_mount"
+log_must mkdir -p $MNTPSNAP
+
+# 2. Verify we can (re)mount the dataset readonly/read-write
+log_must touch $MNTPFS/file.dat
+checkmount $TESTFS 'rw'
+log_must mount -o remount,ro $TESTFS $MNTPFS
+readonlyfs $MNTPFS
+checkmount $TESTFS 'ro'
+log_must mount -o remount,rw $TESTFS $MNTPFS
+log_must touch $MNTPFS/file.dat
+checkmount $TESTFS 'rw'
+
+# 3. Verify we can (re)mount the snapshot readonly
+log_must mount -t zfs $TESTSNAP $MNTPSNAP
+readonlyfs $MNTPSNAP
+checkmount $TESTSNAP 'ro'
+log_must mount -o remount,ro $TESTSNAP $MNTPSNAP
+readonlyfs $MNTPSNAP
+checkmount $TESTSNAP 'ro'
+log_must umount $MNTPSNAP
+
+# 4. Verify we can't remount a snapshot read-write
+# The "mount -o rw" command will succeed but the snapshot is mounted readonly.
+# The "mount -o remount,rw" command must fail with an explicit error.
+log_must mount -t zfs -o rw $TESTSNAP $MNTPSNAP
+readonlyfs $MNTPSNAP
+checkmount $TESTSNAP 'ro'
+log_mustnot mount -o remount,rw $TESTSNAP $MNTPSNAP
+readonlyfs $MNTPSNAP
+checkmount $TESTSNAP 'ro'
+log_must umount $MNTPSNAP
+
+# 5. Re-import the pool readonly
+log_must zpool export $TESTPOOL
+log_must zpool import -o readonly=on $TESTPOOL
+
+# 6. Verify we can't remount its filesystem read-write
+readonlyfs $MNTPFS
+checkmount $TESTFS 'ro'
+log_mustnot mount -o remount,rw $MNTPFS
+readonlyfs $MNTPFS
+checkmount $TESTFS 'ro'
+
+log_pass "Both filesystem and snapshots can be remounted correctly."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Apparently it's not enough to preserve/restore MS_RDONLY on the superblock flags to avoid remounting a snapshot read-write: be explicit about our intentions to the VFS layer so the readonly bit is updated correctly in `do_remount_sb()`.

This is still causing another issue different from the one reported in #6510, i'm still investigating this:

```
[16498.559788] VERIFY(list_is_empty(list)) failed
[16498.560525] PANIC at list.h:88:list_destroy()
[16498.561242] Showing stack for process 908
[16498.561967] CPU: 0 PID: 908 Comm: dbu_evict Tainted: P           OE   4.9.0 #4
[16498.564434] Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
[16498.566161]  0000000000000000 ffffffff88129055 ffffffffc0a4e081 ffffbf2040e73e10
[16498.569740]  ffffffffc07eb03f ffffa08c4a3586c0 ffffffff00000028 ffffbf2040e73e20
[16498.573670]  ffffbf2040e73dc0 6c28594649524556 655f73695f747369 73696c287974706d
[16498.575983] Call Trace:
[16498.576456]  [<ffffffff88129055>] ? dump_stack+0x5c/0x77
[16498.578307]  [<ffffffffc07eb03f>] ? spl_panic+0xbf/0xf0 [spl]
[16498.580339]  [<ffffffff883f8dce>] ? mutex_lock+0xe/0x30
[16498.582178]  [<ffffffff883f8dce>] ? mutex_lock+0xe/0x30
[16498.584078]  [<ffffffffc0986fb9>] ? refcount_remove_many+0x179/0x280 [zfs]
[16498.585849]  [<ffffffffc0930935>] ? dbuf_rele_and_unlock+0x1e5/0x450 [zfs]
[16498.586479]  [<ffffffffc0930b65>] ? dbuf_rele_and_unlock+0x415/0x450 [zfs]
[16498.588155]  [<ffffffffc098525a>] ? multilist_insert+0xca/0x1a0 [zfs]
[16498.590031]  [<ffffffffc091cd0a>] ? remove_reference+0x8a/0x180 [zfs]
[16498.591858]  [<ffffffff883f8dce>] ? mutex_lock+0xe/0x30
[16498.592541]  [<ffffffffc0986fb9>] ? refcount_remove_many+0x179/0x280 [zfs]
[16498.594420]  [<ffffffffc096bffe>] ? dsl_dir_evict+0x1ae/0x1e0 [zfs]
[16498.596174]  [<ffffffffc07e8eb9>] ? taskq_thread+0x269/0x520 [spl]
[16498.597929]  [<ffffffff87ea9170>] ? wake_up_q+0x60/0x60
[16498.599595]  [<ffffffffc07e8c50>] ? taskq_thread_spawn+0x50/0x50 [spl]
[16498.600174]  [<ffffffff87e9dc10>] ? kthread+0xe0/0x100
[16498.601646]  [<ffffffff87e2b76b>] ? __switch_to+0x2bb/0x700
[16498.602361]  [<ffffffff87e9db30>] ? kthread_park+0x60/0x60
[16498.604091]  [<ffffffff883fbaf5>] ? ret_from_fork+0x25/0x30
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #6510

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
