### PR TITLE
systemd: order zfs-import-* before local-fs-pre

### DIFF
--- a/etc/systemd/system/Makefile.am
+++ b/etc/systemd/system/Makefile.am
@@ -7,6 +7,7 @@ systemdunit_DATA = \
 	zfs-import-scan.service \
 	zfs-mount.service \
 	zfs-share.service \
+	zfs-import.target \
 	zfs.target
 
 EXTRA_DIST = \
@@ -15,6 +16,7 @@ EXTRA_DIST = \
 	$(top_srcdir)/etc/systemd/system/zfs-import-scan.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-mount.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-share.service.in \
+	$(top_srcdir)/etc/systemd/system/zfs-import.target.in \
 	$(top_srcdir)/etc/systemd/system/zfs.target.in \
 	$(top_srcdir)/etc/systemd/system/50-zfs.preset.in
 

--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -7,6 +7,7 @@ After=systemd-udev-settle.service
 After=cryptsetup.target
 After=systemd-remount-fs.service
 Before=dracut-mount.service
+Before=zfs-import.target
 ConditionPathExists=@sysconfdir@/zfs/zpool.cache
 
 [Service]
@@ -16,5 +17,4 @@ ExecStartPre=/sbin/modprobe zfs
 ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
 
 [Install]
-WantedBy=zfs-mount.service
-WantedBy=zfs.target
+WantedBy=zfs-import.target

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -6,6 +6,7 @@ Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
 Before=dracut-mount.service
+Before=zfs-import.target
 ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
 
 [Service]
@@ -15,5 +16,4 @@ ExecStartPre=/sbin/modprobe zfs
 ExecStart=@sbindir@/zpool import -aN -o cachefile=none
 
 [Install]
-WantedBy=zfs-mount.service
-WantedBy=zfs.target
+WantedBy=zfs-import.target

--- a/etc/systemd/system/zfs-import.target.in
+++ b/etc/systemd/system/zfs-import.target.in
@@ -1,0 +1,6 @@
+[Unit]
+Description=ZFS pool import target
+
+[Install]
+WantedBy=zfs-mount.service
+WantedBy=zfs.target

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -3,8 +3,7 @@ Description=Mount ZFS filesystems
 Documentation=man:zfs(8)
 DefaultDependencies=no
 After=systemd-udev-settle.service
-After=zfs-import-cache.service
-After=zfs-import-scan.service
+After=zfs-import.target
 After=systemd-remount-fs.service
 Before=local-fs.target
 

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -461,7 +461,16 @@ If needed, ZFS file systems can also be managed with traditional tools
 If a file system's mount point is set to
 .Sy legacy ,
 ZFS makes no attempt to manage the file system, and the administrator is
-responsible for mounting and unmounting the file system.
+responsible for mounting and unmounting the file system. Because pools must
+be imported before a legacy mount can succeed, administrators should ensure
+that legacy mounts are only attempted after the zpool import process
+finishes at boot time. For example, on machines using systemd, the mount
+option
+.Pp
+.Nm x-systemd.requires=zfs-import.target
+.Pp
+will ensure that the zfs-import completes before systemd attempts mounting
+the filesystem. See systemd.mount(5) for details.
 .Ss Deduplication
 Deduplication is the process for removing redundant data at the block level,
 reducing the total amount of data stored. If a file system has the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
### Description
<!--- Describe your changes in detail -->

A new `zfs-import.target` is created, which should be `After` any zpool import target, and should be `Before` `zfs-mount.service`.

The `zfs(8)` man page is updated to suggest an explicit `x-systemd.after=zfs-import.target` dependency (thanks @Fabian-Gruenbichler for pointing to this systemd directive) for legacy zfs mounts.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`zfs-import-{cache,scan}.service` must complete before any mounting of legacy fstab ZFS filesystems can occur, creating a race between each legacy zfs `.mount` and `zfs-import-*.service`

This patch introduces documentation and framework to simplify ordering for legacy mounts.

~~Ideally, only the ZFS legacy mounts would be ordered after `zfs-import-*`, but that level of fine-grained tuning will have to wait for #4943, but that PR is far more comprehensive and sophisticated. This should work now.~~

~~**If an installation doesn't have `zpool` in its root partition, this will presumably cause a dependency loop or `zfs-import-*` to fail.** I don't know how significant the number of people who have the `zpool`/`zfs` on non-root filesystems. I also was not brave enough to try booting my system without this patch, so I don't know how critical it is.~~

By separating out a uniform `zfs-import.target`, a great deal of flexibility is allowed to system administrators. Unlike the earlier revision of this change, there should be no backwards incompatibility.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

I am running this on a machine that mounts several system directories via legacy fstab. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
