### PR TITLE
Fix ZTS grow_pool/setup

### DIFF
--- a/tests/zfs-tests/tests/functional/grow_pool/setup.ksh
+++ b/tests/zfs-tests/tests/functional/grow_pool/setup.ksh
@@ -40,12 +40,15 @@ fi
 
 if [[ -n $DISK ]]; then
 	log_note "No spare disks available. Using slices on $DISK"
+	log_must zero_partitions $DISK
 	for i in $SLICE0 $SLICE1 ; do
 		log_must set_partition $i "$cyl" $SIZE $DISK
 		cyl=$(get_endslice $DISK $i)
 	done
 	tmp=$DISK"s"$SLICE0
 else
+	log_must zero_partitions $DISK0
+	log_must zero_partitions $DISK1
 	log_must set_partition $SLICE "" $SIZE $DISK0
 	log_must set_partition $SLICE "" $SIZE $DISK1
 	tmp=$DISK0$SLICE_PREFIX$SLICE


### PR DESCRIPTION
### Description

The addition of the large_dnode_008_pos test case, which runs
right before this one, exposed some racy behavior in grow_pool
setup.sh on the Ubuntu kmemleak builder.  Before creating
partitions on a device destroying any existing ones.

  ERROR: set_partition 1  100mb loop0 exited 1

### Motivation and Context

Issue #6499

### How Has This Been Tested?

Reproduced locally and verified the patch resolves the issue.  Pending buildbot verification.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
