### PR TITLE
OpenZFS 8081 - Compiler warnings in zdb

### DIFF
--- a/cmd/zdb/Makefile.am
+++ b/cmd/zdb/Makefile.am
@@ -10,7 +10,8 @@ sbin_PROGRAMS = zdb
 
 zdb_SOURCES = \
 	zdb.c \
-	zdb_il.c
+	zdb_il.c \
+	zdb.h
 
 zdb_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \

--- a/cmd/zdb/zdb.h
+++ b/cmd/zdb/zdb.h
@@ -1,0 +1,33 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2017 Spectra Logic Corp Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+
+#ifndef	_ZDB_H
+#define	_ZDB_H
+
+void dump_intent_log(zilog_t *);
+extern uint8_t dump_opt[256];
+
+#endif	/* _ZDB_H */

--- a/cmd/zdb/zdb_il.c
+++ b/cmd/zdb/zdb_il.c
@@ -44,9 +44,11 @@
 #include <sys/zil_impl.h>
 #include <sys/abd.h>
 
+#include "zdb.h"
+
 extern uint8_t dump_opt[256];
 
-static char prefix[4] = "\t\t\t";
+static char tab_prefix[4] = "\t\t\t";
 
 static void
 print_log_bp(const blkptr_t *bp, const char *prefix)
@@ -59,8 +61,9 @@ print_log_bp(const blkptr_t *bp, const char *prefix)
 
 /* ARGSUSED */
 static void
