### PR TITLE
Move from str{dup,free} to spa_str{dup,free}

### DIFF
--- a/module/icp/spi/kcf_spi.c
+++ b/module/icp/spi/kcf_spi.c
@@ -261,7 +261,7 @@ crypto_register_provider(crypto_provider_info_t *info,
 			prov_desc->pd_kstat->ks_update = kcf_prov_kstat_update;
 			kstat_install(prov_desc->pd_kstat);
 		}
-		strfree(ks_name);
+		kmem_free(ks_name, strlen(ks_name) + 1);
 	}
 
 	if (prov_desc->pd_prov_type == CRYPTO_HW_PROVIDER)

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1281,7 +1281,7 @@ dmu_objset_snapshot_one(const char *fsname, const char *snapname)
 	nvlist_t *snaps = fnvlist_alloc();
 
 	fnvlist_add_boolean(snaps, longsnap);
-	strfree(longsnap);
+	spa_strfree(longsnap);
 	err = dsl_dataset_snapshot(snaps, NULL, NULL);
 	fnvlist_free(snaps);
 	return (err);
@@ -2544,7 +2544,7 @@ dmu_objset_find_impl(spa_t *spa, const char *name,
 			err = dmu_objset_find_impl(spa, child,
 			    func, arg, flags);
 			dsl_pool_config_enter(dp, FTAG);
-			strfree(child);
+			spa_strfree(child);
 			if (err != 0)
 				break;
 		}
@@ -2582,7 +2582,7 @@ dmu_objset_find_impl(spa_t *spa, const char *name,
 				dsl_pool_config_exit(dp, FTAG);
 				err = func(child, arg);
 				dsl_pool_config_enter(dp, FTAG);
-				strfree(child);
+				spa_strfree(child);
 				if (err != 0)
 					break;
 			}

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -1891,7 +1891,7 @@ get_receive_resume_stats(dsl_dataset_t *ds, nvlist_t *nv)
 		kmem_free(packed, packed_size);
 		kmem_free(str, compressed_size * 2 + 1);
 		kmem_free(compressed, packed_size);
-		strfree(propval);
+		spa_strfree(propval);
 	}
 }
 

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -979,7 +979,7 @@ dsl_pool_user_hold_rele_impl(dsl_pool_t *dp, uint64_t dsobj,
 		error = zap_add(mos, zapobj, name, 8, 1, &now, tx);
 	else
 		error = zap_remove(mos, zapobj, name, tx);
-	strfree(name);
+	spa_strfree(name);
 
 	return (error);
 }

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -150,8 +150,8 @@ dsl_prop_get_dd(dsl_dir_t *dd, const char *propname,
 	if (err == ENOENT)
 		err = dodefault(prop, intsz, numints, buf);
 
-	strfree(inheritstr);
-	strfree(recvdstr);
+	spa_strfree(inheritstr);
+	spa_strfree(recvdstr);
 
 	return (err);
 }
@@ -190,7 +190,7 @@ dsl_prop_get_ds(dsl_dataset_t *ds, const char *propname,
 			char *inheritstr = kmem_asprintf("%s%s", propname,
 			    ZPROP_INHERIT_SUFFIX);
 			err = zap_contains(mos, zapobj, inheritstr);
-			strfree(inheritstr);
+			spa_strfree(inheritstr);
 			if (err != 0 && err != ENOENT)
 				return (err);
 		}
@@ -201,7 +201,7 @@ dsl_prop_get_ds(dsl_dataset_t *ds, const char *propname,
 			    ZPROP_RECVD_SUFFIX);
 			err = zap_lookup(mos, zapobj, recvdstr,
 			    intsz, numints, buf);
