### PR TITLE
Fix ZTS MMP tests and ztest -M behavior

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -5669,6 +5669,9 @@ ztest_reguid(ztest_ds_t *zd, uint64_t id)
 	uint64_t orig, load;
 	int error;
 
+	if (ztest_opts.zo_mmp_test)
+		return;
+
 	orig = spa_guid(spa);
 	load = spa_load_guid(spa);
 

--- a/tests/zfs-tests/tests/functional/mmp/mmp_active_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_active_import.ksh
@@ -60,10 +60,9 @@ log_must is_pool_imported $MMP_POOL "-d $MMP_DIR"
 
 # 3. Verify 'zpool import [-f] $MMP_POOL' cannot import the pool.
 MMP_IMPORTED_MSG="Cannot import '$MMP_POOL': pool is imported"
-log_must try_pool_import $MMP_POOL "-d $MMP_DIR" $MMP_IMPORTED_MSG
+log_must try_pool_import $MMP_POOL "-d $MMP_DIR" "$MMP_IMPORTED_MSG"
 for i in {1..10}; do
-	log_must pgrep ztest >/dev/null
-	log_must try_pool_import $MMP_POOL "-f -d $MMP_DIR" $MMP_IMPORTED_MSG
+	log_must try_pool_import $MMP_POOL "-f -d $MMP_DIR" "$MMP_IMPORTED_MSG"
 done
 
 # 4. Kill ztest to make pool eligible for import.  Poll with 'zpool status'.
@@ -79,21 +78,21 @@ log_must wait_pool_imported $MMP_POOL "-d $MMP_DIR"
 #    - hostid=different - previously imported on a different system
 #
 log_must mmp_clear_hostid
-MMP_IMPORTED_MSG="Set the system hostid"
-log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "action" $MMP_IMPORTED_MSG
+MMP_IMPORTED_MSG="Set a unique system hostid"
+log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "action" "$MMP_IMPORTED_MSG"
 
 log_must mmp_set_hostid $HOSTID1
 MMP_IMPORTED_MSG="The pool can be imported"
-log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "action" $MMP_IMPORTED_MSG
+log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "action" "$MMP_IMPORTED_MSG"
 
 log_must mmp_clear_hostid
 log_must mmp_set_hostid $HOSTID2
 MMP_IMPORTED_MSG="The pool was last accessed by another system."
-log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "status" $MMP_IMPORTED_MSG
+log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "status" "$MMP_IMPORTED_MSG"
 
 # 6. Verify 'zpool import $MMP_POOL' fails with the expected message.
 MMP_IMPORTED_MSG="pool was previously in use from another system."
-log_must try_pool_import $MMP_POOL "-d $MMP_DIR" $MMP_IMPORTED_MSG
+log_must try_pool_import $MMP_POOL "-d $MMP_DIR" "$MMP_IMPORTED_MSG"
 
 # 7. Verify 'zpool import -f $MMP_POOL' can now import the pool.
 log_must import_activity_check $MMP_POOL "-f -d $MMP_DIR"

--- a/tests/zfs-tests/tests/functional/mmp/mmp_exported_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_exported_import.ksh
@@ -98,8 +98,8 @@ log_must zpool export $TESTPOOL
 log_must mmp_clear_hostid
 
 for opt in "" "-f"; do
-	MMP_IMPORTED_MSG="Set the system hostid"
-	log_must check_pool_import $TESTPOOL "" "action" $MMP_IMPORTED_MSG
+	MMP_IMPORTED_MSG="Set a unique system hostid"
+	log_must check_pool_import $TESTPOOL "" "action" "$MMP_IMPORTED_MSG"
 	log_mustnot import_no_activity_check $TESTPOOL $opt
 done
 

--- a/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
@@ -90,8 +90,8 @@ log_must import_activity_check $TESTPOOL "-f"
 # 7. Verify multihost=on and hostid zero fails (no activity check)
 log_must zpool export -F $TESTPOOL
 log_must mmp_clear_hostid
-MMP_IMPORTED_MSG="Set the system hostid"
-log_must check_pool_import $TESTPOOL "-f" "action" $MMP_IMPORTED_MSG
+MMP_IMPORTED_MSG="Set a unique system hostid"
+log_must check_pool_import $TESTPOOL "-f" "action" "$MMP_IMPORTED_MSG"
 log_mustnot import_no_activity_check $TESTPOOL "-f"
 
 log_pass "multihost=on|off inactive pool activity checks passed"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Quote "$MMP_IMPORT_MSG" when it is passed as an argument, as it is a
multi-word string.  Some tests were passing when they should not have,
because the grep was only testing for the first word.

Correct the message expected when no hostid is set and the test attempts
to enable multihost.  It did not match the actual output in that
situation.

Disable ztest_reguid() when ztest is invoked with the -M option.  If
ztest performs a reguid, a concurrent import attempt may fail with the
error "one or more devices is currently unavailable" if the guid sum is
calculated on the original device guids but compared against the guid
sum ztest wrote based on the new device guids.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Automated test suite false negatives due to `ztest_reguid()` calls, and false positives due to incorrect string checking.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Repeated local runs of the mmp test suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
