### PR TITLE
Fix ASSERT in dmu_free_long_object_raw()

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -932,9 +932,10 @@ dmu_free_long_object_impl(objset_t *os, uint64_t object, boolean_t raw)
 	dmu_tx_mark_netfree(tx);
 	err = dmu_tx_assign(tx, TXG_WAIT);
 	if (err == 0) {
-		err = dmu_object_free(os, object, tx);
-		if (err == 0 && raw)
-			VERIFY0(dmu_object_dirty_raw(os, object, tx));
+		if (raw)
+			err = dmu_object_dirty_raw(os, object, tx);
+		if (err == 0)
+			err = dmu_object_free(os, object, tx);
 
 		dmu_tx_commit(tx);
 	} else {


### PR DESCRIPTION
This small patch fixes an issue where dmu_free_long_object_raw()
calls dnode_hold() after freeing the dnode a line above.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
