### PR TITLE
OpenZFS 8414 - Implemented zpool scrub pause/resume

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1846,9 +1846,11 @@ Stop scrubbing.
 .Bl -tag -width Ds
 .It Fl p
 Pause scrubbing.
-Scrub progress is periodically synced to disk so if the system
-is restarted or pool is exported during a paused scrub, the scrub will resume
-from the place where it was last checkpointed to disk.
+Scrub pause state and progress are periodically synced to disk.
+If the system is restarted or pool is exported during a paused scrub,
+even after import, scrub will remain paused until it is resumed.
+Once resumed the scrub will pick up from the place where it was last
+checkpointed to disk.
 To resume a paused scrub issue
 .Nm zpool Cm scrub
 again.

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -449,7 +449,6 @@ dsl_scrub_pause_resume_sync(void *arg, dmu_tx_t *tx)
 	spa_t *spa = dp->dp_spa;
 	dsl_scan_t *scn = dp->dp_scan;
 
-
 	if (*cmd == POOL_SCRUB_PAUSE) {
 		/* can't pause a scrub when there is no in-progress scrub */
 		spa->spa_scan_pass_scrub_pause = gethrestime_sec();


### PR DESCRIPTION
Authored by: Alek Pinchuk <apinchuk@datto.com>
Reviewed by: George Melikov <mail@gmelikov.ru>
Reviewed by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed by: Brad Lewis <brad.lewis@delphix.com>
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>
Reviewed by: Matt Ahrens <mahrens@delphix.com>
Approved by: Dan McDonald <danmcd@joyent.com>
Ported-by: Alek Pinchuk <apinchuk@datto.com>

OpenZFS-issue: https://www.illumos.org/issues/8414
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/c29616076

This is a "port" of the OpenZFS scrub pause changes. Since we have scrub pause already these changes just bring us to parity with what landed in https://github.com/openzfs/openzfs/commit/c29616076