### PR TITLE
ARC tunable callback, arc_flush, dbuf cache kstats

### DIFF
--- a/cmd/dbufstat/dbufstat.py
+++ b/cmd/dbufstat/dbufstat.py
@@ -34,7 +34,7 @@ import errno
 
 bhdr = ["pool", "objset", "object", "level", "blkid", "offset", "dbsize"]
 bxhdr = ["pool", "objset", "object", "level", "blkid", "offset", "dbsize",
-         "meta", "state", "dbholds", "list", "atype", "flags",
+         "meta", "state", "dbholds", "dbc", "list", "atype", "flags",
          "count", "asize", "access", "mru", "gmru", "mfu", "gmfu", "l2",
          "l2_dattr", "l2_asize", "l2_comp", "aholds", "dtype", "btype",
          "data_bs", "meta_bs", "bsize", "lvls", "dholds", "blocks", "dsize"]
@@ -45,7 +45,7 @@ dxhdr = ["pool", "objset", "object", "dtype", "btype", "data_bs", "meta_bs",
          "bsize", "lvls", "dholds", "blocks", "dsize", "cached", "direct",
          "indirect", "bonus", "spill"]
 dincompat = ["level", "blkid", "offset", "dbsize", "meta", "state", "dbholds",
-             "list", "atype", "flags", "count", "asize", "access",
+             "dbc", "list", "atype", "flags", "count", "asize", "access",
              "mru", "gmru", "mfu", "gmfu", "l2", "l2_dattr", "l2_asize",
              "l2_comp", "aholds"]
 
@@ -53,7 +53,7 @@ thdr = ["pool", "objset", "dtype", "cached"]
 txhdr = ["pool", "objset", "dtype", "cached", "direct", "indirect",
          "bonus", "spill"]
 tincompat = ["object", "level", "blkid", "offset", "dbsize", "meta", "state",
-             "dbholds", "list", "atype", "flags", "count", "asize",
+             "dbc", "dbholds", "list", "atype", "flags", "count", "asize",
              "access", "mru", "gmru", "mfu", "gmfu", "l2", "l2_dattr",
              "l2_asize", "l2_comp", "aholds", "btype", "data_bs", "meta_bs",
              "bsize", "lvls", "dholds", "blocks", "dsize"]
@@ -70,9 +70,10 @@ cols = {
     "meta":       [4,    -1, "is this buffer metadata?"],
     "state":      [5,    -1, "state of buffer (read, cached, etc)"],
     "dbholds":    [7,  1000, "number of holds on buffer"],
+    "dbc":        [3,    -1, "in dbuf cache?"],
     "list":       [4,    -1, "which ARC list contains this buffer"],
     "atype":      [7,    -1, "ARC header type (data or metadata)"],
-    "flags":      [8,    -1, "ARC read flags"],
+    "flags":      [9,    -1, "ARC read flags"],
     "count":      [5,    -1, "ARC data count"],
     "asize":      [7,  1024, "size of this ARC buffer"],
     "access":     [10,   -1, "time this ARC buffer was last accessed"],

--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -75,7 +75,7 @@ typedef void arc_write_done_func_t(zio_t *zio, arc_buf_t *buf, void *private);
 typedef void arc_prune_func_t(int64_t bytes, void *private);
 
 /* Shared module parameters */
-extern int zfs_arc_average_blocksize;
+extern unsigned long zfs_arc_average_blocksize;
 
 /* generic arc_done_func_t's which you can use */
 arc_read_done_func_t arc_bcopy_func;

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -325,20 +325,20 @@ static kcondvar_t	arc_reclaim_waiters_cv;
 int zfs_arc_evict_batch_limit = 10;
 
 /* number of seconds before growing cache again */
-static int		arc_grow_retry = 5;
+static unsigned long	arc_grow_retry = 5;
 
 /* shift of arc_c for calculating overflow limit in arc_get_data_impl */
-int		zfs_arc_overflow_shift = 8;
+static unsigned long	zfs_arc_overflow_shift = 8;
 
 /* shift of arc_c for calculating both min and max arc_p */
-static int		arc_p_min_shift = 4;
+static unsigned long	arc_p_min_shift = 4;
 
 /* log2(fraction of arc to reclaim) */
-static int		arc_shrink_shift = 7;
+static unsigned long	arc_shrink_shift = 7;
 
 /* percent of pagecache to reclaim arc to */
 #ifdef _KERNEL
-static uint_t		zfs_arc_pc_percent = 0;
+static unsigned long	zfs_arc_pc_percent = 0;
 #endif
 
 /*
@@ -385,10 +385,10 @@ unsigned long zfs_arc_meta_limit = 0;
 unsigned long zfs_arc_meta_min = 0;
 unsigned long zfs_arc_dnode_limit = 0;
 unsigned long zfs_arc_dnode_reduce_percent = 10;
-int zfs_arc_grow_retry = 0;
-int zfs_arc_shrink_shift = 0;
-int zfs_arc_p_min_shift = 0;
-int zfs_arc_average_blocksize = 8 * 1024; /* 8KB */
+unsigned long zfs_arc_grow_retry = 0;
+unsigned long zfs_arc_shrink_shift = 0;
+unsigned long zfs_arc_p_min_shift = 0;
+unsigned long zfs_arc_average_blocksize = 8 * 1024; /* 8KB */
 
 int zfs_compressed_arc_enabled = B_TRUE;
 
@@ -407,13 +407,14 @@ unsigned long zfs_arc_dnode_limit_percent = 10;
  * These tunables are Linux specific
  */
 unsigned long zfs_arc_sys_free = 0;
+unsigned long zfs_arc_lotsfree_percent = 10;
 int zfs_arc_min_prefetch_lifespan = 0;
 int zfs_arc_p_aggressive_disable = 1;
 int zfs_arc_p_dampener_disable = 1;
 int zfs_arc_meta_prune = 10000;
 int zfs_arc_meta_strategy = ARC_STRATEGY_META_BALANCED;
 int zfs_arc_meta_adjust_restarts = 4096;
-int zfs_arc_lotsfree_percent = 10;
+char *zfs_arc_flush = "";
 
 /* The 6 states: */
 static arc_state_t ARC_anon;
@@ -1013,6 +1014,18 @@ typedef enum arc_fill_flags {
 	ARC_FILL_IN_PLACE	= 1 << 4  /* fill in place (special case) */
 } arc_fill_flags_t;
 
+typedef struct flush_state {
+	uint64_t	pool_guid;
+	boolean_t	arc_mru;
+	boolean_t	arc_mfu;
+	boolean_t	arc_mru_ghost;
+	boolean_t	arc_mfu_ghost;
+	boolean_t	l2arc;
+	boolean_t	data;
+	boolean_t	metadata;
+	boolean_t	retry;
+} flush_state_t;
+
 static kmutex_t l2arc_feed_thr_lock;
 static kcondvar_t l2arc_feed_thr_cv;
 static uint8_t l2arc_thread_exit;
@@ -1028,7 +1041,6 @@ static void arc_hdr_alloc_abd(arc_buf_hdr_t *, boolean_t);
 static void arc_access(arc_buf_hdr_t *, kmutex_t *);
 static boolean_t arc_is_overflowing(void);
 static void arc_buf_watch(arc_buf_t *);
-static void arc_tuning_update(void);
 static void arc_prune_async(int64_t);
 static uint64_t arc_all_memory(void);
 
@@ -1039,6 +1051,7 @@ static inline void arc_hdr_clear_flags(arc_buf_hdr_t *hdr, arc_flags_t flags);
 
 static boolean_t l2arc_write_eligible(uint64_t, arc_buf_hdr_t *);
 static void l2arc_read_done(zio_t *);
+static void l2arc_evict(l2arc_dev_t *dev, uint64_t distance, boolean_t all);
 
 static uint64_t
 buf_hash(uint64_t spa, const dva_t *dva, uint64_t birth)
@@ -4606,9 +4619,64 @@ arc_adjust(void)
 	return (total_evicted);
 }
 
