### PR TITLE
Increase default zloop.sh vdev size

### DIFF
--- a/scripts/zloop.sh
+++ b/scripts/zloop.sh
@@ -36,7 +36,7 @@ DEFAULTCOREDIR=/var/tmp/zloop
 
 function usage
 {
-	echo -e "\n$0 [-t <timeout>] [-c <dump directory>]" \
+	echo -e "\n$0 [-t <timeout>] [ -s <vdev size> ] [-c <dump directory>]" \
 	    "[ -- [extra ztest parameters]]\n" \
 	    "\n" \
 	    "  This script runs ztest repeatedly with randomized arguments.\n" \
@@ -48,6 +48,7 @@ function usage
 	    "  Options:\n" \
 	    "    -t  Total time to loop for, in seconds. If not provided,\n" \
 	    "        zloop runs forever.\n" \
+	    "    -s  Size of vdev devices.\n" \
 	    "    -f  Specify working directory for ztest vdev files.\n" \
 	    "    -c  Specify a core dump directory to use.\n" \
 	    "    -h  Print this help message.\n" \
@@ -152,9 +153,11 @@ coredir=$DEFAULTCOREDIR
 basedir=$DEFAULTWORKDIR
 rundir="zloop-run"
 timeout=0
-while getopts ":ht:c:f:" opt; do
+size="512m"
+while getopts ":ht:s:c:f:" opt; do
 	case $opt in
 		t ) [[ $OPTARG -gt 0 ]] && timeout=$OPTARG ;;
+		s ) [[ $OPTARG ]] && size=$OPTARG ;;
 		c ) [[ $OPTARG ]] && coredir=$OPTARG ;;
 		f ) [[ $OPTARG ]] && basedir=$(readlink -f "$OPTARG") ;;
 		h ) usage
@@ -220,7 +223,6 @@ while [[ $timeout -eq 0 ]] || [[ $curtime -le $((starttime + timeout)) ]]; do
 	align=$(((RANDOM % 2) * 3 + 9))
 	runtime=$((RANDOM % 100))
 	passtime=$((RANDOM % (runtime / 3 + 1) + 10))
-	size=128m
 
 	zopt="$zopt -m $mirrors"
 	zopt="$zopt -r $raidz"


### PR DESCRIPTION
### Description

The default 128M vdev size used by zloop.sh isn't always large
enough and can result in ENOSPC failures which suspend the pool.
Increase the default size to 512M and provide a -s option which
can be used to specify an alternate size.

This will increase the free space requirements to run zloop.sh.
However, since the vdevs are sparse 4x the space is not required.

### Motivation and Context

Eliminate spurious `zloop.sh` failures where we happen to get unlucky.

### How Has This Been Tested?

Locally running `zloop.sh`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.