### PR TITLE
Minor code cleanups in arc_summary.py

### DIFF
--- a/cmd/arc_summary/arc_summary.py
+++ b/cmd/arc_summary/arc_summary.py
@@ -63,7 +63,7 @@ def get_Kstat():
         del kstats[0:2]
         for kstat in kstats:
             kstat = kstat.strip()
-            name, unused, value = kstat.split()
+            name, _, value = kstat.split()
             Kstat[namespace + name] = D(value)
 
     Kstat = {}
@@ -75,17 +75,6 @@ def get_Kstat():
                      'kstat.zfs.misc.vdev_cache_stats.')
 
     return Kstat
-
-
-def div1():
-    sys.stdout.write("\n")
-    for i in range(18):
-        sys.stdout.write("%s" % "----")
-    sys.stdout.write("\n")
-
-
-def div2():
-    sys.stdout.write("\n")
 
 
 def fBytes(b=0):
@@ -908,11 +897,13 @@ unSub = [
 
 
 def zfs_header():
-    daydate = time.strftime("%a %b %d %H:%M:%S %Y")
+    """Print title string with date
+    """
+    daydate = time.strftime('%a %b %d %H:%M:%S %Y')
 
-    div1()
-    sys.stdout.write("ZFS Subsystem Report\t\t\t\t%s" % daydate)
-    div2()
+    sys.stdout.write('\n'+'-'*72+'\n')
+    sys.stdout.write('ZFS Subsystem Report\t\t\t\t%s' % daydate)
+    sys.stdout.write('\n')
 
 
 def usage():
@@ -975,7 +966,7 @@ def main():
     zfs_header()
     for page in pages:
         page(Kstat)
-        div2()
+        sys.stdout.write("\n")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description

Inline single-use function div1() with simpler code; inline twice-used function div2() (prints a newline); remove both original functions. Add documentation string to function zfs_header(). 

Separately, in get_Kstat(), replace unused variable "unused" from tuple with "_" to follow common Python convention. Though not a PEP8 specified format, this is accepted by pylint.

### How Has This Been Tested?

In-tree comparison with output of arc_summary.py on Ubuntu 16.04 LTS with stock ZFS version 0.6.5.9-2 with Python 2.7.12 and Python 3.5.2.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