+static void
+arc_flush_impl(flush_state_t *fs)
+{
+	uint64_t guid = fs->pool_guid;
+	boolean_t retry = fs->retry;
+
+	if (fs->arc_mru == B_TRUE && fs->data == B_TRUE)
+		(void) arc_flush_state(arc_mru, guid, ARC_BUFC_DATA, retry);
+
+	if (fs->arc_mru == B_TRUE && fs->metadata == B_TRUE)
+		(void) arc_flush_state(arc_mru, guid, ARC_BUFC_METADATA, retry);
+
+	if (fs->arc_mfu == B_TRUE && fs->data == B_TRUE)
+		(void) arc_flush_state(arc_mfu, guid, ARC_BUFC_DATA, retry);
+
+	if (fs->arc_mfu == B_TRUE && fs->metadata == B_TRUE)
+		(void) arc_flush_state(arc_mfu, guid, ARC_BUFC_METADATA, retry);
+
+	if (fs->arc_mru_ghost == B_TRUE && fs->data == B_TRUE)
+		(void) arc_flush_state(arc_mru_ghost, guid, ARC_BUFC_DATA,
+		    retry);
+	if (fs->arc_mru_ghost == B_TRUE && fs->metadata == B_TRUE)
+		(void) arc_flush_state(arc_mru_ghost, guid, ARC_BUFC_METADATA,
+		    retry);
+
+	if (fs->arc_mfu_ghost == B_TRUE && fs->data == B_TRUE)
+		(void) arc_flush_state(arc_mfu_ghost, guid, ARC_BUFC_DATA,
+		    retry);
+	if (fs->arc_mfu_ghost == B_TRUE && fs->metadata == B_TRUE)
+		(void) arc_flush_state(arc_mfu_ghost, guid, ARC_BUFC_METADATA,
+		    retry);
+
+	if (fs->l2arc) {
+		l2arc_dev_t *dev;
+
+		mutex_enter(&spa_namespace_lock);
+		mutex_enter(&l2arc_dev_mtx);
+
+		dev = list_head(l2arc_dev_list);
+		while (dev != NULL) {
+			spa_t *spa = dev->l2ad_spa;
+
+			spa_config_enter(spa, SCL_L2ARC, dev, RW_READER);
+			l2arc_evict(dev, 0, B_TRUE);
+			spa_config_exit(spa, SCL_L2ARC, dev);
+
+			dev = list_next(l2arc_dev_list, dev);
+		}
+
+		mutex_exit(&l2arc_dev_mtx);
+		mutex_exit(&spa_namespace_lock);
+	}
+}
+
 void
 arc_flush(spa_t *spa, boolean_t retry)
 {
+	flush_state_t fs;
 	uint64_t guid = 0;
 
 	/*
@@ -4621,17 +4689,15 @@ arc_flush(spa_t *spa, boolean_t retry)
 	if (spa != NULL)
 		guid = spa_load_guid(spa);
 
-	(void) arc_flush_state(arc_mru, guid, ARC_BUFC_DATA, retry);
-	(void) arc_flush_state(arc_mru, guid, ARC_BUFC_METADATA, retry);
+	memset(&fs, 0, sizeof (flush_state_t));
+	fs.pool_guid = guid;
+	fs.retry = retry;
+	fs.l2arc = B_FALSE;
+	fs.arc_mru = fs.arc_mfu = B_TRUE;
+	fs.arc_mru_ghost = fs.arc_mfu_ghost = B_TRUE;
+	fs.data = fs.metadata = B_TRUE;
 
-	(void) arc_flush_state(arc_mfu, guid, ARC_BUFC_DATA, retry);
-	(void) arc_flush_state(arc_mfu, guid, ARC_BUFC_METADATA, retry);
-
-	(void) arc_flush_state(arc_mru_ghost, guid, ARC_BUFC_DATA, retry);
-	(void) arc_flush_state(arc_mru_ghost, guid, ARC_BUFC_METADATA, retry);
-
-	(void) arc_flush_state(arc_mfu_ghost, guid, ARC_BUFC_DATA, retry);
-	(void) arc_flush_state(arc_mfu_ghost, guid, ARC_BUFC_METADATA, retry);
+	arc_flush_impl(&fs);
 }
 
 void
@@ -4950,7 +5016,6 @@ arc_reclaim_thread(void *unused)
 		int64_t to_free;
 		uint64_t evicted = 0;
 		uint64_t need_free = arc_need_free;
-		arc_tuning_update();
 
 		/*
 		 * This is necessary in order for the mdb ::arc dcmd to
@@ -8950,6 +9015,8 @@ l2arc_stop(void)
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
+#include <linux/mod_compat.h>
+
 EXPORT_SYMBOL(arc_buf_size);
 EXPORT_SYMBOL(arc_write);
 EXPORT_SYMBOL(arc_read);
@@ -8958,104 +9025,280 @@ EXPORT_SYMBOL(arc_getbuf_func);
 EXPORT_SYMBOL(arc_add_prune_callback);
 EXPORT_SYMBOL(arc_remove_prune_callback);
 
+static int
+param_set_arc_tunable(const char *val, zfs_kernel_param_t *kp)
+{
+	int ret;
+
+	ret = param_set_ulong(val, kp);
+	if (ret < 0)
+		return (ret);
+
+	arc_tuning_update();
+
+	return (ret);
+}
+
+/*
+ * The passed string value is expected to include one of the allowed states
+ * listed below and an allowed type.
+ *
+ * Allowed States:
+ * - mru       - Only flush the MRU list
+ * - mfu       - Only flush the MFU list
+ * - mru_ghost - Only flush the MRU ghost list
+ * - mfu_ghost - Only flush the MFU ghost list
+ *
+ * Allowed Types:
+ * - data      - Only flush data
+ * - metadata  - Only flush metadata
+ *
+ * Aliases:
+ * - all-states = mru, mfu, mru_ghost, mfu_ghost
+ * - all-types  = data, metadata
+ * - all        = all-states, all-types
+ */
+enum {
+	TOKEN_STATE_MRU,
+	TOKEN_STATE_MFU,
+	TOKEN_STATE_MRU_GHOST,
+	TOKEN_STATE_MFU_GHOST,
+	TOKEN_STATE_L2ARC,
+	TOKEN_STATE_ALL,
+	TOKEN_TYPE_DATA,
+	TOKEN_TYPE_METADATA,
+	TOKEN_TYPE_ALL,
+	TOKEN_POOL_NAME,
+	TOKEN_ALL,
+	TOKEN_LAST,
+};
+
+static const match_table_t flush_tokens = {
+	{ TOKEN_STATE_MRU,		"mru" },
+	{ TOKEN_STATE_MFU,		"mfu" },
+	{ TOKEN_STATE_MRU_GHOST,	"mru_ghost" },
+	{ TOKEN_STATE_MFU_GHOST,	"mfu_ghost" },
+	{ TOKEN_STATE_L2ARC,		"l2arc" },
+	{ TOKEN_STATE_ALL,		"all-states" },
+	{ TOKEN_TYPE_DATA,		"data" },
+	{ TOKEN_TYPE_METADATA,		"metadata" },
+	{ TOKEN_TYPE_ALL,		"all-types" },
+	{ TOKEN_POOL_NAME,		"pool=%s" },
+	{ TOKEN_ALL,			"all" },
+	{ TOKEN_LAST,			NULL },
+};
+
+static int
+parse_arc_flush(char *option, int token, substring_t *args, flush_state_t *fs)
+{
+	spa_t *spa;
+	char *name = match_strdup(&args[0]);
+	int error = 0;
+
+	switch (token) {
+	case TOKEN_STATE_MRU:
+		fs->arc_mru = B_TRUE;
+		break;
+	case TOKEN_STATE_MFU:
+		fs->arc_mfu = B_TRUE;
+		break;
+	case TOKEN_STATE_MRU_GHOST:
+		fs->arc_mru_ghost = B_TRUE;
+		break;
+	case TOKEN_STATE_MFU_GHOST:
+		fs->arc_mfu_ghost = B_TRUE;
+		break;
+	case TOKEN_STATE_L2ARC:
+		fs->l2arc = B_TRUE;
+		break;
+	case TOKEN_STATE_ALL:
+		fs->arc_mru = fs->arc_mru_ghost = B_TRUE;
+		fs->arc_mfu = fs->arc_mfu_ghost = B_TRUE;
+		fs->l2arc = B_TRUE;
+		break;
+	case TOKEN_TYPE_DATA:
+		fs->data = B_TRUE;
+		break;
+	case TOKEN_TYPE_METADATA:
+		fs->metadata = B_TRUE;
+		break;
+	case TOKEN_TYPE_ALL:
+		fs->data = fs->metadata = B_TRUE;
+		break;
+	case TOKEN_POOL_NAME:
+		name = match_strdup(&args[0]);
+
+		mutex_enter(&spa_namespace_lock);
+		if ((spa = spa_lookup(name)) != NULL)
+			fs->pool_guid = spa_load_guid(spa);
+		else
+			error = SET_ERROR(-ENOENT);
+		mutex_exit(&spa_namespace_lock);
+
+		strfree(name);
+		break;
+	case TOKEN_ALL:
+		fs->arc_mru = fs->arc_mru_ghost = B_TRUE;
+		fs->arc_mfu = fs->arc_mfu_ghost = B_TRUE;
+		fs->l2arc = B_TRUE;
+		fs->data = fs->metadata = B_TRUE;
+	default:
+		break;
+	}
+
+	return (error);
+}
+
+static int
+param_set_arc_flush(const char *val, zfs_kernel_param_t *kp)
+{
+	substring_t args[MAX_OPT_ARGS];
+	flush_state_t fs;
+	char *tmp_val, *p, *t;
+	int error = 0, token;
+
+	if (val == NULL)
+		return (SET_ERROR(-EINVAL));
+
+	tmp_val = t = strdup(val);
+	if (tmp_val == NULL)
+		return (SET_ERROR(-ENOMEM));
+
+	if ((p = strchr(tmp_val, '\n')) != NULL)
+		*p = '\0';
+
+	memset(&fs, 0, sizeof (flush_state_t));
+
+	while ((p = strsep(&t, ",")) != NULL) {
+		if (!*p)
+			continue;
+
+		args[0].to = args[0].from = NULL;
+		token = match_token(p, flush_tokens, args);
+
+		error = parse_arc_flush(p, token, args, &fs);
+		if (error)
+			break;
+	}
+
+	strfree(tmp_val);
+
+	if (fs.data == B_FALSE && fs.metadata == B_FALSE)
+		error = SET_ERROR(-EINVAL);
+
+	if (fs.arc_mru == B_FALSE && fs.arc_mru_ghost == B_FALSE &&
+	    fs.arc_mfu == B_FALSE && fs.arc_mfu_ghost == B_FALSE)
+		error = SET_ERROR(-EINVAL);
+
+	dprintf("ARC flush: mru=%d mfu=%d mru_ghost=%d mfu_ghost=%d l2arc=%d "
+	    "data=%d metadata=%d guid=%llu\n", fs.arc_mru, fs.arc_mfu,
+	    fs.arc_mru_ghost, fs.arc_mfu_ghost, fs.l2arc, fs.data,
+	    fs.metadata, fs.pool_guid);
+
+	if (error == 0)
+		arc_flush_impl(&fs);
+
+	return (error);
+}
+
 /* BEGIN CSTYLED */
-module_param(zfs_arc_min, ulong, 0644);
-MODULE_PARM_DESC(zfs_arc_min, "Min arc size");
+#define MODULE_PARM_ARC_CALLBACK(x, str) \
+    module_param_call(x, param_set_arc_tunable, param_get_ulong, &x, 0644); \
+    MODULE_PARM_DESC(x, str)
 
-module_param(zfs_arc_max, ulong, 0644);
-MODULE_PARM_DESC(zfs_arc_max, "Max arc size");
+/*
+ * Changing the following tunings will result in param_set_arc_tunable() being
+ * called in order to apply the updated value as appropriate to the ARC.
+ */
+MODULE_PARM_ARC_CALLBACK(zfs_arc_min,
+    "Min ARC size");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_max,
+    "Max ARC size");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_meta_min,
+    "Min ARC meta data");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_meta_limit,
+    "Bytes of ARC for meta data");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_meta_limit_percent,
+    "Percent of ARC for meta data");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_dnode_limit,
+    "Bytes of ARC meta data for dnodes");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_dnode_limit_percent,
+    "Percent of ARC meta data for dnodes");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_grow_retry,
+    "Seconds before growing ARC size");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_shrink_shift,
+    "log2(fraction of ARC to reclaim)");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_p_min_shift,
+    "arc_c shift to calc min/max arc_p");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_min_prefetch_lifespan,
+    "Min life of prefetch block");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_lotsfree_percent,
+    "System free memory I/O throttle in bytes");
+MODULE_PARM_ARC_CALLBACK(zfs_arc_sys_free,
+    "System free memory target size in bytes");
 
