### PR TITLE
dmu_objset: release bonus buffer in failure path

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -2032,6 +2032,7 @@ dmu_objset_space_upgrade(objset_t *os)
 		dmu_tx_hold_bonus(tx, obj);
 		objerr = dmu_tx_assign(tx, TXG_WAIT);
 		if (objerr != 0) {
+			dmu_buf_rele(db, FTAG);
 			dmu_tx_abort(tx);
 			continue;
 		}


### PR DESCRIPTION
Reported by kmemleak during testing of a new patch::
```
unreferenced object 0xffff9f1c12e38800 (size 1024):
  comm "z_upgrade", pid 17842, jiffies 4296870904 (age 8746.268s)
  backtrace:
    [<ffffffff9ec8d22a>] kmemleak_alloc+0x7a/0x100
    [<ffffffff9e31f3bc>] __kmalloc_node+0x26c/0x510
    [<ffffffffc09e80b9>] range_tree_create+0x39/0xa0 [zfs]
    [<ffffffffc098f313>] dmu_zfetch_init+0x73/0xe0 [zfs]
    [<ffffffffc099168c>] dnode_create+0x12c/0x3b0 [zfs]
    [<ffffffffc0994986>] dnode_hold_impl+0x1096/0x1130 [zfs]
    [<ffffffffc0994a43>] dnode_hold+0x23/0x30 [zfs]
    [<ffffffffc096d45b>] dmu_bonus_hold_impl+0x6b/0x370 [zfs]
    [<ffffffffc096d77e>] dmu_bonus_hold+0x1e/0x30 [zfs]
    [<ffffffffc0975d84>] dmu_objset_space_upgrade+0x114/0x310 [zfs]
    [<ffffffffc0976058>] dmu_objset_userobjspace_upgrade_cb+0xd8/0x150 [zfs]
    [<ffffffffc0971c86>] dmu_objset_upgrade_task_cb+0x136/0x1e0 [zfs]
    [<ffffffffc078c81b>] 0xffffffffc078c81b
    [<ffffffff9e0fabd9>] kthread+0x119/0x150
```

Signed-off-by: Gvozden Neskovic <neskovic@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
