### PR TITLE
zimport.sh: Allow custom pool create options

### DIFF
--- a/scripts/zfs.sh
+++ b/scripts/zfs.sh
@@ -125,8 +125,13 @@ load_module() {
 load_modules() {
 	mkdir -p /etc/zfs
 
-	modprobe "$KMOD_ZLIB_DEFLATE" >/dev/null
-	modprobe "$KMOD_ZLIB_INFLATE" >/dev/null
+	if modinfo "$KMOD_ZLIB_DEFLATE" >/dev/null 2>&1; then
+		modprobe "$KMOD_ZLIB_DEFLATE" >/dev/null 2>&1
+	fi
+
+	if modinfo "$KMOD_ZLIB_INFLATE">/dev/null 2>&1; then
+		modprobe "$KMOD_ZLIB_INFLATE" >/dev/null 2>&1
+	fi
 
 	for KMOD in $KMOD_SPL $KMOD_SPLAT $KMOD_ZAVL $KMOD_ZNVPAIR \
 	    $KMOD_ZUNICODE $KMOD_ZCOMMON $KMOD_ICP $KMOD_ZFS; do
@@ -166,6 +171,14 @@ unload_modules() {
 			unload_module "$KMOD" || return 1
 		fi
 	done
+
+	if modinfo "$KMOD_ZLIB_DEFLATE" >/dev/null 2>&1; then
+		modprobe -r "$KMOD_ZLIB_DEFLATE" >/dev/null 2>&1
+	fi
+
+	if modinfo "$KMOD_ZLIB_INFLATE">/dev/null 2>&1; then
+		modprobe -r "$KMOD_ZLIB_INFLATE" >/dev/null 2>&1
+	fi
 
 	if [ "$VERBOSE" = "yes" ]; then
 		echo "Successfully unloaded ZFS module stack"


### PR DESCRIPTION

### Description

Allow custom options to be passed to 'zpool create` when creating
a new pool.

Normally zimport.sh is intented to prevent accidentally introduced
incompatibilities so we want the default behavior.  However, when
introducing a known incompatibility with a feature flag we need a
way to disable the feature.  By adding a line like the following
to the commit message the feature can be disabled allowing the
pool to be compatibile with older versions.

TEST_ZIMPORT_OPTIONS="-o feature@encryption=disabled"

Additionally fix /dev/nul -> /dev/null typo.

### Motivation and Context

Facilitate testing PRs which add new feature flags.

### How Has This Been Tested?

Locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