-module_param(zfs_arc_meta_limit, ulong, 0644);
-MODULE_PARM_DESC(zfs_arc_meta_limit, "Meta limit for arc size");
-
-module_param(zfs_arc_meta_limit_percent, ulong, 0644);
-MODULE_PARM_DESC(zfs_arc_meta_limit_percent,
-	"Percent of arc size for arc meta limit");
-
-module_param(zfs_arc_meta_min, ulong, 0644);
-MODULE_PARM_DESC(zfs_arc_meta_min, "Min arc metadata");
-
+/* ARC Tunings */
 module_param(zfs_arc_meta_prune, int, 0644);
-MODULE_PARM_DESC(zfs_arc_meta_prune, "Meta objects to scan for prune");
-
+MODULE_PARM_DESC(zfs_arc_meta_prune,
+    "Meta objects to scan for prune");
 module_param(zfs_arc_meta_adjust_restarts, int, 0644);
 MODULE_PARM_DESC(zfs_arc_meta_adjust_restarts,
-	"Limit number of restarts in arc_adjust_meta");
-
+    "Limit number of restarts in arc_adjust_meta");
 module_param(zfs_arc_meta_strategy, int, 0644);
-MODULE_PARM_DESC(zfs_arc_meta_strategy, "Meta reclaim strategy");
-
-module_param(zfs_arc_grow_retry, int, 0644);
-MODULE_PARM_DESC(zfs_arc_grow_retry, "Seconds before growing arc size");
-
+MODULE_PARM_DESC(zfs_arc_meta_strategy,
+    "Meta reclaim strategy");
 module_param(zfs_arc_p_aggressive_disable, int, 0644);