-			strfree(recvdstr);
+			spa_strfree(recvdstr);
 			if (err != ENOENT) {
 				if (setpoint != NULL && err == 0)
 					(void) strcpy(setpoint,
@@ -424,7 +424,7 @@ dsl_prop_predict(dsl_dir_t *dd, const char *propname,
 		panic("unexpected property source: %d", source);
 	}
 
-	strfree(recvdstr);
+	spa_strfree(recvdstr);
 
 	if (err == ENOENT)
 		return (0);
@@ -752,8 +752,8 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		cmn_err(CE_PANIC, "unexpected property source: %d", source);
 	}
 
-	strfree(inheritstr);
-	strfree(recvdstr);
+	spa_strfree(inheritstr);
+	spa_strfree(recvdstr);
 
 	if (isint) {
 		VERIFY0(dsl_prop_get_int_ds(ds, propname, &intval));
@@ -1020,7 +1020,7 @@ dsl_prop_get_all_impl(objset_t *mos, uint64_t propobj,
 				valstr = kmem_asprintf("%s%s", propname,
 				    ZPROP_INHERIT_SUFFIX);
 				err = zap_contains(mos, propobj, valstr);
-				strfree(valstr);
+				spa_strfree(valstr);
 				if (err == 0)
 					continue;
 				if (err != ENOENT)

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -387,7 +387,7 @@ dsl_dataset_user_release_check_one(dsl_dataset_user_release_arg_t *ddura,
 				    snapname, holdname);
 				fnvlist_add_int32(ddura->ddura_errlist, errtag,
 				    ENOENT);
-				strfree(errtag);
+				spa_strfree(errtag);
 			}
 			continue;
 		}

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -537,7 +537,7 @@ log_internal(nvlist_t *nvl, const char *operation, spa_t *spa,
 
 	msg = kmem_vasprintf(fmt, adx);
 	fnvlist_add_string(nvl, ZPOOL_HIST_INT_STR, msg);
-	strfree(msg);
+	spa_strfree(msg);
 
 	fnvlist_add_string(nvl, ZPOOL_HIST_INT_NAME, operation);
 	fnvlist_add_uint64(nvl, ZPOOL_HIST_TXG, tx->tx_txg);

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -168,7 +168,7 @@ spa_read_history_init(spa_t *spa)
 		    spa_read_history_data, spa_read_history_addr);
 		kstat_install(ksp);
 	}
-	strfree(name);
+	spa_strfree(name);
 }
 
 static void
@@ -392,7 +392,7 @@ spa_txg_history_init(spa_t *spa)
 		    spa_txg_history_data, spa_txg_history_addr);
 		kstat_install(ksp);
 	}
-	strfree(name);
+	spa_strfree(name);
 }
 
 static void
@@ -634,7 +634,7 @@ spa_tx_assign_init(spa_t *spa)
 		ksp->ks_update = spa_tx_assign_update;
 		kstat_install(ksp);
 	}
-	strfree(name);
+	spa_strfree(name);
 }
 
 static void
@@ -697,7 +697,7 @@ spa_io_history_init(spa_t *spa)
 		ksp->ks_update = spa_io_history_update;
 		kstat_install(ksp);
 	}
-	strfree(name);
+	spa_strfree(name);
 }
 
 static void
@@ -793,7 +793,7 @@ spa_mmp_history_update(kstat_t *ksp, int rw)
 		while ((smh = list_remove_head(&ssh->list))) {
 			ssh->size--;
 			if (smh->vdev_path)
-				strfree(smh->vdev_path);
+				spa_strfree(smh->vdev_path);
 			kmem_free(smh, sizeof (spa_mmp_history_t));
 		}
 
@@ -836,7 +836,7 @@ spa_mmp_history_init(spa_t *spa)
 		    spa_mmp_history_data, spa_mmp_history_addr);
 		kstat_install(ksp);
 	}
-	strfree(name);
+	spa_strfree(name);
 }
 
 static void
@@ -854,7 +854,7 @@ spa_mmp_history_destroy(spa_t *spa)
 	while ((smh = list_remove_head(&ssh->list))) {
 		ssh->size--;
 		if (smh->vdev_path)
-			strfree(smh->vdev_path);
+			spa_strfree(smh->vdev_path);
 		kmem_free(smh, sizeof (spa_mmp_history_t));
 	}
 
