### PR TITLE
Enable building the DKMS package on Debian-based distributions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,5 +98,6 @@ etags:
 tags: ctags etags
 
 pkg: @DEFAULT_PACKAGE@
+pkg-dkms: @DEFAULT_PACKAGE@-dkms
 pkg-kmod: @DEFAULT_PACKAGE@-kmod
 pkg-utils: @DEFAULT_PACKAGE@-utils

--- a/config/deb.am
+++ b/config/deb.am
@@ -15,28 +15,23 @@ deb-local:
 	fi)
 
 deb-kmod: deb-local rpm-kmod
-if CONFIG_KERNEL
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-kmod-$${version}.src.rpm --qf %{arch} | tail -1`; \
 	pkg1=kmod-$${name}*$${version}.$${arch}.rpm; \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
 	$(RM) $$pkg1
-endif
 
 
 deb-dkms: deb-local rpm-dkms
-if CONFIG_KERNEL
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-dkms-$${version}.src.rpm --qf %{arch} | tail -1`; \
 	pkg1=$${name}-dkms-$${version}.$${arch}.rpm; \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
 	$(RM) $$pkg1
-endif
 
 deb-utils: deb-local rpm-utils
-if CONFIG_USER
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-$${version}.src.rpm --qf %{arch} | tail -1`; \
@@ -69,6 +64,5 @@ if CONFIG_USER
 	rmdir $${path_prepend}; \
 	$(RM) $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
 	    $$pkg8 $$pkg9;
-endif
 
 deb: deb-kmod deb-dkms deb-utils

--- a/config/deb.am
+++ b/config/deb.am
@@ -24,6 +24,17 @@ if CONFIG_KERNEL
 	$(RM) $$pkg1
 endif
 
+
+deb-dkms: deb-local rpm-dkms
+if CONFIG_KERNEL
+	name=${PACKAGE}; \
+	version=${VERSION}-${RELEASE}; \
+	arch=`$(RPM) -qp $${name}-dkms-$${version}.src.rpm --qf %{arch} | tail -1`; \
+	pkg1=$${name}-dkms-$${version}.$${arch}.rpm; \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
+	$(RM) $$pkg1
+endif
+
 deb-utils: deb-local rpm-utils
 if CONFIG_USER
 	name=${PACKAGE}; \
@@ -60,4 +71,4 @@ if CONFIG_USER
 	    $$pkg8 $$pkg9;
 endif
 
-deb: deb-kmod deb-utils
+deb: deb-kmod deb-dkms deb-utils

--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -1,5 +1,9 @@
 %{?!packager: %define packager Brian Behlendorf <behlendorf1@llnl.gov>}
 
+%if ! 0%{?rhel}%{?fedora}%{?mageia}%{?suse_version}
+%define not_rpm 1
+%endif
+
 %define module  @PACKAGE@
 %define mkconf  scripts/dkms.mkconf
 
@@ -16,10 +20,12 @@ Source0:        %{module}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 
-Requires:       dkms >= 2.2.0.3-20
+Requires:       dkms >= 2.2.0.3
 Requires:       spl-dkms = %{version}
 Requires:       gcc, make, perl
+%if 0%{?rhel}%{?fedora}%{?mageia}%{?suse_version}
 Requires:       kernel-devel
+%endif
 Provides:       %{module}-kmod = %{version}
 
 %description
@@ -69,7 +75,7 @@ DKMS_META_ALIAS=`cat $CONFIG_H 2>/dev/null |
 if [ "$SPEC_META_ALIAS" = "$DKMS_META_ALIAS" ]; then
     echo -e
     echo -e "Uninstall of %{module} module ($SPEC_META_ALIAS) beginning:"
-    dkms remove -m %{module} -v %{version} --all --rpm_safe_upgrade
+    dkms remove -m %{module} -v %{version} --all %{!?not_rpm:--rpm_safe_upgrade}
 fi
 exit 0
 


### PR DESCRIPTION
### Description
This pull request adds the ability to generate DKMS packages that are compatible and installable for Debian and derivatives.

This depends on zfsonlinux/spl/pull/657.

### Motivation and Context
This change is intended to fix zfsonlinux/zfs/issues/6044.

### How Has This Been Tested?
I built it and installed the DKMS packages on Debian 9.0 (Stretch) for x86_64/amd64. The packages installed and did the right things (built the module and installed it).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