-MODULE_PARM_DESC(zfs_arc_p_aggressive_disable, "disable aggressive arc_p grow");
-
+MODULE_PARM_DESC(zfs_arc_p_aggressive_disable,
+    "Disable aggressive arc_p grow");
 module_param(zfs_arc_p_dampener_disable, int, 0644);
-MODULE_PARM_DESC(zfs_arc_p_dampener_disable, "disable arc_p adapt dampener");
-
-module_param(zfs_arc_shrink_shift, int, 0644);
-MODULE_PARM_DESC(zfs_arc_shrink_shift, "log2(fraction of arc to reclaim)");
-
-module_param(zfs_arc_pc_percent, uint, 0644);
-MODULE_PARM_DESC(zfs_arc_pc_percent,
-	"Percent of pagecache to reclaim arc to");
-
-module_param(zfs_arc_p_min_shift, int, 0644);
-MODULE_PARM_DESC(zfs_arc_p_min_shift, "arc_c shift to calc min/max arc_p");
-
-module_param(zfs_arc_average_blocksize, int, 0444);
-MODULE_PARM_DESC(zfs_arc_average_blocksize, "Target average block size");
-
+MODULE_PARM_DESC(zfs_arc_p_dampener_disable,
+    "Disable arc_p adapt dampener");
 module_param(zfs_compressed_arc_enabled, int, 0644);
