### PR TITLE
Fix printk() calls missing log level

### DIFF
--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -99,7 +99,7 @@ static void
 vdev_disk_error(zio_t *zio)
 {
 #ifdef ZFS_DEBUG
-	printk("ZFS: zio error=%d type=%d offset=%llu size=%llu "
+	printk(KERN_WARNING "ZFS: zio error=%d type=%d offset=%llu size=%llu "
 	    "flags=%x\n", zio->io_error, zio->io_type,
 	    (u_longlong_t)zio->io_offset, (u_longlong_t)zio->io_size,
 	    zio->io_flags);
@@ -173,8 +173,9 @@ vdev_elevator_switch(vdev_t *v, char *elevator)
 	strfree(argv[2]);
 #endif /* HAVE_ELEVATOR_CHANGE */
 	if (error)
-		printk("ZFS: Unable to set \"%s\" scheduler for %s (%s): %d\n",
-		    elevator, v->vdev_path, device, error);
+		printk(KERN_NOTICE "ZFS: Unable to set \"%s\" scheduler"
+		    " for %s (%s): %d\n", elevator, v->vdev_path, device,
+		    error);
 }
 
 /*


### PR DESCRIPTION
### Description
Missing log levels in some `printk()` calls

### Motivation and Context
Trivial error fix

### How Has This Been Tested?
Build tested

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
