### PR TITLE
Add 'Requires: bzip2' to redhat RPM spec

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -179,11 +179,12 @@ Requires:       lsscsi
 Requires:       mdadm
 Requires:       bc
 Requires:       ksh
-Requires:	fio
-Requires:	acl
-Requires:	sudo
-Requires:	sysstat
+Requires:       fio
+Requires:       acl
+Requires:       sudo
+Requires:       sysstat
 Requires:       rng-tools
+Requires:       bzip2
 
 %description test
 This package contains test infrastructure and support scripts for


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Adds bzip2 as a required package for the zfs-test subpackage on redhat builds. It was already required in the general RPM spec.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes test failures noting 'bzcat: not found' when running against a Minimal Fedora or Red Hat installation.

### How Has This Been Tested?
(No code changes)

Build & mock installed the RPM packages after spec change to test dependencies

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
