### PR TITLE
Update codecov.io behavior

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,30 +1,21 @@
 codecov:
   notify:
-    require_ci_to_pass: no
+    require_ci_to_pass: false	# always post
+    after_n_builds: 2		# user and kernel
 
 coverage:
-  precision: 2
-  round: down
-  range: "50...100"
+  precision: 2			# 2 digits of precision
+  range: "50...90"		# red -> yellow -> green
 
   status:
     project:
       default:
-        threshold: 1%
+        threshold: 1%		# allow 1% coverage variance
 
     patch:
       default:
-        threshold: 1%
-
-parsers:
-  gcov:
-    branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
+        threshold: 1%		# allow 1% coverage variance
 
 comment:
-  layout: "header, sunburst, diff"
-  behavior: default
-  require_changes: no
+  layout: "reach, diff, flags, footer"
+  behavior: "new"		# delete old, post new


### PR DESCRIPTION
### Description

Update the codecov.yml included in the repository to behave as
originally intended.  This can be refined as needed.

* Always post coverage results to the GitHub PR after two builds
  have been uploaded.  This is the normal case since there will
  be a build uploaded for both kernel and user coverage results.

* Adjust red -> yellow -> green coloring in the web interface.
  Due to the number of unlikely error conditions which are hard
  to force consider 90% coverage an excellent level of coverage.

* Allow a 1% variance in coverage between test runs.  This is
  approximately 10x larger than the typical variance observed
  which leaves us a reasonable margin to prevent false positives.

* Always post a new smaller comment to PRs which does not include
  a file list.  Old coverage reports are removed.

### Motivation and Context

Tune codecov to act as useful aid for PR submitters and reviewers.
Some values in the current yaml file appear to be ignored, fix that.

### How Has This Been Tested?

`curl --data-binary @.github/codecov.yml https://codecov.io/validate`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.