### PR TITLE
Fix dryrun and intra-pool resumable 'zfs send'

### DIFF
--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -428,10 +428,10 @@ zfs_iter_children(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 {
 	int ret;
 
-	if ((ret = zfs_iter_filesystems(zhp, func, data)) != 0)
+	if ((ret = zfs_iter_snapshots(zhp, B_FALSE, func, data)) != 0)
 		return (ret);
 
-	return (zfs_iter_snapshots(zhp, B_FALSE, func, data));
+	return (zfs_iter_filesystems(zhp, func, data));
 }
 
 

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -1654,6 +1654,7 @@ zfs_send_resume(libzfs_handle_t *hdl, sendflags_t *flags, int outfd,
 	int error = 0;
 	char name[ZFS_MAX_DATASET_NAME_LEN];
 	enum lzc_send_flags lzc_flags = 0;
+	FILE *fout = (flags->verbose && flags->dryrun) ? stdout : stderr;
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
 	    "cannot resume send"));
@@ -1668,9 +1669,9 @@ zfs_send_resume(libzfs_handle_t *hdl, sendflags_t *flags, int outfd,
 		return (zfs_error(hdl, EZFS_FAULT, errbuf));
 	}
 	if (flags->verbose) {
-		(void) fprintf(stderr, dgettext(TEXT_DOMAIN,
+		(void) fprintf(fout, dgettext(TEXT_DOMAIN,
 		    "resume token contents:\n"));
-		nvlist_print(stderr, resume_nvl);
+		nvlist_print(fout, resume_nvl);
 	}
 
 	if (nvlist_lookup_string(resume_nvl, "toname", &toname) != 0 ||
@@ -1729,7 +1730,7 @@ zfs_send_resume(libzfs_handle_t *hdl, sendflags_t *flags, int outfd,
 		    lzc_flags, &size);
 		if (error == 0)
 			size = MAX(0, (int64_t)(size - bytes));
-		send_print_verbose(stderr, zhp->zfs_name, fromname,
+		send_print_verbose(fout, zhp->zfs_name, fromname,
 		    size, flags->parsable);
 	}
 

--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -505,11 +505,13 @@ function test_fs_setup
 {
 	typeset sendfs=$1
 	typeset recvfs=$2
+	typeset streamfs=$3
 	typeset sendpool=${sendfs%%/*}
 	typeset recvpool=${recvfs%%/*}
 
 	datasetexists $sendfs && log_must_busy zfs destroy -r $sendpool
 	datasetexists $recvfs && log_must_busy zfs destroy -r $recvpool
+	datasetexists $streamfs && log_must_busy zfs destroy -r $streamfs
 
 	if $(datasetexists $sendfs || zfs create -o compress=lz4 $sendfs); then
 		mk_files 1000 256 0 $sendfs &
@@ -538,10 +540,7 @@ function test_fs_setup
 		    ">/$sendpool/incremental.zsend"
 	fi
 
-	if datasetexists $streamfs; then
-		log_must_busy zfs destroy -r $streamfs
-	fi
-	log_must zfs create -o compress=lz4 $sendpool/stream
+	log_must zfs create -o compress=lz4 $streamfs
 }
 
 #
@@ -655,9 +654,10 @@ function resume_cleanup
 {
 	typeset sendfs=$1
 	typeset streamfs=$2
+	typeset sendpool=${sendfs%%/*}
 
 	datasetexists $sendfs && log_must_busy zfs destroy -r $sendfs
 	datasetexists $streamfs && log_must_busy zfs destroy -r $streamfs
 	cleanup_pool $POOL2
-	rm -f /$POOL/initial.zsend /$POOL/incremental.zsend
+	rm -f /$sendpool/initial.zsend /$sendpool/incremental.zsend
 }

--- a/tests/zfs-tests/tests/functional/rsend/rsend_019_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_019_pos.ksh
@@ -48,8 +48,8 @@ sendfs=$POOL/sendfs
 recvfs=$POOL3/recvfs
 streamfs=$POOL2/stream
 
-for sendfs in $POOL2/sendfs $POOL2; do
-	test_fs_setup $sendfs $recvfs
+for sendfs in $POOL2/sendfs $POOL3; do
+	test_fs_setup $sendfs $recvfs $streamfs
 	resume_test "zfs send -v $sendfs@a" $streamfs $recvfs
 	resume_test "zfs send -v -i @a $sendfs@b" $streamfs $recvfs
 	file_check $sendfs $recvfs

--- a/tests/zfs-tests/tests/functional/rsend/rsend_020_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_020_pos.ksh
@@ -47,7 +47,7 @@ streamfs=$POOL/stream
 
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 resume_test "zfs send -D -v $sendfs@a" $streamfs $recvfs
 file_check $sendfs $recvfs
 

--- a/tests/zfs-tests/tests/functional/rsend/rsend_021_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_021_pos.ksh
@@ -49,7 +49,7 @@ streamfs=$POOL/stream
 
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 resume_test "zfs send -v -e $sendfs@a" $streamfs $recvfs
 resume_test "zfs send -v -e -i @a $sendfs@b" $streamfs $recvfs
 file_check $sendfs $recvfs

--- a/tests/zfs-tests/tests/functional/rsend/rsend_022_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_022_pos.ksh
@@ -52,7 +52,7 @@ streamfs=$POOL/stream
 
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 log_must zfs bookmark $sendfs@a $sendfs#bm_a
 log_must_busy zfs destroy $sendfs@a
 log_must zfs receive -v $recvfs </$POOL/initial.zsend

--- a/tests/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
@@ -49,7 +49,7 @@ streamfs=$POOL/stream
 
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 log_must zfs unmount -f $sendfs
 resume_test "zfs send $sendfs" $streamfs $recvfs
 file_check $sendfs $recvfs

--- a/tests/zfs-tests/tests/functional/rsend/send-c_resume.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_resume.ksh
@@ -41,7 +41,7 @@ streamfs=$POOL/stream
 log_assert "Verify compressed send streams can be resumed if interrupted"
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 resume_test "zfs send -c -v $sendfs@a" $streamfs $recvfs
 resume_test "zfs send -c -v -i @a $sendfs@b" $streamfs $recvfs
 file_check $sendfs $recvfs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

This PR fixes a couple of issue with resumable `zfs send`.

* `zfs send -n -t <token>` should dump its output to stdout, not stderr, for consistency with other dry-run commands.
* `zfs send -t <token>` for an incremental send should be able to resume successfully when sending to the same pool: a subtle issue in `zfs_iter_children()` doesn't currently allow this.
Because resuming from a token requires "guid" -> "dataset" mapping (`guid_to_name()`), we have to walk the whole hierarchy to find the right snapshots to send.
When resuming an incremental send both source and destination live in the same pool and have the same guid: this is where `zfs_iter_children()` gets confused and picks up the wrong snapshot, so we end up trying to send  an incremental "_destination@snap1 -> source@snap2_" stream instead of "_source@snap1 -> source@snap2_": this fails with an "Invalid cross-device link" (`EXDEV`) error.

EDIT: just to reiterate, the second bug looks like this

```
root@linux:~# zfs send -vt $TOKEN > /dev/null
resume token contents:
nvlist version: 0
	fromguid = 0x46f626fea92a89af
	object = 0x1
	offset = 0x0
	bytes = 0x0
	toguid = 0x7b604c01bd7168bd
	toname = testpool/fs@snap2
send from testpool/fs/newfs@snap1 to testpool/fs@snap2
TIME        SENT   SNAPSHOT
warning: cannot send 'testpool/fs@snap2': Invalid cross-device link
```
We need to know which snapshot to send from by its guid (_fromguid = 0x46f626fea92a89af_). Both _testpool/fs@snap1_ and _testpool/fs/newfs@snap1_ are good candidates:
```
root@linux:~# zfs get guid
NAME                     PROPERTY  VALUE  SOURCE
testpool                 guid      3700393278039286775  -
testpool/fs              guid      10649419692702751658  -
testpool/fs@snap1        guid      5113317302127462831  -
testpool/fs@snap2        guid      8890189234786363581  -
testpool/fs/newfs        guid      16613946719253299331  -
testpool/fs/newfs@snap1  guid      5113317302127462831  -
root@linux:~# 
root@linux:~# printf '%d\n' 0x46f626fea92a89af
5113317302127462831
```

`zfs_iter_children(testpool/fs)` currently walks the dataset hierarchy in this order (children first, then snapshots)

1. testpool/fs
2. testpool/fs/newfs
3. testpool/fs/newfs@snap1
4. testpool/fs@snap1
5. testpool/fs@snap2

when it should be doing (snapshot first, then children)

1. testpool/fs
2. testpool/fs@snap1
3. testpool/fs@snap2
4. testpool/fs/newfs
5. testpool/fs/newfs@snap1

to find the correct snapshot (_testpool/fs@snap1_).

NOTE: i've yet to add a new test case to the ZTS but don't know where the best place would be ("rsend" or "zfs_send"?). `rsend_019_pos` would probably be a good choice but it's currently disabled.

EDIT: waiting for https://github.com/zfsonlinux/zfs/pull/6632 to get merged so `rsend_019_pos` is back in business.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/6618
Fix https://github.com/zfsonlinux/zfs/issues/6619

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

```
# misc functions
function is_linux() {
   if [[ "$(uname)" == "Linux" ]]; then
      return 0
   else
      return 1
   fi
}
# setup
POOLNAME='testpool'
if is_linux; then
   TMPDIR='/var/tmp'
   mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   fallocate -l 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
else
   TMPDIR='/tmp'
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   mkfile 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
fi
#
dd if=/dev/urandom of=/$POOLNAME/data.bin bs=1M count=10
zfs snapshot $POOLNAME@snap1
zfs send $POOLNAME@snap1 | zfs recv -s $POOLNAME/mirror
#
dd if=/dev/urandom of=/$POOLNAME/data.bin bs=1M count=10
zfs snapshot $POOLNAME@snap2
zfs send -i $POOLNAME@snap1 $POOLNAME@snap2 | dd bs=1M count=1 | zfs recv -s $POOLNAME/mirror
#
TOKEN=$(zfs get -H -o value receive_resume_token $POOLNAME/mirror)
zfs send -nP -t $TOKEN > /dev/null
zfs send -t $TOKEN > /dev/null
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
