### PR TITLE
Fix library linking on multilib systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,8 @@ AC_CONFIG_HEADERS([zfs_config.h], [
 	(mv zfs_config.h zfs_config.h.tmp &&
 	awk -f ${ac_srcdir}/config/config.awk zfs_config.h.tmp >zfs_config.h &&
 	rm zfs_config.h.tmp) || exit 1])
+AC_CACHE_VAL([lt_cv_sys_lib_dlsearch_path_spec],[
+	lt_cv_sys_lib_dlsearch_path_spec="\$libdir `rpm --eval '/%{_lib}'`"])
 
 AC_PROG_INSTALL
 AC_PROG_CC


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
When building ZFS packages libdir is, by default, calculated with the RPM expression "/%{_lib}" in zfs.spec: on multilib systems this results in /lib64.

```
[root@centos7 ~]# lsb_release -a
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	CentOS
Description:	CentOS Linux release 7.3.1611 (Core) 
Release:	7.3.1611
Codename:	Core
[root@centos7 ~]# rpm --eval "/%{_lib}"
/lib64
[root@centos7 ~]# 
```

```
root@debian-9:~# lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 9.0 (stretch)
Release:	9.0
Codename:	stretch
root@debian-9:~# rpm --eval "/%{_lib}"
/lib64
root@debian-9:~# 
```

However, on Debian and Ubuntu, `ld(8)` default search path does not contain /lib64.

```
[root@centos7 ~]# ldconfig -v 2>/dev/null | grep '^/'
/usr/lib64/mysql:
/lib:
/lib64:
/lib/sse2: (hwcap: 0x0000000004000000)
/lib64/sse2: (hwcap: 0x0000000004000000)
/lib64/tls: (hwcap: 0x8000000000000000)
```

```
root@debian-9:~# ldconfig -v 2>/dev/null | grep '^/'
/usr/lib/x86_64-linux-gnu/libfakeroot:
/usr/local/lib:
/lib/x86_64-linux-gnu:
/usr/lib/x86_64-linux-gnu:
/lib:
/usr/lib:
```

When this happens libtool detects it and automatically appends and additional "-Wl,-rpath -Wl,/lib64" to the compiler cmdline.

This could result in compile-time linking failures when we're building on a system with and older ZFS version already installed and the newer executables need new symbols not defined by the older library in /lib64.

```
[...]
make[6]: Entering directory '/usr/src/zfs/tests/zfs-tests/tests/functional/libzfs'
  CCLD     many_fds
../../../../../lib/libzfs/.libs/libzfs.so: undefined reference to `lzc_load_key'
../../../../../lib/libzfs/.libs/libzfs.so: undefined reference to `lzc_change_key'
../../../../../lib/libzfs/.libs/libzfs.so: undefined reference to `lzc_unload_key'
[...]
root@linux:/usr/src/zfs# readelf -d lib/libzfs/.libs/libzfs.so

Dynamic section at offset 0x90438 contains 38 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libnvpair.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libuutil.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libzpool.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libzfs_core.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libblkid.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libudev.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libuuid.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x000000000000000e (SONAME)             Library soname: [libzfs.so.2]
 0x000000000000000f (RPATH)              Library rpath: [/usr/src/zfs/lib/libnvpair/.libs:/usr/src/zfs/lib/libuutil/.libs:/usr/src/zfs/lib/libzpool/.libs:/usr/src/zfs/lib/libzfs_core/.libs:/lib64]
 0x000000000000000c (INIT)               0x15a10
 0x000000000000000d (FINI)               0x71608
 0x0000000000000019 (INIT_ARRAY)         0x290000
 0x000000000000001b (INIT_ARRAYSZ)       16 (bytes)
 0x000000000000001a (FINI_ARRAY)         0x290010
 0x000000000000001c (FINI_ARRAYSZ)       8 (bytes)
 0x000000006ffffef5 (GNU_HASH)           0x1f0
 0x0000000000000005 (STRTAB)             0x8b78
 0x0000000000000006 (SYMTAB)             0x1b88
 0x000000000000000a (STRSZ)              19622 (bytes)
 0x000000000000000b (SYMENT)             24 (bytes)
 0x0000000000000003 (PLTGOT)             0x290988
 0x0000000000000002 (PLTRELSZ)           17856 (bytes)
 0x0000000000000014 (PLTREL)             RELA
 0x0000000000000017 (JMPREL)             0x11450
 0x0000000000000007 (RELA)               0xe2e8
 0x0000000000000008 (RELASZ)             12648 (bytes)
 0x0000000000000009 (RELAENT)            24 (bytes)
 0x000000006ffffffe (VERNEED)            0xe178
 0x000000006fffffff (VERNEEDNUM)         8
 0x000000006ffffff0 (VERSYM)             0xd81e
 0x000000006ffffff9 (RELACOUNT)          423
 0x0000000000000000 (NULL)               0x0