-zil_prt_rec_create(zilog_t *zilog, int txtype, lr_create_t *lr)
+zil_prt_rec_create(zilog_t *zilog, int txtype, void *arg)
 {
+	lr_create_t *lr = arg;
 	time_t crtime = lr->lr_crtime[0];
 	char *name, *link;
 	lr_attr_t *lrattr;
@@ -75,49 +78,55 @@ zil_prt_rec_create(zilog_t *zilog, int txtype, lr_create_t *lr)
 
 	if (txtype == TX_SYMLINK) {
 		link = name + strlen(name) + 1;
-		(void) printf("%s%s -> %s\n", prefix, name, link);
+		(void) printf("%s%s -> %s\n", tab_prefix, name, link);
 	} else if (txtype != TX_MKXATTR) {
-		(void) printf("%s%s\n", prefix, name);
+		(void) printf("%s%s\n", tab_prefix, name);
 	}
 
-	(void) printf("%s%s", prefix, ctime(&crtime));
-	(void) printf("%sdoid %llu, foid %llu, slots %llu, mode %llo\n", prefix,
-	    (u_longlong_t)lr->lr_doid,
+	(void) printf("%s%s", tab_prefix, ctime(&crtime));
+	(void) printf("%sdoid %llu, foid %llu, slots %llu, mode %llo\n",
+	    tab_prefix, (u_longlong_t)lr->lr_doid,
 	    (u_longlong_t)LR_FOID_GET_OBJ(lr->lr_foid),
 	    (u_longlong_t)LR_FOID_GET_SLOTS(lr->lr_foid),
 	    (longlong_t)lr->lr_mode);
-	(void) printf("%suid %llu, gid %llu, gen %llu, rdev 0x%llx\n", prefix,
+	(void) printf("%suid %llu, gid %llu, gen %llu, rdev 0x%llx\n",
+	    tab_prefix,
 	    (u_longlong_t)lr->lr_uid, (u_longlong_t)lr->lr_gid,
 	    (u_longlong_t)lr->lr_gen, (u_longlong_t)lr->lr_rdev);
 }
 
 /* ARGSUSED */
 static void
-zil_prt_rec_remove(zilog_t *zilog, int txtype, lr_remove_t *lr)
+zil_prt_rec_remove(zilog_t *zilog, int txtype, void *arg)
 {
-	(void) printf("%sdoid %llu, name %s\n", prefix,
+	lr_remove_t *lr = arg;
+
+	(void) printf("%sdoid %llu, name %s\n", tab_prefix,
 	    (u_longlong_t)lr->lr_doid, (char *)(lr + 1));
 }
 
 /* ARGSUSED */
 static void
-zil_prt_rec_link(zilog_t *zilog, int txtype, lr_link_t *lr)
+zil_prt_rec_link(zilog_t *zilog, int txtype, void *arg)
 {
-	(void) printf("%sdoid %llu, link_obj %llu, name %s\n", prefix,
+	lr_link_t *lr = arg;
+
+	(void) printf("%sdoid %llu, link_obj %llu, name %s\n", tab_prefix,
 	    (u_longlong_t)lr->lr_doid, (u_longlong_t)lr->lr_link_obj,
 	    (char *)(lr + 1));
 }
 
 /* ARGSUSED */
 static void
-zil_prt_rec_rename(zilog_t *zilog, int txtype, lr_rename_t *lr)
+zil_prt_rec_rename(zilog_t *zilog, int txtype, void *arg)
 {
+	lr_rename_t *lr = arg;
 	char *snm = (char *)(lr + 1);
 	char *tnm = snm + strlen(snm) + 1;
 
-	(void) printf("%ssdoid %llu, tdoid %llu\n", prefix,
+	(void) printf("%ssdoid %llu, tdoid %llu\n", tab_prefix,
 	    (u_longlong_t)lr->lr_sdoid, (u_longlong_t)lr->lr_tdoid);
-	(void) printf("%ssrc %s tgt %s\n", prefix, snm, tnm);
+	(void) printf("%ssrc %s tgt %s\n", tab_prefix, snm, tnm);
 }
 
 /* ARGSUSED */
@@ -125,9 +134,8 @@ static int
 zil_prt_rec_write_cb(void *data, size_t len, void *unused)
 {
 	char *cdata = data;
-	int i;
 
-	for (i = 0; i < len; i++) {
+	for (size_t i = 0; i < len; i++) {
 		if (isprint(*cdata))
 			(void) printf("%c ", *cdata);
 		else
@@ -139,15 +147,16 @@ zil_prt_rec_write_cb(void *data, size_t len, void *unused)
 
 /* ARGSUSED */
 static void
-zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
+zil_prt_rec_write(zilog_t *zilog, int txtype, void *arg)
 {
+	lr_write_t *lr = arg;
 	abd_t *data;
 	blkptr_t *bp = &lr->lr_blkptr;
 	zbookmark_phys_t zb;
 	int verbose = MAX(dump_opt['d'], dump_opt['i']);
 	int error;
 
-	(void) printf("%sfoid %llu, offset %llx, length %llx\n", prefix,
+	(void) printf("%sfoid %llu, offset %llx, length %llx\n", tab_prefix,
 	    (u_longlong_t)lr->lr_foid, (u_longlong_t)lr->lr_offset,
 	    (u_longlong_t)lr->lr_length);
 
@@ -155,20 +164,21 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 		return;
 
 	if (lr->lr_common.lrc_reclen == sizeof (lr_write_t)) {
-		(void) printf("%shas blkptr, %s\n", prefix,
+		(void) printf("%shas blkptr, %s\n", tab_prefix,
 		    !BP_IS_HOLE(bp) &&
 		    bp->blk_birth >= spa_first_txg(zilog->zl_spa) ?
 		    "will claim" : "won't claim");
-		print_log_bp(bp, prefix);
+		print_log_bp(bp, tab_prefix);
 
 		if (BP_IS_HOLE(bp)) {
 			(void) printf("\t\t\tLSIZE 0x%llx\n",
 			    (u_longlong_t)BP_GET_LSIZE(bp));
-			(void) printf("%s<hole>\n", prefix);
+			(void) printf("%s<hole>\n", tab_prefix);
 			return;
 		}
 		if (bp->blk_birth < zilog->zl_header->zh_claim_txg) {
-			(void) printf("%s<block already committed>\n", prefix);
+			(void) printf("%s<block already committed>\n",
+			    tab_prefix);
 			return;
 		}
 
@@ -188,7 +198,7 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 		abd_copy_from_buf(data, lr + 1, lr->lr_length);
 	}
 
-	(void) printf("%s", prefix);
+	(void) printf("%s", tab_prefix);
 	(void) abd_iterate_func(data,
 	    0, MIN(lr->lr_length, (verbose < 6 ? 20 : SPA_MAXBLOCKSIZE)),
 	    zil_prt_rec_write_cb, NULL);
@@ -200,52 +210,55 @@ out:
 
 /* ARGSUSED */
 static void
-zil_prt_rec_truncate(zilog_t *zilog, int txtype, lr_truncate_t *lr)
+zil_prt_rec_truncate(zilog_t *zilog, int txtype, void *arg)
 {
-	(void) printf("%sfoid %llu, offset 0x%llx, length 0x%llx\n", prefix,
+	lr_truncate_t *lr = arg;
+
+	(void) printf("%sfoid %llu, offset 0x%llx, length 0x%llx\n", tab_prefix,
 	    (u_longlong_t)lr->lr_foid, (longlong_t)lr->lr_offset,
 	    (u_longlong_t)lr->lr_length);
 }
 
 /* ARGSUSED */
 static void
-zil_prt_rec_setattr(zilog_t *zilog, int txtype, lr_setattr_t *lr)
+zil_prt_rec_setattr(zilog_t *zilog, int txtype, void *arg)
 {
+	lr_setattr_t *lr = arg;
 	time_t atime = (time_t)lr->lr_atime[0];
 	time_t mtime = (time_t)lr->lr_mtime[0];
 
-	(void) printf("%sfoid %llu, mask 0x%llx\n", prefix,
+	(void) printf("%sfoid %llu, mask 0x%llx\n", tab_prefix,
 	    (u_longlong_t)lr->lr_foid, (u_longlong_t)lr->lr_mask);
 
 	if (lr->lr_mask & AT_MODE) {
-		(void) printf("%sAT_MODE  %llo\n", prefix,
+		(void) printf("%sAT_MODE  %llo\n", tab_prefix,
 		    (longlong_t)lr->lr_mode);
 	}
 
 	if (lr->lr_mask & AT_UID) {
-		(void) printf("%sAT_UID   %llu\n", prefix,
+		(void) printf("%sAT_UID   %llu\n", tab_prefix,
 		    (u_longlong_t)lr->lr_uid);
 	}
 
 	if (lr->lr_mask & AT_GID) {
-		(void) printf("%sAT_GID   %llu\n", prefix,
+		(void) printf("%sAT_GID   %llu\n", tab_prefix,
 		    (u_longlong_t)lr->lr_gid);
 	}
 
 	if (lr->lr_mask & AT_SIZE) {
-		(void) printf("%sAT_SIZE  %llu\n", prefix,
+		(void) printf("%sAT_SIZE  %llu\n", tab_prefix,
 		    (u_longlong_t)lr->lr_size);
 	}
 
 	if (lr->lr_mask & AT_ATIME) {
-		(void) printf("%sAT_ATIME %llu.%09llu %s", prefix,
+		(void) printf("%sAT_ATIME %llu.%09llu %s", tab_prefix,
 		    (u_longlong_t)lr->lr_atime[0],
 		    (u_longlong_t)lr->lr_atime[1],
 		    ctime(&atime));
 	}
 
 	if (lr->lr_mask & AT_MTIME) {
-		(void) printf("%sAT_MTIME %llu.%09llu %s", prefix,
+		(void) printf("%sAT_MTIME %llu.%09llu %s", tab_prefix,
 		    (u_longlong_t)lr->lr_mtime[0],
 		    (u_longlong_t)lr->lr_mtime[1],
 		    ctime(&mtime));
@@ -254,41 +267,43 @@ zil_prt_rec_setattr(zilog_t *zilog, int txtype, lr_setattr_t *lr)
 
 /* ARGSUSED */
 static void
-zil_prt_rec_acl(zilog_t *zilog, int txtype, lr_acl_t *lr)
+zil_prt_rec_acl(zilog_t *zilog, int txtype, void *arg)
 {
-	(void) printf("%sfoid %llu, aclcnt %llu\n", prefix,
+	lr_acl_t *lr = arg;
+
+	(void) printf("%sfoid %llu, aclcnt %llu\n", tab_prefix,
 	    (u_longlong_t)lr->lr_foid, (u_longlong_t)lr->lr_aclcnt);
 }
 
 typedef void (*zil_prt_rec_func_t)(zilog_t *, int, void *);
 typedef struct zil_rec_info {
 	zil_prt_rec_func_t	zri_print;
-	char			*zri_name;
+	const char		*zri_name;
 	uint64_t		zri_count;
 } zil_rec_info_t;
 
 static zil_rec_info_t zil_rec_info[TX_MAX_TYPE] = {
-	{ NULL,			"Total              " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_CREATE          " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_MKDIR           " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_MKXATTR         " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_SYMLINK         " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_remove,	"TX_REMOVE          " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_remove,	"TX_RMDIR           " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_link,		"TX_LINK            " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_rename,	"TX_RENAME          " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_write,	"TX_WRITE           " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_truncate,	"TX_TRUNCATE        " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_setattr,	"TX_SETATTR         " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_acl,		"TX_ACL_V0          " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_acl,		"TX_ACL_ACL         " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_CREATE_ACL      " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_CREATE_ATTR     " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_CREATE_ACL_ATTR " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_MKDIR_ACL       " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_MKDIR_ATTR      " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_create,	"TX_MKDIR_ACL_ATTR  " },
-	{ (zil_prt_rec_func_t)zil_prt_rec_write,	"TX_WRITE2          " },
+	{.zri_print = NULL,		    .zri_name = "Total              "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_CREATE          "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKDIR           "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKXATTR         "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_SYMLINK         "},
+	{.zri_print = zil_prt_rec_remove,   .zri_name = "TX_REMOVE          "},
+	{.zri_print = zil_prt_rec_remove,   .zri_name = "TX_RMDIR           "},
+	{.zri_print = zil_prt_rec_link,	    .zri_name = "TX_LINK            "},
+	{.zri_print = zil_prt_rec_rename,   .zri_name = "TX_RENAME          "},
+	{.zri_print = zil_prt_rec_write,    .zri_name = "TX_WRITE           "},
+	{.zri_print = zil_prt_rec_truncate, .zri_name = "TX_TRUNCATE        "},
+	{.zri_print = zil_prt_rec_setattr,  .zri_name = "TX_SETATTR         "},
+	{.zri_print = zil_prt_rec_acl,	    .zri_name = "TX_ACL_V0          "},
+	{.zri_print = zil_prt_rec_acl,	    .zri_name = "TX_ACL_ACL         "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_CREATE_ACL      "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_CREATE_ATTR     "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_CREATE_ACL_ATTR "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKDIR_ACL       "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKDIR_ATTR      "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKDIR_ACL_ATTR  "},
+	{.zri_print = zil_prt_rec_write,    .zri_name = "TX_WRITE2          "},
 };
 
 /* ARGSUSED */
@@ -315,7 +330,7 @@ print_log_record(zilog_t *zilog, lr_t *lr, void *arg, uint64_t claim_txg)
 		if (!zilog->zl_os->os_encrypted) {
 			zil_rec_info[txtype].zri_print(zilog, txtype, lr);
 		} else {
-			(void) printf("%s(encrypted)\n", prefix);
+			(void) printf("%s(encrypted)\n", tab_prefix);
 		}
 	}
 
@@ -331,7 +346,7 @@ print_log_block(zilog_t *zilog, blkptr_t *bp, void *arg, uint64_t claim_txg)
 {
 	char blkbuf[BP_SPRINTF_LEN + 10];
 	int verbose = MAX(dump_opt['d'], dump_opt['i']);
-	char *claim;
+	const char *claim;
 
 	if (verbose <= 3)
 		return (0);
@@ -360,7 +375,7 @@ print_log_block(zilog_t *zilog, blkptr_t *bp, void *arg, uint64_t claim_txg)
 static void
 print_log_stats(int verbose)
 {
-	int i, w, p10;
+	unsigned i, w, p10;
 
 	if (verbose > 3)
 		(void) printf("\n");

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -1709,8 +1709,10 @@ ztest_log_setattr(ztest_ds_t *zd, dmu_tx_t *tx, lr_setattr_t *lr)
  * ZIL replay ops
  */
 static int
-ztest_replay_create(ztest_ds_t *zd, lr_create_t *lr, boolean_t byteswap)
+ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_create_t *lr = arg2;
 	char *name = (void *)(lr + 1);		/* name follows lr */
 	objset_t *os = zd->zd_os;
 	ztest_block_tag_t *bbt;
@@ -1797,8 +1799,10 @@ ztest_replay_create(ztest_ds_t *zd, lr_create_t *lr, boolean_t byteswap)
 }
 
 static int
-ztest_replay_remove(ztest_ds_t *zd, lr_remove_t *lr, boolean_t byteswap)
+ztest_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_remove_t *lr = arg2;
 	char *name = (void *)(lr + 1);		/* name follows lr */
 	objset_t *os = zd->zd_os;
 	dmu_object_info_t doi;
@@ -1848,8 +1852,10 @@ ztest_replay_remove(ztest_ds_t *zd, lr_remove_t *lr, boolean_t byteswap)
 }
 
 static int
-ztest_replay_write(ztest_ds_t *zd, lr_write_t *lr, boolean_t byteswap)
+ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_write_t *lr = arg2;
 	objset_t *os = zd->zd_os;
 	void *data = lr + 1;			/* data follows lr */
 	uint64_t offset, length;
@@ -1974,8 +1980,10 @@ ztest_replay_write(ztest_ds_t *zd, lr_write_t *lr, boolean_t byteswap)
 }
 
 static int
-ztest_replay_truncate(ztest_ds_t *zd, lr_truncate_t *lr, boolean_t byteswap)
+ztest_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_truncate_t *lr = arg2;
 	objset_t *os = zd->zd_os;
 	dmu_tx_t *tx;
 	uint64_t txg;
@@ -2013,8 +2021,10 @@ ztest_replay_truncate(ztest_ds_t *zd, lr_truncate_t *lr, boolean_t byteswap)
 }
 
 static int
-ztest_replay_setattr(ztest_ds_t *zd, lr_setattr_t *lr, boolean_t byteswap)
+ztest_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_setattr_t *lr = arg2;
 	objset_t *os = zd->zd_os;
 	dmu_tx_t *tx;
 	dmu_buf_t *db;
@@ -2085,27 +2095,27 @@ ztest_replay_setattr(ztest_ds_t *zd, lr_setattr_t *lr, boolean_t byteswap)
 	return (0);
 }
 
-zil_replay_func_t ztest_replay_vector[TX_MAX_TYPE] = {
-	NULL,				/* 0 no such transaction type */
-	(zil_replay_func_t)ztest_replay_create,		/* TX_CREATE */
-	NULL,						/* TX_MKDIR */
-	NULL,						/* TX_MKXATTR */
-	NULL,						/* TX_SYMLINK */
-	(zil_replay_func_t)ztest_replay_remove,		/* TX_REMOVE */
-	NULL,						/* TX_RMDIR */
-	NULL,						/* TX_LINK */
-	NULL,						/* TX_RENAME */
-	(zil_replay_func_t)ztest_replay_write,		/* TX_WRITE */
-	(zil_replay_func_t)ztest_replay_truncate,	/* TX_TRUNCATE */
-	(zil_replay_func_t)ztest_replay_setattr,	/* TX_SETATTR */
-	NULL,						/* TX_ACL */
-	NULL,						/* TX_CREATE_ACL */
-	NULL,						/* TX_CREATE_ATTR */
-	NULL,						/* TX_CREATE_ACL_ATTR */
-	NULL,						/* TX_MKDIR_ACL */
-	NULL,						/* TX_MKDIR_ATTR */
-	NULL,						/* TX_MKDIR_ACL_ATTR */
-	NULL,						/* TX_WRITE2 */
+zil_replay_func_t *ztest_replay_vector[TX_MAX_TYPE] = {
+	NULL,			/* 0 no such transaction type */
+	ztest_replay_create,	/* TX_CREATE */
+	NULL,			/* TX_MKDIR */
+	NULL,			/* TX_MKXATTR */
+	NULL,			/* TX_SYMLINK */
+	ztest_replay_remove,	/* TX_REMOVE */
+	NULL,			/* TX_RMDIR */
+	NULL,			/* TX_LINK */
+	NULL,			/* TX_RENAME */
+	ztest_replay_write,	/* TX_WRITE */
+	ztest_replay_truncate,	/* TX_TRUNCATE */
+	ztest_replay_setattr,	/* TX_SETATTR */
+	NULL,			/* TX_ACL */
+	NULL,			/* TX_CREATE_ACL */
+	NULL,			/* TX_CREATE_ATTR */
+	NULL,			/* TX_CREATE_ACL_ATTR */
+	NULL,			/* TX_MKDIR_ACL */
+	NULL,			/* TX_MKDIR_ATTR */
+	NULL,			/* TX_MKDIR_ACL_ATTR */
+	NULL,			/* TX_WRITE2 */
 };
 
 /*

--- a/include/sys/refcount.h
+++ b/include/sys/refcount.h
@@ -39,7 +39,7 @@ extern "C" {
  * particular object, use FTAG (which is a string) for the holder_tag.
  * Otherwise, use the object that holds the reference.
  */
-#define	FTAG ((char *)__func__)
+#define	FTAG ((char *)(uintptr_t)__func__)
 
 /*
  * Starting with 4.11, torvalds/linux@f405df5, the linux kernel defines a

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -352,7 +352,7 @@ extern void zfs_unmap_page(page_t *, caddr_t);
 #endif /* HAVE_UIO_RW */
 
 extern zil_get_data_t zfs_get_data;
-extern zil_replay_func_t zfs_replay_vector[TX_MAX_TYPE];
+extern zil_replay_func_t *zfs_replay_vector[TX_MAX_TYPE];
 extern int zfsfstype;
 
 #endif /* _KERNEL */

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -463,7 +463,7 @@ typedef int zil_parse_blk_func_t(zilog_t *zilog, blkptr_t *bp, void *arg,
     uint64_t txg);
 typedef int zil_parse_lr_func_t(zilog_t *zilog, lr_t *lr, void *arg,
     uint64_t txg);
-typedef int (*const zil_replay_func_t)(void *, char *, boolean_t);
+typedef int zil_replay_func_t(void *arg1, void *arg2, boolean_t byteswap);
 typedef int zil_get_data_t(void *arg, lr_write_t *lr, char *dbuf, zio_t *zio);
 
 extern int zil_parse(zilog_t *zilog, zil_parse_blk_func_t *parse_blk_func,
@@ -480,7 +480,7 @@ extern zilog_t	*zil_open(objset_t *os, zil_get_data_t *get_data);
 extern void	zil_close(zilog_t *zilog);
 
 extern void	zil_replay(objset_t *os, void *arg,
-    zil_replay_func_t replay_func[TX_MAX_TYPE]);
+    zil_replay_func_t *replay_func[TX_MAX_TYPE]);
 extern boolean_t zil_replaying(zilog_t *zilog, dmu_tx_t *tx);
 extern void	zil_destroy(zilog_t *zilog, boolean_t keep_first);
 extern void	zil_destroy_sync(zilog_t *zilog, dmu_tx_t *tx);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4935,6 +4935,7 @@ arc_kmem_reap_now(void)
  * This possible deadlock is avoided by always acquiring a hash lock
  * using mutex_tryenter() from arc_reclaim_thread().
  */
+/* ARGSUSED */
 static void
 arc_reclaim_thread(void *unused)
 {
@@ -8687,6 +8688,7 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
  * This thread feeds the L2ARC at regular intervals.  This is the beating
  * heart of the L2ARC.
  */
+/* ARGSUSED */
 static void
 l2arc_feed_thread(void *unused)
 {

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -540,6 +540,7 @@ dbuf_evict_one(void)
  * of the dbuf cache is at or below the maximum size. Once the dbuf is aged
  * out of the cache it is destroyed and becomes eligible for arc eviction.
  */
+/* ARGSUSED */
 static void
 dbuf_evict_thread(void *unused)
 {

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6126,7 +6126,7 @@ static void
 spa_async_thread(void *arg)
 {
 	spa_t *spa = (spa_t *)arg;
-	int tasks, i;
+	int tasks;
 
 	ASSERT(spa->spa_sync_on);
 
@@ -6164,9 +6164,9 @@ spa_async_thread(void *arg)
 	if (tasks & SPA_ASYNC_REMOVE) {
 		spa_vdev_state_enter(spa, SCL_NONE);
 		spa_async_remove(spa, spa->spa_root_vdev);
-		for (i = 0; i < spa->spa_l2cache.sav_count; i++)
+		for (int i = 0; i < spa->spa_l2cache.sav_count; i++)
 			spa_async_remove(spa, spa->spa_l2cache.sav_vdevs[i]);
-		for (i = 0; i < spa->spa_spares.sav_count; i++)
+		for (int i = 0; i < spa->spa_spares.sav_count; i++)
 			spa_async_remove(spa, spa->spa_spares.sav_vdevs[i]);
 		(void) spa_vdev_state_exit(spa, NULL, 0);
 	}

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -108,8 +108,8 @@
  * now transition to the syncing state.
  */
 
-static void txg_sync_thread(void *dp);
-static void txg_quiesce_thread(void *dp);
+static void txg_sync_thread(void *arg);
+static void txg_quiesce_thread(void *arg);
 
 int zfs_txg_timeout = 5;	/* max seconds worth of delta per txg */
 
@@ -479,7 +479,7 @@ txg_wait_callbacks(dsl_pool_t *dp)
 static void
 txg_sync_thread(void *arg)
 {
-	dsl_pool_t *dp = (dsl_pool_t *)arg;
+	dsl_pool_t *dp = arg;
 	spa_t *spa = dp->dp_spa;
 	tx_state_t *tx = &dp->dp_tx;
 	callb_cpr_t cpr;
@@ -564,7 +564,7 @@ txg_sync_thread(void *arg)
 static void
 txg_quiesce_thread(void *arg)
 {
-	dsl_pool_t *dp = (dsl_pool_t *)arg;
+	dsl_pool_t *dp = arg;
 	tx_state_t *tx = &dp->dp_tx;
 	callb_cpr_t cpr;
 

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -72,7 +72,7 @@ zfs_init_vattr(vattr_t *vap, uint64_t mask, uint64_t mode,
 
 /* ARGSUSED */
 static int
-zfs_replay_error(zfsvfs_t *zfsvfs, lr_t *lr, boolean_t byteswap)
+zfs_replay_error(void *arg1, void *arg2, boolean_t byteswap)
 {
 	return (SET_ERROR(ENOTSUP));
 }
@@ -265,9 +265,10 @@ zfs_replay_swap_attrs(lr_attr_t *lrattr)
  * as option FUID information.
  */
 static int
-zfs_replay_create_acl(zfsvfs_t *zfsvfs,
-    lr_acl_create_t *lracl, boolean_t byteswap)
+zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_acl_create_t *lracl = arg2;
 	char *name = NULL;		/* location determined later */
 	lr_create_t *lr = (lr_create_t *)lracl;
 	znode_t *dzp;
@@ -413,8 +414,10 @@ bail:
 }
 
 static int
-zfs_replay_create(zfsvfs_t *zfsvfs, lr_create_t *lr, boolean_t byteswap)
+zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_create_t *lr = arg2;
 	char *name = NULL;		/* location determined later */
 	char *link;			/* symlink content follows name */
 	znode_t *dzp;
@@ -545,8 +548,10 @@ out:
 }
 
 static int
-zfs_replay_remove(zfsvfs_t *zfsvfs, lr_remove_t *lr, boolean_t byteswap)
+zfs_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_remove_t *lr = arg2;
 	char *name = (char *)(lr + 1);	/* name follows lr_remove_t */
 	znode_t *dzp;
 	int error;
@@ -578,8 +583,10 @@ zfs_replay_remove(zfsvfs_t *zfsvfs, lr_remove_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_link(zfsvfs_t *zfsvfs, lr_link_t *lr, boolean_t byteswap)
+zfs_replay_link(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_link_t *lr = arg2;
 	char *name = (char *)(lr + 1);	/* name follows lr_link_t */
 	znode_t *dzp, *zp;
 	int error;
@@ -608,8 +615,10 @@ zfs_replay_link(zfsvfs_t *zfsvfs, lr_link_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_rename(zfsvfs_t *zfsvfs, lr_rename_t *lr, boolean_t byteswap)
+zfs_replay_rename(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_rename_t *lr = arg2;
 	char *sname = (char *)(lr + 1);	/* sname and tname follow lr_rename_t */
 	char *tname = sname + strlen(sname) + 1;
 	znode_t *sdzp, *tdzp;
@@ -639,8 +648,10 @@ zfs_replay_rename(zfsvfs_t *zfsvfs, lr_rename_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_write(zfsvfs_t *zfsvfs, lr_write_t *lr, boolean_t byteswap)
+zfs_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_write_t *lr = arg2;
 	char *data = (char *)(lr + 1);	/* data follows lr_write_t */
 	znode_t	*zp;
 	int error, written;
@@ -708,8 +719,10 @@ zfs_replay_write(zfsvfs_t *zfsvfs, lr_write_t *lr, boolean_t byteswap)
  * the file is grown.
  */
 static int
-zfs_replay_write2(zfsvfs_t *zfsvfs, lr_write_t *lr, boolean_t byteswap)
+zfs_replay_write2(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_write_t *lr = arg2;
 	znode_t	*zp;
 	int error;
 	uint64_t end;
@@ -753,8 +766,10 @@ top:
 }
 
 static int
-zfs_replay_truncate(zfsvfs_t *zfsvfs, lr_truncate_t *lr, boolean_t byteswap)
+zfs_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_truncate_t *lr = arg2;
 	znode_t *zp;
 	flock64_t fl;
 	int error;
@@ -780,8 +795,10 @@ zfs_replay_truncate(zfsvfs_t *zfsvfs, lr_truncate_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_setattr(zfsvfs_t *zfsvfs, lr_setattr_t *lr, boolean_t byteswap)
+zfs_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_setattr_t *lr = arg2;
 	znode_t *zp;
 	xvattr_t xva;
 	vattr_t *vap = &xva.xva_vattr;
@@ -834,8 +851,10 @@ zfs_replay_setattr(zfsvfs_t *zfsvfs, lr_setattr_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_acl_v0(zfsvfs_t *zfsvfs, lr_acl_v0_t *lr, boolean_t byteswap)
+zfs_replay_acl_v0(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_acl_v0_t *lr = arg2;
 	ace_t *ace = (ace_t *)(lr + 1);	/* ace array follows lr_acl_t */
 	vsecattr_t vsa;
 	znode_t *zp;
@@ -878,8 +897,10 @@ zfs_replay_acl_v0(zfsvfs_t *zfsvfs, lr_acl_v0_t *lr, boolean_t byteswap)
  *
  */
 static int
-zfs_replay_acl(zfsvfs_t *zfsvfs, lr_acl_t *lr, boolean_t byteswap)
+zfs_replay_acl(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_acl_t *lr = arg2;
 	ace_t *ace = (ace_t *)(lr + 1);
 	vsecattr_t vsa;
 	znode_t *zp;
@@ -928,26 +949,26 @@ zfs_replay_acl(zfsvfs_t *zfsvfs, lr_acl_t *lr, boolean_t byteswap)
 /*
  * Callback vectors for replaying records
  */
-zil_replay_func_t zfs_replay_vector[TX_MAX_TYPE] = {
-	(zil_replay_func_t)zfs_replay_error,		/* no such type */
-	(zil_replay_func_t)zfs_replay_create,		/* TX_CREATE */
-	(zil_replay_func_t)zfs_replay_create,		/* TX_MKDIR */
-	(zil_replay_func_t)zfs_replay_create,		/* TX_MKXATTR */
-	(zil_replay_func_t)zfs_replay_create,		/* TX_SYMLINK */
-	(zil_replay_func_t)zfs_replay_remove,		/* TX_REMOVE */
-	(zil_replay_func_t)zfs_replay_remove,		/* TX_RMDIR */
-	(zil_replay_func_t)zfs_replay_link,		/* TX_LINK */
-	(zil_replay_func_t)zfs_replay_rename,		/* TX_RENAME */
-	(zil_replay_func_t)zfs_replay_write,		/* TX_WRITE */
-	(zil_replay_func_t)zfs_replay_truncate,		/* TX_TRUNCATE */
-	(zil_replay_func_t)zfs_replay_setattr,		/* TX_SETATTR */
-	(zil_replay_func_t)zfs_replay_acl_v0,		/* TX_ACL_V0 */
-	(zil_replay_func_t)zfs_replay_acl,		/* TX_ACL */
-	(zil_replay_func_t)zfs_replay_create_acl,	/* TX_CREATE_ACL */
-	(zil_replay_func_t)zfs_replay_create,		/* TX_CREATE_ATTR */
-	(zil_replay_func_t)zfs_replay_create_acl,	/* TX_CREATE_ACL_ATTR */
-	(zil_replay_func_t)zfs_replay_create_acl,	/* TX_MKDIR_ACL */
-	(zil_replay_func_t)zfs_replay_create,		/* TX_MKDIR_ATTR */
-	(zil_replay_func_t)zfs_replay_create_acl,	/* TX_MKDIR_ACL_ATTR */
-	(zil_replay_func_t)zfs_replay_write2,		/* TX_WRITE2 */
+zil_replay_func_t *zfs_replay_vector[TX_MAX_TYPE] = {
+	zfs_replay_error,	/* no such type */
+	zfs_replay_create,	/* TX_CREATE */
+	zfs_replay_create,	/* TX_MKDIR */
+	zfs_replay_create,	/* TX_MKXATTR */
+	zfs_replay_create,	/* TX_SYMLINK */
+	zfs_replay_remove,	/* TX_REMOVE */
+	zfs_replay_remove,	/* TX_RMDIR */
+	zfs_replay_link,	/* TX_LINK */
+	zfs_replay_rename,	/* TX_RENAME */
+	zfs_replay_write,	/* TX_WRITE */
+	zfs_replay_truncate,	/* TX_TRUNCATE */
+	zfs_replay_setattr,	/* TX_SETATTR */
+	zfs_replay_acl_v0,	/* TX_ACL_V0 */
+	zfs_replay_acl,		/* TX_ACL */
+	zfs_replay_create_acl,	/* TX_CREATE_ACL */
+	zfs_replay_create,	/* TX_CREATE_ATTR */
+	zfs_replay_create_acl,	/* TX_CREATE_ACL_ATTR */
+	zfs_replay_create_acl,	/* TX_MKDIR_ACL */
+	zfs_replay_create,	/* TX_MKDIR_ATTR */
+	zfs_replay_create_acl,	/* TX_MKDIR_ACL_ATTR */
+	zfs_replay_write2,	/* TX_WRITE2 */
 };

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -2178,7 +2178,7 @@ zil_resume(void *cookie)
 }
 
 typedef struct zil_replay_arg {
-	zil_replay_func_t *zr_replay;
+	zil_replay_func_t **zr_replay;
 	void		*zr_arg;
 	boolean_t	zr_byteswap;
 	char		*zr_lr;
@@ -2297,7 +2297,7 @@ zil_incr_blks(zilog_t *zilog, blkptr_t *bp, void *arg, uint64_t claim_txg)
  * If this dataset has a non-empty intent log, replay it and destroy it.
  */
 void
-zil_replay(objset_t *os, void *arg, zil_replay_func_t replay_func[TX_MAX_TYPE])
+zil_replay(objset_t *os, void *arg, zil_replay_func_t *replay_func[TX_MAX_TYPE])
 {
 	zilog_t *zilog = dmu_objset_zil(os);
 	const zil_header_t *zh = zilog->zl_header;


### PR DESCRIPTION
### Description

Fix compiler warnings in zdb.  With these changes, FreeBSD can compile
zdb with all compiler warnings enabled save -Wunused-parameter.

usr/src/cmd/zdb/zdb.c
usr/src/cmd/zdb/zdb_il.c
usr/src/uts/common/fs/zfs/sys/sa.h
usr/src/uts/common/fs/zfs/sys/spa.h
	Fix numerous warnings, including:
	* const-correctness
	* shadowing global definitions
	* signed vs unsigned comparisons
	* missing prototypes, or missing static declarations
	* unused variables and functions
	* Unreadable array initializations
	* Missing struct initializers

usr/src/cmd/zdb/zdb.h
	Add a header file to declare common symbols

usr/src/lib/libzpool/common/sys/zfs_context.h
usr/src/uts/common/fs/zfs/arc.c
usr/src/uts/common/fs/zfs/dbuf.c
usr/src/uts/common/fs/zfs/spa.c
usr/src/uts/common/fs/zfs/txg.c
	Add a function prototype for zk_thread_create, and ensure that every
	callback supplied to this function actually matches the prototype.

usr/src/cmd/ztest/ztest.c
usr/src/uts/common/fs/zfs/sys/zil.h
usr/src/uts/common/fs/zfs/zfs_replay.c
usr/src/uts/common/fs/zfs/zvol.c
	Add a function prototype for zil_replay_func_t, and ensure that
	every function of this type actually matches the prototype.

usr/src/uts/common/fs/zfs/sys/refcount.h
	Change FTAG so it discards any constness of __func__, necessary
	since existing APIs expect it passed as void *.

Porting Notes:
- Many of these fixes have already been applied to Linux.  For
  consistency the OpenZFS version of a change was applied if the
  warning was addressed in an equivalent but different fashion.

Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>
Authored by: Alan Somers <asomers@gmail.com>
Approved by: Richard Lowe <richlowe@richlowe.net>
Ported-by: Brian Behlendorf <behlendorf1@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/8081
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/843abe1b8a

### Motivation and Context

Keep up to date with OpenZFS changes.

### How Has This Been Tested?

Locally builds.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
