### PR TITLE
Support integration with new QAT products

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -532,10 +532,10 @@ AC_DEFUN([ZFS_AC_QAT], [
 
 		AC_MSG_RESULT([$qatbuild])
 		QAT_OBJ=${qatbuild}
-		AS_IF([ ! test -e "$QAT_OBJ/icp_qa_al.ko"], [
+		AS_IF([ ! test -e "$QAT_OBJ/icp_qa_al.ko" && ! test -e "$QAT_OBJ/qat_api.ko"], [
 			AC_MSG_ERROR([
 		*** Please make sure the qat driver is installed then try again.
-		*** Failed to find icp_qa_al.ko in:
+		*** Failed to find icp_qa_al.ko or qat_api.ko in:
 		$QAT_OBJ])
 		])
 

--- a/module/zfs/qat_compress.c
+++ b/module/zfs/qat_compress.c
@@ -34,9 +34,11 @@
 
 /*
  * Max instances in QAT device, each instance is a channel to submit
- * jobs to QAT hardware
+ * jobs to QAT hardware, this is only for pre-allocating instance,
+ * and session arrays, the actual number of instances are defined in
+ * the QAT driver's configure file.
  */
-#define	MAX_INSTANCES		6
+#define	MAX_INSTANCES		48
 
 /*
  * ZLIB head and foot size
@@ -104,7 +106,7 @@ static kstat_t *qat_ksp;
 static CpaInstanceHandle dc_inst_handles[MAX_INSTANCES];
 static CpaDcSessionHandle session_handles[MAX_INSTANCES];
 static CpaBufferList **buffer_array[MAX_INSTANCES];
-static Cpa32U num_inst = 0;
+static Cpa16U num_inst = 0;
 static Cpa32U inst_num = 0;
 static boolean_t qat_init_done = B_FALSE;
 int zfs_qat_disable = 0;


### PR DESCRIPTION
Support integration with new QAT products: Intel(R) C62x Chipset,
or Atom(R) C3000 Processor Product Family SoC:
https://01.org/sites/default/files/downloads/intelr-quickassist-technology/336212qatswgsgrev002review.pdf
1. Detect new file name in auto-conf.
2. Change MAX_INSTANCES to 48.
3. Change "num_inst" to U16 to clean a build warning.

Signed-off-by: Weigang Li <weigang.li@intel.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are some slight changes in the new QAT driver, e.g., the driver file name is changed, and max instances is increased. To integrate with the new driver, the changes in ZFS code are required.
These changes do not impact the previous QAT product.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [X] Change has been approved by a ZFS on Linux member.
