### PR TITLE
Undo c89 workarounds to match with upstream

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -638,7 +638,6 @@ _NOTE(CONSTCOND) } while (0)
 	    { "zero", "single", "double", "triple" };			\
 	int len = 0;							\
 	int copies = 0;							\
-	int d;								\
 									\
 	if (bp == NULL) {						\
 		len += func(buf + len, size - len, "<NULL>");		\
@@ -662,7 +661,7 @@ _NOTE(CONSTCOND) } while (0)
 		    (u_longlong_t)BPE_GET_PSIZE(bp),			\
 		    (u_longlong_t)bp->blk_birth);			\
 	} else {							\
-		for (d = 0; d < BP_GET_NDVAS(bp); d++) {		\
+		for (int d = 0; d < BP_GET_NDVAS(bp); d++) {		\
 			const dva_t *dva = &bp->blk_dva[d];		\
 			if (DVA_IS_VALID(dva))				\
 				copies++;				\

--- a/module/zcommon/zfeature_common.c
+++ b/module/zcommon/zfeature_common.c
@@ -91,26 +91,21 @@ zfeature_is_valid_guid(const char *name)
 boolean_t
 zfeature_is_supported(const char *guid)
 {
-	spa_feature_t i;
-
 	if (zfeature_checks_disable)
 		return (B_TRUE);
 
-	for (i = 0; i < SPA_FEATURES; i++) {
+	for (spa_feature_t i = 0; i < SPA_FEATURES; i++) {
 		zfeature_info_t *feature = &spa_feature_table[i];
 		if (strcmp(guid, feature->fi_guid) == 0)
 			return (B_TRUE);
 	}
-
 	return (B_FALSE);
 }
 
 int
 zfeature_lookup_name(const char *name, spa_feature_t *res)
 {
-	spa_feature_t i;
-
-	for (i = 0; i < SPA_FEATURES; i++) {
+	for (spa_feature_t i = 0; i < SPA_FEATURES; i++) {
 		zfeature_info_t *feature = &spa_feature_table[i];
 		if (strcmp(name, feature->fi_uname) == 0) {
 			if (res != NULL)
@@ -126,9 +121,8 @@ boolean_t
 zfeature_depends_on(spa_feature_t fid, spa_feature_t check)
 {
 	zfeature_info_t *feature = &spa_feature_table[fid];
-	int i;
 
-	for (i = 0; feature->fi_depends[i] != SPA_FEATURE_NONE; i++) {
+	for (int i = 0; feature->fi_depends[i] != SPA_FEATURE_NONE; i++) {
 		if (feature->fi_depends[i] == check)
 			return (B_TRUE);
 	}
@@ -138,9 +132,7 @@ zfeature_depends_on(spa_feature_t fid, spa_feature_t check)
 static boolean_t
 deps_contains_feature(const spa_feature_t *deps, const spa_feature_t feature)
 {
-	int i;
-
-	for (i = 0; deps[i] != SPA_FEATURE_NONE; i++)
+	for (int i = 0; deps[i] != SPA_FEATURE_NONE; i++)
 		if (deps[i] == feature)
 			return (B_TRUE);
 

--- a/module/zcommon/zfs_namecheck.c
+++ b/module/zcommon/zfs_namecheck.c
@@ -136,12 +136,13 @@ permset_namecheck(const char *path, namecheck_err_t *why, char *what)
 int
 entity_namecheck(const char *path, namecheck_err_t *why, char *what)
 {
-	const char *start, *end, *loc;
+	const char *start, *end;
 	int found_delim;
 
 	/*
 	 * Make sure the name is not too long.
 	 */
+
 	if (strlen(path) >= ZFS_MAX_DATASET_NAME_LEN) {
 		if (why)
 			*why = NAME_ERR_TOOLONG;
@@ -178,7 +179,7 @@ entity_namecheck(const char *path, namecheck_err_t *why, char *what)
 		}
 
 		/* Validate the contents of this component */
-		for (loc = start; loc != end; loc++) {
+		for (const char *loc = start; loc != end; loc++) {
 			if (!valid_char(*loc) && *loc != '%') {
 				if (why) {
 					*why = NAME_ERR_INVALCHAR;

--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -166,7 +166,7 @@ int
 zprop_iter_common(zprop_func func, void *cb, boolean_t show_all,
     boolean_t ordered, zfs_type_t type)
 {
-	int i, j, num_props, size, prop;
+	int i, num_props, size, prop;
 	zprop_desc_t *prop_tbl;
 	zprop_desc_t **order;
 
@@ -181,7 +181,7 @@ zprop_iter_common(zprop_func func, void *cb, boolean_t show_all,
 		return (ZPROP_CONT);
 #endif
 
-	for (j = 0; j < num_props; j++)
+	for (int j = 0; j < num_props; j++)
 		order[j] = &prop_tbl[j];
 
 	if (ordered) {

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -581,14 +581,12 @@ abd_free_struct(abd_t *abd)
 abd_t *
 abd_alloc(size_t size, boolean_t is_metadata)
 {
-	abd_t *abd;
-
 	if (!zfs_abd_scatter_enabled || size <= PAGESIZE)
 		return (abd_alloc_linear(size, is_metadata));
 
 	VERIFY3U(size, <=, SPA_MAXBLOCKSIZE);
 
-	abd = abd_alloc_struct();
+	abd_t *abd = abd_alloc_struct();
 	abd->abd_flags = ABD_FLAG_OWNER;
 	abd_alloc_pages(abd, size);
 
@@ -1108,10 +1106,9 @@ abd_iterate_func(abd_t *abd, size_t off, size_t size,
 	abd_iter_advance(&aiter, off);
 
 	while (size > 0) {
-		size_t len;
 		abd_iter_map(&aiter);
 
-		len = MIN(aiter.iter_mapsize, size);
+		size_t len = MIN(aiter.iter_mapsize, size);
 		ASSERT3U(len, >, 0);
 
 		ret = func(aiter.iter_mapaddr, len, private);
@@ -1242,13 +1239,12 @@ abd_iterate_func2(abd_t *dabd, abd_t *sabd, size_t doff, size_t soff,
 	abd_iter_advance(&saiter, soff);
 
 	while (size > 0) {
-		size_t dlen, slen, len;
 		abd_iter_map(&daiter);
 		abd_iter_map(&saiter);
 
-		dlen = MIN(daiter.iter_mapsize, size);
-		slen = MIN(saiter.iter_mapsize, size);
-		len = MIN(dlen, slen);
+		size_t dlen = MIN(daiter.iter_mapsize, size);
+		size_t slen = MIN(saiter.iter_mapsize, size);
+		size_t len = MIN(dlen, slen);
 		ASSERT(dlen > 0 || slen > 0);
 
 		ret = func(daiter.iter_mapaddr, saiter.iter_mapaddr, len,

--- a/module/zfs/blkptr.c
+++ b/module/zfs/blkptr.c
@@ -50,7 +50,6 @@ encode_embedded_bp_compressed(blkptr_t *bp, void *data,
 	uint64_t *bp64 = (uint64_t *)bp;
 	uint64_t w = 0;
 	uint8_t *data8 = data;
-	int i;
 
 	ASSERT3U(compressed_size, <=, BPE_PAYLOAD_SIZE);
 	ASSERT(uncompressed_size == compressed_size ||
@@ -69,7 +68,7 @@ encode_embedded_bp_compressed(blkptr_t *bp, void *data,
 	 * Encode the byte array into the words of the block pointer.
 	 * First byte goes into low bits of first word (little endian).
 	 */
-	for (i = 0; i < compressed_size; i++) {
+	for (int i = 0; i < compressed_size; i++) {
 		BF64_SET(w, (i % sizeof (w)) * NBBY, NBBY, data8[i]);
 		if (i % sizeof (w) == sizeof (w) - 1) {
 			/* we've reached the end of a word */
@@ -97,7 +96,6 @@ decode_embedded_bp_compressed(const blkptr_t *bp, void *buf)
 	uint8_t *buf8 = buf;
 	uint64_t w = 0;
 	const uint64_t *bp64 = (const uint64_t *)bp;
-	int i;
 
 	ASSERT(BP_IS_EMBEDDED(bp));
 
@@ -107,7 +105,7 @@ decode_embedded_bp_compressed(const blkptr_t *bp, void *buf)
 	 * Decode the words of the block pointer into the byte array.
 	 * Low bits of first word are the first byte (little endian).
 	 */
-	for (i = 0; i < psize; i++) {
+	for (int i = 0; i < psize; i++) {
 		if (i % sizeof (w) == 0) {
 			/* beginning of a word */
 			ASSERT3P(bp64, <, bp + 1);

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -378,7 +378,6 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 {
 	bpobj_t subbpo;
 	uint64_t used, comp, uncomp, subsubobjs;
-	ASSERTV(dmu_object_info_t doi);
 
 	ASSERT(bpo->bpo_havesubobj);
 	ASSERT(bpo->bpo_havecomp);
@@ -407,6 +406,7 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		    DMU_OT_NONE, 0, tx);
 	}
 
+	ASSERTV(dmu_object_info_t doi);
 	ASSERT0(dmu_object_info(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs, &doi));
 	ASSERT3U(doi.doi_type, ==, DMU_OT_BPOBJ_SUBOBJ);
 

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -261,10 +261,9 @@ ddt_object_name(ddt_t *ddt, enum ddt_type type, enum ddt_class class,
 void
 ddt_bp_fill(const ddt_phys_t *ddp, blkptr_t *bp, uint64_t txg)
 {
-	int d;
 	ASSERT(txg != 0);
 
-	for (d = 0; d < SPA_DVAS_PER_BP; d++)
+	for (int d = 0; d < SPA_DVAS_PER_BP; d++)
 		bp->blk_dva[d] = ddp->ddp_dva[d];
 	BP_SET_BIRTH(bp, txg, ddp->ddp_phys_birth);
 }
@@ -313,10 +312,9 @@ ddt_key_fill(ddt_key_t *ddk, const blkptr_t *bp)
 void
 ddt_phys_fill(ddt_phys_t *ddp, const blkptr_t *bp)
 {
-	int d;
 	ASSERT(ddp->ddp_phys_birth == 0);
 
-	for (d = 0; d < SPA_DVAS_PER_BP; d++)
+	for (int d = 0; d < SPA_DVAS_PER_BP; d++)
 		ddp->ddp_dva[d] = bp->blk_dva[d];
 	ddp->ddp_phys_birth = BP_PHYSICAL_BIRTH(bp);
 }
@@ -356,9 +354,8 @@ ddt_phys_t *
 ddt_phys_select(const ddt_entry_t *dde, const blkptr_t *bp)
 {
 	ddt_phys_t *ddp = (ddt_phys_t *)dde->dde_phys;
-	int p;
 
-	for (p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
+	for (int p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
 		if (DVA_EQUAL(BP_IDENTITY(bp), &ddp->ddp_dva[0]) &&
 		    BP_PHYSICAL_BIRTH(bp) == ddp->ddp_phys_birth)
 			return (ddp);
@@ -370,9 +367,8 @@ uint64_t
 ddt_phys_total_refcnt(const ddt_entry_t *dde)
 {
 	uint64_t refcnt = 0;
-	int p;
 
-	for (p = DDT_PHYS_SINGLE; p <= DDT_PHYS_TRIPLE; p++)
+	for (int p = DDT_PHYS_SINGLE; p <= DDT_PHYS_TRIPLE; p++)
 		refcnt += dde->dde_phys[p].ddp_refcnt;
 
 	return (refcnt);
@@ -386,18 +382,17 @@ ddt_stat_generate(ddt_t *ddt, ddt_entry_t *dde, ddt_stat_t *dds)
 	ddt_key_t *ddk = &dde->dde_key;
 	uint64_t lsize = DDK_GET_LSIZE(ddk);
 	uint64_t psize = DDK_GET_PSIZE(ddk);
-	int p, d;
 
 	bzero(dds, sizeof (*dds));
 
-	for (p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
+	for (int p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
 		uint64_t dsize = 0;
 		uint64_t refcnt = ddp->ddp_refcnt;
 
 		if (ddp->ddp_phys_birth == 0)
 			continue;
 
-		for (d = 0; d < DDE_GET_NDVAS(dde); d++)
+		for (int d = 0; d < DDE_GET_NDVAS(dde); d++)
 			dsize += dva_get_dsize_sync(spa, &ddp->ddp_dva[d]);
 
 		dds->dds_blocks += 1;
@@ -445,20 +440,16 @@ ddt_stat_update(ddt_t *ddt, ddt_entry_t *dde, uint64_t neg)
 void
 ddt_histogram_add(ddt_histogram_t *dst, const ddt_histogram_t *src)
 {
-	int h;
-
-	for (h = 0; h < 64; h++)
+	for (int h = 0; h < 64; h++)
 		ddt_stat_add(&dst->ddh_stat[h], &src->ddh_stat[h], 0);
 }
 
 void
 ddt_histogram_stat(ddt_stat_t *dds, const ddt_histogram_t *ddh)
 {
-	int h;
-
 	bzero(dds, sizeof (*dds));
 
-	for (h = 0; h < 64; h++)
+	for (int h = 0; h < 64; h++)
 		ddt_stat_add(dds, &ddh->ddh_stat[h], 0);
 }
 
@@ -478,15 +469,11 @@ ddt_histogram_empty(const ddt_histogram_t *ddh)
 void
 ddt_get_dedup_object_stats(spa_t *spa, ddt_object_t *ddo_total)
 {
-	enum zio_checksum c;
-	enum ddt_type type;
-	enum ddt_class class;
-
 	/* Sum the statistics we cached in ddt_object_sync(). */
-	for (c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
+	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
 		ddt_t *ddt = spa->spa_ddt[c];
-		for (type = 0; type < DDT_TYPES; type++) {
-			for (class = 0; class < DDT_CLASSES;
+		for (enum ddt_type type = 0; type < DDT_TYPES; type++) {
+			for (enum ddt_class class = 0; class < DDT_CLASSES;
 			    class++) {
 				ddt_object_t *ddo =
 				    &ddt->ddt_object_stats[type][class];
@@ -507,14 +494,10 @@ ddt_get_dedup_object_stats(spa_t *spa, ddt_object_t *ddo_total)
 void
 ddt_get_dedup_histogram(spa_t *spa, ddt_histogram_t *ddh)
 {
-	enum zio_checksum c;
-	enum ddt_type type;
-	enum ddt_class class;
-
-	for (c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
+	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
 		ddt_t *ddt = spa->spa_ddt[c];
-		for (type = 0; type < DDT_TYPES; type++) {
-			for (class = 0; class < DDT_CLASSES;
+		for (enum ddt_type type = 0; type < DDT_TYPES; type++) {
+			for (enum ddt_class class = 0; class < DDT_CLASSES;
 			    class++) {
 				ddt_histogram_add(ddh,
 				    &ddt->ddt_histogram_cache[type][class]);
@@ -571,9 +554,8 @@ ddt_ditto_copies_needed(ddt_t *ddt, ddt_entry_t *dde, ddt_phys_t *ddp_willref)
 	int total_copies = 0;
 	int desired_copies = 0;
 	int copies_needed = 0;
-	int p;
 
-	for (p = DDT_PHYS_SINGLE; p <= DDT_PHYS_TRIPLE; p++) {
+	for (int p = DDT_PHYS_SINGLE; p <= DDT_PHYS_TRIPLE; p++) {
 		ddt_phys_t *ddp = &dde->dde_phys[p];
 		zio_t *zio = dde->dde_lead_zio[p];
 		uint64_t refcnt = ddp->ddp_refcnt;	/* committed refs */
@@ -612,9 +594,8 @@ ddt_ditto_copies_present(ddt_entry_t *dde)
 	ddt_phys_t *ddp = &dde->dde_phys[DDT_PHYS_DITTO];
 	dva_t *dva = ddp->ddp_dva;
 	int copies = 0 - DVA_GET_GANG(dva);
-	int d;
 
-	for (d = 0; d < DDE_GET_NDVAS(dde); d++, dva++)
+	for (int d = 0; d < DDE_GET_NDVAS(dde); d++, dva++)
 		if (DVA_IS_VALID(dva))
 			copies++;
 
@@ -722,11 +703,9 @@ ddt_alloc(const ddt_key_t *ddk)
 static void
 ddt_free(ddt_entry_t *dde)
 {
-	int p;
-
 	ASSERT(!dde->dde_loading);
 
-	for (p = 0; p < DDT_PHYS_TYPES; p++)
+	for (int p = 0; p < DDT_PHYS_TYPES; p++)
 		ASSERT(dde->dde_lead_zio[p] == NULL);
 
 	if (dde->dde_repair_abd != NULL)
@@ -813,8 +792,6 @@ ddt_prefetch(spa_t *spa, const blkptr_t *bp)
 {
 	ddt_t *ddt;
 	ddt_entry_t dde;
-	enum ddt_type type;
-	enum ddt_class class;
 
 	if (!zfs_dedup_prefetch || bp == NULL || !BP_GET_DEDUP(bp))
 		return;
@@ -827,8 +804,8 @@ ddt_prefetch(spa_t *spa, const blkptr_t *bp)
 	ddt = ddt_select(spa, bp);
 	ddt_key_fill(&dde.dde_key, bp);
 
-	for (type = 0; type < DDT_TYPES; type++) {
-		for (class = 0; class < DDT_CLASSES; class++) {
+	for (enum ddt_type type = 0; type < DDT_TYPES; type++) {
+		for (enum ddt_class class = 0; class < DDT_CLASSES; class++) {
 			ddt_object_prefetch(ddt, type, class, &dde);
 		}
 	}
@@ -851,9 +828,8 @@ ddt_entry_compare(const void *x1, const void *x2)
 	const ddt_key_cmp_t *k1 = (const ddt_key_cmp_t *)&dde1->dde_key;
 	const ddt_key_cmp_t *k2 = (const ddt_key_cmp_t *)&dde2->dde_key;
 	int32_t cmp = 0;
-	int i;
 
-	for (i = 0; i < DDT_KEY_CMP_LEN; i++) {
+	for (int i = 0; i < DDT_KEY_CMP_LEN; i++) {
 		cmp = (int32_t)k1->u16[i] - (int32_t)k2->u16[i];
 		if (likely(cmp))
 			break;
@@ -896,20 +872,15 @@ ddt_table_free(ddt_t *ddt)
 void
 ddt_create(spa_t *spa)
 {
-	enum zio_checksum c;
-
 	spa->spa_dedup_checksum = ZIO_DEDUPCHECKSUM;
 
-	for (c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++)
+	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++)
 		spa->spa_ddt[c] = ddt_table_alloc(spa, c);
 }
 
 int
 ddt_load(spa_t *spa)
 {
-	enum zio_checksum c;
-	enum ddt_type type;
-	enum ddt_class class;
 	int error;
 
 	ddt_create(spa);
@@ -921,10 +892,10 @@ ddt_load(spa_t *spa)
 	if (error)
 		return (error == ENOENT ? 0 : error);
 
-	for (c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
+	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
 		ddt_t *ddt = spa->spa_ddt[c];
-		for (type = 0; type < DDT_TYPES; type++) {
-			for (class = 0; class < DDT_CLASSES;
+		for (enum ddt_type type = 0; type < DDT_TYPES; type++) {
+			for (enum ddt_class class = 0; class < DDT_CLASSES;
 			    class++) {
 				error = ddt_object_load(ddt, type, class);
 				if (error != 0 && error != ENOENT)
@@ -946,9 +917,7 @@ ddt_load(spa_t *spa)
 void
 ddt_unload(spa_t *spa)
 {
-	enum zio_checksum c;
-
-	for (c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
+	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
 		if (spa->spa_ddt[c]) {
 			ddt_table_free(spa->spa_ddt[c]);
 			spa->spa_ddt[c] = NULL;
@@ -961,8 +930,6 @@ ddt_class_contains(spa_t *spa, enum ddt_class max_class, const blkptr_t *bp)
 {
 	ddt_t *ddt;
 	ddt_entry_t *dde;
-	enum ddt_type type;
-	enum ddt_class class;
 
 	if (!BP_GET_DEDUP(bp))
 		return (B_FALSE);
@@ -975,8 +942,8 @@ ddt_class_contains(spa_t *spa, enum ddt_class max_class, const blkptr_t *bp)
 
 	ddt_key_fill(&(dde->dde_key), bp);
 
-	for (type = 0; type < DDT_TYPES; type++) {
-		for (class = 0; class <= max_class; class++) {
+	for (enum ddt_type type = 0; type < DDT_TYPES; type++) {
+		for (enum ddt_class class = 0; class <= max_class; class++) {
 			if (ddt_object_lookup(ddt, type, class, dde) == 0) {
 				kmem_cache_free(ddt_entry_cache, dde);
 				return (B_TRUE);
@@ -993,15 +960,13 @@ ddt_repair_start(ddt_t *ddt, const blkptr_t *bp)
 {
 	ddt_key_t ddk;
 	ddt_entry_t *dde;
-	enum ddt_type type;
-	enum ddt_class class;
 
 	ddt_key_fill(&ddk, bp);
 
 	dde = ddt_alloc(&ddk);
 
-	for (type = 0; type < DDT_TYPES; type++) {
-		for (class = 0; class < DDT_CLASSES; class++) {
+	for (enum ddt_type type = 0; type < DDT_TYPES; type++) {
+		for (enum ddt_class class = 0; class < DDT_CLASSES; class++) {
 			/*
 			 * We can only do repair if there are multiple copies
 			 * of the block.  For anything in the UNIQUE class,
@@ -1051,12 +1016,11 @@ ddt_repair_entry(ddt_t *ddt, ddt_entry_t *dde, ddt_entry_t *rdde, zio_t *rio)
 	ddt_key_t *rddk = &rdde->dde_key;
 	zio_t *zio;
 	blkptr_t blk;
-	int p;
 
 	zio = zio_null(rio, rio->io_spa, NULL,
 	    ddt_repair_entry_done, rdde, rio->io_flags);
 
-	for (p = 0; p < DDT_PHYS_TYPES; p++, ddp++, rddp++) {
+	for (int p = 0; p < DDT_PHYS_TYPES; p++, ddp++, rddp++) {
 		if (ddp->ddp_phys_birth == 0 ||
 		    ddp->ddp_phys_birth != rddp->ddp_phys_birth ||
 		    bcmp(ddp->ddp_dva, rddp->ddp_dva, sizeof (ddp->ddp_dva)))
@@ -1106,12 +1070,11 @@ ddt_sync_entry(ddt_t *ddt, ddt_entry_t *dde, dmu_tx_t *tx, uint64_t txg)
 	enum ddt_class oclass = dde->dde_class;
 	enum ddt_class nclass;
 	uint64_t total_refcnt = 0;
-	int p;
 
 	ASSERT(dde->dde_loaded);
 	ASSERT(!dde->dde_loading);
 
-	for (p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
+	for (int p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
 		ASSERT(dde->dde_lead_zio[p] == NULL);
 		if (ddp->ddp_phys_birth == 0) {
 			ASSERT(ddp->ddp_refcnt == 0);
@@ -1168,8 +1131,6 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx, uint64_t txg)
 	spa_t *spa = ddt->ddt_spa;
 	ddt_entry_t *dde;
 	void *cookie = NULL;
-	enum ddt_type type;
-	enum ddt_class class;
 
 	if (avl_numnodes(&ddt->ddt_tree) == 0)
 		return;
@@ -1187,9 +1148,9 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx, uint64_t txg)
 		ddt_free(dde);
 	}
 
-	for (type = 0; type < DDT_TYPES; type++) {
+	for (enum ddt_type type = 0; type < DDT_TYPES; type++) {
 		uint64_t add, count = 0;
-		for (class = 0; class < DDT_CLASSES; class++) {
+		for (enum ddt_class class = 0; class < DDT_CLASSES; class++) {
 			if (ddt_object_exists(ddt, type, class)) {
 				ddt_object_sync(ddt, type, class, tx);
 				VERIFY(ddt_object_count(ddt, type, class,
@@ -1197,7 +1158,7 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx, uint64_t txg)
 				count += add;
 			}
 		}
-		for (class = 0; class < DDT_CLASSES; class++) {
+		for (enum ddt_class class = 0; class < DDT_CLASSES; class++) {
 			if (count == 0 && ddt_object_exists(ddt, type, class))
 				ddt_object_destroy(ddt, type, class, tx);
 		}
@@ -1214,13 +1175,12 @@ ddt_sync(spa_t *spa, uint64_t txg)
 	dmu_tx_t *tx;
 	zio_t *rio = zio_root(spa, NULL, NULL,
 	    ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE);
-	enum zio_checksum c;
 
 	ASSERT(spa_syncing_txg(spa) == txg);
 
 	tx = dmu_tx_create_assigned(spa->spa_dsl_pool, txg);
 
-	for (c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
+	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
 		ddt_t *ddt = spa->spa_ddt[c];
 		if (ddt == NULL)
 			continue;

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -675,10 +675,8 @@ dmu_prefetch(objset_t *os, uint64_t object, int64_t level, uint64_t offset,
 	}
 
 	if (nblks != 0) {
-		int i;
-
 		blkid = dbuf_whichblock(dn, level, offset);
-		for (i = 0; i < nblks; i++)
+		for (int i = 0; i < nblks; i++)
 			dbuf_prefetch(dn, level, blkid + i, pri, 0);
 	}
 
@@ -704,7 +702,6 @@ get_next_chunk(dnode_t *dn, uint64_t *start, uint64_t minimum)
 	/* bytes of data covered by a level-1 indirect block */
 	uint64_t iblkrange =
 	    dn->dn_datablksz * EPB(dn->dn_indblkshift, SPA_BLKPTRSHIFT);
-	uint64_t blks;
 
 	ASSERT3U(minimum, <=, *start);
 
@@ -714,7 +711,7 @@ get_next_chunk(dnode_t *dn, uint64_t *start, uint64_t minimum)
 	}
 	ASSERT(ISP2(iblkrange));
 
-	for (blks = 0; *start > minimum && blks < maxblks; blks++) {
+	for (uint64_t blks = 0; *start > minimum && blks < maxblks; blks++) {
 		int err;
 
 		/*
@@ -767,7 +764,6 @@ dmu_free_long_range_impl(objset_t *os, dnode_t *dn, uint64_t offset,
 	int err;
 	uint64_t dirty_frees_threshold;
 	dsl_pool_t *dp = dmu_objset_pool(os);
-	int t;
 
 	if (dn == NULL)
 		return (SET_ERROR(EINVAL));
@@ -805,7 +801,7 @@ dmu_free_long_range_impl(objset_t *os, dnode_t *dn, uint64_t offset,
 		chunk_len = chunk_end - chunk_begin;
 
 		mutex_enter(&dp->dp_lock);
-		for (t = 0; t < TXG_SIZE; t++) {
+		for (int t = 0; t < TXG_SIZE; t++) {
 			long_free_dirty_all_txgs +=
 			    dp->dp_long_free_dirty_pertxg[t];
 		}
@@ -2291,7 +2287,6 @@ void
 __dmu_object_info_from_dnode(dnode_t *dn, dmu_object_info_t *doi)
 {
 	dnode_phys_t *dnp = dn->dn_phys;
-	int i;
 
 	doi->doi_data_block_size = dn->dn_datablksz;
 	doi->doi_metadata_block_size = dn->dn_indblkshift ?
@@ -2307,7 +2302,7 @@ __dmu_object_info_from_dnode(dnode_t *dn, dmu_object_info_t *doi)
 	doi->doi_physical_blocks_512 = (DN_USED_BYTES(dnp) + 256) >> 9;
 	doi->doi_max_offset = (dn->dn_maxblkid + 1) * dn->dn_datablksz;
 	doi->doi_fill_count = 0;
-	for (i = 0; i < dnp->dn_nblkptr; i++)
+	for (int i = 0; i < dnp->dn_nblkptr; i++)
 		doi->doi_fill_count += BP_GET_FILL(&dnp->dn_blkptr[i]);
 }
 

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -852,11 +852,9 @@ dmu_objset_evict_dbufs(objset_t *os)
 void
 dmu_objset_evict(objset_t *os)
 {
-	int t;
-
 	dsl_dataset_t *ds = os->os_dsl_dataset;
 
-	for (t = 0; t < TXG_SIZE; t++)
+	for (int t = 0; t < TXG_SIZE; t++)
 		ASSERT(!dmu_objset_is_dirty(os, t));
 
 	if (ds)
@@ -1384,8 +1382,6 @@ dmu_objset_sync_dnodes(multilist_sublist_t *list, dmu_tx_t *tx)
 static void
 dmu_objset_write_ready(zio_t *zio, arc_buf_t *abuf, void *arg)
 {
-	int i;
-
 	blkptr_t *bp = zio->io_bp;
 	objset_t *os = arg;
 	dnode_phys_t *dnp = &os->os_phys->os_meta_dnode;
@@ -1401,7 +1397,7 @@ dmu_objset_write_ready(zio_t *zio, arc_buf_t *abuf, void *arg)
 	 * objects that are stored in the objset_phys_t -- the meta
 	 * dnode and user/group accounting objects).
 	 */
-	for (i = 0; i < dnp->dn_nblkptr; i++)
+	for (int i = 0; i < dnp->dn_nblkptr; i++)
 		fill += BP_GET_FILL(&dnp->dn_blkptr[i]);
 
 	BP_SET_FILL(bp, fill);
@@ -2273,7 +2269,6 @@ static void
 dmu_objset_find_dp_impl(dmu_objset_find_ctx_t *dcp)
 {
 	dsl_pool_t *dp = dcp->dc_dp;
-	dmu_objset_find_ctx_t *child_dcp;
 	dsl_dir_t *dd;
 	dsl_dataset_t *ds;
 	zap_cursor_t zc;
@@ -2315,7 +2310,7 @@ dmu_objset_find_dp_impl(dmu_objset_find_ctx_t *dcp)
 			    sizeof (uint64_t));
 			ASSERT3U(attr->za_num_integers, ==, 1);
 
-			child_dcp =
+			dmu_objset_find_ctx_t *child_dcp =
 			    kmem_alloc(sizeof (*child_dcp), KM_SLEEP);
 			*child_dcp = *dcp;
 			child_dcp->dc_ddobj = attr->za_first_integer;

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -702,7 +702,6 @@ traverse_pool(spa_t *spa, uint64_t txg_start, int flags,
     blkptr_cb_t func, void *arg)
 {
 	int err;
-	uint64_t obj;
 	dsl_pool_t *dp = spa_get_dsl(spa);
 	objset_t *mos = dp->dp_meta_objset;
 	boolean_t hard = (flags & TRAVERSE_HARD);
@@ -714,7 +713,7 @@ traverse_pool(spa_t *spa, uint64_t txg_start, int flags,
 		return (err);
 
 	/* visit each dataset */
-	for (obj = 1; err == 0;
+	for (uint64_t obj = 1; err == 0;
 	    err = dmu_object_next(mos, &obj, B_FALSE, txg_start)) {
 		dmu_object_info_t doi;
 

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -392,7 +392,6 @@ dmu_tx_hold_free_impl(dmu_tx_hold_t *txh, uint64_t off, uint64_t len)
 		    SPA_BLKPTRSHIFT;
 		uint64_t start = off >> shift;
 		uint64_t end = (off + len) >> shift;
-		uint64_t i;
 
 		ASSERT(dn->dn_indblkshift != 0);
 
@@ -406,7 +405,7 @@ dmu_tx_hold_free_impl(dmu_tx_hold_t *txh, uint64_t off, uint64_t len)
 
 		zio_t *zio = zio_root(tx->tx_pool->dp_spa,
 		    NULL, NULL, ZIO_FLAG_CANFAIL);
-		for (i = start; i <= end; i++) {
+		for (uint64_t i = start; i <= end; i++) {
 			uint64_t ibyte = i << shift;
 			err = dnode_next_offset(dn, 0, &ibyte, 2, 1, 0);
 			i = ibyte >> shift;
@@ -1114,15 +1113,13 @@ dmu_tx_destroy(dmu_tx_t *tx)
 void
 dmu_tx_commit(dmu_tx_t *tx)
 {
-	dmu_tx_hold_t *txh;
-
 	ASSERT(tx->tx_txg != 0);
 
 	/*
 	 * Go through the transaction's hold list and remove holds on
 	 * associated dnodes, notifying waiters if no holds remain.
 	 */
-	for (txh = list_head(&tx->tx_holds); txh != NULL;
+	for (dmu_tx_hold_t *txh = list_head(&tx->tx_holds); txh != NULL;
 	    txh = list_next(&tx->tx_holds, txh)) {
 		dnode_t *dn = txh->txh_dnode;
 

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1921,8 +1921,7 @@ dnode_free_range(dnode_t *dn, uint64_t off, uint64_t len, dmu_tx_t *tx)
 	 *    amount of space if we copy the freed BPs into deadlists.
 	 */
 	if (dn->dn_nlevels > 1) {
-		uint64_t first, last, i, ibyte;
-		int shift, err;
+		uint64_t first, last;
 
 		first = blkid >> epbs;
 		dnode_dirty_l1(dn, first, tx);
@@ -1933,17 +1932,17 @@ dnode_free_range(dnode_t *dn, uint64_t off, uint64_t len, dmu_tx_t *tx)
 		if (last != first)
 			dnode_dirty_l1(dn, last, tx);
 
-		shift = dn->dn_datablkshift + dn->dn_indblkshift -
+		int shift = dn->dn_datablkshift + dn->dn_indblkshift -
 		    SPA_BLKPTRSHIFT;
-		for (i = first + 1; i < last; i++) {
+		for (uint64_t i = first + 1; i < last; i++) {
 			/*
 			 * Set i to the blockid of the next non-hole
 			 * level-1 indirect block at or after i.  Note
 			 * that dnode_next_offset() operates in terms of
 			 * level-0-equivalent bytes.
 			 */
-			ibyte = i << shift;
-			err = dnode_next_offset(dn, DNODE_FIND_HAVELOCK,
+			uint64_t ibyte = i << shift;
+			int err = dnode_next_offset(dn, DNODE_FIND_HAVELOCK,
 			    &ibyte, 2, 1, 0);
 			i = ibyte >> shift;
 			if (i >= last)

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -149,12 +149,11 @@ dsl_bookmark_create_check(void *arg, dmu_tx_t *tx)
 	dsl_bookmark_create_arg_t *dbca = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	int rv = 0;
-	nvpair_t *pair;
 
 	if (!spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_BOOKMARKS))
 		return (SET_ERROR(ENOTSUP));
 
-	for (pair = nvlist_next_nvpair(dbca->dbca_bmarks, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(dbca->dbca_bmarks, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(dbca->dbca_bmarks, pair)) {
 		dsl_dataset_t *snapds;
 		int error;
@@ -183,11 +182,10 @@ dsl_bookmark_create_sync(void *arg, dmu_tx_t *tx)
 	dsl_bookmark_create_arg_t *dbca = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	objset_t *mos = dp->dp_meta_objset;
-	nvpair_t *pair;
 
 	ASSERT(spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_BOOKMARKS));
 
-	for (pair = nvlist_next_nvpair(dbca->dbca_bmarks, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(dbca->dbca_bmarks, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(dbca->dbca_bmarks, pair)) {
 		dsl_dataset_t *snapds, *bmark_fs;
 		zfs_bookmark_phys_t bmark_phys;
@@ -268,7 +266,6 @@ dsl_get_bookmarks_impl(dsl_dataset_t *ds, nvlist_t *props, nvlist_t *outnvl)
 	for (zap_cursor_init(&zc, dp->dp_meta_objset, bmark_zapobj);
 	    zap_cursor_retrieve(&zc, &attr) == 0;
 	    zap_cursor_advance(&zc)) {
-		nvlist_t *out_props;
 		char *bmark_name = attr.za_name;
 		zfs_bookmark_phys_t bmark_phys;
 
@@ -277,7 +274,7 @@ dsl_get_bookmarks_impl(dsl_dataset_t *ds, nvlist_t *props, nvlist_t *outnvl)
 		if (err != 0)
 			break;
 
-		out_props = fnvlist_alloc();
+		nvlist_t *out_props = fnvlist_alloc();
 		if (nvlist_exists(props,
 		    zfs_prop_to_name(ZFS_PROP_GUID))) {
 			dsl_prop_nvlist_add_uint64(out_props,
@@ -356,7 +353,6 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 	dsl_bookmark_destroy_arg_t *dbda = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	int rv = 0;
-	nvpair_t *pair;
 
 	ASSERT(nvlist_empty(dbda->dbda_success));
 	ASSERT(nvlist_empty(dbda->dbda_errors));
@@ -364,7 +360,7 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 	if (!spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_BOOKMARKS))
 		return (0);
 
-	for (pair = nvlist_next_nvpair(dbda->dbda_bmarks, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(dbda->dbda_bmarks, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(dbda->dbda_bmarks, pair)) {
 		const char *fullname = nvpair_name(pair);
 		dsl_dataset_t *ds;
@@ -408,9 +404,8 @@ dsl_bookmark_destroy_sync(void *arg, dmu_tx_t *tx)
 	dsl_bookmark_destroy_arg_t *dbda = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	objset_t *mos = dp->dp_meta_objset;
-	nvpair_t *pair;
 
-	for (pair = nvlist_next_nvpair(dbda->dbda_success, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(dbda->dbda_success, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(dbda->dbda_success, pair)) {
 		dsl_dataset_t *ds;
 		char *shortname;

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -245,14 +245,11 @@ dsl_dataset_remove_clones_key(dsl_dataset_t *ds, uint64_t mintxg, dmu_tx_t *tx)
 void
 dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 {
-	spa_feature_t f;
 	int after_branch_point = FALSE;
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
 	objset_t *mos = dp->dp_meta_objset;
 	dsl_dataset_t *ds_prev = NULL;
-	uint64_t obj, old_unique, used = 0, comp = 0, uncomp = 0;
-	dsl_dataset_t *ds_next, *ds_head, *hds;
-
+	uint64_t obj;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
@@ -279,7 +276,7 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 
 	obj = ds->ds_object;
 
-	for (f = 0; f < SPA_FEATURES; f++) {
+	for (spa_feature_t f = 0; f < SPA_FEATURES; f++) {
 		if (ds->ds_feature_inuse[f]) {
 			dsl_dataset_deactivate_feature(obj, f, tx);
 			ds->ds_feature_inuse[f] = B_FALSE;
@@ -309,6 +306,10 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 			    dsl_dataset_phys(ds)->ds_next_snap_obj;
 		}
 	}
+
+	dsl_dataset_t *ds_next;
+	uint64_t old_unique;
+	uint64_t used = 0, comp = 0, uncomp = 0;
 
 	VERIFY0(dsl_dataset_hold_obj(dp,
 	    dsl_dataset_phys(ds)->ds_next_snap_obj, FTAG, &ds_next));
@@ -388,6 +389,7 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 		ASSERT3P(ds_next->ds_prev, ==, NULL);
 
 		/* Collapse range in this head. */
+		dsl_dataset_t *hds;
 		VERIFY0(dsl_dataset_hold_obj(dp,
 		    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &hds));
 		dsl_deadlist_remove_key(&hds->ds_deadlist,
@@ -435,6 +437,7 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	}
 
 	/* remove from snapshot namespace */
+	dsl_dataset_t *ds_head;
 	ASSERT(dsl_dataset_phys(ds)->ds_snapnames_zapobj == 0);
 	VERIFY0(dsl_dataset_hold_obj(dp,
 	    dsl_dir_phys(ds->ds_dir)->dd_head_dataset_obj, FTAG, &ds_head));
@@ -726,11 +729,9 @@ void
 dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = dmu_tx_pool(tx);
-	spa_feature_t f;
 	objset_t *mos = dp->dp_meta_objset;
 	uint64_t obj, ddobj, prevobj = 0;
 	boolean_t rmorigin;
-	objset_t *os;
 
 	ASSERT3U(dsl_dataset_phys(ds)->ds_num_children, <=, 1);
 	ASSERT(ds->ds_prev == NULL ||
@@ -758,7 +759,7 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 
 	obj = ds->ds_object;
 
-	for (f = 0; f < SPA_FEATURES; f++) {
+	for (spa_feature_t f = 0; f < SPA_FEATURES; f++) {
 		if (ds->ds_feature_inuse[f]) {
 			dsl_dataset_deactivate_feature(obj, f, tx);
 			ds->ds_feature_inuse[f] = B_FALSE;
@@ -794,6 +795,7 @@ dsl_destroy_head_sync_impl(dsl_dataset_t *ds, dmu_tx_t *tx)
 	dmu_buf_will_dirty(ds->ds_dbuf, tx);
 	dsl_dataset_phys(ds)->ds_deadlist_obj = 0;
 
+	objset_t *os;
 	VERIFY0(dmu_objset_from_ds(ds, &os));
 
 	if (!spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_ASYNC_DESTROY)) {
@@ -959,11 +961,10 @@ dsl_destroy_head(const char *name)
 		error = dmu_objset_own(name, DMU_OST_ANY, B_FALSE, B_FALSE,
 		    FTAG, &os);
 		if (error == 0) {
-			uint64_t obj;
 			uint64_t prev_snap_txg =
 			    dsl_dataset_phys(dmu_objset_ds(os))->
 			    ds_prev_snap_txg;
-			for (obj = 0; error == 0;
+			for (uint64_t obj = 0; error == 0;
 			    error = dmu_object_next(os, &obj, FALSE,
 			    prev_snap_txg))
 				(void) dmu_free_long_object(os, obj);

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -83,7 +83,6 @@ dsl_dataset_user_hold_check(void *arg, dmu_tx_t *tx)
 {
 	dsl_dataset_user_hold_arg_t *dduha = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
-	nvpair_t *pair;
 
 	if (spa_version(dp->dp_spa) < SPA_VERSION_USERREFS)
 		return (SET_ERROR(ENOTSUP));
@@ -91,7 +90,7 @@ dsl_dataset_user_hold_check(void *arg, dmu_tx_t *tx)
 	if (!dmu_tx_is_syncing(tx))
 		return (0);
 
-	for (pair = nvlist_next_nvpair(dduha->dduha_holds, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(dduha->dduha_holds, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(dduha->dduha_holds, pair)) {
 		dsl_dataset_t *ds;
 		int error = 0;
@@ -255,14 +254,13 @@ dsl_dataset_user_hold_sync(void *arg, dmu_tx_t *tx)
 	dsl_dataset_user_hold_arg_t *dduha = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	nvlist_t *tmpholds;
-	nvpair_t *pair;
 	uint64_t now = gethrestime_sec();
 
 	if (dduha->dduha_minor != 0)
 		tmpholds = fnvlist_alloc();
 	else
 		tmpholds = NULL;
-	for (pair = nvlist_next_nvpair(dduha->dduha_chkholds, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(dduha->dduha_chkholds, NULL);
 	    pair != NULL;
 	    pair = nvlist_next_nvpair(dduha->dduha_chkholds, pair)) {
 		dsl_dataset_t *ds;
@@ -351,7 +349,6 @@ dsl_dataset_user_release_check_one(dsl_dataset_user_release_arg_t *ddura,
 {
 	uint64_t zapobj;
 	nvlist_t *holds_found;
-	nvpair_t *pair;
 	objset_t *mos;
 	int numholds;
 
@@ -366,7 +363,7 @@ dsl_dataset_user_release_check_one(dsl_dataset_user_release_arg_t *ddura,
 	zapobj = dsl_dataset_phys(ds)->ds_userrefs_obj;
 	VERIFY0(nvlist_alloc(&holds_found, NV_UNIQUE_NAME, KM_SLEEP));
 
-	for (pair = nvlist_next_nvpair(holds, NULL); pair != NULL;
+	for (nvpair_t *pair = nvlist_next_nvpair(holds, NULL); pair != NULL;
 	    pair = nvlist_next_nvpair(holds, pair)) {
 		uint64_t tmp;
 		int error;
@@ -427,7 +424,6 @@ dsl_dataset_user_release_check(void *arg, dmu_tx_t *tx)
 	dsl_dataset_user_release_arg_t *ddura;
 	dsl_holdfunc_t *holdfunc;
 	dsl_pool_t *dp;
-	nvpair_t *pair;
 
 	if (!dmu_tx_is_syncing(tx))
 		return (0);
@@ -439,7 +435,7 @@ dsl_dataset_user_release_check(void *arg, dmu_tx_t *tx)
 	ddura = arg;
 	holdfunc = ddura->ddura_holdfunc;
 
-	for (pair = nvlist_next_nvpair(ddura->ddura_holds, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(ddura->ddura_holds, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(ddura->ddura_holds, pair)) {
 		int error;
 		dsl_dataset_t *ds;
@@ -479,9 +475,8 @@ dsl_dataset_user_release_sync_one(dsl_dataset_t *ds, nvlist_t *holds,
 {
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
 	objset_t *mos = dp->dp_meta_objset;
-	nvpair_t *pair;
 
-	for (pair = nvlist_next_nvpair(holds, NULL); pair != NULL;
+	for (nvpair_t *pair = nvlist_next_nvpair(holds, NULL); pair != NULL;
 	    pair = nvlist_next_nvpair(holds, pair)) {
 		int error;
 		const char *holdname = nvpair_name(pair);
@@ -505,11 +500,10 @@ dsl_dataset_user_release_sync(void *arg, dmu_tx_t *tx)
 	dsl_dataset_user_release_arg_t *ddura = arg;
 	dsl_holdfunc_t *holdfunc = ddura->ddura_holdfunc;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
-	nvpair_t *pair;
 
 	ASSERT(RRW_WRITE_HELD(&dp->dp_config_rwlock));
 
-	for (pair = nvlist_next_nvpair(ddura->ddura_chkholds, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(ddura->ddura_chkholds, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(ddura->ddura_chkholds,
 	    pair)) {
 		dsl_dataset_t *ds;

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -307,7 +307,7 @@ metaslab_class_histogram_verify(metaslab_class_t *mc)
 {
 	vdev_t *rvd = mc->mc_spa->spa_root_vdev;
 	uint64_t *mc_hist;
-	int i, c;
+	int i;
 
 	if ((zfs_flags & ZFS_DEBUG_HISTOGRAM_VERIFY) == 0)
 		return;
@@ -315,7 +315,7 @@ metaslab_class_histogram_verify(metaslab_class_t *mc)
 	mc_hist = kmem_zalloc(sizeof (uint64_t) * RANGE_TREE_HISTOGRAM_SIZE,
 	    KM_SLEEP);
 
-	for (c = 0; c < rvd->vdev_children; c++) {
+	for (int c = 0; c < rvd->vdev_children; c++) {
 		vdev_t *tvd = rvd->vdev_child[c];
 		metaslab_group_t *mg = tvd->vdev_mg;
 
@@ -350,11 +350,10 @@ metaslab_class_fragmentation(metaslab_class_t *mc)
 {
 	vdev_t *rvd = mc->mc_spa->spa_root_vdev;
 	uint64_t fragmentation = 0;
-	int c;
 
 	spa_config_enter(mc->mc_spa, SCL_VDEV, FTAG, RW_READER);
 
-	for (c = 0; c < rvd->vdev_children; c++) {
+	for (int c = 0; c < rvd->vdev_children; c++) {
 		vdev_t *tvd = rvd->vdev_child[c];
 		metaslab_group_t *mg = tvd->vdev_mg;
 
@@ -401,10 +400,9 @@ metaslab_class_expandable_space(metaslab_class_t *mc)
 {
 	vdev_t *rvd = mc->mc_spa->spa_root_vdev;
 	uint64_t space = 0;
-	int c;
 
 	spa_config_enter(mc->mc_spa, SCL_VDEV, FTAG, RW_READER);
-	for (c = 0; c < rvd->vdev_children; c++) {
+	for (int c = 0; c < rvd->vdev_children; c++) {
 		vdev_t *tvd = rvd->vdev_child[c];
 		metaslab_group_t *mg = tvd->vdev_mg;
 
@@ -449,7 +447,6 @@ metaslab_verify_space(metaslab_t *msp, uint64_t txg)
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
 	uint64_t allocated = 0;
 	uint64_t sm_free_space, msp_free_space;
-	int t;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 
@@ -474,7 +471,7 @@ metaslab_verify_space(metaslab_t *msp, uint64_t txg)
 	 * Account for future allocations since we would have already
 	 * deducted that space from the ms_freetree.
 	 */
-	for (t = 0; t < TXG_CONCURRENT_STATES; t++) {
+	for (int t = 0; t < TXG_CONCURRENT_STATES; t++) {
 		allocated +=
 		    range_tree_space(msp->ms_alloctree[(txg + t) & TXG_MASK]);
 	}
@@ -699,7 +696,7 @@ metaslab_group_histogram_verify(metaslab_group_t *mg)
 	uint64_t *mg_hist;
 	vdev_t *vd = mg->mg_vd;
 	uint64_t ashift = vd->vdev_ashift;
-	int i, m;
+	int i;
 
 	if ((zfs_flags & ZFS_DEBUG_HISTOGRAM_VERIFY) == 0)
 		return;
@@ -710,7 +707,7 @@ metaslab_group_histogram_verify(metaslab_group_t *mg)
 	ASSERT3U(RANGE_TREE_HISTOGRAM_SIZE, >=,
 	    SPACE_MAP_HISTOGRAM_SIZE + ashift);
 
-	for (m = 0; m < vd->vdev_ms_count; m++) {
+	for (int m = 0; m < vd->vdev_ms_count; m++) {
 		metaslab_t *msp = vd->vdev_ms[m];
 
 		if (msp->ms_sm == NULL)
@@ -732,14 +729,13 @@ metaslab_group_histogram_add(metaslab_group_t *mg, metaslab_t *msp)
 {
 	metaslab_class_t *mc = mg->mg_class;
 	uint64_t ashift = mg->mg_vd->vdev_ashift;
-	int i;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	if (msp->ms_sm == NULL)
 		return;
 
 	mutex_enter(&mg->mg_lock);
-	for (i = 0; i < SPACE_MAP_HISTOGRAM_SIZE; i++) {
+	for (int i = 0; i < SPACE_MAP_HISTOGRAM_SIZE; i++) {
 		mg->mg_histogram[i + ashift] +=
 		    msp->ms_sm->sm_phys->smp_histogram[i];
 		mc->mc_histogram[i + ashift] +=
@@ -753,14 +749,13 @@ metaslab_group_histogram_remove(metaslab_group_t *mg, metaslab_t *msp)
 {
 	metaslab_class_t *mc = mg->mg_class;
 	uint64_t ashift = mg->mg_vd->vdev_ashift;
-	int i;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	if (msp->ms_sm == NULL)
 		return;
 
 	mutex_enter(&mg->mg_lock);
-	for (i = 0; i < SPACE_MAP_HISTOGRAM_SIZE; i++) {
+	for (int i = 0; i < SPACE_MAP_HISTOGRAM_SIZE; i++) {
 		ASSERT3U(mg->mg_histogram[i + ashift], >=,
 		    msp->ms_sm->sm_phys->smp_histogram[i]);
 		ASSERT3U(mc->mc_histogram[i + ashift], >=,
@@ -834,9 +829,8 @@ metaslab_group_fragmentation(metaslab_group_t *mg)
 	vdev_t *vd = mg->mg_vd;
 	uint64_t fragmentation = 0;
 	uint64_t valid_ms = 0;
-	int m;
 
-	for (m = 0; m < vd->vdev_ms_count; m++) {
+	for (int m = 0; m < vd->vdev_ms_count; m++) {
 		metaslab_t *msp = vd->vdev_ms[m];
 
 		if (msp->ms_fragmentation == ZFS_FRAG_INVALID)
@@ -1347,7 +1341,6 @@ int
 metaslab_load(metaslab_t *msp)
 {
 	int error = 0;
-	int t;
 	boolean_t success = B_FALSE;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
@@ -1373,7 +1366,7 @@ metaslab_load(metaslab_t *msp)
 		ASSERT3P(msp->ms_group, !=, NULL);
 		msp->ms_loaded = B_TRUE;
 
-		for (t = 0; t < TXG_DEFER_SIZE; t++) {
+		for (int t = 0; t < TXG_DEFER_SIZE; t++) {
 			range_tree_walk(msp->ms_defertree[t],
 			    range_tree_remove, msp->ms_tree);
 		}
@@ -1473,8 +1466,6 @@ metaslab_init(metaslab_group_t *mg, uint64_t id, uint64_t object, uint64_t txg,
 void
 metaslab_fini(metaslab_t *msp)
 {
-	int t;
-
 	metaslab_group_t *mg = msp->ms_group;
 
 	metaslab_group_remove(mg, msp);
@@ -1490,11 +1481,11 @@ metaslab_fini(metaslab_t *msp)
 	range_tree_destroy(msp->ms_freeingtree);
 	range_tree_destroy(msp->ms_freedtree);
 
-	for (t = 0; t < TXG_SIZE; t++) {
+	for (int t = 0; t < TXG_SIZE; t++) {
 		range_tree_destroy(msp->ms_alloctree[t]);
 	}
 
-	for (t = 0; t < TXG_DEFER_SIZE; t++) {
+	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
 		range_tree_destroy(msp->ms_defertree[t]);
 	}
 
@@ -1561,7 +1552,6 @@ metaslab_set_fragmentation(metaslab_t *msp)
 	uint64_t total = 0;
 	boolean_t feature_enabled = spa_feature_is_enabled(spa,
 	    SPA_FEATURE_SPACEMAP_HISTOGRAM);
-	int i;
 
 	if (!feature_enabled) {
 		msp->ms_fragmentation = ZFS_FRAG_INVALID;
@@ -1603,7 +1593,7 @@ metaslab_set_fragmentation(metaslab_t *msp)
 		return;
 	}
 
-	for (i = 0; i < SPACE_MAP_HISTOGRAM_SIZE; i++) {
+	for (int i = 0; i < SPACE_MAP_HISTOGRAM_SIZE; i++) {
 		uint64_t space = 0;
 		uint8_t shift = msp->ms_sm->sm_shift;
 
@@ -1710,11 +1700,11 @@ metaslab_weight_from_range_tree(metaslab_t *msp)
 {
 	uint64_t weight = 0;
 	uint32_t segments = 0;
-	int i;
 
 	ASSERT(msp->ms_loaded);
 
-	for (i = RANGE_TREE_HISTOGRAM_SIZE - 1; i >= SPA_MINBLOCKSHIFT; i--) {
+	for (int i = RANGE_TREE_HISTOGRAM_SIZE - 1; i >= SPA_MINBLOCKSHIFT;
+	    i--) {
 		uint8_t shift = msp->ms_group->mg_vd->vdev_ashift;
 		int max_idx = SPACE_MAP_HISTOGRAM_SIZE + shift - 1;
 
@@ -1750,9 +1740,8 @@ static uint64_t
 metaslab_weight_from_spacemap(metaslab_t *msp)
 {
 	uint64_t weight = 0;
-	int i;
 
-	for (i = SPACE_MAP_HISTOGRAM_SIZE - 1; i >= 0; i--) {
+	for (int i = SPACE_MAP_HISTOGRAM_SIZE - 1; i >= 0; i--) {
 		if (msp->ms_sm->sm_phys->smp_histogram[i] != 0) {
 			WEIGHT_SET_COUNT(weight,
 			    msp->ms_sm->sm_phys->smp_histogram[i]);
@@ -1962,8 +1951,6 @@ void
 metaslab_segment_may_passivate(metaslab_t *msp)
 {
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
-	uint64_t weight;
-	int activation_idx, current_idx;
 
 	if (WEIGHT_IS_SPACEBASED(msp->ms_weight) || spa_sync_pass(spa) > 1)
 		return;
@@ -1973,9 +1960,9 @@ metaslab_segment_may_passivate(metaslab_t *msp)
 	 * information that is accessible to us is the in-core range tree
 	 * histogram; calculate the new weight based on that information.
 	 */
-	weight = metaslab_weight_from_range_tree(msp);
-	activation_idx = WEIGHT_GET_INDEX(msp->ms_activation_weight);
-	current_idx = WEIGHT_GET_INDEX(weight);
+	uint64_t weight = metaslab_weight_from_range_tree(msp);
+	int activation_idx = WEIGHT_GET_INDEX(msp->ms_activation_weight);
+	int current_idx = WEIGHT_GET_INDEX(weight);
 
 	if (current_idx <= activation_idx - zfs_metaslab_switch_threshold)
 		metaslab_passivate(msp, weight);
@@ -2118,7 +2105,6 @@ metaslab_condense(metaslab_t *msp, uint64_t txg, dmu_tx_t *tx)
 	spa_t *spa = msp->ms_group->mg_vd->vdev_spa;
 	range_tree_t *condense_tree;
 	space_map_t *sm = msp->ms_sm;
-	int t;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT3U(spa_sync_pass(spa), ==, 1);
@@ -2151,12 +2137,12 @@ metaslab_condense(metaslab_t *msp, uint64_t txg, dmu_tx_t *tx)
 	 */
 	range_tree_walk(msp->ms_freeingtree, range_tree_remove, condense_tree);
 
-	for (t = 0; t < TXG_DEFER_SIZE; t++) {
+	for (int t = 0; t < TXG_DEFER_SIZE; t++) {
 		range_tree_walk(msp->ms_defertree[t],
 		    range_tree_remove, condense_tree);
 	}
 
-	for (t = 1; t < TXG_CONCURRENT_STATES; t++) {
+	for (int t = 1; t < TXG_CONCURRENT_STATES; t++) {
 		range_tree_walk(msp->ms_alloctree[(txg + t) & TXG_MASK],
 		    range_tree_remove, condense_tree);
 	}
@@ -2280,8 +2266,6 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	}
 
 	if (msp->ms_loaded) {
-		int t;
-
 		/*
 		 * When the space map is loaded, we have an accruate
 		 * histogram in the range tree. This gives us an opportunity
@@ -2307,7 +2291,7 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		 * that is completely empty unless the metaslab is fully
 		 * allocated.
 		 */
-		for (t = 0; t < TXG_DEFER_SIZE; t++) {
+		for (int t = 0; t < TXG_DEFER_SIZE; t++) {
 			space_map_histogram_add(msp->ms_sm,
 			    msp->ms_defertree[t], tx);
 		}
@@ -2366,9 +2350,7 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	spa_t *spa = vd->vdev_spa;
 	range_tree_t **defer_tree;
 	int64_t alloc_delta, defer_delta;
-	uint64_t free_space;
 	boolean_t defer_allowed = B_TRUE;
-	int t;
 
 	ASSERT(!vd->vdev_ishole);
 
@@ -2379,7 +2361,7 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	 * range trees and add its capacity to the vdev.
 	 */
 	if (msp->ms_freedtree == NULL) {
-		for (t = 0; t < TXG_SIZE; t++) {
+		for (int t = 0; t < TXG_SIZE; t++) {
 			ASSERT(msp->ms_alloctree[t] == NULL);
 
 			msp->ms_alloctree[t] = range_tree_create(NULL, msp,
@@ -2394,7 +2376,7 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 		msp->ms_freedtree = range_tree_create(NULL, msp,
 		    &msp->ms_lock);
 
-		for (t = 0; t < TXG_DEFER_SIZE; t++) {
+		for (int t = 0; t < TXG_DEFER_SIZE; t++) {
 			ASSERT(msp->ms_defertree[t] == NULL);
 
 			msp->ms_defertree[t] = range_tree_create(NULL, msp,
@@ -2406,7 +2388,7 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 
 	defer_tree = &msp->ms_defertree[txg % TXG_DEFER_SIZE];
 
-	free_space = metaslab_class_get_space(spa_normal_class(spa)) -
+	uint64_t free_space = metaslab_class_get_space(spa_normal_class(spa)) -
 	    metaslab_class_get_alloc(spa_normal_class(spa));
 	if (free_space <= spa_get_slop_space(spa)) {
 		defer_allowed = B_FALSE;
@@ -2470,7 +2452,7 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	if (msp->ms_loaded &&
 	    msp->ms_selected_txg + metaslab_unload_delay < txg) {
 
-		for (t = 1; t < TXG_CONCURRENT_STATES; t++) {
+		for (int t = 1; t < TXG_CONCURRENT_STATES; t++) {
 			VERIFY0(range_tree_space(
 			    msp->ms_alloctree[(txg + t) & TXG_MASK]));
 		}
@@ -2654,13 +2636,11 @@ metaslab_trace_fini(zio_alloc_list_t *zal)
 static void
 metaslab_group_alloc_increment(spa_t *spa, uint64_t vdev, void *tag, int flags)
 {
-	metaslab_group_t *mg;
-
 	if (!(flags & METASLAB_ASYNC_ALLOC) ||
 	    flags & METASLAB_DONT_THROTTLE)
 		return;
 
-	mg = vdev_lookup_top(spa, vdev)->vdev_mg;
+	metaslab_group_t *mg = vdev_lookup_top(spa, vdev)->vdev_mg;
 	if (!mg->mg_class->mc_alloc_throttle_enabled)
 		return;
 
@@ -2670,13 +2650,11 @@ metaslab_group_alloc_increment(spa_t *spa, uint64_t vdev, void *tag, int flags)
 void
 metaslab_group_alloc_decrement(spa_t *spa, uint64_t vdev, void *tag, int flags)
 {
-	metaslab_group_t *mg;
-
 	if (!(flags & METASLAB_ASYNC_ALLOC) ||
 	    flags & METASLAB_DONT_THROTTLE)
 		return;
 
-	mg = vdev_lookup_top(spa, vdev)->vdev_mg;
+	metaslab_group_t *mg = vdev_lookup_top(spa, vdev)->vdev_mg;
 	if (!mg->mg_class->mc_alloc_throttle_enabled)
 		return;
 
@@ -2689,9 +2667,8 @@ metaslab_group_alloc_verify(spa_t *spa, const blkptr_t *bp, void *tag)
 #ifdef ZFS_DEBUG
 	const dva_t *dva = bp->blk_dva;
 	int ndvas = BP_GET_NDVAS(bp);
-	int d;
 
-	for (d = 0; d < ndvas; d++) {
+	for (int d = 0; d < ndvas; d++) {
 		uint64_t vdev = DVA_GET_VDEV(&dva[d]);
 		metaslab_group_t *mg = vdev_lookup_top(spa, vdev)->vdev_mg;
 		VERIFY(refcount_not_held(&mg->mg_alloc_queue_depth, tag));
@@ -2741,7 +2718,6 @@ metaslab_group_alloc_normal(metaslab_group_t *mg, zio_alloc_list_t *zal,
     uint64_t asize, uint64_t txg, uint64_t min_distance, dva_t *dva, int d)
 {
 	metaslab_t *msp = NULL;
-	metaslab_t *search;
 	uint64_t offset = -1ULL;
 	uint64_t activation_weight;
 	uint64_t target_distance;
@@ -2755,7 +2731,7 @@ metaslab_group_alloc_normal(metaslab_group_t *mg, zio_alloc_list_t *zal,
 		}
 	}
 
-	search = kmem_alloc(sizeof (*search), KM_SLEEP);
+	metaslab_t *search = kmem_alloc(sizeof (*search), KM_SLEEP);
 	search->ms_weight = UINT64_MAX;
 	search->ms_start = 0;
 	for (;;) {
@@ -3062,8 +3038,6 @@ metaslab_alloc_dva(spa_t *spa, metaslab_class_t *mc, uint64_t psize,
 top:
 	do {
 		boolean_t allocatable;
-		uint64_t offset;
-		uint64_t distance, asize;
 
 		ASSERT(mg->mg_activation_count == 1);
 		vd = mg->mg_vd;
@@ -3120,7 +3094,7 @@ top:
 		 * in this BP.  If we are trying hard, allow any offset
 		 * to be used (distance=0).
 		 */
-		distance = 0;
+		uint64_t distance = 0;
 		if (!try_hard) {
 			distance = vd->vdev_asize >>
 			    ditto_same_vdev_distance_shift;
@@ -3128,11 +3102,11 @@ top:
 				distance = 0;
 		}
 
-		asize = vdev_psize_to_asize(vd, psize);
+		uint64_t asize = vdev_psize_to_asize(vd, psize);
 		ASSERT(P2PHASE(asize, 1ULL << vd->vdev_ashift) == 0);
 
-		offset = metaslab_group_alloc(mg, zal, asize, txg, distance,
-		    dva, d);
+		uint64_t offset = metaslab_group_alloc(mg, zal, asize, txg,
+		    distance, dva, d);
 
 		if (offset != -1ULL) {
 			/*
@@ -3343,24 +3317,21 @@ metaslab_class_throttle_reserve(metaslab_class_t *mc, int slots, zio_t *zio,
     int flags)
 {
 	uint64_t available_slots = 0;
-	uint64_t reserved_slots;
 	boolean_t slot_reserved = B_FALSE;
 
 	ASSERT(mc->mc_alloc_throttle_enabled);
 	mutex_enter(&mc->mc_lock);
 
-	reserved_slots = refcount_count(&mc->mc_alloc_slots);
+	uint64_t reserved_slots = refcount_count(&mc->mc_alloc_slots);
 	if (reserved_slots < mc->mc_alloc_max_slots)
 		available_slots = mc->mc_alloc_max_slots - reserved_slots;
 
 	if (slots <= available_slots || GANG_ALLOCATION(flags)) {
-		int d;
-
 		/*
 		 * We reserve the slots individually so that we can unreserve
 		 * them individually when an I/O completes.
 		 */
-		for (d = 0; d < slots; d++) {
+		for (int d = 0; d < slots; d++) {
 			reserved_slots = refcount_add(&mc->mc_alloc_slots, zio);
 		}
 		zio->io_flags |= ZIO_FLAG_IO_ALLOCATING;
@@ -3374,11 +3345,9 @@ metaslab_class_throttle_reserve(metaslab_class_t *mc, int slots, zio_t *zio,
 void
 metaslab_class_throttle_unreserve(metaslab_class_t *mc, int slots, zio_t *zio)
 {
-	int d;
-
 	ASSERT(mc->mc_alloc_throttle_enabled);
 	mutex_enter(&mc->mc_lock);
-	for (d = 0; d < slots; d++) {
+	for (int d = 0; d < slots; d++) {
 		(void) refcount_remove(&mc->mc_alloc_slots, zio);
 	}
 	mutex_exit(&mc->mc_lock);
@@ -3391,7 +3360,7 @@ metaslab_alloc(spa_t *spa, metaslab_class_t *mc, uint64_t psize, blkptr_t *bp,
 {
 	dva_t *dva = bp->blk_dva;
 	dva_t *hintdva = hintbp->blk_dva;
-	int d, error = 0;
+	int error = 0;
 
 	ASSERT(bp->blk_birth == 0);
 	ASSERT(BP_PHYSICAL_BIRTH(bp) == 0);
@@ -3408,7 +3377,7 @@ metaslab_alloc(spa_t *spa, metaslab_class_t *mc, uint64_t psize, blkptr_t *bp,
 	ASSERT(hintbp == NULL || ndvas <= BP_GET_NDVAS(hintbp));
 	ASSERT3P(zal, !=, NULL);
 
-	for (d = 0; d < ndvas; d++) {
+	for (int d = 0; d < ndvas; d++) {
 		error = metaslab_alloc_dva(spa, mc, psize, dva, d, hintdva,
 		    txg, flags, zal);
 		if (error != 0) {
@@ -3444,14 +3413,14 @@ void
 metaslab_free(spa_t *spa, const blkptr_t *bp, uint64_t txg, boolean_t now)
 {
 	const dva_t *dva = bp->blk_dva;
-	int d, ndvas = BP_GET_NDVAS(bp);
+	int ndvas = BP_GET_NDVAS(bp);
 
 	ASSERT(!BP_IS_HOLE(bp));
 	ASSERT(!now || bp->blk_birth >= spa_syncing_txg(spa));
 
 	spa_config_enter(spa, SCL_FREE, FTAG, RW_READER);
 
-	for (d = 0; d < ndvas; d++)
+	for (int d = 0; d < ndvas; d++)
 		metaslab_free_dva(spa, &dva[d], txg, now);
 
 	spa_config_exit(spa, SCL_FREE, FTAG);
@@ -3462,7 +3431,7 @@ metaslab_claim(spa_t *spa, const blkptr_t *bp, uint64_t txg)
 {
 	const dva_t *dva = bp->blk_dva;
 	int ndvas = BP_GET_NDVAS(bp);
-	int d, error = 0;
+	int error = 0;
 
 	ASSERT(!BP_IS_HOLE(bp));
 
@@ -3477,7 +3446,7 @@ metaslab_claim(spa_t *spa, const blkptr_t *bp, uint64_t txg)
 
 	spa_config_enter(spa, SCL_ALLOC, FTAG, RW_READER);
 
-	for (d = 0; d < ndvas; d++)
+	for (int d = 0; d < ndvas; d++)
 		if ((error = metaslab_claim_dva(spa, &dva[d], txg)) != 0)
 			break;
 
@@ -3540,13 +3509,11 @@ metaslab_fastwrite_unmark(spa_t *spa, const blkptr_t *bp)
 void
 metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 {
-	int i, j;
-
 	if ((zfs_flags & ZFS_DEBUG_ZIO_FREE) == 0)
 		return;
 
 	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
-	for (i = 0; i < BP_GET_NDVAS(bp); i++) {
+	for (int i = 0; i < BP_GET_NDVAS(bp); i++) {
 		uint64_t vdev = DVA_GET_VDEV(&bp->blk_dva[i]);
 		vdev_t *vd = vdev_lookup_top(spa, vdev);
 		uint64_t offset = DVA_GET_OFFSET(&bp->blk_dva[i]);
@@ -3558,7 +3525,7 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 
 		range_tree_verify(msp->ms_freeingtree, offset, size);
 		range_tree_verify(msp->ms_freedtree, offset, size);
-		for (j = 0; j < TXG_DEFER_SIZE; j++)
+		for (int j = 0; j < TXG_DEFER_SIZE; j++)
 			range_tree_verify(msp->ms_defertree[j], offset, size);
 	}
 	spa_config_exit(spa, SCL_VDEV, FTAG);

--- a/module/zfs/multilist.c
+++ b/module/zfs/multilist.c
@@ -121,11 +121,9 @@ multilist_create(size_t size, size_t offset,
 void
 multilist_destroy(multilist_t *ml)
 {
-	int i;
-
 	ASSERT(multilist_is_empty(ml));
 
-	for (i = 0; i < ml->ml_num_sublists; i++) {
+	for (int i = 0; i < ml->ml_num_sublists; i++) {
 		multilist_sublist_t *mls = &ml->ml_sublists[i];
 
 		ASSERT(list_is_empty(&mls->mls_list));
@@ -243,9 +241,7 @@ multilist_remove(multilist_t *ml, void *obj)
 int
 multilist_is_empty(multilist_t *ml)
 {
-	int i;
-
-	for (i = 0; i < ml->ml_num_sublists; i++) {
+	for (int i = 0; i < ml->ml_num_sublists; i++) {
 		multilist_sublist_t *mls = &ml->ml_sublists[i];
 		/* See comment in multilist_insert(). */
 		boolean_t need_lock = !MUTEX_HELD(&mls->mls_lock);

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -413,7 +413,6 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 	boolean_t locked = B_FALSE;
 	uint64_t split_guid;
 	char *pool_name;
-	int config_gen_flags = 0;
 
 	if (vd == NULL) {
 		vd = rvd;
@@ -463,6 +462,7 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 		fnvlist_add_uint64(config, ZPOOL_CONFIG_HOSTID, hostid);
 	fnvlist_add_string(config, ZPOOL_CONFIG_HOSTNAME, utsname()->nodename);
 
+	int config_gen_flags = 0;
 	if (vd != rvd) {
 		fnvlist_add_uint64(config, ZPOOL_CONFIG_TOP_GUID,
 		    vd->vdev_top->vdev_guid);

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -144,13 +144,11 @@ space_map_histogram_clear(space_map_t *sm)
 boolean_t
 space_map_histogram_verify(space_map_t *sm, range_tree_t *rt)
 {
-	int i;
-
 	/*
 	 * Verify that the in-core range tree does not have any
 	 * ranges smaller than our sm_shift size.
 	 */
-	for (i = 0; i < sm->sm_shift; i++) {
+	for (int i = 0; i < sm->sm_shift; i++) {
 		if (rt->rt_histogram[i] != 0)
 			return (B_FALSE);
 	}
@@ -161,7 +159,6 @@ void
 space_map_histogram_add(space_map_t *sm, range_tree_t *rt, dmu_tx_t *tx)
 {
 	int idx = 0;
-	int i;
 
 	ASSERT(MUTEX_HELD(rt->rt_lock));
 	ASSERT(dmu_tx_is_syncing(tx));
@@ -181,7 +178,7 @@ space_map_histogram_add(space_map_t *sm, range_tree_t *rt, dmu_tx_t *tx)
 	 * map only cares about allocatable blocks (minimum of sm_shift) we
 	 * can safely ignore all ranges in the range tree smaller than sm_shift.
 	 */
-	for (i = sm->sm_shift; i < RANGE_TREE_HISTOGRAM_SIZE; i++) {
+	for (int i = sm->sm_shift; i < RANGE_TREE_HISTOGRAM_SIZE; i++) {
 
 		/*
 		 * Since the largest histogram bucket in the space map is

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -785,9 +785,7 @@ txg_list_empty(txg_list_t *tl, uint64_t txg)
 boolean_t
 txg_all_lists_empty(txg_list_t *tl)
 {
-	int i;
-
-	for (i = 0; i < TXG_SIZE; i++) {
+	for (int i = 0; i < TXG_SIZE; i++) {
 		if (!txg_list_empty(tl, i)) {
 			return (B_FALSE);
 		}

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -97,9 +97,8 @@ vdev_default_asize(vdev_t *vd, uint64_t psize)
 {
 	uint64_t asize = P2ROUNDUP(psize, 1ULL << vd->vdev_top->vdev_ashift);
 	uint64_t csize;
-	int c;
 
-	for (c = 0; c < vd->vdev_children; c++) {
+	for (int c = 0; c < vd->vdev_children; c++) {
 		csize = vdev_psize_to_asize(vd->vdev_child[c], psize);
 		asize = MAX(asize, csize);
 	}
@@ -146,10 +145,9 @@ vdev_get_min_asize(vdev_t *vd)
 void
 vdev_set_min_asize(vdev_t *vd)
 {
-	int c;
 	vd->vdev_min_asize = vdev_get_min_asize(vd);
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_set_min_asize(vd->vdev_child[c]);
 }
 
@@ -172,12 +170,11 @@ vdev_t *
 vdev_lookup_by_guid(vdev_t *vd, uint64_t guid)
 {
 	vdev_t *mvd;
-	int c;
 
 	if (vd->vdev_guid == guid)
 		return (vd);
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		if ((mvd = vdev_lookup_by_guid(vd->vdev_child[c], guid)) !=
 		    NULL)
 			return (mvd);
@@ -189,12 +186,11 @@ static int
 vdev_count_leaves_impl(vdev_t *vd)
 {
 	int n = 0;
-	int c;
 
 	if (vd->vdev_ops->vdev_op_leaf)
 		return (1);
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		n += vdev_count_leaves_impl(vd->vdev_child[c]);
 
 	return (n);
@@ -289,17 +285,16 @@ vdev_compact_children(vdev_t *pvd)
 	vdev_t **newchild, *cvd;
 	int oldc = pvd->vdev_children;
 	int newc;
-	int c;
 
 	ASSERT(spa_config_held(pvd->vdev_spa, SCL_ALL, RW_WRITER) == SCL_ALL);
 
-	for (c = newc = 0; c < oldc; c++)
+	for (int c = newc = 0; c < oldc; c++)
 		if (pvd->vdev_child[c])
 			newc++;
 
 	newchild = kmem_zalloc(newc * sizeof (vdev_t *), KM_SLEEP);
 
-	for (c = newc = 0; c < oldc; c++) {
+	for (int c = newc = 0; c < oldc; c++) {
 		if ((cvd = pvd->vdev_child[c]) != NULL) {
 			newchild[newc] = cvd;
 			cvd->vdev_id = newc++;
@@ -318,7 +313,6 @@ vdev_t *
 vdev_alloc_common(spa_t *spa, uint_t id, uint64_t guid, vdev_ops_t *ops)
 {
 	vdev_t *vd;
-	int t;
 
 	vd = kmem_zalloc(sizeof (vdev_t), KM_SLEEP);
 
@@ -367,7 +361,7 @@ vdev_alloc_common(spa_t *spa, uint_t id, uint64_t guid, vdev_ops_t *ops)
 	mutex_init(&vd->vdev_probe_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&vd->vdev_queue_lock, NULL, MUTEX_DEFAULT, NULL);
 
-	for (t = 0; t < DTL_TYPES; t++) {
+	for (int t = 0; t < DTL_TYPES; t++) {
 		vd->vdev_dtl[t] = range_tree_create(NULL, NULL,
 		    &vd->vdev_dtl_lock);
 	}
@@ -651,7 +645,6 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 void
 vdev_free(vdev_t *vd)
 {
-	int c, t;
 	spa_t *spa = vd->vdev_spa;
 
 	/*
@@ -666,7 +659,7 @@ vdev_free(vdev_t *vd)
 	/*
 	 * Free all children.
 	 */
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_free(vd->vdev_child[c]);
 
 	ASSERT(vd->vdev_child == NULL);
@@ -720,7 +713,7 @@ vdev_free(vdev_t *vd)
 
 	mutex_enter(&vd->vdev_dtl_lock);
 	space_map_close(vd->vdev_dtl_sm);
-	for (t = 0; t < DTL_TYPES; t++) {
+	for (int t = 0; t < DTL_TYPES; t++) {
 		range_tree_vacate(vd->vdev_dtl[t], NULL, NULL);
 		range_tree_destroy(vd->vdev_dtl[t]);
 	}
@@ -812,14 +805,12 @@ vdev_top_transfer(vdev_t *svd, vdev_t *tvd)
 static void
 vdev_top_update(vdev_t *tvd, vdev_t *vd)
 {
-	int c;
-
 	if (vd == NULL)
 		return;
 
 	vd->vdev_top = tvd;
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_top_update(tvd, vd->vdev_child[c]);
 }
 
@@ -1081,7 +1072,6 @@ vdev_probe(vdev_t *vd, zio_t *zio)
 	spa_t *spa = vd->vdev_spa;
 	vdev_probe_stats_t *vps = NULL;
 	zio_t *pio;
-	int l;
 
 	ASSERT(vd->vdev_ops->vdev_op_leaf);
 
@@ -1151,7 +1141,7 @@ vdev_probe(vdev_t *vd, zio_t *zio)
 		return (NULL);
 	}
 
-	for (l = 1; l < VDEV_LABELS; l++) {
+	for (int l = 1; l < VDEV_LABELS; l++) {
 		zio_nowait(zio_read_phys(pio, vd,
 		    vdev_label_offset(vd->vdev_psize, l,
 		    offsetof(vdev_label_t, vl_pad2)), VDEV_PAD_SIZE,
@@ -1180,14 +1170,12 @@ vdev_open_child(void *arg)
 static boolean_t
 vdev_uses_zvols(vdev_t *vd)
 {
-	int c;
-
 #ifdef _KERNEL
 	if (zvol_is_zvol(vd->vdev_path))
 		return (B_TRUE);
 #endif
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		if (vdev_uses_zvols(vd->vdev_child[c]))
 			return (B_TRUE);
 
@@ -1199,7 +1187,6 @@ vdev_open_children(vdev_t *vd)
 {
 	taskq_t *tq;
 	int children = vd->vdev_children;
-	int c;
 
 	/*
 	 * in order to handle pools on top of zvols, do the opens
@@ -1208,7 +1195,7 @@ vdev_open_children(vdev_t *vd)
 	 */
 	if (vdev_uses_zvols(vd)) {
 retry_sync:
-		for (c = 0; c < children; c++)
+		for (int c = 0; c < children; c++)
 			vd->vdev_child[c]->vdev_open_error =
 			    vdev_open(vd->vdev_child[c]);
 	} else {
@@ -1217,7 +1204,7 @@ retry_sync:
 		if (tq == NULL)
 			goto retry_sync;
 
-		for (c = 0; c < children; c++)
+		for (int c = 0; c < children; c++)
 			VERIFY(taskq_dispatch(tq, vdev_open_child,
 			    vd->vdev_child[c], TQ_SLEEP) != TASKQID_INVALID);
 
@@ -1226,7 +1213,7 @@ retry_sync:
 
 	vd->vdev_nonrot = B_TRUE;
 
-	for (c = 0; c < children; c++)
+	for (int c = 0; c < children; c++)
 		vd->vdev_nonrot &= vd->vdev_child[c]->vdev_nonrot;
 }
 
@@ -1242,7 +1229,6 @@ vdev_open(vdev_t *vd)
 	uint64_t max_osize = 0;
 	uint64_t asize, max_asize, psize;
 	uint64_t ashift = 0;
-	int c;
 
 	ASSERT(vd->vdev_open_thread == curthread ||
 	    spa_config_held(spa, SCL_STATE_ALL, RW_WRITER) == SCL_STATE_ALL);
@@ -1321,7 +1307,7 @@ vdev_open(vdev_t *vd)
 	if (vd->vdev_ishole || vd->vdev_ops == &vdev_missing_ops)
 		return (0);
 
-	for (c = 0; c < vd->vdev_children; c++) {
+	for (int c = 0; c < vd->vdev_children; c++) {
 		if (vd->vdev_child[c]->vdev_state != VDEV_STATE_HEALTHY) {
 			vdev_set_state(vd, B_TRUE, VDEV_STATE_DEGRADED,
 			    VDEV_AUX_NONE);
@@ -1479,9 +1465,8 @@ vdev_validate(vdev_t *vd, boolean_t strict)
 	nvlist_t *label;
 	uint64_t guid = 0, top_guid;
 	uint64_t state;
-	int c;
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		if (vdev_validate(vd->vdev_child[c], strict) != 0)
 			return (SET_ERROR(EBADF));
 
@@ -1623,13 +1608,12 @@ void
 vdev_hold(vdev_t *vd)
 {
 	spa_t *spa = vd->vdev_spa;
-	int c;
 
 	ASSERT(spa_is_root(spa));
 	if (spa->spa_state == POOL_STATE_UNINITIALIZED)
 		return;
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_hold(vd->vdev_child[c]);
 
 	if (vd->vdev_ops->vdev_op_leaf)
@@ -1639,10 +1623,8 @@ vdev_hold(vdev_t *vd)
 void
 vdev_rele(vdev_t *vd)
 {
-	int c;
-
 	ASSERT(spa_is_root(vd->vdev_spa));
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_rele(vd->vdev_child[c]);
 
 	if (vd->vdev_ops->vdev_op_leaf)
@@ -1748,9 +1730,7 @@ vdev_dirty(vdev_t *vd, int flags, void *arg, uint64_t txg)
 void
 vdev_dirty_leaves(vdev_t *vd, int flags, uint64_t txg)
 {
-	int c;
-
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_dirty_leaves(vd->vdev_child[c], flags, txg);
 
 	if (vd->vdev_ops->vdev_op_leaf)
@@ -1935,11 +1915,11 @@ vdev_dtl_reassess(vdev_t *vd, uint64_t txg, uint64_t scrub_txg, int scrub_done)
 {
 	spa_t *spa = vd->vdev_spa;
 	avl_tree_t reftree;
-	int c, t, minref;
+	int minref;
 
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_READER) != 0);
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_dtl_reassess(vd->vdev_child[c], txg,
 		    scrub_txg, scrub_done);
 
@@ -2020,9 +2000,7 @@ vdev_dtl_reassess(vdev_t *vd, uint64_t txg, uint64_t scrub_txg, int scrub_done)
 	}
 
 	mutex_enter(&vd->vdev_dtl_lock);
-	for (t = 0; t < DTL_TYPES; t++) {
-		int c;
-
+	for (int t = 0; t < DTL_TYPES; t++) {
 		/* account for child's outage in parent's missing map */
 		int s = (t == DTL_MISSING) ? DTL_OUTAGE: t;
 		if (t == DTL_SCRUB)
@@ -2034,7 +2012,7 @@ vdev_dtl_reassess(vdev_t *vd, uint64_t txg, uint64_t scrub_txg, int scrub_done)
 		else
 			minref = vd->vdev_children;	/* any kind of mirror */
 		space_reftree_create(&reftree);
-		for (c = 0; c < vd->vdev_children; c++) {
+		for (int c = 0; c < vd->vdev_children; c++) {
 			vdev_t *cvd = vd->vdev_child[c];
 			mutex_enter(&cvd->vdev_dtl_lock);
 			space_reftree_add_map(&reftree, cvd->vdev_dtl[s], 1);
@@ -2052,7 +2030,6 @@ vdev_dtl_load(vdev_t *vd)
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa->spa_meta_objset;
 	int error = 0;
-	int c;
 
 	if (vd->vdev_ops->vdev_op_leaf && vd->vdev_dtl_object != 0) {
 		ASSERT(!vd->vdev_ishole);
@@ -2078,7 +2055,7 @@ vdev_dtl_load(vdev_t *vd)
 		return (error);
 	}
 
-	for (c = 0; c < vd->vdev_children; c++) {
+	for (int c = 0; c < vd->vdev_children; c++) {
 		error = vdev_dtl_load(vd->vdev_child[c]);
 		if (error != 0)
 			break;
@@ -2114,8 +2091,6 @@ vdev_create_link_zap(vdev_t *vd, dmu_tx_t *tx)
 void
 vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx)
 {
-	uint64_t i;
-
 	if (vd->vdev_ops != &vdev_hole_ops &&
 	    vd->vdev_ops != &vdev_missing_ops &&
 	    vd->vdev_ops != &vdev_root_ops &&
@@ -2127,7 +2102,7 @@ vdev_construct_zaps(vdev_t *vd, dmu_tx_t *tx)
 			vd->vdev_top_zap = vdev_create_link_zap(vd, tx);
 		}
 	}
-	for (i = 0; i < vd->vdev_children; i++) {
+	for (uint64_t i = 0; i < vd->vdev_children; i++) {
 		vdev_construct_zaps(vd->vdev_child[i], tx);
 	}
 }
@@ -2261,7 +2236,6 @@ vdev_resilver_needed(vdev_t *vd, uint64_t *minp, uint64_t *maxp)
 	boolean_t needed = B_FALSE;
 	uint64_t thismin = UINT64_MAX;
 	uint64_t thismax = 0;
-	int c;
 
 	if (vd->vdev_children == 0) {
 		mutex_enter(&vd->vdev_dtl_lock);
@@ -2274,7 +2248,7 @@ vdev_resilver_needed(vdev_t *vd, uint64_t *minp, uint64_t *maxp)
 		}
 		mutex_exit(&vd->vdev_dtl_lock);
 	} else {
-		for (c = 0; c < vd->vdev_children; c++) {
+		for (int c = 0; c < vd->vdev_children; c++) {
 			vdev_t *cvd = vd->vdev_child[c];
 			uint64_t cmin, cmax;
 
@@ -2296,12 +2270,10 @@ vdev_resilver_needed(vdev_t *vd, uint64_t *minp, uint64_t *maxp)
 void
 vdev_load(vdev_t *vd)
 {
-	int c;
-
 	/*
 	 * Recursively load all children.
 	 */
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_load(vd->vdev_child[c]);
 
 	/*
@@ -2368,7 +2340,6 @@ vdev_remove(vdev_t *vd, uint64_t txg)
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa->spa_meta_objset;
 	dmu_tx_t *tx;
-	int m, i;
 
 	tx = dmu_tx_create_assigned(spa_get_dsl(spa), txg);
 	ASSERT(vd == vd->vdev_top);
@@ -2380,7 +2351,7 @@ vdev_remove(vdev_t *vd, uint64_t txg)
 		metaslab_group_histogram_verify(mg);
 		metaslab_class_histogram_verify(mg->mg_class);
 
-		for (m = 0; m < vd->vdev_ms_count; m++) {
+		for (int m = 0; m < vd->vdev_ms_count; m++) {
 			metaslab_t *msp = vd->vdev_ms[m];
 
 			if (msp == NULL || msp->ms_sm == NULL)
@@ -2405,7 +2376,7 @@ vdev_remove(vdev_t *vd, uint64_t txg)
 
 		metaslab_group_histogram_verify(mg);
 		metaslab_class_histogram_verify(mg->mg_class);
-		for (i = 0; i < RANGE_TREE_HISTOGRAM_SIZE; i++)
+		for (int i = 0; i < RANGE_TREE_HISTOGRAM_SIZE; i++)
 			ASSERT0(mg->mg_histogram[i]);
 
 	}
@@ -2778,7 +2749,6 @@ void
 vdev_clear(spa_t *spa, vdev_t *vd)
 {
 	vdev_t *rvd = spa->spa_root_vdev;
-	int c;
 
 	ASSERT(spa_config_held(spa, SCL_STATE_ALL, RW_WRITER) == SCL_STATE_ALL);
 
@@ -2789,7 +2759,7 @@ vdev_clear(spa_t *spa, vdev_t *vd)
 	vd->vdev_stat.vs_write_errors = 0;
 	vd->vdev_stat.vs_checksum_errors = 0;
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_clear(spa, vd->vdev_child[c]);
 
 	/*
@@ -2949,7 +2919,7 @@ vdev_get_child_stat_ex(vdev_t *cvd, vdev_stat_ex_t *vsx, vdev_stat_ex_t *cvsx)
 static void
 vdev_get_stats_ex_impl(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 {
-	int c, t;
+	int t;
 	/*
 	 * If we're getting stats on the root vdev, aggregate the I/O counts
 	 * over all top-level vdevs (i.e. the direct children of the root).
@@ -2962,7 +2932,7 @@ vdev_get_stats_ex_impl(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 		if (vsx)
 			memset(vsx, 0, sizeof (*vsx));
 
-		for (c = 0; c < vd->vdev_children; c++) {
+		for (int c = 0; c < vd->vdev_children; c++) {
 			vdev_t *cvd = vd->vdev_child[c];
 			vdev_stat_t *cvs = &cvd->vdev_stat;
 			vdev_stat_ex_t *cvsx = &cvd->vdev_stat_ex;
@@ -3049,9 +3019,8 @@ void
 vdev_scan_stat_init(vdev_t *vd)
 {
 	vdev_stat_t *vs = &vd->vdev_stat;
-	int c;
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_scan_stat_init(vd->vdev_child[c]);
 
 	mutex_enter(&vd->vdev_stat_lock);
@@ -3418,10 +3387,9 @@ vdev_propagate_state(vdev_t *vd)
 	int degraded = 0, faulted = 0;
 	int corrupted = 0;
 	vdev_t *child;
-	int c;
 
 	if (vd->vdev_children > 0) {
-		for (c = 0; c < vd->vdev_children; c++) {
+		for (int c = 0; c < vd->vdev_children; c++) {
 			child = vd->vdev_child[c];
 
 			/*
@@ -3650,14 +3618,12 @@ vdev_is_bootable(vdev_t *vd)
 void
 vdev_load_log_state(vdev_t *nvd, vdev_t *ovd)
 {
-	int c;
-
 	ASSERT(nvd->vdev_top->vdev_islog);
 	ASSERT(spa_config_held(nvd->vdev_spa,
 	    SCL_STATE_ALL, RW_WRITER) == SCL_STATE_ALL);
 	ASSERT3U(nvd->vdev_guid, ==, ovd->vdev_guid);
 
-	for (c = 0; c < nvd->vdev_children; c++)
+	for (int c = 0; c < nvd->vdev_children; c++)
 		vdev_load_log_state(nvd->vdev_child[c], ovd->vdev_child[c]);
 
 	if (nvd->vdev_ops->vdev_op_leaf) {
@@ -3679,13 +3645,11 @@ vdev_load_log_state(vdev_t *nvd, vdev_t *ovd)
 boolean_t
 vdev_log_state_valid(vdev_t *vd)
 {
-	int c;
-
 	if (vd->vdev_ops->vdev_op_leaf && !vd->vdev_faulted &&
 	    !vd->vdev_removed)
 		return (B_TRUE);
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		if (vdev_log_state_valid(vd->vdev_child[c]))
 			return (B_TRUE);
 
@@ -3729,9 +3693,7 @@ vdev_split(vdev_t *vd)
 void
 vdev_deadman(vdev_t *vd)
 {
-	int c;
-
-	for (c = 0; c < vd->vdev_children; c++) {
+	for (int c = 0; c < vd->vdev_children; c++) {
 		vdev_t *cvd = vd->vdev_child[c];
 
 		vdev_deadman(cvd);

--- a/module/zfs/vdev_cache.c
+++ b/module/zfs/vdev_cache.c
@@ -215,7 +215,6 @@ vdev_cache_fill(zio_t *fio)
 	vdev_cache_t *vc = &vd->vdev_cache;
 	vdev_cache_entry_t *ve = fio->io_private;
 	zio_t *pio;
-	zio_link_t *zl;
 
 	ASSERT3U(fio->io_size, ==, VCBS);
 
@@ -235,7 +234,7 @@ vdev_cache_fill(zio_t *fio)
 	 * any reads that were queued up before the missed update are still
 	 * valid, so we can satisfy them from this line before we evict it.
 	 */
-	zl = NULL;
+	zio_link_t *zl = NULL;
 	while ((pio = zio_walk_parents(fio, &zl)) != NULL)
 		vdev_cache_hit(vc, ve, pio);
 

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -602,7 +602,6 @@ vdev_label_read_config(vdev_t *vd, uint64_t txg)
 	int error = 0;
 	int flags = ZIO_FLAG_CONFIG_WRITER | ZIO_FLAG_CANFAIL |
 	    ZIO_FLAG_SPECULATIVE;
-	int l;
 
 	ASSERT(spa_config_held(spa, SCL_STATE_ALL, RW_WRITER) == SCL_STATE_ALL);
 
@@ -613,7 +612,7 @@ vdev_label_read_config(vdev_t *vd, uint64_t txg)
 	vp = abd_to_buf(vp_abd);
 
 retry:
-	for (l = 0; l < VDEV_LABELS; l++) {
+	for (int l = 0; l < VDEV_LABELS; l++) {
 		nvlist_t *label = NULL;
 
 		zio = zio_root(spa, NULL, NULL, flags);
@@ -803,12 +802,10 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 	int error;
 	uint64_t spare_guid = 0, l2cache_guid = 0;
 	int flags = ZIO_FLAG_CONFIG_WRITER | ZIO_FLAG_CANFAIL;
-	int c, l;
-	vdev_t *pvd;
 
 	ASSERT(spa_config_held(spa, SCL_ALL, RW_WRITER) == SCL_ALL);
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		if ((error = vdev_label_init(vd->vdev_child[c],
 		    crtxg, reason)) != 0)
 			return (error);
@@ -844,7 +841,7 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 
 		vd->vdev_guid += guid_delta;
 
-		for (pvd = vd; pvd != NULL; pvd = pvd->vdev_parent)
+		for (vdev_t *pvd = vd; pvd != NULL; pvd = pvd->vdev_parent)
 			pvd->vdev_guid_sum += guid_delta;
 
 		/*
@@ -864,7 +861,7 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 
 		vd->vdev_guid += guid_delta;
 
-		for (pvd = vd; pvd != NULL; pvd = pvd->vdev_parent)
+		for (vdev_t *pvd = vd; pvd != NULL; pvd = pvd->vdev_parent)
 			pvd->vdev_guid_sum += guid_delta;
 
 		/*
@@ -966,7 +963,7 @@ vdev_label_init(vdev_t *vd, uint64_t crtxg, vdev_labeltype_t reason)
 retry:
 	zio = zio_root(spa, NULL, NULL, flags);
 
-	for (l = 0; l < VDEV_LABELS; l++) {
+	for (int l = 0; l < VDEV_LABELS; l++) {
 
 		vdev_label_write(zio, vd, l, vp_abd,
 		    offsetof(vdev_label_t, vl_vdev_phys),
@@ -1251,11 +1248,10 @@ vdev_uberblock_sync_list(vdev_t **svd, int svdcount, uberblock_t *ub, int flags)
 	spa_t *spa = svd[0]->vdev_spa;
 	zio_t *zio;
 	uint64_t good_writes = 0;
-	int v;
 
 	zio = zio_root(spa, NULL, &good_writes, flags);
 
-	for (v = 0; v < svdcount; v++)
+	for (int v = 0; v < svdcount; v++)
 		vdev_uberblock_sync(zio, ub, svd[v], flags);
 
 	(void) zio_wait(zio);
@@ -1267,7 +1263,7 @@ vdev_uberblock_sync_list(vdev_t **svd, int svdcount, uberblock_t *ub, int flags)
 	 */
 	zio = zio_root(spa, NULL, NULL, flags);
 
-	for (v = 0; v < svdcount; v++)
+	for (int v = 0; v < svdcount; v++)
 		zio_flush(zio, svd[v]);
 
 	(void) zio_wait(zio);
@@ -1321,9 +1317,8 @@ vdev_label_sync(zio_t *zio, vdev_t *vd, int l, uint64_t txg, int flags)
 	abd_t *vp_abd;
 	char *buf;
 	size_t buflen;
-	int c;
 
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_label_sync(zio, vd->vdev_child[c], l, txg, flags);
 
 	if (!vd->vdev_ops->vdev_op_leaf)
@@ -1373,12 +1368,11 @@ vdev_label_sync_list(spa_t *spa, int l, uint64_t txg, int flags)
 
 	for (vd = list_head(dl); vd != NULL; vd = list_next(dl, vd)) {
 		uint64_t *good_writes;
-		zio_t *vio;
 
 		ASSERT(!vd->vdev_ishole);
 
 		good_writes = kmem_zalloc(sizeof (uint64_t), KM_SLEEP);
-		vio = zio_null(zio, spa, NULL,
+		zio_t *vio = zio_null(zio, spa, NULL,
 		    (vd->vdev_islog || vd->vdev_aux != NULL) ?
 		    vdev_label_sync_ignore_done : vdev_label_sync_top_done,
 		    good_writes, flags);

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -282,7 +282,6 @@ vdev_mirror_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 {
 	int numerrors = 0;
 	int lasterror = 0;
-	int c;
 
 	if (vd->vdev_children == 0) {
 		vd->vdev_stat.vs_aux = VDEV_AUX_BAD_LABEL;
@@ -291,7 +290,7 @@ vdev_mirror_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 
 	vdev_open_children(vd);
 
-	for (c = 0; c < vd->vdev_children; c++) {
+	for (int c = 0; c < vd->vdev_children; c++) {
 		vdev_t *cvd = vd->vdev_child[c];
 
 		if (cvd->vdev_open_error) {
@@ -316,9 +315,7 @@ vdev_mirror_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 static void
 vdev_mirror_close(vdev_t *vd)
 {
-	int c;
-
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_close(vd->vdev_child[c]);
 }
 
@@ -538,9 +535,9 @@ vdev_mirror_io_start(zio_t *zio)
 static int
 vdev_mirror_worst_error(mirror_map_t *mm)
 {
-	int c, error[2] = { 0, 0 };
+	int error[2] = { 0, 0 };
 
-	for (c = 0; c < mm->mm_children; c++) {
+	for (int c = 0; c < mm->mm_children; c++) {
 		mirror_child_t *mc = &mm->mm_child[c];
 		int s = mc->mc_speculative;
 		error[s] = zio_worst_error(error[s], mc->mc_error);

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -400,9 +400,8 @@ void
 vdev_queue_fini(vdev_t *vd)
 {
 	vdev_queue_t *vq = &vd->vdev_queue;
-	zio_priority_t p;
 
-	for (p = 0; p < ZIO_PRIORITY_NUM_QUEUEABLE; p++)
+	for (zio_priority_t p = 0; p < ZIO_PRIORITY_NUM_QUEUEABLE; p++)
 		avl_destroy(vdev_queue_class_tree(vq, p));
 	avl_destroy(&vq->vq_active_tree);
 	avl_destroy(vdev_queue_type_tree(vq, ZIO_TYPE_READ));

--- a/module/zfs/vdev_root.c
+++ b/module/zfs/vdev_root.c
@@ -59,7 +59,6 @@ vdev_root_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 {
 	int lasterror = 0;
 	int numerrors = 0;
-	int c;
 
 	if (vd->vdev_children == 0) {
 		vd->vdev_stat.vs_aux = VDEV_AUX_BAD_LABEL;
@@ -68,7 +67,7 @@ vdev_root_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 
 	vdev_open_children(vd);
 
-	for (c = 0; c < vd->vdev_children; c++) {
+	for (int c = 0; c < vd->vdev_children; c++) {
 		vdev_t *cvd = vd->vdev_child[c];
 
 		if (cvd->vdev_open_error && !cvd->vdev_islog) {
@@ -92,9 +91,7 @@ vdev_root_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 static void
 vdev_root_close(vdev_t *vd)
 {
-	int c;
-
-	for (c = 0; c < vd->vdev_children; c++)
+	for (int c = 0; c < vd->vdev_children; c++)
 		vdev_close(vd->vdev_child[c]);
 }
 

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -513,7 +513,6 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	zap_leaf_t *l;
 	int bs = FZAP_BLOCK_SHIFT(zap);
 	int err;
-	dnode_t *dn;
 
 	ASSERT(RW_LOCK_HELD(&zap->zap_rwlock));
 
@@ -527,7 +526,7 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	if (blkid == 0)
 		return (SET_ERROR(ENOENT));
 
-	dn = dmu_buf_dnode_enter(zap->zap_dbuf);
+	dnode_t *dn = dmu_buf_dnode_enter(zap->zap_dbuf);
 	err = dmu_buf_hold_by_dnode(dn,
 	    blkid << bs, NULL, &db, DMU_READ_NO_PREFETCH);
 	dmu_buf_dnode_exit(zap->zap_dbuf);

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -541,11 +541,10 @@ zap_lockdir_impl(dmu_buf_t *db, void *tag, dmu_tx_t *tx,
 	    zap->zap_m.zap_num_entries == zap->zap_m.zap_num_chunks) {
 		uint64_t newsz = db->db_size + SPA_MINBLOCKSIZE;
 		if (newsz > MZAP_MAX_BLKSZ) {
-			int err;
 			dprintf("upgrading obj %llu: num_entries=%u\n",
 			    obj, zap->zap_m.zap_num_entries);
 			*zapp = zap;
-			err = mzap_upgrade(zapp, tag, tx, 0);
+			int err = mzap_upgrade(zapp, tag, tx, 0);
 			if (err != 0)
 				rw_exit(&zap->zap_rwlock);
 			return (err);

--- a/module/zfs/zfeature.c
+++ b/module/zfs/zfeature.c
@@ -304,10 +304,8 @@ void
 feature_sync(spa_t *spa, zfeature_info_t *feature, uint64_t refcount,
     dmu_tx_t *tx)
 {
-	uint64_t zapobj;
-
 	ASSERT(VALID_FEATURE_OR_NONE(feature->fi_feature));
-	zapobj = (feature->fi_flags & ZFEATURE_FLAG_READONLY_COMPAT) ?
+	uint64_t zapobj = (feature->fi_flags & ZFEATURE_FLAG_READONLY_COMPAT) ?
 	    spa->spa_feat_for_write_obj : spa->spa_feat_for_read_obj;
 	VERIFY0(zap_update(spa->spa_meta_objset, zapobj, feature->fi_guid,
 	    sizeof (uint64_t), 1, &refcount, tx));
@@ -343,7 +341,6 @@ feature_enable_sync(spa_t *spa, zfeature_info_t *feature, dmu_tx_t *tx)
 	    (feature->fi_flags & ZFEATURE_FLAG_ACTIVATE_ON_ENABLE) ? 1 : 0;
 	uint64_t zapobj = (feature->fi_flags & ZFEATURE_FLAG_READONLY_COMPAT) ?
 	    spa->spa_feat_for_write_obj : spa->spa_feat_for_read_obj;
-	int i;
 
 	ASSERT(0 != zapobj);
 	ASSERT(zfeature_is_valid_guid(feature->fi_guid));
@@ -355,7 +352,7 @@ feature_enable_sync(spa_t *spa, zfeature_info_t *feature, dmu_tx_t *tx)
 	if (zap_contains(spa->spa_meta_objset, zapobj, feature->fi_guid) == 0)
 		return;
 
-	for (i = 0; feature->fi_depends[i] != SPA_FEATURE_NONE; i++)
+	for (int i = 0; feature->fi_depends[i] != SPA_FEATURE_NONE; i++)
 		spa_feature_enable(spa, feature->fi_depends[i], tx);
 
 	VERIFY0(zap_update(spa->spa_meta_objset, spa->spa_feat_desc_obj,

--- a/module/zfs/zfs_fm.c
+++ b/module/zfs/zfs_fm.c
@@ -525,13 +525,12 @@ zei_shrink_ranges(zfs_ecksum_info_t *eip)
 		uint32_t end = r[idx].zr_end;
 
 		while (idx < max - 1) {
-			uint32_t nstart, nend, gap;
-
 			idx++;
-			nstart = r[idx].zr_start;
-			nend = r[idx].zr_end;
 
-			gap = nstart - end;
+			uint32_t nstart = r[idx].zr_start;
+			uint32_t nend = r[idx].zr_end;
+
+			uint32_t gap = nstart - end;
 			if (gap < new_allowed_gap) {
 				end = nend;
 				continue;

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1020,9 +1020,8 @@ static int
 zfs_secpolicy_bookmark(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 {
 	int error = 0;
-	nvpair_t *pair;
 
-	for (pair = nvlist_next_nvpair(innvl, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(innvl, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(innvl, pair)) {
 		char *name = nvpair_name(pair);
 		char *hashp = strchr(name, '#');
@@ -3390,7 +3389,7 @@ zfs_ioc_snapshot(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 	nvlist_t *snaps;
 	nvlist_t *props = NULL;
 	int error, poollen;
-	nvpair_t *pair, *pair2;
+	nvpair_t *pair;
 
 	(void) nvlist_lookup_nvlist(innvl, "props", &props);
 	if ((error = zfs_check_userprops(poolname, props)) != 0)
@@ -3424,7 +3423,7 @@ zfs_ioc_snapshot(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 			return (SET_ERROR(EXDEV));
 
 		/* This must be the only snap of this fs. */
-		for (pair2 = nvlist_next_nvpair(snaps, pair);
+		for (nvpair_t *pair2 = nvlist_next_nvpair(snaps, pair);
 		    pair2 != NULL; pair2 = nvlist_next_nvpair(snaps, pair2)) {
 			if (strncmp(name, nvpair_name(pair2), cp - name + 1)
 			    == 0) {
@@ -3582,9 +3581,7 @@ zfs_ioc_destroy_snaps(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 static int
 zfs_ioc_bookmark(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 {
-	nvpair_t *pair, *pair2;
-
-	for (pair = nvlist_next_nvpair(innvl, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(innvl, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(innvl, pair)) {
 		char *snap_name;
 
@@ -3596,7 +3593,7 @@ zfs_ioc_bookmark(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 
 
 		/* Verify that the keys (bookmarks) are unique */
-		for (pair2 = nvlist_next_nvpair(innvl, pair);
+		for (nvpair_t *pair2 = nvlist_next_nvpair(innvl, pair);
 		    pair2 != NULL; pair2 = nvlist_next_nvpair(innvl, pair2)) {
 			if (strcmp(nvpair_name(pair), nvpair_name(pair2)) == 0)
 				return (SET_ERROR(EINVAL));
@@ -3636,10 +3633,9 @@ zfs_ioc_destroy_bookmarks(const char *poolname, nvlist_t *innvl,
     nvlist_t *outnvl)
 {
 	int error, poollen;
-	nvpair_t *pair;
 
 	poollen = strlen(poolname);
-	for (pair = nvlist_next_nvpair(innvl, NULL);
+	for (nvpair_t *pair = nvlist_next_nvpair(innvl, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(innvl, pair)) {
 		const char *name = nvpair_name(pair);
 		const char *cp = strchr(name, '#');
@@ -5191,17 +5187,15 @@ zfs_ioc_userspace_many(zfs_cmd_t *zc)
 {
 	zfsvfs_t *zfsvfs;
 	int bufsize = zc->zc_nvlist_dst_size;
-	int error;
-	void *buf;
 
 	if (bufsize <= 0)
 		return (SET_ERROR(ENOMEM));
 
-	error = zfsvfs_hold(zc->zc_name, FTAG, &zfsvfs, B_FALSE);
+	int error = zfsvfs_hold(zc->zc_name, FTAG, &zfsvfs, B_FALSE);
 	if (error != 0)
 		return (error);
 
-	buf = vmem_alloc(bufsize, KM_SLEEP);
+	void *buf = vmem_alloc(bufsize, KM_SLEEP);
 
 	error = zfs_userspace_many(zfsvfs, zc->zc_objset_type, &zc->zc_cookie,
 	    buf, &zc->zc_nvlist_dst_size);

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -550,9 +550,8 @@ boolean_t
 zilog_is_dirty(zilog_t *zilog)
 {
 	dsl_pool_t *dp = zilog->zl_dmu_pool;
-	int t;
 
-	for (t = 0; t < TXG_SIZE; t++) {
+	for (int t = 0; t < TXG_SIZE; t++) {
 		if (txg_list_member(&dp->dp_dirty_zilogs, zilog, t))
 			return (B_TRUE);
 	}
@@ -1872,7 +1871,6 @@ zilog_t *
 zil_alloc(objset_t *os, zil_header_t *zh_phys)
 {
 	zilog_t *zilog;
-	int i;
 
 	zilog = kmem_zalloc(sizeof (zilog_t), KM_SLEEP);
 
@@ -1887,7 +1885,7 @@ zil_alloc(objset_t *os, zil_header_t *zh_phys)
 
 	mutex_init(&zilog->zl_lock, NULL, MUTEX_DEFAULT, NULL);
 
-	for (i = 0; i < TXG_SIZE; i++) {
+	for (int i = 0; i < TXG_SIZE; i++) {
 		mutex_init(&zilog->zl_itxg[i].itxg_lock, NULL,
 		    MUTEX_DEFAULT, NULL);
 	}

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -553,9 +553,8 @@ zio_checksum_error(zio_t *zio, zio_bad_cksum_t *info)
 void
 zio_checksum_templates_free(spa_t *spa)
 {
-	enum zio_checksum checksum;
-	for (checksum = 0; checksum < ZIO_CHECKSUM_FUNCTIONS;
-	    checksum++) {
+	for (enum zio_checksum checksum = 0;
+	    checksum < ZIO_CHECKSUM_FUNCTIONS; checksum++) {
 		if (spa->spa_cksum_tmpls[checksum] != NULL) {
 			zio_checksum_info_t *ci = &zio_checksum_table[checksum];
 

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -89,9 +89,7 @@ static int
 zio_compress_zeroed_cb(void *data, size_t len, void *private)
 {
 	uint64_t *end = (uint64_t *)((char *)data + len);
-	uint64_t *word;
-
-	for (word = data; word < end; word++)
+	for (uint64_t *word = (uint64_t *)data; word < end; word++)
 		if (*word != 0)
 			return (1);
 
@@ -103,7 +101,6 @@ zio_compress_data(enum zio_compress c, abd_t *src, void *dst, size_t s_len)
 {
 	size_t c_len, d_len;
 	zio_compress_info_t *ci = &zio_compress_table[c];
-	void *tmp;
 
 	ASSERT((uint_t)c < ZIO_COMPRESS_FUNCTIONS);
 	ASSERT((uint_t)c == ZIO_COMPRESS_EMPTY || ci->ci_compress != NULL);
@@ -122,7 +119,7 @@ zio_compress_data(enum zio_compress c, abd_t *src, void *dst, size_t s_len)
 	d_len = s_len - (s_len >> 3);
 
 	/* No compression algorithms can read from ABDs directly */
-	tmp = abd_borrow_buf_copy(src, s_len);
+	void *tmp = abd_borrow_buf_copy(src, s_len);
 	c_len = ci->ci_compress(tmp, dst, s_len, d_len, ci->ci_level);
 	abd_return_buf(src, tmp, s_len);
 

--- a/module/zfs/zrlock.c
+++ b/module/zfs/zrlock.c
@@ -157,11 +157,9 @@ zrl_exit(zrlock_t *zrl)
 int
 zrl_refcount(zrlock_t *zrl)
 {
-	int n;
-
 	ASSERT3S(zrl->zr_refcount, >, ZRL_DESTROYED);
 
-	n = (int)zrl->zr_refcount;
+	int n = (int)zrl->zr_refcount;
 	return (n <= 0 ? 0 : n);
 }
 


### PR DESCRIPTION
### Description
With PR 5756 the zfs module now supports c99 and the remaining past c89 workarounds can be undone.

### Motivation and Context
This change helps minimize the code differences with upstream OpenZFS, which in turn makes porting from upstream easier. The changes were all related to variables being scoped inline and predominately involved for loop variable declarations.

### How Has This Been Tested?
Tested with ztest and a subset of zfs test suite tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
