### PR TITLE
ZFS send fails to dump objects with size > 128PiB

### DIFF
--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -261,7 +261,7 @@ bpobj_iterate_impl(bpobj_t *bpo, bpobj_itor_t func, void *arg, dmu_tx_t *tx,
 	}
 	if (free) {
 		VERIFY3U(0, ==, dmu_free_range(bpo->bpo_os, bpo->bpo_object,
-		    (i + 1) * sizeof (blkptr_t), -1ULL, tx));
+		    (i + 1) * sizeof (blkptr_t), DMU_OBJECT_END, tx));
 	}
 	if (err || !bpo->bpo_havesubobj || bpo->bpo_phys->bpo_subobjs == 0)
 		goto out;
@@ -339,7 +339,7 @@ bpobj_iterate_impl(bpobj_t *bpo, bpobj_itor_t func, void *arg, dmu_tx_t *tx,
 	if (free) {
 		VERIFY3U(0, ==, dmu_free_range(bpo->bpo_os,
 		    bpo->bpo_phys->bpo_subobjs,
-		    (i + 1) * sizeof (uint64_t), -1ULL, tx));
+		    (i + 1) * sizeof (uint64_t), DMU_OBJECT_END, tx));
 	}
 
 out:

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -967,7 +967,7 @@ dmu_free_range(objset_t *os, uint64_t object, uint64_t offset,
 	if (err)
 		return (err);
 	ASSERT(offset < UINT64_MAX);
-	ASSERT(size == -1ULL || size <= UINT64_MAX - offset);
+	ASSERT(size == DMU_OBJECT_END || size <= UINT64_MAX - offset);
 	dnode_free_range(dn, offset, size, tx);
 	dnode_rele(dn, FTAG);
 	return (0);

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -167,7 +167,8 @@ tests = ['zfs_rollback_001_pos', 'zfs_rollback_002_pos',
 [tests/functional/cli_root/zfs_send]
 tests = ['zfs_send_001_pos', 'zfs_send_002_pos', 'zfs_send_003_pos',
     'zfs_send_004_neg', 'zfs_send_005_pos', 'zfs_send_006_pos',
-    'zfs_send_007_pos', 'zfs_send_encrypted', 'zfs_send_raw']
+    'zfs_send_007_pos', 'zfs_send_encrypted', 'zfs_send_raw',
+    'zfs_send_sparse']
 
 [tests/functional/cli_root/zfs_set]
 tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/Makefile.am
@@ -11,4 +11,5 @@ dist_pkgdata_SCRIPTS = \
 	zfs_send_006_pos.ksh \
 	zfs_send_007_pos.ksh \
 	zfs_send_encrypted.ksh \
-	zfs_send_raw.ksh
+	zfs_send_raw.ksh \
+	zfs_send_sparse.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_sparse.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_sparse.ksh
@@ -1,0 +1,83 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs send' should be able to send (big) sparse files correctly.
+#
+# STRATEGY:
+# 1. Create sparse files of various size
+# 2. Snapshot and send these sparse files
+# 3. Verify these files are received correctly and we don't trigger any issue
+#    like the one described in https://github.com/zfsonlinux/zfs/pull/6760
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+        datasetexists $SENDFS && log_must zfs destroy -r $SENDFS
+        datasetexists $RECVFS && log_must zfs destroy -r $RECVFS
+}
+
+#
+# Write 1 random byte at $offset of "source" file in $sendfs dataset
+# Snapshot and send $sendfs dataset to $recvfs
+# Compare the received file with its source
+#
+function write_compare_files # <sendfs> <recvfs> <offset>
+{
+	typeset sendfs="$1"
+	typeset recvfs="$2"
+	typeset offset="$3"
+
+	# create source filesystem
+	log_must zfs create $sendfs
+	# write sparse file
+	sendfile="$(get_prop mountpoint $sendfs)/data.bin"
+	log_must dd if=/dev/urandom of=$sendfile bs=1 count=1 seek=$offset
+	# send/receive the file
+	log_must zfs snapshot $sendfs@snap
+	log_must eval "zfs send $sendfs@snap | zfs receive $recvfs"
+	# compare sparse files
+	recvfile="$(get_prop mountpoint $recvfs)/data.bin"
+	log_must cmp $sendfile $recvfile $offset $offset
+	sendsz=$(stat -c '%s' $sendfile)
+	recvsz=$(stat -c '%s' $recvfile)
+	if [[ $sendsz -ne $recvsz ]]; then
+		log_fail "$sendfile ($sendsz) and $recvfile ($recvsz) differ."
+	fi
+	# cleanup
+	log_must zfs destroy -r $sendfs
+	log_must zfs destroy -r $recvfs
+}
+
+log_assert "'zfs send' should be able to send (big) sparse files correctly."
+log_onexit cleanup
+
+SENDFS="$TESTPOOL/sendfs"
+RECVFS="$TESTPOOL/recvfs"
+OFF_T_MAX="$(echo '2 ^ 40 * 8 - 1' | bc)"
+
+for i in {1..60}; do
+	offset=$(echo "2 ^ $i" | bc)
+	[[ is_32bit ]] && [[ $offset -ge $OFF_T_MAX ]] && continue;
+	write_compare_files $SENDFS $RECVFS $offset
+done
+
+log_pass "'zfs send' sends (big) sparse files correctly."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When dumping objects larger than 128PiB it's possible for `do_dump()` to miscalculate the FREE_RECORD offset due to an integer overflow condition: this prevents the receiving end from correctly restoring the dumped object.

