### PR TITLE
Provide commit message format for Coverity defects

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,6 +27,8 @@ started?](#what-should-i-know-before-i-get-started)
   * [Commit Message Formats](#commit-message-formats)
     * [New Changes](#new-changes)
     * [OpenZFS Patch Ports](#openzfs-patch-ports)
+    * [Coverity Defect Fixes](#coverity-defect-fixes)
+    * [Signed Off By](#signed-off-by)
 
 Helpful resources
 
@@ -167,18 +169,10 @@ first line in the commit message.
 please summarize important information such as why the proposed
 approach was chosen or a brief description of the bug you are resolving.
 Each line of the body must be 72 characters or less.
-* The last line must be a `Signed-off-by:` tag with the developer's
-name followed by their email. This is the developer's certification
-that they have the right to submit the patch for inclusion into
-the code base and indicates agreement to the [Developer's Certificate
-of Origin](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin).
-Code without a proper signoff cannot be merged.
+* The last line must be a `Signed-off-by:` tag. See the
+[Signed Off By](#signed-off-by) section for more information.
 
-Git can append the `Signed-off-by` line to your commit messages. Simply
-provide the `-s` or `--signoff` option when performing a `git commit`.
-For more information about writing commit messages, visit [How to Write
-a Git Commit Message](https://chris.beams.io/posts/git-commit/).
-An example commit message is provided below.
+An example commit message for new changes is provided below.
 
 ```
 This line is a brief summary of your change
@@ -223,3 +217,43 @@ Provide some porting notes here if necessary.
 OpenZFS-issue: https://www.illumos.org/issues/1234
 OpenZFS-commit: https://github.com/openzfs/openzfs/commit/abcd1234
 ```
+
+#### Coverity Defect Fixes
+If you are submitting a fix to a
+[Coverity defect](https://scan.coverity.com/projects/zfsonlinux-zfs),
+the commit message should meet the following guidelines:
+* Provides a subject line in the format of
+`Fix coverity defects: CID dddd, dddd...` where `dddd` represents
+each CID fixed by the commit.
+* Provides a body which lists each Coverity defect and how it was corrected.
+* The last line must be a `Signed-off-by:` tag. See the
+[Signed Off By](#signed-off-by) section for more information.
+
+An example Coverity defect fix commit message is provided below.
+```
+Fix coverity defects: CID 12345, 67890
+
+CID 12345: Logically dead code (DEADCODE)
+
+Removed the if(var != 0) block because the condition could never be
+satisfied.
+
+CID 67890: Resource Leak (RESOURCE_LEAK)
+
+Ensure free is called after allocating memory in function().
+
+Signed-off-by: Contributor <contributor@email.com>
+```
+
+#### Signed Off By
+A line tagged as `Signed-off-by:` must contain the developer's
+name followed by their email. This is the developer's certification
+that they have the right to submit the patch for inclusion into
+the code base and indicates agreement to the [Developer's Certificate
+of Origin](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin).
+Code without a proper signoff cannot be merged.
+
+Git can append the `Signed-off-by` line to your commit messages. Simply
+provide the `-s` or `--signoff` option when performing a `git commit`.
+For more information about writing commit messages, visit [How to Write
+a Git Commit Message](https://chris.beams.io/posts/git-commit/).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Provide details about the commit message format for Coverity defect
fixes submitted. Will make changes to the commit message checker in the future.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Document Coverity defect fix commit message expectations.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
