### PR TITLE
Long hold the dataset during upgrade

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -28,6 +28,7 @@
  * Copyright (c) 2015, STRATO AG, Inc. All rights reserved.
  * Copyright (c) 2016 Actifio, Inc. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.
+ * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -78,6 +79,8 @@ int dmu_find_threads = 0;
  * if there are enough holes to fill.
  */
 int dmu_rescan_dnode_threshold = 1 << DN_MAX_INDBLKSHIFT;
+
+static char *upgrade_tag = "upgrade_tag";
 
 static void dmu_objset_find_dp_cb(void *arg);
 
@@ -704,13 +707,12 @@ dmu_objset_own(const char *name, dmu_objset_type_t type,
 		return (err);
 	}
 
-	dsl_pool_rele(dp, FTAG);
-
 	/* user accounting requires the dataset to be decrypted */
 	if (dmu_objset_userobjspace_upgradable(*osp) &&
 	    (ds->ds_dir->dd_crypto_obj == 0 || decrypt))
 		dmu_objset_userobjspace_upgrade(*osp);
 
+	dsl_pool_rele(dp, FTAG);
 	return (0);
 }
 
@@ -1311,6 +1313,7 @@ dmu_objset_upgrade_task_cb(void *data)
 	os->os_upgrade_exit = B_TRUE;
 	os->os_upgrade_id = 0;
 	mutex_exit(&os->os_upgrade_lock);
+	dsl_dataset_long_rele(dmu_objset_ds(os), upgrade_tag);
 }
 
 static void
@@ -1319,6 +1322,9 @@ dmu_objset_upgrade(objset_t *os, dmu_objset_upgrade_cb_t cb)
 	if (os->os_upgrade_id != 0)
 		return;
 
+	ASSERT(dsl_pool_config_held(dmu_objset_pool(os)));
+	dsl_dataset_long_hold(dmu_objset_ds(os), upgrade_tag);
+
 	mutex_enter(&os->os_upgrade_lock);
 	if (os->os_upgrade_id == 0 && os->os_upgrade_status == 0) {
 		os->os_upgrade_exit = B_FALSE;
@@ -1326,8 +1332,10 @@ dmu_objset_upgrade(objset_t *os, dmu_objset_upgrade_cb_t cb)
 		os->os_upgrade_id = taskq_dispatch(
 		    os->os_spa->spa_upgrade_taskq,
 		    dmu_objset_upgrade_task_cb, os, TQ_SLEEP);
-		if (os->os_upgrade_id == TASKQID_INVALID)
+		if (os->os_upgrade_id == TASKQID_INVALID) {
+			dsl_dataset_long_rele(dmu_objset_ds(os), upgrade_tag);
 			os->os_upgrade_status = ENOMEM;
+		}
 	}
 	mutex_exit(&os->os_upgrade_lock);
 }
@@ -1343,7 +1351,9 @@ dmu_objset_upgrade_stop(objset_t *os)
 		os->os_upgrade_id = 0;
 		mutex_exit(&os->os_upgrade_lock);
 
-		taskq_cancel_id(os->os_spa->spa_upgrade_taskq, id);
+		if ((taskq_cancel_id(os->os_spa->spa_upgrade_taskq, id)) == 0) {
+			dsl_dataset_long_rele(dmu_objset_ds(os), upgrade_tag);
+		}
 		txg_wait_synced(os->os_spa->spa_dsl_pool, 0);
 	} else {
 		mutex_exit(&os->os_upgrade_lock);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5275,9 +5275,6 @@ zfs_ioc_userobjspace_upgrade(zfs_cmd_t *zc)
 	if (error != 0)
 		return (error);
 
-	dsl_dataset_long_hold(dmu_objset_ds(os), FTAG);
-	dsl_pool_rele(dmu_objset_pool(os), FTAG);
-
 	if (dmu_objset_userobjspace_upgradable(os)) {
 		mutex_enter(&os->os_upgrade_lock);
 		if (os->os_upgrade_id == 0) {
@@ -5290,11 +5287,14 @@ zfs_ioc_userobjspace_upgrade(zfs_cmd_t *zc)
 			mutex_exit(&os->os_upgrade_lock);
 		}
 
+		dsl_pool_rele(dmu_objset_pool(os), FTAG);
+
 		taskq_wait_id(os->os_spa->spa_upgrade_taskq, os->os_upgrade_id);
 		error = os->os_upgrade_status;
+	} else {
+		dsl_pool_rele(dmu_objset_pool(os), FTAG);
 	}
 
-	dsl_dataset_long_rele(dmu_objset_ds(os), FTAG);
 	dsl_dataset_rele_flags(dmu_objset_ds(os), DS_HOLD_FLAG_DECRYPT, FTAG);
 
 	return (error);

--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -834,8 +834,13 @@ zfs_fuid_overobjquota(zfsvfs_t *zfsvfs, boolean_t isgroup, uint64_t fuid)
 	int err;
 
 	if (!dmu_objset_userobjspace_present(zfsvfs->z_os)) {
-		if (dmu_objset_userobjspace_upgradable(zfsvfs->z_os))
+		if (dmu_objset_userobjspace_upgradable(zfsvfs->z_os)) {
+			dsl_pool_config_enter(
+			    dmu_objset_pool(zfsvfs->z_os), FTAG);
 			dmu_objset_userobjspace_upgrade(zfsvfs->z_os);
+			dsl_pool_config_exit(
+			    dmu_objset_pool(zfsvfs->z_os), FTAG);
+		}
 		return (B_FALSE);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Added long hold of dataset during whole upgrade process. The receive and rollback will return an EBUSY error until the upgrade is not finished.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the receive or rollback is performed while filesystem is upgrading the object set may be evicted in `dsl_dataset_clone_swap_sync_impl`. This will lead to NULL pointer dereference when upgrade tries to access evicted object set. Solves #5295.
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested in following scenario:
- Created two pools without features enabled and one dataset for each pool (one for source and one for destination). 
- Created snapshots on source dataset every 15s and send them to the destination. I used the znapzend for testing purposes. It executes send and receive with following parameters:
`zfs send -I src/vol00 autosnap_2017-11-07-080400 src/vol00 autosnap_2017-11-07-080415 | zfs recv -F dst/vol00`
- Wrote about 10GB of small files to source  dataset to make sure that `z_upgrade` will run during execution of `zfs recv` and `zfs rollback`
- Upgraded destination zpool.
- Remounted the destination dataset (kicked z_upgrade to do its job).
- The `zfs recv` commands failed with a busy error.
- The `zfs rollback` command failed with a busy error.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
