### PR TITLE
Fix coverity defects: CID 147474

### DIFF
--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -980,7 +980,8 @@ bail:
 	kmem_free(sa->sa_user_table, count * sizeof (sa_attr_type_t));
 	sa->sa_user_table = NULL;
 	sa_free_attr_table(sa);
-	return ((error != 0) ? error : EINVAL);
+	ASSERT(error != 0);
+	return (error);
 }
 
 int


### PR DESCRIPTION
CID 147474: Logically dead code (DEADCODE)
    
Remove ternary operator and return `error` directly. Add an `ASSERT` to prevent behavior changing at a later date.
    
Currently return value is derived from a ternary operator. The conditional is always true. The ternary operator is therefore redundant i.e dead code.