NOTE: other ZFS implementations seems to be also affected.

EDIT: similar issue https://github.com/zfsonlinux/zfs/commit/c578f007ff9d8ee3d5070960f787fa48d46b7c3c

### Description
<!--- Describe your changes in detail -->

`dump_free()` overflows sending a file > 128PiB: `offset` is reset to `0` because we're dumping a L4 block which spans 128PiB (`dblkszsec == 256`, `indblkshift == 17`) at `blkid == 128`.

```
(gdb) bt
#0  dump_free (dsp=0xffff8800bd13a300, object=2, offset=0, length=144115188075855872) at /usr/src/zfs/module/zfs/dmu_send.c:206
#1  0xffffffffc066be98 in do_dump (dsa=0xffff8800bd13a300, data=0xffff8800c0002d00) at /usr/src/zfs/module/zfs/dmu_send.c:756
#2  0xffffffffc066d00f in dmu_send_impl (tag=0xffffffffc07918eb, dp=0xffff8800ba36c800, to_ds=0xffff88002b8b5000, ancestor_zb=0x0 <irq_stack_union>, is_clone=B_FALSE, embedok=B_FALSE, large_block_ok=B_FALSE, compressok=B_FALSE, rawok=B_FALSE, outfd=1, resumeobj=0, resumeoff=0, vp=0xffff8800db781000, off=0xffff8800bd1dfe28) at /usr/src/zfs/module/zfs/dmu_send.c:1134
#3  0xffffffffc066d74e in dmu_send_obj (pool=0xffff88002c5d4000 "testpool/sendfs@snap", tosnap=76, fromsnap=0, embedok=B_FALSE, large_block_ok=B_FALSE, compressok=B_FALSE, rawok=B_FALSE, outfd=1, vp=0xffff8800db781000, off=0xffff8800bd1dfe28) at /usr/src/zfs/module/zfs/dmu_send.c:1231
#4  0xffffffffc06ee3fe in zfs_ioc_send (zc=0xffff88002c5d4000) at /usr/src/zfs/module/zfs/zfs_ioctl.c:4836
#5  0xffffffffc06f4aab in zfsdev_ioctl (filp=<optimized out>, cmd=<optimized out>, arg=140735279876624) at /usr/src/zfs/module/zfs/zfs_ioctl.c:6819
#6  0xffffffff812086f9 in vfs_ioctl (arg=<optimized out>, cmd=<optimized out>, filp=<optimized out>) at fs/ioctl.c:43
#7  do_vfs_ioctl (filp=0xffff8800cf1fca00, fd=<optimized out>, cmd=<optimized out>, arg=144115188075855872) at fs/ioctl.c:674
#8  0xffffffff81208ca6 in SYSC_ioctl (arg=<optimized out>, cmd=<optimized out>, fd=<optimized out>) at fs/ioctl.c:689
#9  SyS_ioctl (fd=3, cmd=23068, arg=140735279876624) at fs/ioctl.c:680
#10 0xffffffff815cc1b6 in entry_SYSCALL_64 () at arch/x86/entry/entry_64.S:211
#11 0x00007fff7c5dbdd0 in ?? ()
#12 0x0000000000000037 in irq_stack_union ()
#13 0x0000000001c86850 in ?? ()
#14 0x0000000000000246 in irq_stack_union ()
Backtrace stopped: Cannot access memory at address 0x4000
(gdb) info args
dsp = 0xffff8800bd13a300
object = 2
offset = 0
length = 144115188075855872
(gdb) up
#1  0xffffffffc066be98 in do_dump (dsa=0xffff8800bd13a300, data=0xffff8800c0002d00) at /usr/src/zfs/module/zfs/dmu_send.c:756
756			err = dump_free(dsa, zb->zb_object, offset, span);
(gdb) p *zb
$19 = {
  zb_objset = 76, 
  zb_object = 2, 
  zb_level = 4, 
  zb_blkid = 128
}
(gdb) p span
$20 = 144115188075855872
(gdb) p span >> 50
$21 = 128
(gdb) p offset
$22 = 0
(gdb) list
751			uint64_t dnobj = (zb->zb_blkid * span) >> DNODE_SHIFT;
752			err = dump_freeobjects(dsa, dnobj, span >> DNODE_SHIFT);
753		} else if (BP_IS_HOLE(bp)) {
754			uint64_t span = BP_SPAN(dblkszsec, indblkshift, zb->zb_level);
755			uint64_t offset = zb->zb_blkid * span;
756			err = dump_free(dsa, zb->zb_object, offset, span);
757		} else if (zb->zb_level > 0 || type == DMU_OT_OBJSET) {
758			return (0);
759		} else if (type == DMU_OT_DNODE) {
760			dnode_phys_t *blk;
(gdb) 
```

