### PR TITLE
Adjust arc only when needed

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4923,6 +4923,13 @@ arc_reclaim_thread(void *unused)
 #endif
 		mutex_exit(&arc_reclaim_lock);
 
+		/* If arc size if 0, or below c_min, there
+		 * is no need to call arc_adjust as long as
+		 * the meta usage is under the limits.
+		 */
+		if (arc_size <= MIN(arc_meta_limit, arc_c_min))
+			goto skip_adjust;
+
 		/*
 		 * We call arc_adjust() before (possibly) calling
 		 * arc_kmem_reap_now(), so that we can wake up
@@ -4963,6 +4970,7 @@ arc_reclaim_thread(void *unused)
 			arc_no_grow = B_FALSE;
 		}
 
+skip_adjust:
 		mutex_enter(&arc_reclaim_lock);
 
 		/*


### PR DESCRIPTION
Signed-off-by: gaurkuma <gauravk.18@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
ARC reclaim thread unnecessary spend cpu cycles trying to balance and evict buffers even when ARC is not used. 
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
