### PR TITLE
ZTS fix slog_replay_volume.ksh failure

### DIFF
--- a/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
@@ -81,7 +81,7 @@ log_onexit cleanup_volume
 # 1. Create an empty volume (TESTVOL), set sync=always, and format
 #    it with an ext4 filesystem and mount it.
 #
-log_must zpool create $TESTPOOL $VDEV log mirror $LDEV
+log_must zpool create $TESTPOOL ${DISKS%% *}
 log_must zfs create -V 128M $TESTPOOL/$TESTVOL
 log_must zfs set compression=on $TESTPOOL/$TESTVOL
 log_must zfs set sync=always $TESTPOOL/$TESTVOL
@@ -148,7 +148,7 @@ log_must zpool export $TESTPOOL
 # Import the pool to unfreeze it and claim log blocks.  It has to be
 # `zpool import -f` because we can't write a frozen pool's labels!
 #
-log_must zpool import -f -d $VDIR $TESTPOOL
+log_must zpool import -f $TESTPOOL
 log_must block_device_wait
 log_must mount $VOLUME $MNTPNT
 


### PR DESCRIPTION
### Description

The slog_replay_volume.ksh test case will fail when the pool is
layered on files in a filesystem which does not support discard.
Avoid this issue by creating the pool using DISKS which will
either be loopback device or real disk.

### Motivation and Context

ZFS test suite hardening.

### How Has This Been Tested?

Locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
