### PR TITLE
send/recv compatibility with 0.6.5.x

### DIFF
--- a/include/sys/dmu_send.h
+++ b/include/sys/dmu_send.h
@@ -62,6 +62,7 @@ typedef struct dmu_recv_cookie {
 	boolean_t drc_force;
 	boolean_t drc_resumable;
 	boolean_t drc_raw;
+	boolean_t drc_clone;
 	struct avl_tree *drc_guid_to_ds_map;
 	zio_cksum_t drc_cksum;
 	uint64_t drc_newsnapobj;


### PR DESCRIPTION
### Description

ZFS 0.6.5.x does not handle large FREEOBJECTS records referencing non-existing objects well. ZFS 0.7 separately introduced two changes which lead to an incompatibility when sending from ZFS 0.7.x to ZFS 0.6.5.x:

**Receiving full streams as clones** (https://github.com/zfsonlinux/zfs/pull/4221)

generates FREE and FREEOBJECTS records even when generating a full stream, to allow those streams to be received as clones of existing datasets.

**Increasing indirect block sizes** (https://github.com/zfsonlinux/zfs/pull/5679)

blows up the number of objects contained in the final FREEOBJECTS record for the "logical hole" of unused space at the end of most datasets.


This PR caps the FREEOBJECTS records at the maximum possible USED object ID. For incremental streams, this is no problem. For full streams received as clones, this means we need an extra step of freeing any potentially leftover objects of the origin dataset, after processing the whole stream. The latter breaks compatibility for receiving full streams generated with this patch as clones on systems without this patch.

### How Has This Been Tested?

Sending from patched to patched, patched to non-patched (see caveat in description), and patched to 0.6.5.11. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
