### PR TITLE
Fix volume WR_INDIRECT log replay

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -238,8 +238,8 @@ constrain_path() {
 
 	# Exceptions
 	ln -fs "$STF_PATH/awk" "$STF_PATH/nawk"
-	ln -fs /sbin/fsck.ext2 "$STF_PATH/fsck"
-	ln -fs /sbin/mkfs.ext2 "$STF_PATH/newfs"
+	ln -fs /sbin/fsck.ext4 "$STF_PATH/fsck"
+	ln -fs /sbin/mkfs.ext4 "$STF_PATH/newfs"
 	ln -fs "$STF_PATH/gzip" "$STF_PATH/compress"
 	ln -fs "$STF_PATH/gunzip" "$STF_PATH/uncompress"
 	ln -fs "$STF_PATH/exportfs" "$STF_PATH/share"

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -530,7 +530,7 @@ tests = ['scrub_mirror_001_pos', 'scrub_mirror_002_pos',
 tests = ['slog_001_pos', 'slog_002_pos', 'slog_003_pos', 'slog_004_pos',
     'slog_005_pos', 'slog_006_pos', 'slog_007_pos', 'slog_008_neg',
     'slog_009_neg', 'slog_010_neg', 'slog_011_neg', 'slog_012_neg',
-    'slog_013_pos', 'slog_014_pos', 'slog_015_pos']
+    'slog_013_pos', 'slog_014_pos', 'slog_replay_fs', 'slog_replay_volume']
 
 [tests/functional/snapshot]
 tests = ['clone_001_pos', 'rollback_001_pos', 'rollback_002_pos',

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -36,6 +36,7 @@ export SYSTEM_FILES='arp
     egrep
     exportfs
     expr
+    fallocate
     false
     fdisk
     file

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -140,7 +140,7 @@ function ismounted
 
 			[[ "$1" == "$dir" || "$1" == "$name" ]] && return 0
 		;;
-		ext2)
+		ext*)
 			out=$(df -t $fstype $1 2>/dev/null)
 			return $?
 		;;

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/cleanup.ksh
@@ -33,7 +33,7 @@
 . $STF_SUITE/tests/functional/cli_root/zfs_copies/zfs_copies.cfg
 
 #
-# umount the ufs|ext2 fs if there is timedout in the ufs|ext2 test
+# umount the ufs|ext fs if there is timedout in the ufs|ext test
 #
 
 if ismounted $FS_MNTPOINT $NEWFS_DEFAULT_FS ; then

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_common.kshlib
@@ -73,7 +73,7 @@ function setup_snap_env
 		[[ $type == 'volume' ]]; then
 		#
 		# At the first time, Make a UFS file system in volume and
-		# mount it. Otherwise, only check if this ufs|ext2 file system
+		# mount it. Otherwise, only check if this ufs|ext file system
 		# was mounted.
 		#
 		log_must eval "echo "y" | \
@@ -81,8 +81,8 @@ function setup_snap_env
 
 		[[ ! -d $TESTDIR1 ]] && log_must mkdir $TESTDIR1
 
-		# Make sure the ufs|ext2 filesystem hasn't been mounted,
-		# then mount the new ufs|ext2 filesystem.
+		# Make sure the ufs|ext filesystem hasn't been mounted,
+		# then mount the new ufs|ext filesystem.
 		if ! ismounted $TESTDIR1 $NEWFS_DEFAULT_FS; then
 			log_must mount \
 				$ZVOL_DEVDIR/$TESTPOOL/$TESTVOL $TESTDIR1

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.shlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.shlib
@@ -53,11 +53,11 @@ function create_pool_test
 }
 
 #
-# Create a ufs|ext2 file system and make a file within the file
+# Create a ufs|ext file system and make a file within the file
 # system for storage pool vdev
 # $1, file size
 # $2, file name
-# $3, disk name to create ufs|ext2 file system
+# $3, disk name to create ufs|ext file system
 #
 function create_blockfile
 {
@@ -83,7 +83,7 @@ function create_blockfile
 }
 
 #
-# Umount the ext2|ufs filesystem and remove the mountpoint
+# Umount the ufs|ext filesystem and remove the mountpoint
 # $1, the mount point
 #
 function clean_blockfile

--- a/tests/zfs-tests/tests/functional/slog/Makefile.am
+++ b/tests/zfs-tests/tests/functional/slog/Makefile.am
@@ -18,4 +18,5 @@ dist_pkgdata_SCRIPTS = \
 	slog_012_neg.ksh \
 	slog_013_pos.ksh \
 	slog_014_pos.ksh \
-	slog_015_pos.ksh
+	slog_replay_fs.ksh \
+	slog_replay_volume.ksh

