### PR TITLE
Relax (ref)reservation constraints on ZVOLs

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1451,25 +1451,11 @@ badlabel:
 		 * checks to enforce.
 		 */
 		if (type == ZFS_TYPE_VOLUME && zhp != NULL) {
-			uint64_t volsize = zfs_prop_get_int(zhp,
-			    ZFS_PROP_VOLSIZE);
 			uint64_t blocksize = zfs_prop_get_int(zhp,
 			    ZFS_PROP_VOLBLOCKSIZE);
 			char buf[64];
 
 			switch (prop) {
-			case ZFS_PROP_RESERVATION:
-			case ZFS_PROP_REFRESERVATION:
-				if (intval > volsize) {
-					zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-					    "'%s' is greater than current "
-					    "volume size"), propname);
-					(void) zfs_error(hdl, EZFS_BADPROP,
-					    errbuf);
-					goto error;
-				}
-				break;
-
 			case ZFS_PROP_VOLSIZE:
 				if (intval % blocksize != 0) {
 					zfs_nicebytes(blocksize, buf,

--- a/tests/zfs-tests/tests/functional/reservation/reservation_002_pos.sh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_002_pos.sh
@@ -84,16 +84,8 @@ fi
 
 for obj in $TESTPOOL/$TESTFS $OBJ_LIST ; do
 
-	space_avail=`get_prop available $TESTPOOL`
+	space_avail=`get_prop available $obj`
 	resv_size_set=`expr $space_avail + $RESV_DELTA`
-
-	#
-	# For regular (non-sparse) volumes the upper limit is determined
-	# not by the space available in the pool but rather by the size
-	# of the volume itself.
-	#
-	[[ $obj == $TESTPOOL/$TESTVOL ]] && \
-	    ((resv_size_set = vol_set_size + RESV_DELTA))
 
 	log_must zero_reservation $obj
 	log_mustnot zfs set reservation=$resv_size_set $obj

--- a/tests/zfs-tests/tests/functional/reservation/reservation_014_pos.sh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_014_pos.sh
@@ -79,30 +79,23 @@ fi
 
 for obj in $TESTPOOL/$TESTFS $OBJ_LIST ; do
 
-	space_avail=`get_prop available $TESTPOOL`
+	space_avail=`get_prop available $obj`
 	((quota_set_size = space_avail / 3))
 
 	#
-	# A regular (non-sparse) volume's size is effectively
-	# its quota so only need to explicitly set quotas for
-	# filesystems and datasets.
+	# Volumes do not support quota so only need to explicitly
+	# set quotas for filesystems.
 	#
-	# A volumes size is effectively its quota. The maximum
-	# reservation value that can be set on a volume is
-	# determined by the size of the volume or the amount of
-	# space in the pool, whichever is smaller.
+	# The maximum reservation value that can be set on a volume
+	# is determined by the quota set on its parent filesystems or
+	# the amount of space in the pool, whichever is smaller.
 	#
 	if [[ $obj == $TESTPOOL/$TESTFS ]]; then
 		log_must zfs set quota=$quota_set_size $obj
 		((resv_set_size = quota_set_size + RESV_SIZE))
-
-	elif [[ $obj == $TESTPOOL/$TESTVOL2 ]] ; then
-
-		((resv_set_size = sparse_vol_set_size + RESV_SIZE))
-
-	elif [[ $obj == $TESTPOOL/$TESTVOL ]] ; then
-
-		((resv_set_size = vol_set_size + RESV_SIZE))
+	elif [[ $obj == $TESTPOOL/$TESTVOL || $obj == $TESTPOOL/$TESTVOL2 ]]
+	then
+		resv_set_size=`expr $space_avail + $RESV_DELTA`
 	fi
 
 	orig_quota=`get_prop quota $obj`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
This change allow refreservation to be set larger than the current ZVOL size: this **should be** safe as we normally set refreservation > volsize at ZVOL creation time when we account for metadata.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/2468

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
```
root@linux:/usr/src/zfs# # setup
root@linux:/usr/src/zfs# POOLNAME='testpool'
root@linux:/usr/src/zfs# if is_linux; then
>    TMPDIR='/dev/shm'
>    mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
>    zpool destroy $POOLNAME
>    fallocate -l 128m $TMPDIR/zpool.dat
>    zpool create $POOLNAME $TMPDIR/zpool.dat
> else
>    TMPDIR='/tmp'
>    zpool destroy $POOLNAME
>    mkfile 128m $TMPDIR/zpool.dat
>    zpool create $POOLNAME $TMPDIR/zpool.dat
> fi
cannot open 'testpool': no such pool
root@linux:/usr/src/zfs# #
root@linux:/usr/src/zfs# zfs create $POOLNAME/fs
root@linux:/usr/src/zfs# zfs create -V 10M $POOLNAME/zvol
root@linux:/usr/src/zfs# value=`zfs get -p -o value -H refreservation $POOLNAME/zvol`
root@linux:/usr/src/zfs# zfs set refreservation=none $POOLNAME/zvol
root@linux:/usr/src/zfs# zfs set refreservation=$value $POOLNAME/zvol
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