-MODULE_PARM_DESC(zfs_compressed_arc_enabled, "Disable compressed arc buffers");
-
-module_param(zfs_arc_min_prefetch_lifespan, int, 0644);
-MODULE_PARM_DESC(zfs_arc_min_prefetch_lifespan, "Min life of prefetch block");
-
-module_param(l2arc_write_max, ulong, 0644);
-MODULE_PARM_DESC(l2arc_write_max, "Max write bytes per interval");
-
-module_param(l2arc_write_boost, ulong, 0644);
-MODULE_PARM_DESC(l2arc_write_boost, "Extra write bytes during device warmup");
-
-module_param(l2arc_headroom, ulong, 0644);
-MODULE_PARM_DESC(l2arc_headroom, "Number of max device writes to precache");
-
-module_param(l2arc_headroom_boost, ulong, 0644);
-MODULE_PARM_DESC(l2arc_headroom_boost, "Compressed l2arc_headroom multiplier");
-
-module_param(l2arc_feed_secs, ulong, 0644);
-MODULE_PARM_DESC(l2arc_feed_secs, "Seconds between L2ARC writing");
-
-module_param(l2arc_feed_min_ms, ulong, 0644);
-MODULE_PARM_DESC(l2arc_feed_min_ms, "Min feed interval in milliseconds");
-
-module_param(l2arc_noprefetch, int, 0644);
-MODULE_PARM_DESC(l2arc_noprefetch, "Skip caching prefetched buffers");
-
-module_param(l2arc_feed_again, int, 0644);
-MODULE_PARM_DESC(l2arc_feed_again, "Turbo L2ARC warmup");
-
-module_param(l2arc_norw, int, 0644);
-MODULE_PARM_DESC(l2arc_norw, "No reads during writes");
-
-module_param(zfs_arc_lotsfree_percent, int, 0644);
-MODULE_PARM_DESC(zfs_arc_lotsfree_percent,
-	"System free memory I/O throttle in bytes");
-
-module_param(zfs_arc_sys_free, ulong, 0644);
-MODULE_PARM_DESC(zfs_arc_sys_free, "System free memory target size in bytes");
-
-module_param(zfs_arc_dnode_limit, ulong, 0644);
-MODULE_PARM_DESC(zfs_arc_dnode_limit, "Minimum bytes of dnodes in arc");
-
-module_param(zfs_arc_dnode_limit_percent, ulong, 0644);
-MODULE_PARM_DESC(zfs_arc_dnode_limit_percent,
-	"Percent of ARC meta buffers for dnodes");
-
+MODULE_PARM_DESC(zfs_compressed_arc_enabled,
+    "Disable compressed ARC buffers");
+module_param(zfs_arc_pc_percent, ulong, 0644);
+MODULE_PARM_DESC(zfs_arc_pc_percent,
+    "Percent of pagecache to reclaim ARC to");
 module_param(zfs_arc_dnode_reduce_percent, ulong, 0644);
 MODULE_PARM_DESC(zfs_arc_dnode_reduce_percent,
-	"Percentage of excess dnodes to try to unpin");
+    "Percentage of excess dnodes to try to unpin");
+module_param(zfs_arc_average_blocksize, ulong, 0444);
+MODULE_PARM_DESC(zfs_arc_average_blocksize,
+    "Target average block size");
+
+module_param_call(zfs_arc_flush, param_set_arc_flush, param_get_charp,
+    &zfs_arc_flush, 0644);
+MODULE_PARM_DESC(zfs_arc_flush,
+    "A string describing what to flush from the ARC");
+
+/* L2ARC Tunings */
+module_param(l2arc_write_max, ulong, 0644);
+MODULE_PARM_DESC(l2arc_write_max,
+    "Max write bytes per interval");
+module_param(l2arc_write_boost, ulong, 0644);
+MODULE_PARM_DESC(l2arc_write_boost,
+    "Extra write bytes during device warmup");
+module_param(l2arc_headroom, ulong, 0644);
+MODULE_PARM_DESC(l2arc_headroom,
+    "Number of max device writes to precache");
+module_param(l2arc_headroom_boost, ulong, 0644);
+MODULE_PARM_DESC(l2arc_headroom_boost,
+     "Compressed L2ARC_headroom multiplier");
+module_param(l2arc_feed_secs, ulong, 0644);
+MODULE_PARM_DESC(l2arc_feed_secs,
+     "Seconds between L2ARC writing");
+module_param(l2arc_feed_min_ms, ulong, 0644);
+MODULE_PARM_DESC(l2arc_feed_min_ms,
+     "Min feed interval in milliseconds");
+module_param(l2arc_noprefetch, int, 0644);
+MODULE_PARM_DESC(l2arc_noprefetch,
+     "Skip caching prefetched buffers");
+module_param(l2arc_feed_again, int, 0644);
+MODULE_PARM_DESC(l2arc_feed_again,
+     "Turbo L2ARC warmup");
+module_param(l2arc_norw, int, 0644);
+MODULE_PARM_DESC(l2arc_norw,
+     "No reads during writes");
+
 /* END CSTYLED */
 #endif

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -48,6 +48,71 @@
 #include <sys/callb.h>
 #include <sys/abd.h>
 