Meanwhile `send_traverse_thread` is still dumping data over the offset limit:

```
(gdb) b send_cb if zb->zb_object == 2 && zb->zb_level == 4
Breakpoint 5 at 0xffffffffc0666430: file /usr/src/zfs/module/zfs/dmu_send.c, line 649.
(gdb) c
Continuing.
[Switching to Thread 3422]

Thread 168 hit Breakpoint 5, send_cb (spa=0xffff8800ba184000, zilog=0x0 <irq_stack_union>, bp=0xffffc9000134a080, zb=0xffff88002c77ee60, dnp=0xffff8800ba070400, arg=0xffff8800bd1dfbc0) at /usr/src/zfs/module/zfs/dmu_send.c:649
649	{
(gdb) p *zb
$23 = {
  zb_objset = 76, 
  zb_object = 2, 
  zb_level = 4, 
  zb_blkid = 257
}
(gdb) bt
#0  send_cb (spa=0xffff8800ba184000, zilog=0x0 <irq_stack_union>, bp=0xffffc9000134a080, zb=0xffff88002c77ee60, dnp=0xffff8800ba070400, arg=0xffff8800bd1dfbc0) at /usr/src/zfs/module/zfs/dmu_send.c:649
#1  0xffffffffc066fe05 in traverse_visitbp (td=0xffff8800c003eb00, dnp=0xffff8800ba070400, bp=0xffffc9000134a080, zb=0xffff88002c77ee60) at /usr/src/zfs/module/zfs/dmu_traverse.c:280
#2  0xffffffffc06700cd in traverse_visitbp (td=0xffff8800c003eb00, dnp=0xffff8800ba070400, bp=0xffff8800ba070440, zb=0xffff88002c493838) at /usr/src/zfs/module/zfs/dmu_traverse.c:323
#3  0xffffffffc066f9ae in traverse_dnode (td=0xffff8800c003eb00, dnp=0xffff8800ba070400, objset=76, object=2) at /usr/src/zfs/module/zfs/dmu_traverse.c:493
#4  0xffffffffc06703ed in traverse_visitbp (td=0xffff8800c003eb00, dnp=0xffff88002c6a6000, bp=0xffffc90001363000, zb=0xffff88002c77ef60) at /usr/src/zfs/module/zfs/dmu_traverse.c:359
#5  0xffffffffc06700cd in traverse_visitbp (td=0xffff8800c003eb00, dnp=0xffff88002c6a6000, bp=0xffffc90001384000, zb=0xffff88002c77e0a0) at /usr/src/zfs/module/zfs/dmu_traverse.c:323
#6  0xffffffffc06700cd in traverse_visitbp (td=0xffff8800c003eb00, dnp=0xffff88002c6a6000, bp=0xffffc90001193000, zb=0xffff88002c77e0c0) at /usr/src/zfs/module/zfs/dmu_traverse.c:323
#7  0xffffffffc06700cd in traverse_visitbp (td=0xffff8800c003eb00, dnp=0xffff88002c6a6000, bp=0xffffc900011b4000, zb=0xffff88002c77e1c0) at /usr/src/zfs/module/zfs/dmu_traverse.c:323
#8  0xffffffffc06700cd in traverse_visitbp (td=0xffff8800c003eb00, dnp=0xffff88002c6a6000, bp=0xffffc900011d5000, zb=0xffff88002c77e220) at /usr/src/zfs/module/zfs/dmu_traverse.c:323
#9  0xffffffffc06700cd in traverse_visitbp (td=0xffff8800c003eb00, dnp=0xffff88002c6a6000, bp=0xffff88002c6a6040, zb=0xffff88002c493c80) at /usr/src/zfs/module/zfs/dmu_traverse.c:323
#10 0xffffffffc066f9ae in traverse_dnode (td=0xffff8800c003eb00, dnp=0xffff88002c6a6000, objset=76, object=0) at /usr/src/zfs/module/zfs/dmu_traverse.c:493
#11 0xffffffffc06706bd in traverse_visitbp (td=0xffff8800c003eb00, dnp=0x0 <irq_stack_union>, bp=0xffff88002bcd6480, zb=0xffff88002c77e040) at /usr/src/zfs/module/zfs/dmu_traverse.c:396
#12 0xffffffffc0671017 in traverse_impl (spa=0xffff8800ba184000, ds=0xffff88002b8b5000, objset=76, rootbp=0xffff88002bcd6480, txg_start=0, resume=0xffff8800bd1dfce0, flags=13, func=0xffffffffc0666430 <send_cb>, arg=0xffff8800bd1dfbc0) at /usr/src/zfs/module/zfs/dmu_traverse.c:649
#13 0xffffffffc0671258 in traverse_dataset_resume (ds=0xffff88002b8b5000, txg_start=0, resume=0xffff8800bd1dfce0, flags=13, func=0xffffffffc0666430 <send_cb>, arg=0xffff8800bd1dfbc0) at /usr/src/zfs/module/zfs/dmu_traverse.c:677
#14 0xffffffffc06699c5 in send_traverse_thread (arg=0xffff8800bd1dfbc0) at /usr/src/zfs/module/zfs/dmu_send.c:696
#15 0xffffffffc03734ae in thread_generic_wrapper ()
#16 0xffffffff8109ac4f in kthread ()
#17 0xffffffff815cc3f2 in ret_from_fork () at arch/x86/entry/entry_64.S:406
#18 0x0000000000000000 in ?? ()
(gdb) 
```

