### PR TITLE
libtpool: don't clone affinity if not supported

### DIFF
--- a/lib/libtpool/thread_pool.c
+++ b/lib/libtpool/thread_pool.c
@@ -252,6 +252,7 @@ pthread_attr_clone(pthread_attr_t *attr, const pthread_attr_t *old_attr)
 	if (error || (old_attr == NULL))
 		return (error);
 
+#ifdef __GLIBC__
 	cpu_set_t cpuset;
 	size_t cpusetsize = sizeof (cpuset);
 	error = pthread_attr_getaffinity_np(old_attr, cpusetsize, &cpuset);
@@ -259,6 +260,7 @@ pthread_attr_clone(pthread_attr_t *attr, const pthread_attr_t *old_attr)
 		error = pthread_attr_setaffinity_np(attr, cpusetsize, &cpuset);
 	if (error)
 		goto error;
+#endif /* __GLIBC__ */
 
 	int detachstate;
 	error = pthread_attr_getdetachstate(old_attr, &detachstate);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
`pthread_attr_(get/set)affinity_np()` is [glibc-only](http://man7.org/linux/man-pages/man3/pthread_attr_setaffinity_np.3.html#CONFORMING_TO). This commit
disable the code path that use those functions in non-glibc
system.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes the following problem when building with musl libc:
```
../../../../../lib/libzfs/.libs/libzfs.so: undefined reference to `pthread_attr_setaffinity_np'
../../../../../lib/libzfs/.libs/libzfs.so: undefined reference to `pthread_attr_getaffinity_np'
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Currently powering a root on ZFS installation with musl libc

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
