### PR TITLE
update the default for zfs_txg_history

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -12,7 +12,7 @@
 .\" CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
-.TH ZFS-MODULE-PARAMETERS 5 "Nov 16, 2013"
+.TH ZFS-MODULE-PARAMETERS 5 "Sept 28, 2017"
 .SH NAME
 zfs\-module\-parameters \- ZFS module parameters
 .SH DESCRIPTION
@@ -1766,7 +1766,7 @@ Default value: \fB32\fR.
 Historical statistics for the last N txgs will be available in
 \fB/proc/spl/kstat/zfs/<pool>/txgs\fR
 .sp
-Default value: \fB0\fR.
+Default value: \fB100\fR.
 .RE
 
 .sp

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -34,9 +34,9 @@ int zfs_read_history = 0;
 int zfs_read_history_hits = 0;
 
 /*
- * Keeps stats on the last N txgs, disabled by default.
+ * Keeps stats on the last 100 txgs by default.
  */
-int zfs_txg_history = 0;
+int zfs_txg_history = 100;
 
 /*
  * Keeps stats on the last N MMP updates, disabled by default.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
It's often useful to have access to txg history for debugging purposes.
This patch changes the default from 0 to 100 TXGs worth of history preserved.

### Description
<!--- Describe your changes in detail -->
This is changing the default and man page entry for zfs_txg_history.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After the patch is applied we get output from `tail /proc/spl/kstat/zfs/<pool>/txgs`
without having to `echo 100 > /sys/module/zfs/parameters/zfs_txg_history` first.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested by watching `/proc/spl/kstat/zfs/<pool>/txgs`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.