The resulting send stream looks like this:

```
[...]
FREE object = 2 offset = 0 length = 144115188075855872
WRITE object = 2 type = 19 checksum type = 7 compression type = 0
    flags = 0 offset = 144115188075855872 logical_size = 131072 compressed_size = 0 payload_size = 131072 props = 200ff00ff salt = 0000000000000000 iv = 000000000000000000000000 mac = 00000000000000000000000000000000
FREE object = 2 offset = 144115188075986944 length = -288230376151842817
FREE object = 2 offset = 0 length = -144115188075855873
FREE object = 2 offset = 0 length = -144115188075855873
FREE object = 2 offset = 0 length = -144115188075855873
FREE object = 2 offset = 0 length = -144115188075855873
FREE object = 2 offset = 0 length = -144115188075855873
FREE object = 2 offset = 0 length = -144115188075855873
FREE object = 2 offset = 0 length = -144115188075855873
[...]
```

Needless to say the file is not received correctly:

```
root@linux:~# zdb -dddddddd $POOLNAME/sendfs 2
Dataset testpool/sendfs [ZPL], ID 72, cr_txg 8, 162K, 7 objects, rootbp DVA[0]=<0:58800:200> DVA[1]=<0:58a00:200> [L0 DMU objset] fletcher4 lz4 unencrypted LE contiguous unique double size=800L/200P birth=10L/10P fill=7 cksum=c981242e6:4679222f757:cf9bb03683d7:1aaed302e21ee9

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         2    6   128K   128K   138K     512   128P    0.00  ZFS plain file (K=inherit) (Z=inherit)
                                               168   bonus  System attributes
	dnode flags: USED_BYTES USERUSED_ACCOUNTED USEROBJUSED_ACCOUNTED 
	dnode maxblkid: 1099511627776
	path	/overflow.bin
	uid     0
	gid     0
	atime	Sun Oct  8 20:42:42 2017
	mtime	Sun Oct  8 20:42:42 2017
	ctime	Sun Oct  8 20:42:42 2017
	crtime	Sun Oct  8 20:42:42 2017
	gen	10
	mode	100644
	size	144115188075855873
	parent	34
	links	1
	pflags	40800000004
Indirect blocks:
               0 L5      0:54800:400 0:54c00:400 20000L/400P F=1 B=10/10
 200000000000000  L4     0:54000:400 0:54400:400 20000L/400P F=1 B=10/10
 200000000000000   L3    0:53800:400 0:53c00:400 20000L/400P F=1 B=10/10
 200000000000000    L2   0:53000:400 0:53400:400 20000L/400P F=1 B=10/10
 200000000000000     L1  0:52800:400 0:52c00:400 20000L/400P F=1 B=10/10
 200000000000000      L0 0:32800:20000 20000L/20000P F=1 B=10/10

		segment [0200000000000000, 0200000000020000) size  128K

root@linux:~# zfs send $POOLNAME/sendfs@snap | zfs recv $POOLNAME/recvfs
root@linux:~# zdb -dddddddd $POOLNAME/recvfs 2
Dataset testpool/recvfs [ZPL], ID 81, cr_txg 1121, 24.0K, 7 objects, rootbp DVA[0]=<0:9d400:200> DVA[1]=<0:9d600:200> [L0 DMU objset] fletcher4 lz4 unencrypted LE contiguous unique double size=800L/200P birth=1132L/1132P fill=7 cksum=e7d15afba:5907f38c614:11ad4e2d334e6:26a11a49353011

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         2    6   128K   128K      0     512   128K    0.00  ZFS plain file (K=inherit) (Z=inherit)
                                               168   bonus  System attributes
	dnode flags: USED_BYTES USERUSED_ACCOUNTED USEROBJUSED_ACCOUNTED 
	dnode maxblkid: 0
	path	/overflow.bin
	uid     0
	gid     0
	atime	Sun Oct  8 20:42:42 2017
	mtime	Sun Oct  8 20:42:42 2017
	ctime	Sun Oct  8 20:42:42 2017
	crtime	Sun Oct  8 20:42:42 2017
	gen	10
	mode	100644
	size	144115188075855873
	parent	34
	links	1
	pflags	40800000004
Indirect blocks:


root@linux:~# 
```