--- a/tests/zfs-tests/tests/functional/slog/setup.ksh
+++ b/tests/zfs-tests/tests/functional/slog/setup.ksh
@@ -45,6 +45,6 @@ if [[ -d $VDEV2 ]]; then
 	log_must rm -rf $VDIR2
 fi
 log_must mkdir -p $VDIR $VDIR2
-log_must mkfile $MINVDEVSIZE $VDEV $SDEV $LDEV $VDEV2 $SDEV2 $LDEV2
+log_must truncate -s $MINVDEVSIZE $VDEV $SDEV $LDEV $VDEV2 $SDEV2 $LDEV2
 
 log_pass

--- a/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
@@ -1,0 +1,164 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/tests/functional/slog/slog.kshlib
+
+#
+# DESCRIPTION:
+#	Verify slogs are replayed correctly for a volume.
+#
+#	The general idea is to build up an intent log from a bunch of
+#	diverse user commands without actually committing them to the
+#	file system.  Then generate checksums for files and volume,
+#	replay the intent log and verify the checksums.
+#
+#	To enable this automated testing of the intent log some minimal
+#	support is required of the file system.  In particular, a
+#	"freeze" command is required to flush the in-flight transactions;
+#	to stop the actual committing of transactions; and to ensure no
+#	deltas are discarded. All deltas past a freeze point are kept
+#	for replay and comparison later. Here is the flow:
+#
+# STRATEGY:
+#	1. Create an empty volume (TESTVOL), set sync=always, and format
+#	   it with an ext4 filesystem and mount it.
+#	2. Freeze TESTVOL.
+#	3. Create log records of various types to verify replay.
+#	4. Generate checksums for all ext4 files.
+#	5. Unmount filesystem and export the pool
+#	   <at this stage TESTVOL is empty again and unfrozen, and the
+#	   intent log contains a complete set of deltas to replay it>
+#	6. Import TESTVOL <which replays the intent log> and mount it.
+#	7. Verify the stored checksums
+#
+
+verify_runnable "global"
+
+VOLUME=$ZVOL_DEVDIR/$TESTPOOL/$TESTVOL
+MNTPNT=$TESTDIR/$TESTVOL
+
+function cleanup_volume
+{
+	if ismounted $MNTPNT ext4; then
+		log_must umount $MNTPNT
+		rmdir $MNTPNT
+	fi
+
+	rm -f $TESTDIR/checksum.files
+
+	cleanup
+}
+
+log_assert "Replay of intent log succeeds."
+log_onexit cleanup_volume
+
+#
+# 1. Create an empty volume (TESTVOL), set sync=always, and format
+#    it with an ext4 filesystem and mount it.
+#
+log_must zpool create $TESTPOOL $VDEV log mirror $LDEV
+log_must zfs create -V 128M $TESTPOOL/$TESTVOL
+log_must zfs set compression=on $TESTPOOL/$TESTVOL
+log_must zfs set sync=always $TESTPOOL/$TESTVOL
+log_must mkdir -p $TESTDIR
+log_must block_device_wait
+echo "y" | newfs -t ext4 -v $VOLUME
+log_must mkdir -p $MNTPNT
+log_must mount -o discard $VOLUME $MNTPNT
+log_must rmdir $MNTPNT/lost+found
+log_must zpool sync
+
+#
+# 2. Freeze TESTVOL
+#
+log_must zpool freeze $TESTPOOL
+
+#
+# 3. Create log records of various types to verify replay.
+#
+
+# TX_WRITE
+log_must dd if=/dev/urandom of=$MNTPNT/latency-8k bs=8k count=1 oflag=sync
+log_must dd if=/dev/urandom of=$MNTPNT/latency-128k bs=128k count=1 oflag=sync
+
+# TX_WRITE (WR_INDIRECT)
+log_must zfs set logbias=throughput $TESTPOOL/$TESTVOL
+log_must dd if=/dev/urandom of=$MNTPNT/throughput-8k bs=8k count=1
+log_must dd if=/dev/urandom of=$MNTPNT/throughput-128k bs=128k count=1
+
+# TX_WRITE (holes)
+log_must dd if=/dev/urandom of=$MNTPNT/holes bs=128k count=8
+log_must dd if=/dev/zero of=$MNTPNT/holes bs=128k count=2 seek=2 conv=notrunc
+
+# TX_TRUNCATE
+if fallocate --punch-hole 2>&1 | grep -q "unrecognized option"; then
+	log_note "fallocate(1) does not support --punch-hole"
+else
+	log_must dd if=/dev/urandom of=$MNTPNT/discard bs=128k count=16
+	log_must fallocate --punch-hole -l 128K -o 512K $MNTPNT/discard
+	log_must fallocate --punch-hole -l 512K -o 1M $MNTPNT/discard
+fi
+
+#
+# 4. Generate checksums for all ext4 files.
+#
+log_must sha256sum -b $MNTPNT/* >$TESTDIR/checksum
+
+#
+# 5. Unmount filesystem and export the pool
+#
+# At this stage TESTVOL is initialized with the random data and frozen,
+# the intent log contains a complete set of deltas to replay.
+#
+log_must umount $MNTPNT
+
+log_note "Verify transactions to replay:"
+log_must zdb -iv $TESTPOOL/$TESTVOL
+
+log_must zpool export $TESTPOOL
+
+#
+# 6. Import TESTPOOL, the intent log is replayed during minor creation.
+#
+# Import the pool to unfreeze it and claim log blocks.  It has to be
+# `zpool import -f` because we can't write a frozen pool's labels!
+#
+log_must zpool import -f -d $VDIR $TESTPOOL
+log_must block_device_wait
+log_must mount $VOLUME $MNTPNT
+
+#
+# 7. Verify the stored checksums
+#
+log_note "Verify current block usage:"
+log_must zdb -bcv $TESTPOOL
+
+log_note "Verify checksums"
+log_must sha256sum -c $TESTDIR/checksum
+
+log_pass "Replay of intent log succeeds."

--- a/tests/zfs-tests/tests/functional/xattr/xattr_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_004_pos.ksh
@@ -33,23 +33,21 @@
 #
 # DESCRIPTION:
 #
-# Creating files on ufs|ext2 and tmpfs, and copying those files to ZFS with
+# Creating files on ufs|ext and tmpfs, and copying those files to ZFS with
 # appropriate cp flags, the xattrs will still be readable.
 #
 # STRATEGY:
-#	1. Create files in ufs|ext2 and tmpfs with xattrs
-#       2. Copy those files to zfs
+#	1. Create files in ufs|ext and tmpfs with xattrs
+#	2. Copy those files to zfs
 #	3. Ensure the xattrs can be read and written
 #	4. Do the same in reverse.
 #
 
-# we need to be able to create zvols to hold our test
-# ufs|ext2 filesystem.
+# we need to be able to create zvols to hold our test ufs|ext filesystem.
 verify_runnable "global"
 
 # Make sure we clean up properly
 function cleanup {
-
 	if ismounted /tmp/$NEWFS_DEFAULT_FS.$$ $NEWFS_DEFAULT_FS; then
 		log_must umount /tmp/$NEWFS_DEFAULT_FS.$$
 		log_must rm -rf /tmp/$NEWFS_DEFAULT_FS.$$
@@ -59,7 +57,7 @@ function cleanup {
 log_assert "Files from $NEWFS_DEFAULT_FS,tmpfs with xattrs copied to zfs retain xattr info."
 log_onexit cleanup
 
-# Create a UFS|EXT2 file system that we can work in
+# Create a ufs|ext file system that we can work in
 log_must zfs create -V128m $TESTPOOL/$TESTFS/zvol
 block_device_wait
 log_must eval "echo y | newfs $ZVOL_DEVDIR/$TESTPOOL/$TESTFS/zvol > /dev/null 2>&1"
@@ -69,8 +67,8 @@ if is_linux; then
 	log_must mount -o user_xattr \
 	    $ZVOL_DEVDIR/$TESTPOOL/$TESTFS/zvol /tmp/$NEWFS_DEFAULT_FS.$$
 
-	# Create files in ext2 and tmpfs, and set some xattrs on them.
-	# Use small values for xattrs for ext2 compatibility.
+	# Create files in ext and tmpfs, and set some xattrs on them.
+	# Use small values for xattrs for ext compatibility.
 	log_must touch /tmp/$NEWFS_DEFAULT_FS.$$/$NEWFS_DEFAULT_FS-file.$$
 
 	log_must touch /tmp/tmpfs-file.$$


### PR DESCRIPTION
### Description

The portion of the zvol_replay_write() handler responsible for
replaying indirect log records for some reason never existed.
As a result indirect log records were not being correctly replayed.

This went largely unnoticed since the majority of zvol log records
were of the type WR_COPIED or WR_NEED_COPY prior to OpenZFS 7578.

This patch updates zvol_replay_write() to correctly handle these
log records and adds a new test case which verifies volume replay
to prevent any regression.  The existing test case which verified
replay on filesystem was renamed slog_replay_fs.ksh for clarity.

### Motivation and Context

Fix issue #6603 so I can sleep again.

### How Has This Been Tested?

Added a new test case to verify replay.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.