### PR TITLE
Fix ARC behavior on 32-bit systems

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
@@ -50,7 +50,7 @@ function cleanup
         poolexists $TESTPOOL1 && \
                 log_must zpool destroy -f $TESTPOOL1
 
-        for file in `ls $TESTDIR/file.*`; do
+        for file in `ls $TEST_BASE_DIR/file.*`; do
 		log_must rm -f $file
         done
 }
@@ -62,12 +62,12 @@ log_onexit cleanup
 #make raw files to create various configuration pools
 typeset -i i=0
 while (( i < 3 )); do
-	log_must mkfile $FILESIZE $TESTDIR/file.$i
+	log_must truncate -s $FILESIZE $TEST_BASE_DIR/file.$i
 
 	(( i = i + 1 ))
 done
 
-fbase=$TESTDIR/file
+fbase=$TEST_BASE_DIR/file
 set -A poolconf "mirror $fbase.0 $fbase.1 $fbase.2" \
                 "raidz1 $fbase.0 $fbase.1 $fbase.2" \
                 "raidz2 $fbase.0 $fbase.1 $fbase.2"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
@@ -50,9 +50,9 @@ function create_old_pool
 	for pool_file in $pool_files; do
 		log_must bzcat \
 		    $STF_SUITE/tests/functional/cli_root/zpool_upgrade/$pool_file.bz2 \
-		    >/$TESTPOOL/$pool_file
+		    >$TEST_BASE_DIR/$pool_file
 	done
-	log_must zpool import -d /$TESTPOOL $pool_name
+	log_must zpool import -d $TEST_BASE_DIR $pool_name
 
 	# Put some random contents into the pool
 	for i in {1..1024} ; do
@@ -97,7 +97,7 @@ function destroy_upgraded_pool
 		log_must zpool destroy $pool_name
 	fi
 	for file in $pool_files; do
-		rm -f /$TESTPOOL/$file
+		rm -f $TEST_BASE_DIR/$file
 	done
 }
 
@@ -112,8 +112,8 @@ function check_pool
 	typeset pool=$1
 	typeset flag=$2
 	find /$pool -type f -exec cksum {} + > \
-		/$TESTPOOL/pool-checksums.$pool.$flag
-	echo /$TESTPOOL/pool-checksums.$pool.$flag
+		$TEST_BASE_DIR/pool-checksums.$pool.$flag
+	echo $TEST_BASE_DIR/pool-checksums.$pool.$flag
 }
 
 # This function simply checks that a pool has a particular version number

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_004_pos.ksh
@@ -78,10 +78,10 @@ for config in $CONFIGS ; do
 	typeset -n pool_name=ZPOOL_VERSION_${config}_NAME
 
 	check_pool $pool_name post > /dev/null
-	log_must diff /$TESTPOOL/pool-checksums.$pool_name.pre \
-	    /$TESTPOOL/pool-checksums.$pool_name.post
-	rm /$TESTPOOL/pool-checksums.$pool_name.pre \
-	    /$TESTPOOL/pool-checksums.$pool_name.post
+	log_must diff $TEST_BASE_DIR/pool-checksums.$pool_name.pre \
+	    $TEST_BASE_DIR/pool-checksums.$pool_name.post
+	rm $TEST_BASE_DIR/pool-checksums.$pool_name.pre \
+	    $TEST_BASE_DIR/pool-checksums.$pool_name.post
 	destroy_upgraded_pool $config
 done
 

--- a/tests/zfs-tests/tests/functional/features/async_destroy/async_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/async_destroy/async_destroy_001_pos.ksh
@@ -56,12 +56,9 @@ log_assert "async_destroy can suspend and resume traversal"
 
 log_must zfs create -o recordsize=512 -o compression=off $TEST_FS
 
-# Create enough blocks that it will take 4 TXGs to free them all.
-typeset zfs_free_max_blocks=100000
-typeset blocks=$((zfs_free_max_blocks * 4 * 512 / 1024 / 1024))
-
-log_must dd bs=1024k count=$blocks if=/dev/zero of=/$TEST_FS/file
-
+# Create enough blocks that it will take multiple TXGs to free them all.
+log_must dd bs=1024k count=128 if=/dev/zero of=/$TEST_FS/file
+log_must sync
 log_must zfs destroy $TEST_FS
 
 #


### PR DESCRIPTION
### Description

With the addition of the ABD changes consumption of the virtual address space has been greatly reduced.  This exposed an issue on CONFIG_HIGHMEM systems where free memory was being calculated incorrectly.  Functionally this didn't cause any major problems prior to ABD because a lack of available virtual address space was used as an indicator of low memory.

This patch makes the following changes to address the issue andin the process realigns the code further with OpenZFS.  There are no substantive changes in behavior for 64-bit systems.

* Added CONFIG_HIGHMEM case to the arc_all_memory() and arc_free_memory() functions to only consider low memory pages on CONFIG_HIGHMEM systems.

* The arc_free_memory() function was updated to return bytes instead of pages to be consistent with the other helper  functions.  In user space we make up some reasonable values since currently only testing is performed in this context.

* Adds three new values to the arcstats kstat to provide visibility  in to the ARC's assessment of the memory situation:  memory_all_bytes, memory_free_bytes, and memory_available_bytes.

* Added kmem_reap() call to arc_available_memory() for 32-bit  builds to realign code with OpenZFS.

* Reduced size of test file in /async_destroy_001_pos.ksh to  speed up test case.  Multiple txgs are still required.

* Move vdevs used by zpool_clear_001_pos and zpool_upgrade_002_pos  to TEST_BASE_DIR location to speed up test cases.

### Motivation and Context

Resolve 32-bit testing failures when running the ZTS.  The async_destroy_001_pos test was particularly good at triggering a low memory situation which could trigger the OOM killer.  More broadly speaking these changes should bring increased stability to 32-bit platforms.  Tuning is still required to achieve good performance when operating with an ARC that is only 100MB in size.

### How Has This Been Tested?

Locally by running various stress tests and observing the system.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