Additionally, trying to `zfs send` the snapshot on a DEBUG build triggers the following ASSERT:

```
root@linux:/usr/src/zfs# zfs send $POOLNAME/sendfs@snap | zfs recv $POOLNAME/recvfs
[ 8908.883178] VERIFY(length != -1ULL) failed
[ 8908.883881] PANIC at dmu_send.c:250:dump_free()
[ 8908.885703] Showing stack for process 28434
[ 8908.887449] CPU: 0 PID: 28434 Comm: zfs Tainted: P           OE   4.6.4 #1
[ 8908.889611] Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
[ 8908.891590]  0000000000000000 00000000d94682ae ffffffff81315815 ffffffffc0ca5ee8
[ 8908.893916]  ffff8800cf0b79f0 ffffffffc0394a39 0000000000000001 0000000000000028
[ 8908.897313]  ffff8800cf0b7a00 ffff8800cf0b79a0 6c28594649524556 3d21206874676e65
[ 8908.899586] Call Trace:
[ 8908.899971]  [<ffffffff81315815>] ? dump_stack+0x5c/0x77
[ 8908.901835]  [<ffffffffc0394a39>] ? spl_panic+0xc9/0x110 [spl]
[ 8908.903885]  [<ffffffffc0054067>] ? 0xffffffffc0054067
[ 8908.905682]  [<ffffffff81140219>] ? stack_trace_call+0x49/0x80
[ 8908.907576]  [<ffffffff815ce787>] ? ftrace_call+0x5/0x34
[ 8908.909395]  [<ffffffff81140219>] ? stack_trace_call+0x49/0x80
[ 8908.911283]  [<ffffffffc0054067>] ? 0xffffffffc0054067
[ 8908.913078]  [<ffffffff815ce787>] ? ftrace_call+0x5/0x34
[ 8908.913846]  [<ffffffff810bbfa4>] ? __wake_up+0x34/0x50
[ 8908.915702]  [<ffffffffc0b109e2>] ? dump_free+0x212/0x220 [zfs]
[ 8908.917650]  [<ffffffffc0b1361b>] ? dmu_send_impl+0x149b/0x2390 [zfs]
[ 8908.919619]  [<ffffffff815ce787>] ? ftrace_call+0x5/0x34
[ 8908.921423]  [<ffffffff815c8695>] ? _cond_resched+0x5/0x20
[ 8908.923228]  [<ffffffff815ca205>] ? mutex_unlock+0x5/0x20
[ 8908.925035]  [<ffffffffc0b5c701>] ? refcount_add_many+0x91/0x100 [zfs]
[ 8908.927016]  [<ffffffffc0b14702>] ? dmu_send_obj+0x1f2/0x290 [zfs]
[ 8908.927943]  [<ffffffffc0bb6dc4>] ? zfs_ioc_send+0x104/0x320 [zfs]
[ 8908.929923]  [<ffffffffc0bc0c89>] ? zfsdev_ioctl+0x729/0x840 [zfs]
[ 8908.931816]  [<ffffffff812086f9>] ? do_vfs_ioctl+0x99/0x5d0
[ 8908.933693]  [<ffffffff81208665>] ? do_vfs_ioctl+0x5/0x5d0
[ 8908.935739]  [<ffffffff81208ca6>] ? SyS_ioctl+0x76/0x90
[ 8908.937725]  [<ffffffff815cc1b6>] ? system_call_fast_compare_end+0xc/0x96
```

