### PR TITLE
Add support for DMU_OTN_* types in dbufstat.py

### DIFF
--- a/cmd/dbufstat/dbufstat.py
+++ b/cmd/dbufstat/dbufstat.py
@@ -228,7 +228,8 @@ def print_header():
 
 
 def get_typestring(t):
-    type_strings = ["DMU_OT_NONE",
+    ot_strings = [
+                    "DMU_OT_NONE",
                     # general:
                     "DMU_OT_OBJECT_DIRECTORY",
                     "DMU_OT_OBJECT_ARRAY",
@@ -291,15 +292,39 @@ def get_typestring(t):
                     "DMU_OT_DEADLIST_HDR",
                     "DMU_OT_DSL_CLONES",
                     "DMU_OT_BPOBJ_SUBOBJ"]
+    otn_strings = {
+                    0x80: "DMU_OTN_UINT8_DATA",
+                    0xc0: "DMU_OTN_UINT8_METADATA",
+                    0x81: "DMU_OTN_UINT16_DATA",
+                    0xc1: "DMU_OTN_UINT16_METADATA",
+                    0x82: "DMU_OTN_UINT32_DATA",
+                    0xc2: "DMU_OTN_UINT32_METADATA",
+                    0x83: "DMU_OTN_UINT64_DATA",
+                    0xc3: "DMU_OTN_UINT64_METADATA",
+                    0x84: "DMU_OTN_ZAP_DATA",
+                    0xc4: "DMU_OTN_ZAP_METADATA",
+                    0xa0: "DMU_OTN_UINT8_ENC_DATA",
+                    0xe0: "DMU_OTN_UINT8_ENC_METADATA",
+                    0xa1: "DMU_OTN_UINT16_ENC_DATA",
+                    0xe1: "DMU_OTN_UINT16_ENC_METADATA",
+                    0xa2: "DMU_OTN_UINT32_ENC_DATA",
+                    0xe2: "DMU_OTN_UINT32_ENC_METADATA",
+                    0xa3: "DMU_OTN_UINT64_ENC_DATA",
+                    0xe3: "DMU_OTN_UINT64_ENC_METADATA",
+                    0xa4: "DMU_OTN_ZAP_ENC_DATA",
+                    0xe4: "DMU_OTN_ZAP_ENC_METADATA"}
 
     # If "-rr" option is used, don't convert to string representation
     if raw > 1:
         return "%i" % t
 
     try:
-        return type_strings[t]
-    except IndexError:
-        return "%i" % t
+        if t < len(ot_strings):
+            return ot_strings[t]
+        else:
+            return otn_strings[t]
+    except (IndexError, KeyError):
+        return "(UNKNOWN)"
 
 
 def get_compstring(c):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
This enable us to view DMU_OTN_* types with dbufstat.py.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was investigating the ARC meta leak/accounting issue when i noticed some dbuf type values were not translated to their type names (`196` instead of `DMU_OTN_ZAP_METADATA`).

Additional notes:

1. I've added the new types as hardcoded values to avoid the amount of work required to dynamically calculate them at runtime (every time we execute `get_typestring()`)
2. `DMU_OTN_*_ENC_(META)DATA` values are included for completeness: they will probably never be used, AFAIK (meta)data is not encrypted in memory.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Manual testing on debian box:

Before:
```
           pool  objset      object                        dtype  cached  
       testpool       0          59                          196     512  
       testpool       0          58                          196     512  
       testpool       0          61                 DMU_OT_BPOBJ     16K  
```

After:
```
           pool  objset      object                        dtype  cached  
       testpool       0          59         DMU_OTN_ZAP_METADATA     512  
       testpool       0          58         DMU_OTN_ZAP_METADATA     512  
       testpool       0          61                 DMU_OT_BPOBJ     16K  
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
