### PR TITLE
Fix inclusion of libgcc_s.so on Void

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -46,7 +46,7 @@ install() {
 		# On systems with gcc-config (Gentoo, Funtoo, etc.):
 		# Use the current profile to resolve the appropriate path
 		dracut_install "/usr/lib/gcc/$(s=$(gcc-config -c); echo ${s%-*}/${s##*-})/libgcc_s.so.1"
-	elif [[ -n "$(ls /usr/lib/libgcc_s.so*)" ]]; then
+	elif [[ -n "$(ls /usr/lib/libgcc_s.so* 2>/dev/null)" ]]; then
 		# Try a simple path first
 		dracut_install /usr/lib/libgcc_s.so*
 	else

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -46,6 +46,9 @@ install() {
 		# On systems with gcc-config (Gentoo, Funtoo, etc.):
 		# Use the current profile to resolve the appropriate path
 		dracut_install "/usr/lib/gcc/$(s=$(gcc-config -c); echo ${s%-*}/${s##*-})/libgcc_s.so.1"
+	elif [[ -n "$(ls /usr/lib/libgcc_s.so*)" ]]; then
+		# Try a simple path first
+		dracut_install /usr/lib/libgcc_s.so*
 	else
 		# Fallback: Guess the path and include all matches
 		dracut_install /usr/lib/gcc/*/*/libgcc_s.so*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Add a simple additional path check for "/usr/lib/libgcc_s.so*" and install it in the initramfs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
On Void Linux (x86_64 musl) libgcc_s.so is located in "/usr/lib" so it is not found by dracut (in the fallback case) and it produces an error.
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Changes result in the successful inclusion of "/usr/lib/libgcc_s.so" within the initramfs and no error is seen.
<!--- Include details of your testing environment, and the tests you ran to -->
Void Linux x86_64 musl
Kernel 4.12.13_1
Zfs 0.7.1_1
Spl 0.7.1_1
Libgcc 6.3.0_5
Dracut 046_1
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