```
Loading modules: [ unix genunix specfs dtrace mac cpu.generic uppc pcplusmp scsi_vhci zfs ip hook neti sockfs arp usba uhci fctl stmf stmf_sbd mm lofs sata random sd idm cpc fcip ufs logindmux ptm nfs sppp ]
> ::status
debugging crash dump vmcore.1 (64-bit) from openindiana
operating system: 5.11 master-0-g7624f180cf (i86pc)
image uuid: 571887d8-07f6-c40d-f23f-c3fed6b29d6f
panic message: assertion failed: length != -1ULL, file: ../../common/fs/zfs/dmu_send.c, line: 217
dump content: kernel pages only
> $C
ffffff000c8c7760 vpanic()
ffffff000c8c7790 0xfffffffffbdff538()
ffffff000c8c77f0 dump_free+0x190(ffffff0333e21230, 8, fe00000000000000, 200000000000000)
ffffff000c8c78a0 do_dump+0xea(ffffff0333e21230, ffffff03387adc98)
ffffff000c8c7a40 dmu_send_impl+0x587(fffffffff7964fb3, ffffff032d516380, ffffff0311158040, 0, 0, 0, ffffff0000000000, ffffff0300000000, ffffff0300000001, 0, 0, ffffff0333246100, ffffff000c8c7b88)
ffffff000c8c7b30 dmu_send_obj+0x1e8(ffffff0338c69000, 2e, 0, 0, 0, 0, ffffff0300000001, ffffff0333246100, ffffff000c8c7b88)
ffffff000c8c7bd0 zfs_ioc_send+0xf7(ffffff0338c69000)
ffffff000c8c7c70 zfsdev_ioctl+0x546(10e00000000, 5a1c, 8044c78, 100003, ffffff032be4ed28, ffffff000c8c7e58)
ffffff000c8c7cb0 cdev_ioctl+0x39(10e00000000, 5a1c, 8044c78, 100003, ffffff032be4ed28, ffffff000c8c7e58)
ffffff000c8c7d00 spec_ioctl+0x60(ffffff0318cc3b00, 5a1c, 8044c78, 100003, ffffff032be4ed28, ffffff000c8c7e58, 0)
ffffff000c8c7d90 fop_ioctl+0x55(ffffff0318cc3b00, 5a1c, 8044c78, 100003, ffffff032be4ed28, ffffff000c8c7e58, 0)
ffffff000c8c7eb0 ioctl+0x9b(3, 5a1c, 8044c78)
ffffff000c8c7f00 _sys_sysenter_post_swapgs+0x234()
> 
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Tested on a local box with the following commands; will (gladly) add a new test to the ZTS if needed.

```
# misc functions
function is_linux() {
   if [[ "$(uname)" == "Linux" ]]; then
      return 0
   else
      return 1
   fi
}
# setup
POOLNAME='testpool'
if is_linux; then
   TMPDIR='/var/tmp'
   mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   fallocate -l 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
