### PR TITLE
Add Coverity defect fix commit checker support

### DIFF
--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -15,6 +15,19 @@ function test_url()
     return 0
 }
 
+# test commit body for length
+function test_commit_bodylength()
+{
+    length="72"
+    body=$(git log -n 1 --pretty=%b "$REF" | egrep -m 1 ".{$((length + 1))}")
+    if [ -n "$body" ]; then
+        echo "error: commit message body contains line over ${length} characters"
+        return 1
+    fi
+
+    return 0
+}
+
 # check for a tagged line
 function check_tagged_line()
 {
@@ -29,7 +42,7 @@ function check_tagged_line()
 }
 
 # check for a tagged line and check that the link is valid
-function check_tagged_line_with_url ()
+function check_tagged_line_with_url()
 {
     regex='^\s*'"$1"':\s\K([[:graph:]]+)$'
     foundline=$(git log -n 1 "$REF" | grep -Po "$regex")
@@ -63,9 +76,7 @@ function new_change_commit()
     fi
 
     # ensure that no lines in the body of the commit are over 72 characters
-    body=$(git log -n 1 --pretty=%b "$REF" | egrep -m 1 '.{73}')
-    if [ -n "$body" ]; then
-        echo "error: commit message body contains line over 72 characters"
+    if ! test_commit_bodylength ; then
         error=1
     fi
 
@@ -85,10 +96,12 @@ function is_openzfs_port()
 
 function openzfs_port_commit()
 {
+    error=0
+
     # subject starts with OpenZFS dddd
     subject=$(git log -n 1 --pretty=%s "$REF" | egrep -m 1 '^OpenZFS [[:digit:]]+ - ')
     if [ -z "$subject" ]; then
-        echo "OpenZFS patch ports must have a summary that starts with \"OpenZFS dddd - \""
+        echo "error: OpenZFS patch ports must have a subject line that starts with \"OpenZFS dddd - \""
         error=1
     fi
 
@@ -125,6 +138,54 @@ function openzfs_port_commit()
     return $error
 }
 
+function is_coverity_fix()
+{
+    # subject starts with Fix coverity defects means it's a coverity fix
+    subject=$(git log -n 1 --pretty=%s "$REF" | egrep -m 1 '^Fix coverity defects')
+    if [ -n "$subject" ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+function coverity_fix_commit()
+{
+    error=0
+
+    # subject starts with Fix coverity defects: CID dddd, dddd...
+    subject=$(git log -n 1 --pretty=%s "$REF" |
+        egrep -m 1 'Fix coverity defects: CID [[:digit:]]+(, [[:digit:]]+)*')
+    if [ -z "$subject" ]; then
+        echo "error: Coverity defect fixes must have a subject line that starts with \"Fix coverity defects: CID dddd\""
+        error=1
+    fi
+
+    # need a signed off by
+    if ! check_tagged_line "Signed-off-by" ; then
+        error=1
+    fi
+
+    # test each summary line for the proper format
+    OLDIFS=$IFS
+    IFS=$'\n'
+    for line in $(git log -n 1 --pretty=%b "$REF" | egrep '^CID'); do
+        echo "$line" | egrep '^CID [[:digit:]]+: ([[:graph:]]+|[[:space:]])+ \(([[:upper:]]|\_)+\)' > /dev/null
+        if [[ $? -ne 0 ]]; then
+            echo "error: commit message has an improperly formatted CID defect line"
+            error=1
+        fi
+    done
+    IFS=$OLDIFS
+
+    # ensure that no lines in the body of the commit are over 72 characters
+    if ! test_commit_bodylength; then
+        error=1
+    fi
+
+    return $error
+}
+
 if [ -n "$1" ]; then
     REF="$1"
 fi
@@ -132,6 +193,15 @@ fi
 # if openzfs port, test against that
 if is_openzfs_port; then
     if ! openzfs_port_commit ; then
+        exit 1
+    else
+        exit 0
+    fi
+fi
+
+# if coverity fix, test against that
+if is_coverity_fix; then
+    if ! coverity_fix_commit; then
         exit 1
     else
         exit 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Enable commitcheck.sh to test if a commit message is
in the expected format for coverity defect fixes.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Automate commit message checking for coverity defect fixes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Locally on a RHEL 7 based system.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.