@@ -885,7 +885,7 @@ spa_mmp_history_add(uint64_t txg, uint64_t timestamp, uint64_t mmp_delay,
 	smh->mmp_delay = mmp_delay;
 	smh->vdev_guid = vd->vdev_guid;
 	if (vd->vdev_path)
-		smh->vdev_path = strdup(vd->vdev_path);
+		smh->vdev_path = spa_strdup(vd->vdev_path);
 	smh->vdev_label = label;
 
 	mutex_enter(&ssh->lock);
@@ -897,7 +897,7 @@ spa_mmp_history_add(uint64_t txg, uint64_t timestamp, uint64_t mmp_delay,
 		ssh->size--;
 		rm = list_remove_tail(&ssh->list);
 		if (rm->vdev_path)
-			strfree(rm->vdev_path);
+			spa_strfree(rm->vdev_path);
 		kmem_free(rm, sizeof (spa_mmp_history_t));
 	}
 

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -170,7 +170,7 @@ vdev_elevator_switch(vdev_t *v, char *elevator)
 
 	argv[2] = kmem_asprintf(SET_SCHEDULER_CMD, device, elevator);
 	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
-	strfree(argv[2]);
+	spa_strfree(argv[2]);
 #endif /* HAVE_ELEVATOR_CHANGE */
 	if (error)
 		printk("ZFS: Unable to set \"%s\" scheduler for %s (%s): %d\n",

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -137,8 +137,8 @@ zfsctl_snapshot_alloc(char *full_name, char *full_path, spa_t *spa,
 
 	se = kmem_zalloc(sizeof (zfs_snapentry_t), KM_SLEEP);
 
-	se->se_name = strdup(full_name);
-	se->se_path = strdup(full_path);
+	se->se_name = spa_strdup(full_name);
+	se->se_path = spa_strdup(full_path);
 	se->se_spa = spa;
 	se->se_objsetid = objsetid;
 	se->se_root_dentry = root_dentry;
@@ -157,8 +157,8 @@ static void
 zfsctl_snapshot_free(zfs_snapentry_t *se)
 {
 	refcount_destroy(&se->se_refcount);
-	strfree(se->se_name);
-	strfree(se->se_path);
+	spa_strfree(se->se_name);
+	spa_strfree(se->se_path);
 
 	kmem_free(se, sizeof (zfs_snapentry_t));
 }
@@ -311,8 +311,8 @@ zfsctl_snapshot_rename(char *old_snapname, char *new_snapname)
 		return (SET_ERROR(ENOENT));
 
 	zfsctl_snapshot_remove(se);
-	strfree(se->se_name);
-	se->se_name = strdup(new_snapname);
+	spa_strfree(se->se_name);
+	se->se_name = spa_strdup(new_snapname);
 	zfsctl_snapshot_add(se);
 	zfsctl_snapshot_rele(se);
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3461,7 +3461,7 @@ zfs_ioc_log_history(const char *unused, nvlist_t *innvl, nvlist_t *outnvl)
 		return (SET_ERROR(EINVAL));
 	(void) tsd_set(zfs_allow_log_key, NULL);
 	error = spa_open(poolname, &spa, FTAG);
-	strfree(poolname);
+	spa_strfree(poolname);
 	if (error != 0)
 		return (error);
 
@@ -3779,7 +3779,7 @@ recursive_unmount(const char *fsname, void *arg)
 
 	fullname = kmem_asprintf("%s@%s", fsname, snapname);
 	error = zfs_unmount_snap(fullname);
-	strfree(fullname);
+	spa_strfree(fullname);
 
 	return (error);
 }
@@ -5347,8 +5347,8 @@ zfs_ioc_tmp_snapshot(zfs_cmd_t *zc)
 	if (error == 0)
 		(void) strlcpy(zc->zc_value, snap_name,
 		    sizeof (zc->zc_value));
-	strfree(snap_name);
-	strfree(hold_name);
+	spa_strfree(snap_name);
+	spa_strfree(hold_name);
 	zfs_onexit_fd_rele(zc->zc_cleanup_fd);
 	return (error);
 }
@@ -6754,7 +6754,7 @@ zfsdev_ioctl(struct file *filp, unsigned cmd, unsigned long arg)
 		goto out;
 
 	/* legacy ioctls can modify zc_name */
-	saved_poolname = strdup(zc->zc_name);
+	saved_poolname = spa_strdup(zc->zc_name);
 	if (saved_poolname == NULL) {
 		error = SET_ERROR(ENOMEM);
 		goto out;
@@ -6828,11 +6828,11 @@ out:
 	if (error == 0 && vec->zvec_allow_log) {
 		char *s = tsd_get(zfs_allow_log_key);
 		if (s != NULL)
-			strfree(s);
+			spa_strfree(s);
 		(void) tsd_set(zfs_allow_log_key, saved_poolname);
 	} else {
 		if (saved_poolname != NULL)
-			strfree(saved_poolname);
+			spa_strfree(saved_poolname);
 	}
 
 	kmem_free(zc, sizeof (zfs_cmd_t));
@@ -6904,7 +6904,7 @@ zfs_allow_log_destroy(void *arg)
 	char *poolname = arg;
 
 	if (poolname != NULL)
-		strfree(poolname);
+		spa_strfree(poolname);
 }
 
 #ifdef DEBUG

--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -119,7 +119,7 @@ zfsvfs_vfs_free(vfs_t *vfsp)
 {
 	if (vfsp != NULL) {
 		if (vfsp->vfs_mntpoint != NULL)
-			strfree(vfsp->vfs_mntpoint);
+			spa_strfree(vfsp->vfs_mntpoint);
 
 		kmem_free(vfsp, sizeof (vfs_t));
 	}
@@ -230,7 +230,7 @@ zfsvfs_parse_options(char *mntopts, vfs_t **vfsp)
 		char *tmp_mntopts, *p, *t;
 		int token;
 
-		tmp_mntopts = t = strdup(mntopts);
+		tmp_mntopts = t = spa_strdup(mntopts);
 		if (tmp_mntopts == NULL)
 			return (SET_ERROR(ENOMEM));
 
@@ -242,13 +242,13 @@ zfsvfs_parse_options(char *mntopts, vfs_t **vfsp)
 			token = match_token(p, zpl_tokens, args);
 			error = zfsvfs_parse_option(p, token, args, tmp_vfsp);
 			if (error) {
-				strfree(tmp_mntopts);
+				spa_strfree(tmp_mntopts);
 				zfsvfs_vfs_free(tmp_vfsp);
 				return (error);
 			}
 		}
 
-		strfree(tmp_mntopts);
+		spa_strfree(tmp_mntopts);
 	}
 
 	*vfsp = tmp_vfsp;