+#define	DBUF_MAX_LEVEL	7
+
+kstat_t *dbuf_ksp;
+
+typedef struct dbuf_stats {
+	kstat_named_t dbuf_cache_size;
+	kstat_named_t dbuf_cache_size_max;
+	kstat_named_t dbuf_cache_max_bytes;
+	kstat_named_t dbuf_cache_lowater_bytes;
+	kstat_named_t dbuf_cache_hiwater_bytes;
+	kstat_named_t dbuf_cache_total_evicts;
+	kstat_named_t dbuf_cache_levels[DBUF_MAX_LEVEL];
+	kstat_named_t dbuf_cache_levels_bytes[DBUF_MAX_LEVEL];
+	kstat_named_t hash_hits;
+	kstat_named_t hash_misses;
+	kstat_named_t hash_collisions;
+	kstat_named_t hash_elements;
+	kstat_named_t hash_elements_max;
+	kstat_named_t hash_chains;
+	kstat_named_t hash_chain_max;
+	kstat_named_t hash_insert_race;
+	kstat_named_t hash_dbuf_levels[DBUF_MAX_LEVEL];
+	kstat_named_t hash_dbuf_levels_bytes[DBUF_MAX_LEVEL];
+} dbuf_stats_t;
+
+dbuf_stats_t dbuf_stats = {
+	{ "dbuf_cache_size",			KSTAT_DATA_UINT64 },
+	{ "dbuf_cache_size_max",		KSTAT_DATA_UINT64 },
+	{ "dbuf_cache_max_bytes",		KSTAT_DATA_UINT64 },
+	{ "dbuf_cache_lowater_bytes",		KSTAT_DATA_UINT64 },
+	{ "dbuf_cache_hiwater_bytes",		KSTAT_DATA_UINT64 },
+	{ "dbuf_cache_total_evicts",		KSTAT_DATA_UINT64 },
+	{ { "dbuf_cache_levels_N",		KSTAT_DATA_UINT64 } },
+	{ { "dbuf_cache_levels_bytes_N",	KSTAT_DATA_UINT64 } },
+	{ "hash_hits",				KSTAT_DATA_UINT64 },
+	{ "hash_misses",			KSTAT_DATA_UINT64 },
+	{ "hash_collisions",			KSTAT_DATA_UINT64 },
+	{ "hash_elements",			KSTAT_DATA_UINT64 },
+	{ "hash_elements_max",			KSTAT_DATA_UINT64 },
+	{ "hash_chains",			KSTAT_DATA_UINT64 },
+	{ "hash_chain_max",			KSTAT_DATA_UINT64 },
+	{ "hash_insert_race",			KSTAT_DATA_UINT64 },
+	{ { "hash_dbuf_levels_N",		KSTAT_DATA_UINT64 } },
+	{ { "hash_dbuf_levels_bytes_N",		KSTAT_DATA_UINT64 } }
+};
+
+#define	DBUF_STAT_SET(stat, val)	\
+	(dbuf_stats.stat.value.ui64 = (val));
+#define	DBUF_STAT_INCR(stat, val)	\
+	atomic_add_64(&dbuf_stats.stat.value.ui64, (val));
+#define	DBUF_STAT_DECR(stat, val)	\
+	DBUF_STAT_INCR(stat, -(val));
+#define	DBUF_STAT_BUMP(stat)		\
+	DBUF_STAT_INCR(stat, 1);
+#define	DBUF_STAT_BUMPDOWN(stat)	\
+	DBUF_STAT_INCR(stat, -1);
+#define	DBUF_STAT_MAX(stat, val) {					\
+	uint64_t m;							\
+	while ((val) > (m = dbuf_stats.stat.value.ui64) &&		\
+	    (m != atomic_cas_64(&dbuf_stats.stat.value.ui64, m, (val))))\
+		continue;						\
+}
+#define	DBUF_STAT_MAXSTAT(stat)	\
+	DBUF_STAT_MAX(stat##_max, dbuf_stats.stat.value.ui64)
+
 struct dbuf_hold_impl_data {
 	/* Function arguments */
 	dnode_t *dh_dn;
@@ -93,6 +158,8 @@ static kthread_t *dbuf_cache_evict_thread;
 static kmutex_t dbuf_evict_lock;
 static kcondvar_t dbuf_evict_cv;
 static boolean_t dbuf_evict_thread_exit;
+
+unsigned long dbuf_flush = 0;
 
 /*
  * LRU cache of dbufs. The dbuf cache maintains a list of dbufs that
@@ -273,6 +340,7 @@ dbuf_hash_insert(dmu_buf_impl_t *db)
 	int level = db->db_level;
 	uint64_t blkid, hv, idx;
 	dmu_buf_impl_t *dbf;
+	uint64_t depth = 0;
 
 	blkid = db->db_blkid;
 	hv = dbuf_hash(os, obj, level, blkid);
@@ -280,6 +348,7 @@ dbuf_hash_insert(dmu_buf_impl_t *db)
 
 	mutex_enter(DBUF_HASH_MUTEX(h, idx));
 	for (dbf = h->hash_table[idx]; dbf != NULL; dbf = dbf->db_hash_next) {
+		depth++;
 		if (DBUF_EQUAL(dbf, os, obj, level, blkid)) {
 			mutex_enter(&dbf->db_mtx);
 			if (dbf->db_state != DB_EVICTING) {
@@ -290,11 +359,22 @@ dbuf_hash_insert(dmu_buf_impl_t *db)
 		}
 	}
 
+	if (depth > 0) {
+		DBUF_STAT_BUMP(hash_chains);
+		if (depth == 1)
+			DBUF_STAT_BUMP(hash_collisions);
+		DBUF_STAT_MAX(hash_chain_max, depth);
+	}
+
 	mutex_enter(&db->db_mtx);
 	db->db_hash_next = h->hash_table[idx];
 	h->hash_table[idx] = db;
 	mutex_exit(DBUF_HASH_MUTEX(h, idx));
 	atomic_inc_64(&dbuf_hash_count);
+	DBUF_STAT_SET(hash_elements, dbuf_hash_count);
+	DBUF_STAT_MAXSTAT(hash_elements);
+	DBUF_STAT_BUMP(hash_dbuf_levels[db->db_level]);
+	DBUF_STAT_INCR(hash_dbuf_levels_bytes[db->db_level], db->db.db_size);
 
 	return (NULL);
 }
@@ -331,6 +411,10 @@ dbuf_hash_remove(dmu_buf_impl_t *db)
 	db->db_hash_next = NULL;
 	mutex_exit(DBUF_HASH_MUTEX(h, idx));
 	atomic_dec_64(&dbuf_hash_count);
+	DBUF_STAT_SET(hash_elements, dbuf_hash_count);
+	DBUF_STAT_MAXSTAT(hash_elements);
+	DBUF_STAT_BUMPDOWN(hash_dbuf_levels[db->db_level]);
+	DBUF_STAT_DECR(hash_dbuf_levels_bytes[db->db_level], db->db.db_size);
 }
 
 typedef enum {
@@ -470,28 +554,32 @@ dbuf_cache_target_bytes(void)
 	    arc_target_bytes() >> dbuf_cache_max_shift);
 }
 
+static inline uint64_t
+dbuf_cache_hiwater_bytes(void)
+{
+	uint64_t dbuf_cache_target = dbuf_cache_target_bytes();
+	return (dbuf_cache_target +
+	    (dbuf_cache_target * dbuf_cache_hiwater_pct) / 100);
+}
+
+static inline uint64_t
+dbuf_cache_lowater_bytes(void)
+{
+	uint64_t dbuf_cache_target = dbuf_cache_target_bytes();
+	return (dbuf_cache_target -
+	    (dbuf_cache_target * dbuf_cache_hiwater_pct) / 100);
+}
+
 static inline boolean_t
 dbuf_cache_above_hiwater(void)
 {
-	uint64_t dbuf_cache_target = dbuf_cache_target_bytes();
-
-	uint64_t dbuf_cache_hiwater_bytes =
-	    (dbuf_cache_target * dbuf_cache_hiwater_pct) / 100;
-
-	return (refcount_count(&dbuf_cache_size) >
-	    dbuf_cache_target + dbuf_cache_hiwater_bytes);
+	return (refcount_count(&dbuf_cache_size) > dbuf_cache_hiwater_bytes());
 }
 
 static inline boolean_t
 dbuf_cache_above_lowater(void)
 {
-	uint64_t dbuf_cache_target = dbuf_cache_target_bytes();
-
-	uint64_t dbuf_cache_lowater_bytes =
-	    (dbuf_cache_target * dbuf_cache_lowater_pct) / 100;
-
-	return (refcount_count(&dbuf_cache_size) >
-	    dbuf_cache_target - dbuf_cache_lowater_bytes);
+	return (refcount_count(&dbuf_cache_size) > dbuf_cache_lowater_bytes());
 }
 
 /*
@@ -526,7 +614,14 @@ dbuf_evict_one(void)
 		multilist_sublist_unlock(mls);
 		(void) refcount_remove_many(&dbuf_cache_size,
 		    db->db.db_size, db);
+		DBUF_STAT_BUMPDOWN(dbuf_cache_levels[db->db_level]);
+		DBUF_STAT_DECR(dbuf_cache_levels_bytes[db->db_level],
+		    db->db.db_size);
 		dbuf_destroy(db);
+		DBUF_STAT_SET(dbuf_cache_size,
+		    refcount_count(&dbuf_cache_size));
+		DBUF_STAT_MAXSTAT(dbuf_cache_size);
+		DBUF_STAT_BUMP(dbuf_cache_total_evicts);
 	} else {
 		multilist_sublist_unlock(mls);
 	}
@@ -550,6 +645,12 @@ dbuf_evict_thread(void *unused)
 
 	mutex_enter(&dbuf_evict_lock);
 	while (!dbuf_evict_thread_exit) {
+		DBUF_STAT_SET(dbuf_cache_lowater_bytes,
+		    dbuf_cache_lowater_bytes());
+		DBUF_STAT_SET(dbuf_cache_hiwater_bytes,
+		    dbuf_cache_hiwater_bytes());
+		DBUF_STAT_SET(dbuf_cache_max_bytes, dbuf_cache_max_bytes);
+
 		while (!dbuf_cache_above_lowater() && !dbuf_evict_thread_exit) {
 			CALLB_CPR_SAFE_BEGIN(&cpr);
 			(void) cv_timedwait_sig_hires(&dbuf_evict_cv,
@@ -619,7 +720,24 @@ dbuf_evict_notify(void)
 	}
 }
 
+void
+dbuf_flush_impl(void)
+{
+	unsigned int retries = 0;
+	int64_t prev_size = -1;
+	int64_t size = refcount_count(&dbuf_cache_size);
 
+	while (size > 0 && retries < 10) {
+		dbuf_evict_one();
+
+		size = refcount_count(&dbuf_cache_size);
+		if (size < prev_size)
+			retries = 0;
+		else
+			retries++;
+		prev_size = size;
+	}
+}
 
 void
 dbuf_init(void)
@@ -688,6 +806,33 @@ retry:
 	cv_init(&dbuf_evict_cv, NULL, CV_DEFAULT, NULL);
 	dbuf_cache_evict_thread = thread_create(NULL, 0, dbuf_evict_thread,
 	    NULL, 0, &p0, TS_RUN, minclsyspri);
+
+	dbuf_ksp = kstat_create("zfs", 0, "dbuf_stats", "misc",
+	    KSTAT_TYPE_NAMED, sizeof (dbuf_stats) / sizeof (kstat_named_t),
+	    KSTAT_FLAG_VIRTUAL);
+	if (dbuf_ksp != NULL) {
+		dbuf_ksp->ks_data = &dbuf_stats;
+		kstat_install(dbuf_ksp);
+
+		for (i = 0; i < DBUF_MAX_LEVEL; i++) {
+			snprintf(dbuf_stats.dbuf_cache_levels[i].name,
+			    KSTAT_STRLEN, "dbuf_cache_level_%d", i);
+			dbuf_stats.dbuf_cache_levels[i].data_type =
+			    KSTAT_DATA_UINT64;
+			snprintf(dbuf_stats.dbuf_cache_levels_bytes[i].name,
+			    KSTAT_STRLEN, "dbuf_cache_level_%d_bytes", i);
+			dbuf_stats.dbuf_cache_levels_bytes[i].data_type =
+			    KSTAT_DATA_UINT64;
+			snprintf(dbuf_stats.hash_dbuf_levels[i].name,
+			    KSTAT_STRLEN, "hash_dbuf_level_%d", i);
+			dbuf_stats.hash_dbuf_levels[i].data_type =
+			    KSTAT_DATA_UINT64;
+			snprintf(dbuf_stats.hash_dbuf_levels_bytes[i].name,
+			    KSTAT_STRLEN, "hash_dbuf_level_%d_bytes", i);
+			dbuf_stats.hash_dbuf_levels_bytes[i].data_type =
+			    KSTAT_DATA_UINT64;
+		}
+	}
 }
 
 void
@@ -726,6 +871,11 @@ dbuf_fini(void)
 
 	refcount_destroy(&dbuf_cache_size);
 	multilist_destroy(dbuf_cache);
+
+	if (dbuf_ksp != NULL) {
+		kstat_delete(dbuf_ksp);
+		dbuf_ksp = NULL;
+	}
 }
 
 /*
@@ -1267,6 +1417,7 @@ dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 		if ((flags & DB_RF_HAVESTRUCT) == 0)
 			rw_exit(&dn->dn_struct_rwlock);
 		DB_DNODE_EXIT(db);
+		DBUF_STAT_BUMP(hash_hits);
 	} else if (db->db_state == DB_UNCACHED) {
 		spa_t *spa = dn->dn_objset->os_spa;
 		boolean_t need_wait = B_FALSE;
@@ -1286,6 +1437,7 @@ dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 		if ((flags & DB_RF_HAVESTRUCT) == 0)
 			rw_exit(&dn->dn_struct_rwlock);
 		DB_DNODE_EXIT(db);
+		DBUF_STAT_BUMP(hash_misses);
 
 		if (!err && need_wait)
 			err = zio_wait(zio);
@@ -1304,6 +1456,7 @@ dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 		if ((flags & DB_RF_HAVESTRUCT) == 0)
 			rw_exit(&dn->dn_struct_rwlock);
 		DB_DNODE_EXIT(db);
+		DBUF_STAT_BUMP(hash_misses);
 
 		/* Skip the wait per the caller's request. */
 		mutex_enter(&db->db_mtx);
@@ -2230,6 +2383,12 @@ dbuf_destroy(dmu_buf_impl_t *db)
 		multilist_remove(dbuf_cache, db);
 		(void) refcount_remove_many(&dbuf_cache_size,
 		    db->db.db_size, db);
+		DBUF_STAT_BUMPDOWN(dbuf_cache_levels[db->db_level]);
+		DBUF_STAT_DECR(dbuf_cache_levels_bytes[db->db_level],
+		    db->db.db_size);
+		DBUF_STAT_SET(dbuf_cache_size,
+		    refcount_count(&dbuf_cache_size));
+		DBUF_STAT_MAXSTAT(dbuf_cache_size);
 	}
 
 	ASSERT(db->db_state == DB_UNCACHED || db->db_state == DB_NOFILL);
@@ -2459,6 +2618,7 @@ dbuf_create(dnode_t *dn, uint8_t level, uint64_t blkid,
 		/* someone else inserted it first */
 		kmem_cache_free(dbuf_kmem_cache, db);
 		mutex_exit(&dn->dn_dbufs_mtx);
+		DBUF_STAT_BUMP(hash_insert_race);
 		return (odb);
 	}
 	avl_add(&dn->dn_dbufs, db);
@@ -2801,6 +2961,12 @@ __dbuf_hold_impl(struct dbuf_hold_impl_data *dh)
 		multilist_remove(dbuf_cache, dh->dh_db);
 		(void) refcount_remove_many(&dbuf_cache_size,
 		    dh->dh_db->db.db_size, dh->dh_db);
+		DBUF_STAT_BUMPDOWN(dbuf_cache_levels[dh->dh_db->db_level]);
+		DBUF_STAT_DECR(dbuf_cache_levels_bytes[dh->dh_db->db_level],
+		    dh->dh_db->db.db_size);
+		DBUF_STAT_SET(dbuf_cache_size,
+		    refcount_count(&dbuf_cache_size));
+		DBUF_STAT_MAXSTAT(dbuf_cache_size);
 	}
 	(void) refcount_add(&dh->dh_db->db_holds, dh->dh_tag);
 	DBUF_VERIFY(dh->dh_db);
