### PR TITLE
Increase default arc_c_min

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7353,16 +7353,17 @@ arc_init(void)
 	/* Set max to 1/2 of all memory */
 	arc_c_max = allmem / 2;
 
+#ifdef	_KERNEL
+	/* Set min cache to 1/32 of all memory, or 32MB, whichever is more */
+	arc_c_min = MAX(allmem / 32, 2ULL << SPA_MAXBLOCKSHIFT);
+#else
 	/*
 	 * In userland, there's only the memory pressure that we artificially
 	 * create (see arc_available_memory()).  Don't let arc_c get too
 	 * small, because it can cause transactions to be larger than
 	 * arc_c, causing arc_tempreserve_space() to fail.
 	 */
-#ifndef	_KERNEL
 	arc_c_min = MAX(arc_c_max / 2, 2ULL << SPA_MAXBLOCKSHIFT);
-#else
-	arc_c_min = 2ULL << SPA_MAXBLOCKSHIFT;
 #endif
 
 	arc_c = arc_c_max;


### PR DESCRIPTION
### Description

Increase the default arc_c_min value to which whichever is larger,
either 32M or 1/32 of total system memory.  This is advantageous for
systems with more than 1G of memory where performance issues may
occur when the ARC is allowed to collapse below a minimum size.
At the same time we want to use the bare minimum value which is
still functional so the filesystem can be used in very low memory
environments.

### Motivation and Context

By increasing the default `arc_c_min` on systems which have more
total memory available it's possible to avoid some performance
pathologiies caused by the ARC collapsing due to competing
application demand for memory.  The change complements recent
fixes such as 787acae0b5cd139ea0f9fa60558cca28d4673b23 which prevent the ARC from mistakenly
decreasing in size needlessly.

### How Has This Been Tested?

* Locally
* Buildbot
* User testing which specifically increased `zfs_arc_c_min` for their workload.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
