### PR TITLE
Remove dead code from AVL tree

### DIFF
--- a/include/sys/avl.h
+++ b/include/sys/avl.h
@@ -260,17 +260,6 @@ extern void avl_add(avl_tree_t *tree, void *node);
 extern void avl_remove(avl_tree_t *tree, void *node);
 
 /*
- * Reinsert a node only if its order has changed relative to its nearest
- * neighbors. To optimize performance avl_update_lt() checks only the previous
- * node and avl_update_gt() checks only the next node. Use avl_update_lt() and
- * avl_update_gt() only if you know the direction in which the order of the
- * node may change.
- */
-extern boolean_t avl_update(avl_tree_t *, void *);
-extern boolean_t avl_update_lt(avl_tree_t *, void *);
-extern boolean_t avl_update_gt(avl_tree_t *, void *);
-
-/*
  * Swaps the contents of the two trees.
  */
 extern void avl_swap(avl_tree_t *tree1, avl_tree_t *tree2);

--- a/module/avl/avl.c
+++ b/module/avl/avl.c
@@ -626,25 +626,16 @@ avl_insert_here(
 }
 
 /*
- * Add a new node to an AVL tree.
+ * Add a new node to an AVL tree.  Strictly enforce that no duplicates can
+ * be added to the tree with a VERIFY which is enabled for non-DEBUG builds.
  */
 void
 avl_add(avl_tree_t *tree, void *new_node)
 {
 	avl_index_t where = 0;
 
-	/*
-	 * This is unfortunate.  We want to call panic() here, even for
-	 * non-DEBUG kernels.  In userland, however, we can't depend on anything
-	 * in libc or else the rtld build process gets confused.  So, all we can
-	 * do in userland is resort to a normal ASSERT().
-	 */
-	if (avl_find(tree, new_node, &where) != NULL)
-#ifdef _KERNEL
-		panic("avl_find() succeeded inside avl_add()");
-#else
-		ASSERT(0);
-#endif
+	VERIFY(avl_find(tree, new_node, &where) == NULL);
+
 	avl_insert(tree, new_node, where);
 }
 
@@ -815,64 +806,6 @@ avl_remove(avl_tree_t *tree, void *data)
 		else if (!avl_rotation(tree, node, new_balance))
 			break;
 	} while (parent != NULL);
-}
-
-#define	AVL_REINSERT(tree, obj)		\
-	avl_remove((tree), (obj));	\
-	avl_add((tree), (obj))
-
-boolean_t
-avl_update_lt(avl_tree_t *t, void *obj)
-{
-	void *neighbor;
-
-	ASSERT(((neighbor = AVL_NEXT(t, obj)) == NULL) ||
-	    (t->avl_compar(obj, neighbor) <= 0));
-
-	neighbor = AVL_PREV(t, obj);
-	if ((neighbor != NULL) && (t->avl_compar(obj, neighbor) < 0)) {
-		AVL_REINSERT(t, obj);
-		return (B_TRUE);
-	}
-
-	return (B_FALSE);
-}
-
-boolean_t
-avl_update_gt(avl_tree_t *t, void *obj)
-{
-	void *neighbor;
-
-	ASSERT(((neighbor = AVL_PREV(t, obj)) == NULL) ||
-	    (t->avl_compar(obj, neighbor) >= 0));
-
-	neighbor = AVL_NEXT(t, obj);
-	if ((neighbor != NULL) && (t->avl_compar(obj, neighbor) > 0)) {
-		AVL_REINSERT(t, obj);
-		return (B_TRUE);
-	}
-
-	return (B_FALSE);
-}
-
-boolean_t
-avl_update(avl_tree_t *t, void *obj)
-{
-	void *neighbor;
-
-	neighbor = AVL_PREV(t, obj);
-	if ((neighbor != NULL) && (t->avl_compar(obj, neighbor) < 0)) {
-		AVL_REINSERT(t, obj);
-		return (B_TRUE);
-	}
-
-	neighbor = AVL_NEXT(t, obj);
-	if ((neighbor != NULL) && (t->avl_compar(obj, neighbor) > 0)) {
-		AVL_REINSERT(t, obj);
-		return (B_TRUE);
-	}
-
-	return (B_FALSE);
 }
 
 void


### PR DESCRIPTION
### Description

The avl_update_* functions are never used by ZFS and are therefore
being removed.  They're barely even used in Illumos.  Additionally,
simplify avl_add() by using a VERIFY which produces exactly the same
behavior under Linux.

### Motivation and Context

Code cleanup resulting from code coverage reporting.  There's no reason to keep this around.

### How Has This Been Tested?

Local build.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.