### PR TITLE
Fail importing if cached config has wrong number of vdev children

### DIFF
--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -49,7 +49,7 @@ extern int zfs_nocacheflush;
 
 extern int vdev_open(vdev_t *);
 extern void vdev_open_children(vdev_t *);
-extern int vdev_validate(vdev_t *, boolean_t);
+extern int vdev_validate(vdev_t *, boolean_t, boolean_t);
 extern void vdev_close(vdev_t *);
 extern int vdev_create(vdev_t *, uint64_t txg, boolean_t isreplace);
 extern void vdev_reopen(vdev_t *);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -1941,6 +1941,12 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 			    "the maximum allowable length"));
 			(void) zfs_error(hdl, EZFS_NAMETOOLONG, desc);
 			break;
+		case EBADF:
+			/* EBADF could also happen for fd mishandling */
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "configuration cache is out of date"));
+			(void) zfs_error(hdl, EZFS_BADCACHE, desc);
+			break;
 		default:
 			(void) zpool_standard_error(hdl, error, desc);
 			zpool_explain_recover(hdl,

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2617,7 +2617,7 @@ spa_load_impl(spa_t *spa, uint64_t pool_guid, nvlist_t *config,
 	 */
 	if (type != SPA_IMPORT_ASSEMBLE) {
 		spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
-		error = vdev_validate(rvd, mosconfig);
+		error = vdev_validate(rvd, mosconfig, B_TRUE);
 		spa_config_exit(spa, SCL_ALL, FTAG);
 
 		if (error != 0)
@@ -3440,9 +3440,10 @@ spa_open_common(const char *pool, spa_t **spapp, void *tag, nvlist_t *nvpolicy,
 			/*
 			 * If vdev_validate() returns failure (indicated by
 			 * EBADF), it indicates that one of the vdevs indicates
-			 * that the pool has been exported or destroyed.  If
-			 * this is the case, the config cache is out of sync and
-			 * we should remove the pool from the namespace.
+			 * that the pool may be exported, destroyed or the
+			 * cache may be inaccurate.  If this is the case, the
+			 * config cache is out of sync and we should remove the
+			 * pool from the namespace.
 			 */
 			spa_unload(spa);
 			spa_deactivate(spa);


### PR DESCRIPTION
During import compare the labels' configs with the import config
and fail if the labels indicate more vdevs than the cached config

Signed-off-by: DHE <git@dehacked.net>
Fixes #6671

### Description
When the zpool.cache says `vdev_children=X` but the pool actually has `vdev_children=Y` where `X<Y`, blkptr errors will occur during the import process. We detect this specific case and refuse imports from this cache file.

### Motivation and Context
See #6671

### How Has This Been Tested?
`ztest` only

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
