### PR TITLE
Add lcov branch exclusions

### DIFF
--- a/cmd/ztest/Makefile.am
+++ b/cmd/ztest/Makefile.am
@@ -3,7 +3,7 @@ include $(top_srcdir)/config/Rules.am
 # -Wnoformat-truncation to get rid of compiler warning for unchecked
 #  truncating snprintfs on gcc 7.1.1.
 AM_CFLAGS += $(DEBUG_STACKFLAGS) $(FRAME_LARGER_THAN) $(NO_FORMAT_TRUNCATION)
-AM_CPPFLAGS += -DDEBUG -UNDEBUG
+AM_CPPFLAGS += -DDEBUG -UNDEBUG -CC
 
 DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+/* LCOV_EXCL_START */
 static inline int
 libspl_assert(const char *buf, const char *file, const char *func, int line)
 {
@@ -54,26 +55,33 @@ libspl_assertf(const char *file, const char *func, int line, char *format, ...)
 	va_end(args);
 	abort();
 }
+/* LCOV_EXCL_STOP */
 
 #ifdef verify
 #undef verify
 #endif
 
 #define	VERIFY(cond)							\
+	/* LCOV_EXCL_BR_START */					\
 	(void) ((!(cond)) &&						\
-	    libspl_assert(#cond, __FILE__, __FUNCTION__, __LINE__))
+	    libspl_assert(#cond, __FILE__, __FUNCTION__, __LINE__))	\
+	/* LCOV_EXCL_BR_STOP */
 #define	verify(cond)							\
+	/* LCOV_EXCL_BR_START */					\
 	(void) ((!(cond)) &&						\
-	    libspl_assert(#cond, __FILE__, __FUNCTION__, __LINE__))
+	    libspl_assert(#cond, __FILE__, __FUNCTION__, __LINE__))	\
+	/* LCOV_EXCL_BR_STOP */
 
 #define	VERIFY3_IMPL(LEFT, OP, RIGHT, TYPE)				\
 do {									\
 	const TYPE __left = (TYPE)(LEFT);				\
 	const TYPE __right = (TYPE)(RIGHT);				\
+	/* LCOV_EXCL_BR_START */					\
 	if (!(__left OP __right))					\
 		libspl_assertf(__FILE__, __FUNCTION__, __LINE__,	\
 		    "%s %s %s (0x%llx %s 0x%llx)", #LEFT, #OP, #RIGHT,	\
 		    (u_longlong_t)__left, #OP, (u_longlong_t)__right);	\
+	/* LCOV_EXCL_BR_STOP */						\
 } while (0)
 
 #define	VERIFY3S(x, y, z)	VERIFY3_IMPL(x, y, z, int64_t)
@@ -111,14 +119,18 @@ do {									\
 #define	ASSERT(x)		VERIFY(x)
 #define	assert(x)		VERIFY(x)
 #define	ASSERTV(x)		x
-#define	IMPLY(A, B) \
-	((void)(((!(A)) || (B)) || \
-	    libspl_assert("(" #A ") implies (" #B ")", \
-	    __FILE__, __FUNCTION__, __LINE__)))
-#define	EQUIV(A, B) \
-	((void)((!!(A) == !!(B)) || \
-	    libspl_assert("(" #A ") is equivalent to (" #B ")", \
-	    __FILE__, __FUNCTION__, __LINE__)))
+#define	IMPLY(A, B)							\
+	/* LCOV_EXCL_BR_START */					\
+	((void) (((!(A)) || (B)) ||					\
+	    libspl_assert("(" #A ") implies (" #B ")",			\
+	    __FILE__, __FUNCTION__, __LINE__)))				\
+	/* LCOV_EXCL_BR_STOP */
+#define	EQUIV(A, B)							\
+	/* LCOV_EXCL_BR_START */					\
+	((void) ((!!(A) == !!(B)) ||					\
+	    libspl_assert("(" #A ") is equivalent to (" #B ")",		\
+	    __FILE__, __FUNCTION__, __LINE__)))				\
+	/* LCOV_EXCL_BR_STOP */
 
 #endif  /* NDEBUG */
 


### PR DESCRIPTION
### Description

* Test if lcov branch exclusions are possible when used in a macro.
  They cannot be placed in a normal comment because comments are
  stripped before macro expansion.

* Test both comment styles for lcov code exclusions.

### Motivation and Context

Exclude the failure branches from the lcov testing.  These are expected to never run.

### How Has This Been Tested?

Local compile.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
