### PR TITLE
commitcheck: Multiple OpenZFS ports in commit

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -186,23 +186,23 @@ Signed-off-by: Contributor <contributor@email.com>
 ```
 
 #### OpenZFS Patch Ports
-If you are porting an OpenZFS patch, the commit message must meet
+If you are porting OpenZFS patches, the commit message must meet
 the following guidelines:
-* The first line must be the summary line from the OpenZFS commit.
-It must begin with `OpenZFS dddd - ` where `dddd` is the OpenZFS issue number.
-* Provides a `Authored by:` line to attribute the patch to the original author.
-* Provides the `Reviewed by:` and `Approved by:` lines from the original
+* The first line must be the summary line from the most important OpenZFS commit being ported.
+It must begin with `OpenZFS dddd, dddd - ` where `dddd` are OpenZFS issue numbers.
+* Provides a `Authored by:` line to attribute each patch for each original author.
+* Provides the `Reviewed by:` and `Approved by:` lines from each original
 OpenZFS commit.
 * Provides a `Ported-by:` line with the developer's name followed by
-their email.
-* Provides a `OpenZFS-issue:` line which is a link to the original illumos
+their email for each OpenZFS commit.
+* Provides a `OpenZFS-issue:` line with link for each original illumos
 issue.
-* Provides a `OpenZFS-commit:` line which links back to the original OpenZFS
-commit.
+* Provides a `OpenZFS-commit:` line with link for each original OpenZFS commit.
 * If necessary, provide some porting notes to describe any deviations from
-the original OpenZFS commit.
+the original OpenZFS commits.
 
-An example OpenZFS patch port commit message is provided below.
+An example OpenZFS patch port commit message for a single patch is provided
+below.
 ```
 OpenZFS 1234 - Summary from the original OpenZFS commit
 
@@ -216,6 +216,37 @@ Provide some porting notes here if necessary.
 
 OpenZFS-issue: https://www.illumos.org/issues/1234
 OpenZFS-commit: https://github.com/openzfs/openzfs/commit/abcd1234
+```
+
+If necessary, multiple OpenZFS patches can be combined in a single port.
+This is useful when you are porting a new patch and its subsequent bug
+fixes. An example commit message is provided below.
+```
+OpenZFS 1234, 5678 - Summary of most important OpenZFS commit
+
+1234 Summary from original OpenZFS commit for 1234
+
+Authored by: Original Author <original@email.com>
+Reviewed by: Reviewer Two <reviewer2@email.com>
+Approved by: Approver One <approver1@email.com>
+Ported-by: ZFS Contributor <contributor@email.com>
+
+Provide some porting notes here for 1234 if necessary.
+
+OpenZFS-issue: https://www.illumos.org/issues/1234
+OpenZFS-commit: https://github.com/openzfs/openzfs/commit/abcd1234
+
+5678 Summary from original OpenZFS commit for 5678
+
+Authored by: Original Author2 <original2@email.com>
+Reviewed by: Reviewer One <reviewer1@email.com>
+Approved by: Approver Two <approver2@email.com>
+Ported-by: ZFS Contributor <contributor@email.com>
+
+Provide some porting notes here for 5678 if necessary.
+
+OpenZFS-issue: https://www.illumos.org/issues/5678
+OpenZFS-commit: https://github.com/openzfs/openzfs/commit/efgh5678
 ```
 
 #### Coverity Defect Fixes

--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -38,9 +38,14 @@ function check_tagged_line_with_url ()
         return 1
     fi
 
-    if ! test_url "$foundline"; then
-        return 1
-    fi
+    OLDIFS=$IFS
+    IFS=$'\n'
+    for url in $(echo -e "$foundline"); do
+        if ! test_url "$url"; then
+            return 1
+        fi
+    done
+    IFS=$OLDIFS
 
     return 0
 }
@@ -85,8 +90,10 @@ function is_openzfs_port()
 
 function openzfs_port_commit()
 {
+    error=0
+
     # subject starts with OpenZFS dddd
-    subject=$(git log -n 1 --pretty=%s "$REF" | egrep -m 1 '^OpenZFS [[:digit:]]+ - ')
+    subject=$(git log -n 1 --pretty=%s "$REF" | egrep -m 1 '^OpenZFS [[:digit:]]+(, [[:digit:]]+)* - ')
     if [ -z "$subject" ]; then
         echo "OpenZFS patch ports must have a summary that starts with \"OpenZFS dddd - \""
         error=1


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Allow commitcheck.sh to handle multiple OpenZFS ports in
a single commit. This is useful in the cases when a change
upstream has bug fixes and it makes sense to port them with
the original patch.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested locally with various OpenZFS commits.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
