### PR TITLE
Correct make mancheck recipe

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,9 +62,10 @@ shellcheck:
 
 mancheck:
 	@if type mandoc > /dev/null 2>&1; then \
-		for file in zfs zpool zdb zgenhostid; do \
-			mandoc -Tlint -Werror ${top_srcdir}/man/man8/$$file.8; \
-		done \
+		find ${top_srcdir}/man/man8 -type f -name 'zfs.8' \
+			-o -name 'zpool.8' -o -name 'zdb.8' \
+			-o -name 'zgenhostid.8' | \
+			xargs mandoc -Tlint -Werror; \
 	fi
 
 lint: cppcheck paxcheck

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1747,6 +1747,7 @@ Reopen all the vdevs associated with the pool.
 .It Fl n
 Do not restart an in-progress scrub operation. This is not recommended and can
 result in partially resilvered devices unless a second scrub is performed.
+.El
 .It Xo
 .Nm
 .Cm remove


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
The current make recipe for mancheck silently ignores errors. Correct
the recipe so errors cause the mancheck recipe fail.

The zpool reopen command in the zpool.8 manpage had a bullet list
without an .El.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
STYLE builder keeps throwing a mandoc warning.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Will be tested by the STYLE builder.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
