### PR TITLE
Ensure arc_size_break are filled in arc_summary.py

### DIFF
--- a/cmd/arc_summary/arc_summary.py
+++ b/cmd/arc_summary/arc_summary.py
@@ -185,7 +185,8 @@ def get_arc_summary(Kstat):
 
     # ARC Sizing
     arc_size = Kstat["kstat.zfs.misc.arcstats.size"]
-    mru_size = Kstat["kstat.zfs.misc.arcstats.p"]
+    mru_size = Kstat["kstat.zfs.misc.arcstats.mru_size"]
+    mfu_size = Kstat["kstat.zfs.misc.arcstats.mfu_size"]
     target_max_size = Kstat["kstat.zfs.misc.arcstats.c_max"]
     target_min_size = Kstat["kstat.zfs.misc.arcstats.c_min"]
     target_size = Kstat["kstat.zfs.misc.arcstats.c"]
@@ -230,27 +231,14 @@ def get_arc_summary(Kstat):
         ]
 
     output['arc_size_break'] = {}
-    if arc_size > target_size:
-        mfu_size = (arc_size - mru_size)
-        output['arc_size_break']['recently_used_cache_size'] = {
-            'per': fPerc(mru_size, arc_size),
-            'num': fBytes(mru_size),
-        }
-        output['arc_size_break']['frequently_used_cache_size'] = {
-            'per': fPerc(mfu_size, arc_size),
-            'num': fBytes(mfu_size),
-        }
-
-    elif arc_size < target_size:
-        mfu_size = (target_size - mru_size)
-        output['arc_size_break']['recently_used_cache_size'] = {
-            'per': fPerc(mru_size, target_size),
-            'num': fBytes(mru_size),
-        }
-        output['arc_size_break']['frequently_used_cache_size'] = {
-            'per': fPerc(mfu_size, target_size),
-            'num': fBytes(mfu_size),
-        }
+    output['arc_size_break']['recently_used_cache_size'] = {
+        'per': fPerc(mru_size, mru_size + mfu_size),
+        'num': fBytes(mru_size),
+    }
+    output['arc_size_break']['frequently_used_cache_size'] = {
+        'per': fPerc(mfu_size, mru_size + mfu_size),
+        'num': fBytes(mfu_size),
+    }
 
     # ARC Hash Breakdown
     hash_chain_max = Kstat["kstat.zfs.misc.arcstats.hash_chain_max"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
When printing output in arc_summary, all possible keys
are expected in the output data structure. For the arc
size breakdown, output is conditionally filled and does
not expect arc target size to be equal to the arc size.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Just a small bug fix.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Locally, on a VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
