### PR TITLE
Fix zfs-tests.sh single test functionality

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -41,7 +41,7 @@ FILEDIR=${FILEDIR:-/var/tmp}
 DISKS=${DISKS:-""}
 SINGLETEST=()
 SINGLETESTUSER="root"
-TAGS="functional"
+TAGS=""
 ITERATIONS=1
 ZFS_DBGMSG="$STF_SUITE/callbacks/zfs_dbgmsg.ksh"
 ZFS_DMESG="$STF_SUITE/callbacks/zfs_dmesg.ksh"
@@ -272,7 +272,7 @@ OPTIONS:
 	-s SIZE     Use vdevs of SIZE (default: 4G)
 	-r RUNFILE  Run tests in RUNFILE (default: linux.run)
 	-t PATH     Run single test at PATH relative to test suite
-	-T TAGS     Comma separated list of tags
+	-T TAGS     Comma separated list of tags (default: 'functional')
 	-u USER     Run single test as USER (default: root)
 
 EXAMPLES:
@@ -355,6 +355,9 @@ FILES=${FILES:-"$FILEDIR/file-vdev0 $FILEDIR/file-vdev1 $FILEDIR/file-vdev2"}
 LOOPBACKS=${LOOPBACKS:-""}
 
 if [ ${#SINGLETEST[@]} -ne 0 ]; then
+	if [ -n "$TAGS" ]; then
+		fail "-t and -T are mutually exclusive."
+	fi
 	RUNFILE_DIR="/var/tmp"
 	RUNFILE="zfs-tests.$$.run"
 	SINGLEQUIET="False"
@@ -395,9 +398,15 @@ EOF
 tests = ['$SINGLETESTFILE']
 pre = $SETUPSCRIPT
 post = $CLEANUPSCRIPT
+tags = ['functional']
 EOF
 	done
 fi
+
+#
+# Use default tag if none was specified
+#
+TAGS=${TAGS:='functional'}
 
 #
 # Attempt to locate the runfile describing the test workload.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Add tag information to the custom, runtime-generated runfile when executing a single test from `zfs-tests.sh`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without any tag specified into the runtime-generated runfile the test-runner will not execute the test provided from the command line:

```
root@linux:~# chattr +a /var/tmp/
root@linux:~# sudo -u nobody -s /usr/share/zfs/zfs-tests.sh -d /var/tmp -v -t tests/functional/atime/atime_001_pos  

--- Configuration ---
Runfile:         /var/tmp/zfs-tests.30959.run
STF_TOOLS:       /usr/share/zfs/test-runner
STF_SUITE:       /usr/share/zfs/zfs-tests
STF_PATH:        /var/tmp/constrained_path.fRg5
FILEDIR:         /var/tmp
FILES:           /var/tmp/file-vdev0 /var/tmp/file-vdev1 /var/tmp/file-vdev2
LOOPBACKS:       /dev/loop0 /dev/loop1 /dev/loop2 
DISKS:           loop0 loop1 loop2 
NUM_DISKS:       3
FILESIZE:        4G
ITERATIONS:      1
TAGS:            functional
Keep pool(s):    rpool
Missing util(s): fio umask wait 

/usr/share/zfs/test-runner/bin/test-runner.py  -c /var/tmp/zfs-tests.30959.run -T functional -i /usr/share/zfs/zfs-tests -I 1

rm: cannot remove '/var/tmp/constrained_path.fRg5': Operation not permitted
root@linux:~# cat /var/tmp/zfs-tests.30959.run
[DEFAULT]
pre =
quiet = False
pre_user = root
user = root
timeout = 600
post_user = root
post =
outputdir = /var/tmp/test_results

[tests/functional/atime]
tests = ['atime_001_pos']
pre = setup
post = cleanup
root@linux:~# 
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested locally with patch applied.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
