### PR TITLE
Use /sbin/openrc-run for openrc init scripts

### DIFF
--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -22,7 +22,7 @@ $(init_SCRIPTS) $(initconf_SCRIPTS) $(initcommon_SCRIPTS):%:%.in
 		NFS_SRV=nfs; \
 	  fi; \
 	  if [ -e /sbin/openrc-run ]; then \
-		SHELL=/sbin/runscript; \
+		SHELL=/sbin/openrc-run; \
 	  else \
 		SHELL=/bin/sh; \
 	  fi; \


### PR DESCRIPTION
Using /sbin/runscript is deprecated and throws a QA warning when still used in init scripts.