### PR TITLE
ZTEST: Always enable asserts

### DIFF
--- a/cmd/ztest/Makefile.am
+++ b/cmd/ztest/Makefile.am
@@ -2,7 +2,7 @@ include $(top_srcdir)/config/Rules.am
 
 # -Wnoformat-truncation to get rid of compiler warning for unchecked
 #  truncating snprintfs on gcc 7.1.1.
-AM_CFLAGS += $(DEBUG_STACKFLAGS) $(FRAME_LARGER_THAN) $(NO_FORMAT_TRUNCATION)
+AM_CFLAGS += $(DEBUG_STACKFLAGS) $(FRAME_LARGER_THAN) $(NO_FORMAT_TRUNCATION) -UNDEBUG
 AM_CPPFLAGS += -DDEBUG
 
 DEFAULT_INCLUDES += \


### PR DESCRIPTION
The build for ztest always enabled debug information but does not enable
asserts unless --enable-debug is used. This will always enable asserts in the
ztest code.

Signed-Off-By: David Quigley <david.quigley@intel.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
Build ztest with an ASSERT0(1); at the beginning of main and ran it triggering the assert.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