--- a/module/zfs/zpl_xattr.c
+++ b/module/zfs/zpl_xattr.c
@@ -698,7 +698,7 @@ __zpl_xattr_user_get(struct inode *ip, const char *name,
 
 	xattr_name = kmem_asprintf("%s%s", XATTR_USER_PREFIX, name);
 	error = zpl_xattr_get(ip, xattr_name, value, size);
-	strfree(xattr_name);
+	spa_strfree(xattr_name);
 
 	return (error);
 }
@@ -720,7 +720,7 @@ __zpl_xattr_user_set(struct inode *ip, const char *name,
 
 	xattr_name = kmem_asprintf("%s%s", XATTR_USER_PREFIX, name);
 	error = zpl_xattr_set(ip, xattr_name, value, size, flags);
-	strfree(xattr_name);
+	spa_strfree(xattr_name);
 
 	return (error);
 }
@@ -767,7 +767,7 @@ __zpl_xattr_trusted_get(struct inode *ip, const char *name,
 #endif
 	xattr_name = kmem_asprintf("%s%s", XATTR_TRUSTED_PREFIX, name);
 	error = zpl_xattr_get(ip, xattr_name, value, size);
-	strfree(xattr_name);
+	spa_strfree(xattr_name);
 
 	return (error);
 }
@@ -789,7 +789,7 @@ __zpl_xattr_trusted_set(struct inode *ip, const char *name,
 #endif
 	xattr_name = kmem_asprintf("%s%s", XATTR_TRUSTED_PREFIX, name);
 	error = zpl_xattr_set(ip, xattr_name, value, size, flags);
-	strfree(xattr_name);
+	spa_strfree(xattr_name);
 
 	return (error);
 }
@@ -836,7 +836,7 @@ __zpl_xattr_security_get(struct inode *ip, const char *name,
 #endif
 	xattr_name = kmem_asprintf("%s%s", XATTR_SECURITY_PREFIX, name);
 	error = zpl_xattr_get(ip, xattr_name, value, size);
-	strfree(xattr_name);
+	spa_strfree(xattr_name);
 
 	return (error);
 }
@@ -855,7 +855,7 @@ __zpl_xattr_security_set(struct inode *ip, const char *name,
 #endif
 	xattr_name = kmem_asprintf("%s%s", XATTR_SECURITY_PREFIX, name);
 	error = zpl_xattr_set(ip, xattr_name, value, size, flags);
-	strfree(xattr_name);
+	spa_strfree(xattr_name);
 
 	return (error);
 }

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1954,7 +1954,7 @@ zvol_create_snap_minor_cb(const char *dsname, void *arg)
 		    "%s is not a shapshot name\n", dsname);
 	} else {
 		minors_job_t *job;
-		char *n = strdup(dsname);
+		char *n = spa_strdup(dsname);
 		if (n == NULL)
 			return (0);
 
@@ -1996,7 +1996,7 @@ zvol_create_minors_cb(const char *dsname, void *arg)
 	 */
 	if (strchr(dsname, '@') == 0) {
 		minors_job_t *job;
-		char *n = strdup(dsname);
+		char *n = spa_strdup(dsname);
 		if (n == NULL)
 			return (0);
 
@@ -2097,7 +2097,7 @@ zvol_create_minors_impl(const char *name)
 		list_remove(&minors_list, job);
 		if (!job->error)
 			zvol_create_minor_impl(job->name);
-		strfree(job->name);
+		spa_strfree(job->name);
 		kmem_free(job, sizeof (minors_job_t));
 	}
 


### PR DESCRIPTION
This pull request addresses the zfs half of zfsonlinux/spl#650.

### Description
I'm concerned about switching to spa_strfree when we have a perfectly serviceable strfree macro in zfs_context.h.
icp was, on the other hand, truly importing strfree from spl.ko.

### Motivation and Context
This solves half of spl issue zfsonlinux/spl#650, which prevents usermode linux from launching with zfs+spl built-in.

### How Has This Been Tested?
Built into a usermode linux kernel, pool created, root dataset snapshotted, and destroyed.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
