### PR TITLE
Fix "--enable-code-coverage" debug build

### DIFF
--- a/config/ax_code_coverage.m4
+++ b/config/ax_code_coverage.m4
@@ -124,7 +124,7 @@ AC_DEFUN([AX_CODE_COVERAGE],[
 
 		dnl Build the code coverage flags
 		dnl Define CODE_COVERAGE_LDFLAGS for backwards compatibility
-		CODE_COVERAGE_CPPFLAGS="-DNDEBUG"
+		CODE_COVERAGE_CPPFLAGS=""
 		CODE_COVERAGE_CFLAGS="-O0 -g -fprofile-arcs -ftest-coverage"
 		CODE_COVERAGE_CXXFLAGS="-O0 -g -fprofile-arcs -ftest-coverage"
 		CODE_COVERAGE_LIBS="-lgcov"


### PR DESCRIPTION
### Description

When `--enable-code-coverage` is provided it should not result
in `NDEBUG` being defined.  This is controlled by `--enable-debug`.

### Motivation and Context

Fix build issue accidentally introduced by acf044420b134b022da5c866b19df69934ad3778.

### How Has This Been Tested?

Local build.

```
sh autogen.sh
./configure --enable-debug --enable-debuginfo --enable-code-coverage
make
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
