### PR TITLE
Fix status command options in zpool(8)

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1983,9 +1983,10 @@ Display real paths for vdevs resolving all symbolic links. This can
 be used to look up the current block device name regardless of the
 .Pa /dev/disk/
 path used to open it.
-.It Fl p
-Display numbers in parsable (exact) values. Time values are in
-nanoseconds.
+.It Fl P
+Display full paths for vdevs instead of only the last component of
+the path. This can be used in conjunction with the
+.Fl L flag.
 .It Fl D
 Display a histogram of deduplication statistics, showing the allocated
 .Pq physically present on disk


### PR DESCRIPTION
### Description

The 'zpool status' command supports the -P option for printing full
path names.  It does not support the -p parsable option for printing
exact values.

### Motivation and Context

Issue #6792 

### How Has This Been Tested?

`man man/man8/zpool.8`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