@@ -3073,6 +3239,13 @@ dbuf_rele_and_unlock(dmu_buf_impl_t *db, void *tag)
 				multilist_insert(dbuf_cache, db);
 				(void) refcount_add_many(&dbuf_cache_size,
 				    db->db.db_size, db);
+				DBUF_STAT_BUMP(dbuf_cache_levels[db->db_level]);
+				DBUF_STAT_INCR(
+				    dbuf_cache_levels_bytes[db->db_level],
+				    db->db.db_size);
+				DBUF_STAT_SET(dbuf_cache_size,
+				    refcount_count(&dbuf_cache_size));
+				DBUF_STAT_MAXSTAT(dbuf_cache_size);
 				mutex_exit(&db->db_mtx);
 
 				dbuf_evict_notify();
@@ -3989,6 +4162,22 @@ EXPORT_SYMBOL(dmu_buf_set_user_ie);
 EXPORT_SYMBOL(dmu_buf_get_user);
 EXPORT_SYMBOL(dmu_buf_get_blkptr);
 
+#include <linux/mod_compat.h>
+
+static int
+param_set_dbuf_flush(const char *val, zfs_kernel_param_t *kp)
+{
+	int ret;
+
+	ret = param_set_ulong(val, kp);
+	if (ret < 0)
+		return (ret);
+
+	dbuf_flush_impl();
+
+	return (ret);
+}
+
 /* BEGIN CSTYLED */
 module_param(dbuf_cache_max_bytes, ulong, 0644);
 MODULE_PARM_DESC(dbuf_cache_max_bytes,
@@ -4007,5 +4196,10 @@ MODULE_PARM_DESC(dbuf_cache_lowater_pct,
 module_param(dbuf_cache_max_shift, int, 0644);
 MODULE_PARM_DESC(dbuf_cache_max_shift,
 	"Cap the size of the dbuf cache to a log2 fraction of arc size.");
+
+module_param_call(dbuf_flush, param_set_dbuf_flush,
+	param_get_ulong, &dbuf_flush, 0644);
+MODULE_PARM_DESC(dbuf_flush,
+	"Start a flush of the dbuf cache");
 /* END CSTYLED */
 #endif

--- a/module/zfs/dbuf_stats.c
+++ b/module/zfs/dbuf_stats.c
@@ -46,14 +46,14 @@ static int
 dbuf_stats_hash_table_headers(char *buf, size_t size)
 {
 	(void) snprintf(buf, size,
-	    "%-88s | %-124s | %s\n"
-	    "%-16s %-8s %-8s %-8s %-8s %-8s %-8s %-5s %-5s %5s | "
-	    "%-5s %-5s %-8s %-6s %-8s %-12s "
-	    "%-6s %-6s %-6s %-6s %-6s %-8s %-8s %-8s %-5s | "
-	    "%-6s %-6s %-8s %-8s %-6s %-6s %-5s %-8s %-8s\n",
+	    "%-96s | %-119s | %s\n"
+	    "%-16s %-8s %-8s %-8s %-8s %-10s %-8s %-5s %-5s %-7s %3s | "
+	    "%-5s %-5s %-9s %-6s %-8s %-12s "
+	    "%-6s %-6s %-6s %-6s %-6s %-8s %-8s %-8s %-6s | "
+	    "%-6s %-6s %-8s %-8s %-6s %-6s %-6s %-8s %-8s\n",
 	    "dbuf", "arcbuf", "dnode", "pool", "objset", "object", "level",
-	    "blkid", "offset", "dbsize", "meta", "state", "dbholds", "list",
-	    "atype", "flags", "count", "asize", "access",
+	    "blkid", "offset", "dbsize", "meta", "state", "dbholds", "dbc",
+	    "list", "atype", "flags", "count", "asize", "access",
 	    "mru", "gmru", "mfu", "gmfu", "l2", "l2_dattr", "l2_asize",
 	    "l2_comp", "aholds", "dtype", "btype", "data_bs", "meta_bs",
 	    "bsize", "lvls", "dholds", "blocks", "dsize");
@@ -75,10 +75,10 @@ __dbuf_stats_hash_table_data(char *buf, size_t size, dmu_buf_impl_t *db)
 	__dmu_object_info_from_dnode(dn, &doi);
 
 	nwritten = snprintf(buf, size,
-	    "%-16s %-8llu %-8lld %-8lld %-8lld %-8llu %-8llu %-5d %-5d %-5lu | "
-	    "%-5d %-5d 0x%-6x %-6lu %-8llu %-12llu "
-	    "%-6lu %-6lu %-6lu %-6lu %-6lu %-8llu %-8llu %-8d %-5lu | "
-	    "%-6d %-6d %-8lu %-8lu %-6llu %-6lu %-5lu %-8llu %-8llu\n",
+	    "%-16s %-8llu %-8lld %-8lld %-8lld %-10llu %-8llu %-5d %-5d "
+	    "%-7lu %-3d | %-5d %-5d 0x%-7x %-6lu %-8llu %-12llu "
+	    "%-6lu %-6lu %-6lu %-6lu %-6lu %-8llu %-8llu %-8d %-6lu | "
+	    "%-6d %-6d %-8lu %-8lu %-6llu %-6lu %-6lu %-8llu %-8llu\n",
 	    /* dmu_buf_impl_t */
 	    spa_name(dn->dn_objset->os_spa),
 	    (u_longlong_t)dmu_objset_id(db->db_objset),
@@ -90,6 +90,7 @@ __dbuf_stats_hash_table_data(char *buf, size_t size, dmu_buf_impl_t *db)
 	    !!dbuf_is_metadata(db),
 	    db->db_state,
 	    (ulong_t)refcount_count(&db->db_holds),
+	    multilist_link_active(&db->db_cache_link),
 	    /* arc_buf_info_t */
 	    abi.abi_state_type,
 	    abi.abi_state_contents,


### PR DESCRIPTION
### Description
When changing the following ARC tunings immediately apply the
change to the ARC instead of deferring it until the arc_reclaim
thread runs.  In order to keep the logic simple several types
were changed to unsigned longs.

  zfs_arc_min
  zfs_arc_max
  zfs_arc_meta_min
  zfs_arc_meta_limit
  zfs_arc_meta_limit_percent
  zfs_arc_dnode_limit
  zfs_arc_dnode_limit_percent
  zfs_arc_grow_retry
  zfs_arc_shrink_shift
  zfs_arc_p_min_shift
  zfs_arc_min_prefetch_lifespan
  zfs_arc_lotsfree_percent
  zfs_arc_sys_free

Introduce arc_flush module option.

Introduce relevant kstats for the dbuf cache to help
gain insight into how the dbuf cache is functioning.
This kstat can be useful to debug potential caching
issues or help determine if a new change impacts dbuf
cache behavior.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Locally on a VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.