### PR TITLE
Correct flake8 errors after STYLE builder update

### DIFF
--- a/cmd/arcstat/arcstat.py
+++ b/cmd/arcstat/arcstat.py
@@ -238,7 +238,7 @@ def get_terminal_lines():
         data = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, '1234')
         sz = struct.unpack('hh', data)
         return sz[0]
-    except:
+    except Exception:
         pass
 
 

--- a/tests/test-runner/bin/test-runner.py
+++ b/tests/test-runner/bin/test-runner.py
@@ -150,7 +150,7 @@ class Cmd(object):
         try:
             kp = Popen(cmd)
             kp.wait()
-        except:
+        except Exception:
             pass
 
     def update_cmd_privs(self, cmd, user):
@@ -629,16 +629,16 @@ class TestRun(object):
         base = self.outputdir
 
         while not done:
-            l = []
+            paths = []
             components -= 1
             for testfile in tmp_dict.keys():
                 uniq = '/'.join(testfile.split('/')[components:]).lstrip('/')
-                if uniq not in l:
-                    l.append(uniq)
+                if uniq not in paths:
+                    paths.append(uniq)
                     tmp_dict[testfile].outputdir = os.path.join(base, uniq)
                 else:
                     break
-            done = total == len(l)
+            done = total == len(paths)
 
     def setup_logging(self, options):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Fix new flake8 errors related to bare excepts and ambiguous
variable names due to a STYLE builder update.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
New version of flake8 on the buildbot STYLE builder picks up new style issues.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Will be tested by buildbot.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
