### PR TITLE
Initramfs fixes

### DIFF
--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -150,7 +150,7 @@ get_pools()
 		fi
 	fi
 
-        # Filter out any exceptions...
+	# Filter out any exceptions...
 	if [ -n "$ZFS_POOL_EXCEPTIONS" ]
 	then
 		local found=""

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -925,7 +925,7 @@ mountroot()
 	#   NOTE: Mounted in the order specified in the
 	#         ZFS_INITRD_ADDITIONAL_DATASETS variable so take care!
 
-	# Go through the complete list (recursivly) of all filesystems below
+	# Go through the complete list (recursively) of all filesystems below
 	# the real root dataset
 	filesystems=$("${ZFS}" list -oname -tfilesystem -H -r "${ZFS_BOOTFS}")
 	for fs in $filesystems $ZFS_INITRD_ADDITIONAL_DATASETS

--- a/contrib/initramfs/scripts/zfs
+++ b/contrib/initramfs/scripts/zfs
@@ -883,6 +883,24 @@ mountroot()
 		/bin/sh
 	fi
 
+	# Set elevator=noop on the root pool's vdevs' disks.  ZFS already
+	# does this for wholedisk vdevs (for all pools), so this is only
+	# important for partitions.
+	"${ZPOOL}" status -L "${ZFS_RPOOL}" 2> /dev/null |
+	    awk '/^\t / && !/(mirror|raidz)/ {
+	        dev=$1;
+	        sub(/[0-9]+$/, "", dev);
+	        print dev
+	    }' |
+	    while read i
+	do
+		if [ -e "/sys/block/$i/queue/scheduler" ]
+		then
+			echo noop > "/sys/block/$i/queue/scheduler"
+		fi
+	done
+
+
 	# ----------------------------------------------------------------
 	# P R E P A R E   R O O T   F I L E S Y S T E M
 


### PR DESCRIPTION
### Description

Besides the two minor cleanups (one whitespace and one typo), the point of this pull request is to make the initramfs script set elevator=noop on the root pool's disks.

ZFS already sets elevator=noop for wholedisk vdevs (for all pools), but typical root-on-ZFS installations use partitions.  This sets elevator=noop on the disks in the root pool.

Ubuntu 16.04 and 16.10 had this.  It was lost in 17.04 due to Debian switching to the upstream initramfs script.

### How Has This Been Tested?

I originally tested the main code for this feature for Ubuntu 16.04, and it was integrated and has seen real-world use.

I tested this particular integration on an Ubuntu 17.10 system.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
