### PR TITLE
Enable systemd in packages when detected

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -34,29 +34,12 @@
 %endif
 
 %bcond_with    debug
-%bcond_with    systemd
+%bcond_without systemd
 
-# Generic enable switch for systemd
-%if %{with systemd}
+# Enable systemd when _unitdir is defined or with generic enable switch.
+%if %{with systemd} && %{defined _unitdir}
 %define _systemd 1
 %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target
-%endif
-
-# RHEL >= 7 comes with systemd
-%if 0%{?rhel} >= 7
-%define _systemd 1
-%endif
-
-# Fedora >= 15 comes with systemd, but only >= 18 has
-# the proper macros
-%if 0%{?fedora} >= 18
-%define _systemd 1
-%endif
-
-# opensuse >= 12.1 comes with systemd, but only >= 13.1
-# has the proper macros
-%if 0%{?suse_version} >= 1310
-%define _systemd 1
 %endif
 
 Name:           @PACKAGE@


### PR DESCRIPTION
### Description

Key of the _unitdir rpm macro to determine if a distribution
supports systemd.  When support is detected include the systemd
unit files in the package, otherwise include in the init
scripts.  Pass --without systemd to disable auto-detection.

### Motivation and Context

Attempt to automatically do the right thing.

### How Has This Been Tested?

Locally on Ubuntu 16.04 and CentOS 7.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
