### PR TITLE
Scale the dbuf cache with arc_c instead of arc_c_max

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -289,7 +289,7 @@ void arc_flush(spa_t *spa, boolean_t retry);
 void arc_tempreserve_clear(uint64_t reserve);
 int arc_tempreserve_space(uint64_t reserve, uint64_t txg);
 
-uint64_t arc_max_bytes(void);
+uint64_t arc_target_bytes(void);
 void arc_init(void);
 void arc_fini(void);
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7320,9 +7320,9 @@ arc_state_fini(void)
 }
 
 uint64_t
-arc_max_bytes(void)
+arc_target_bytes(void)
 {
-	return (arc_c_max);
+	return (arc_c);
 }
 
 void


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Scale the size of the dbuf cache according to the ARC target size rather than use a static size based on the maximum ARC size.

### Motivation and Context
Commit d3c2ae1 introduced a dbuf cache with a default size of the minimum of 100M or 1/32 maximum ARC size. (These figures may be adjusted using dbuf_cache_max_bytes and dbuf_cache_max_shift.)

On a 1GB box, the ARC defaults to maximum 370GB and minimum 16G, and the dbuf cache size comes out at 12G. I.e. the dbuf cache is an significant proportion of the minimum ARC size. With other overheads involved this actually means the ARC can't get down to the minimum.

This patch dynamically scales the dbuf cache to the target ARC size instead of statically scaling it to the maximum ARC size. (The scale is still set by dbuf_cache_max_shift and the maximum size is still fixed by dbuf_cache_max_bytes.) Using the target ARC size rather than the current ARC size is done to help the ARC reach the target rather than simply focusing on the current size.

Relates to #6506

### How Has This Been Tested?

Tests per #6506:
- fresh module load
- 2 x directories with 32769 empty files
- find dirs -mtime +100
- echo 3 > /proc/sys/vm/drop_caches

Various `arcstats`:
```
a: stock 9b84076
b: patched 9b84076

                       fresh    post-find    post-drop
a: c             517,185,536  517,185,536  113,351,288        
b: c             517,185,536  517,185,536  127,592,224

a: c_min          33,554,432   33,554,432   33,554,432        
b: c_min          33,554,432   33,554,432   33,554,432

a: size            2,026,488  330,604,488   92,910,384
b: size            2,097,696  330,619,392   26,472,472

a: arc_meta_used   2,026,488  330,604,488   92,910,384
b: arc_meta_used   2,097,696  330,619,392   26,472,472

a: dbuf_size          42,976   64,609,992   18,403,208
b: dbuf_size          46,768   64,612,520    4,473,296

a: dnode_size        126,048  158,995,008   45,673,008
b: dnode_size        130,896  158,999,856   11,134,240

a: metadata_size   1,809,408   71,885,824   16,996,864
b: metadata_size   1,866,240   71,891,456    6,053,376

```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.