root@linux:/usr/src/zfs# cd ./tests/zfs-tests/tests/functional/libzfs
root@linux:/usr/src/zfs/tests/zfs-tests/tests/functional/libzfs# strace -f -e trace=execve -s 1024 make |& grep execve
execve("/usr/bin/make", ["make"], [/* 14 vars */]) = 0
[pid 21670] execve("/bin/bash", ["/bin/bash", "-c", "rm -f many_fds"], [/* 17 vars */]) = 0
[pid 21670] execve("/bin/rm", ["rm", "-f", "many_fds"], [/* 16 vars */]) = 0
[pid 21671] execve("/bin/bash", ["/bin/bash", "-c", "echo \"  CCLD    \" many_fds;/bin/bash ../../../../../libtool --silent --tag=CC --silent  --mode=link gcc -DNDEBUG -Wall -Wstrict-prototypes -Wno-unused-but-set-variable  -fno-strict-aliasing -std=gnu99 -g -O2   -o many_fds many_fds.o ../../../../../lib/libzfs/libzfs.la -ludev -luuid -lz "], [/* 17 vars */]) = 0
[pid 21672] execve("/bin/bash", ["/bin/bash", "../../../../../libtool", "--silent", "--tag=CC", "--silent", "--mode=link", "gcc", "-DNDEBUG", "-Wall", "-Wstrict-prototypes", "-Wno-unused-but-set-variable", "-fno-strict-aliasing", "-std=gnu99", "-g", "-O2", "-o", "many_fds", "many_fds.o", "../../../../../lib/libzfs/libzfs.la", "-ludev", "-luuid", "-lz"], [/* 16 vars */]) = 0
[pid 21679] execve("/bin/sed", ["/bin/sed", "s/:/ /g"], [/* 19 vars */] <unfinished ...>
[pid 21679] <... execve resumed> )      = 0
[pid 21682] execve("/bin/sed", ["/bin/sed", "s,:*$,,"], [/* 19 vars */] <unfinished ...>
[pid 21682] <... execve resumed> )      = 0
[pid 21685] execve("/bin/sed", ["/bin/sed", "s/-framework \\([^ $]*\\)/\\1.ltframework/g"], [/* 19 vars */] <unfinished ...>
[pid 21685] <... execve resumed> )      = 0
[pid 21688] execve("/bin/sed", ["/bin/sed", "s% \\([^ $]*\\).ltframework% -framework \\1%g"], [/* 19 vars */]) = 0
[pid 21691] execve("/bin/sed", ["/bin/sed", "s/-framework \\([^ $]*\\)/\\1.ltframework/g"], [/* 19 vars */] <unfinished ...>
[pid 21691] <... execve resumed> )      = 0
[pid 21694] execve("/bin/sed", ["/bin/sed", "s% \\([^ $]*\\).ltframework% -framework \\1%g"], [/* 19 vars */]) = 0
[pid 21698] execve("/bin/sed", ["/bin/sed", "s/-framework \\([^ $]*\\)/\\1.ltframework/g"], [/* 19 vars */]) = 0
[pid 21701] execve("/bin/sed", ["/bin/sed", "s% \\([^ $]*\\).ltframework% -framework \\1%g"], [/* 19 vars */] <unfinished ...>
[pid 21701] <... execve resumed> )      = 0
[pid 21705] execve("/bin/sed", ["sed", "s%[^a-zA-Z0-9]%_%g"], [/* 19 vars */]) = 0
[pid 21708] execve("/bin/sed", ["/bin/sed", "s% @SYMFILE@%%"], [/* 19 vars */] <unfinished ...>
[pid 21708] <... execve resumed> )      = 0
[pid 21711] execve("/bin/sed", ["/bin/sed", "s% @SYMFILE@%%"], [/* 19 vars */] <unfinished ...>
[pid 21711] <... execve resumed> )      = 0
[pid 21714] execve("/bin/sed", ["/bin/sed", "s%@OUTPUT@%$progdir/$file%g"], [/* 19 vars */] <unfinished ...>
[pid 21714] <... execve resumed> )      = 0
[pid 21717] execve("/bin/sed", ["/bin/sed", "s%@OUTPUT@%.libs/many_fds%g"], [/* 19 vars */]) = 0
[pid 21718] execve("/bin/rm", ["rm", "-f", "many_fds", ".libs/many_fds", ".libs/lt-many_fds"], [/* 19 vars */]) = 0
[pid 21719] execve("/usr/bin/gcc", ["gcc", "-DNDEBUG", "-Wall", "-Wstrict-prototypes", "-Wno-unused-but-set-variable", "-fno-strict-aliasing", "-std=gnu99", "-g", "-O2", "-o", ".libs/many_fds", "many_fds.o", "../../../../../lib/libzfs/.libs/libzfs.so", "-ludev", "-luuid", "-lz", "-pthread", "-Wl,-rpath", "-Wl,/lib64"], [/* 19 vars */]) = 0
[pid 21720] execve("/usr/lib/gcc/x86_64-linux-gnu/4.9/collect2", ["/usr/lib/gcc/x86_64-linux-gnu/4.9/collect2", "-plugin", "/usr/lib/gcc/x86_64-linux-gnu/4.9/liblto_plugin.so", "-plugin-opt=/usr/lib/gcc/x86_64-linux-gnu/4.9/lto-wrapper", "-plugin-opt=-fresolution=/tmp/ccyDqmWc.res", "-plugin-opt=-pass-through=-lgcc", "-plugin-opt=-pass-through=-lgcc_s", "-plugin-opt=-pass-through=-lpthread", "-plugin-opt=-pass-through=-lc", "-plugin-opt=-pass-through=-lgcc", "-plugin-opt=-pass-through=-lgcc_s", "--sysroot=/", "--build-id", "--eh-frame-hdr", "-m", "elf_x86_64", "--hash-style=gnu", "-dynamic-linker", "/lib64/ld-linux-x86-64.so.2", "-o", ".libs/many_fds", "/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crt1.o", "/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crti.o", "/usr/lib/gcc/x86_64-linux-gnu/4.9/crtbegin.o", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../lib", "-L/lib/x86_64-linux-gnu", "-L/lib/../lib", "-L/usr/lib/x86_64-linux-gnu", "-L/usr/lib/../lib", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9/../../..", "many_fds.o", "../../../../../lib/libzfs/.libs/libzfs.so", "-ludev", "-luuid", "-lz", "-rpath", "/lib64", "-lgcc", "--as-needed", "-lgcc_s", "--no-as-needed", "-lpthread", "-lc", "-lgcc", "--as-needed", "-lgcc_s", "--no-as-needed", "/usr/lib/gcc/x86_64-linux-gnu/4.9/crtend.o", "/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crtn.o"], [/* 24 vars */]) = 0
[pid 21721] execve("/usr/bin/ld", ["/usr/bin/ld", "-plugin", "/usr/lib/gcc/x86_64-linux-gnu/4.9/liblto_plugin.so", "-plugin-opt=/usr/lib/gcc/x86_64-linux-gnu/4.9/lto-wrapper", "-plugin-opt=-fresolution=/tmp/ccyDqmWc.res", "-plugin-opt=-pass-through=-lgcc", "-plugin-opt=-pass-through=-lgcc_s", "-plugin-opt=-pass-through=-lpthread", "-plugin-opt=-pass-through=-lc", "-plugin-opt=-pass-through=-lgcc", "-plugin-opt=-pass-through=-lgcc_s", "--sysroot=/", "--build-id", "--eh-frame-hdr", "-m", "elf_x86_64", "--hash-style=gnu", "-dynamic-linker", "/lib64/ld-linux-x86-64.so.2", "-o", ".libs/many_fds", "/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crt1.o", "/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crti.o", "/usr/lib/gcc/x86_64-linux-gnu/4.9/crtbegin.o", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../lib", "-L/lib/x86_64-linux-gnu", "-L/lib/../lib", "-L/usr/lib/x86_64-linux-gnu", "-L/usr/lib/../lib", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9/../../..", "many_fds.o", "../../../../../lib/libzfs/.libs/libzfs.so", "-ludev", "-luuid", "-lz", "-rpath", "/lib64", "-lgcc", "--as-needed", "-lgcc_s", "--no-as-needed", "-lpthread", "-lc", "-lgcc", "--as-needed", "-lgcc_s", "--no-as-needed", "/usr/lib/gcc/x86_64-linux-gnu/4.9/crtend.o", "/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crtn.o"], [/* 24 vars */]) = 0
```

Things to note:

>  0x000000000000000f (RPATH)              Library rpath: [/usr/src/zfs/lib/libnvpair/.libs:/usr/src/zfs/lib/libuutil/.libs:/usr/src/zfs/lib/libzpool/.libs:/usr/src/zfs/lib/libzfs_core/.libs: **/lib64**]

> [pid 21719] execve("/usr/bin/gcc", ["gcc", "-DNDEBUG", "-Wall", "-Wstrict-prototypes", "-Wno-unused-but-set-variable", "-fno-strict-aliasing", "-std=gnu99", "-g", "-O2", "-o", ".libs/many_fds", "many_fds.o", "../../../../../lib/libzfs/.libs/libzfs.so", "-ludev", "-luuid", "-lz", "-pthread", **"-Wl,-rpath", "-Wl,/lib64"**], [/* 19 vars */]) = 0

> [pid 21721] execve("/usr/bin/ld", ["/usr/bin/ld", "-plugin", "/usr/lib/gcc/x86_64-linux-gnu/4.9/liblto_plugin.so", "-plugin-opt=/usr/lib/gcc/x86_64-linux-gnu/4.9/lto-wrapper", "-plugin-opt=-fresolution=/tmp/ccyDqmWc.res", "-plugin-opt=-pass-through=-lgcc", "-plugin-opt=-pass-through=-lgcc_s", "-plugin-opt=-pass-through=-lpthread", "-plugin-opt=-pass-through=-lc", "-plugin-opt=-pass-through=-lgcc", "-plugin-opt=-pass-through=-lgcc_s", "--sysroot=/", "--build-id", "--eh-frame-hdr", "-m", "elf_x86_64", "--hash-style=gnu", "-dynamic-linker", "/lib64/ld-linux-x86-64.so.2", "-o", ".libs/many_fds", "/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crt1.o", "/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crti.o", "/usr/lib/gcc/x86_64-linux-gnu/4.9/crtbegin.o", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../lib", "-L/lib/x86_64-linux-gnu", "-L/lib/../lib", "-L/usr/lib/x86_64-linux-gnu", "-L/usr/lib/../lib", "-L/usr/lib/gcc/x86_64-linux-gnu/4.9/../../..", "many_fds.o", "../../../../../lib/libzfs/.libs/libzfs.so", "-ludev", "-luuid", "-lz", **"-rpath", "/lib64"**, "-lgcc", "--as-needed", "-lgcc_s", "--no-as-needed", "-lpthread", "-lc", "-lgcc", "--as-needed", "-lgcc_s", "--no-as-needed", "/usr/lib/gcc/x86_64-linux-gnu/4.9/crtend.o", "/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crtn.o"], [/* 24 vars */]) = 0

When `ld` tries to link `many_fds` against libzfs_core it picks up then (older) one already installed in /lib64.

Fix this by adding $libdir to libtool's sys_lib_dlsearch_path_spec.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/6539
Fix https://github.com/zfsonlinux/zfs/issues/6550

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
On Debian9 and Ubuntu16 build and install an older (pre-crypto) ZFS version and subsequently try to build git HEAD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
