### PR TITLE
Cleanup systemd dependencies

### DIFF
--- a/etc/systemd/system/50-zfs.preset.in
+++ b/etc/systemd/system/50-zfs.preset.in
@@ -1,6 +1,7 @@
 # ZFS is enabled by default
 enable zfs-import-cache.service
 disable zfs-import-scan.service
+enable zfs-import.target
 enable zfs-mount.service
 enable zfs-share.service
 enable zfs-zed.service

--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -6,7 +6,6 @@ Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
 After=systemd-remount-fs.service
-Before=dracut-mount.service
 Before=zfs-import.target
 ConditionPathExists=@sysconfdir@/zfs/zpool.cache
 

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -5,7 +5,6 @@ DefaultDependencies=no
 Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target
-Before=dracut-mount.service
 Before=zfs-import.target
 ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
 

--- a/etc/systemd/system/zfs-import.target.in
+++ b/etc/systemd/system/zfs-import.target.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=ZFS pool import target
+Before=dracut-mount.service
 
 [Install]
-WantedBy=zfs-mount.service
 WantedBy=zfs.target

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -13,5 +13,4 @@ RemainAfterExit=yes
 ExecStart=@sbindir@/zfs mount -a
 
 [Install]
-WantedBy=zfs-share.service
 WantedBy=zfs.target

--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -3,7 +3,7 @@ Description=ZFS file system shares
 Documentation=man:zfs(8)
 After=nfs-server.service nfs-kernel-server.service
 After=smb.service
-After=zfs-mount.service
+Wants=zfs-mount.service
 PartOf=nfs-server.service nfs-kernel-server.service
 PartOf=smb.service
 

--- a/etc/systemd/system/zfs-zed.service.in
+++ b/etc/systemd/system/zfs-zed.service.in
@@ -1,8 +1,7 @@
 [Unit]
 Description=ZFS Event Daemon (zed)
 Documentation=man:zed(8)
-After=zfs-import-cache.service
-After=zfs-import-scan.service
+After=zfs-import.target
 
 [Service]
 ExecStart=@sbindir@/zed -F


### PR DESCRIPTION
Some redundancy is present in the systemd dependencies, as
noticed in PR#6764. Existing setups might rely on these quirks,
so these cleanups have been moved to the development branch.

<!--- Provide a general summary of your changes in the Title above -->



<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Enable zfs-import.target by default, move dracut-mount and zfs-zed dependencies from zfs-import-*.unit to zfs-import.target, cleanup zfs-share dependency by relying on systemd default dependencies. Relax zfs-mount dependency on zfs-import to help for pools mounted before systemd, e.g., by initrd.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
I don't use dracut, zed, use zfs-share or have zfs on root, so I cannot test most of this. This will require eyes, and especially other users to test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