else
   TMPDIR='/tmp'
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   mkfile 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
fi
#
zfs create $POOLNAME/sendfs
zfs set recordsize=128K $POOLNAME/sendfs
dd if=/dev/zero of=/$POOLNAME/sendfs/overflow.bin bs=1 count=1 seek=0
dd if=/dev/zero of=/$POOLNAME/sendfs/overflow.bin bs=1 count=1 seek=$((1024*128)) conv=notrunc
dd if=/dev/zero of=/$POOLNAME/sendfs/overflow.bin bs=1 count=1 seek=$((1024*1024*128)) conv=notrunc
dd if=/dev/zero of=/$POOLNAME/sendfs/overflow.bin bs=1 count=1 seek=$((1024*1024*1024*1024*128)) conv=notrunc
dd if=/dev/zero of=/$POOLNAME/sendfs/overflow.bin bs=1 count=1 seek=$((1024*1024*1024*1024*1024*128)) conv=notrunc
obj=`ls -i /$POOLNAME/sendfs/overflow.bin | awk '{print $1}'`
zpool sync
zdb -ddddddd $POOLNAME/sendfs/ $obj
zfs snap $POOLNAME/sendfs@snap
zfs send $POOLNAME/sendfs@snap | zfs recv $POOLNAME/recvfs
zdb -ddddddd $POOLNAME/recvfs/ $obj
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
