### PR TITLE
Various ZED fixes

### DIFF
--- a/cmd/zed/agents/zfs_agents.c
+++ b/cmd/zed/agents/zfs_agents.c
@@ -350,19 +350,3 @@ zfs_agent_fini(void)
 
 	g_zfs_hdl = NULL;
 }
-
-/*
- * In ZED context, all the FMA agents run in the same thread
- * and do not require a unique libzfs instance. Modules should
- * use these stubs.
- */
-libzfs_handle_t *
-__libzfs_init(void)
-{
-	return (g_zfs_hdl);
-}
-
-void
-__libzfs_fini(libzfs_handle_t *hdl)
-{
-}

--- a/cmd/zed/agents/zfs_agents.h
+++ b/cmd/zed/agents/zfs_agents.h
@@ -39,13 +39,6 @@ extern int zfs_slm_init(void);
 extern void zfs_slm_fini(void);
 extern void zfs_slm_event(const char *, const char *, nvlist_t *);
 
-/*
- * In ZED context, all the FMA agents run in the same thread
- * and do not require a unique libzfs instance.
- */
-extern libzfs_handle_t *__libzfs_init(void);
-extern void __libzfs_fini(libzfs_handle_t *);
-
 #ifdef	__cplusplus
 }
 #endif

--- a/cmd/zed/agents/zfs_diagnosis.c
+++ b/cmd/zed/agents/zfs_diagnosis.c
@@ -919,27 +919,27 @@ _zfs_diagnosis_init(fmd_hdl_t *hdl)
 {
 	libzfs_handle_t *zhdl;
 
-	if ((zhdl = __libzfs_init()) == NULL)
+	if ((zhdl = libzfs_init()) == NULL)
 		return;
 
 	if ((zfs_case_pool = uu_list_pool_create("zfs_case_pool",
 	    sizeof (zfs_case_t), offsetof(zfs_case_t, zc_node),
 	    NULL, UU_LIST_POOL_DEBUG)) == NULL) {
-		__libzfs_fini(zhdl);
+		libzfs_fini(zhdl);
 		return;
 	}
 
 	if ((zfs_cases = uu_list_create(zfs_case_pool, NULL,
 	    UU_LIST_DEBUG)) == NULL) {
 		uu_list_pool_destroy(zfs_case_pool);
-		__libzfs_fini(zhdl);
+		libzfs_fini(zhdl);
 		return;
 	}
 
 	if (fmd_hdl_register(hdl, FMD_API_VERSION, &fmd_info) != 0) {
 		uu_list_destroy(zfs_cases);
 		uu_list_pool_destroy(zfs_case_pool);
-		__libzfs_fini(zhdl);
+		libzfs_fini(zhdl);
 		return;
 	}
 
@@ -975,5 +975,5 @@ _zfs_diagnosis_fini(fmd_hdl_t *hdl)
 	uu_list_pool_destroy(zfs_case_pool);
 
 	zhdl = fmd_hdl_getspecific(hdl);
-	__libzfs_fini(zhdl);
+	libzfs_fini(zhdl);
 }

--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -64,7 +64,6 @@
  * trigger the FMA fault that we skipped earlier.
  *
  * ZFS on Linux porting notes:
- *	In lieu of a thread pool, just spawn a thread on demmand.
  *	Linux udev provides a disk insert for both the disk and the partition
  *
  */
@@ -83,6 +82,7 @@
 #include <sys/sunddi.h>
 #include <sys/sysevent/eventdefs.h>
 #include <sys/sysevent/dev.h>
+#include <thread_pool.h>
 #include <pthread.h>
 #include <unistd.h>
 #include "zfs_agents.h"
@@ -97,12 +97,12 @@ typedef void (*zfs_process_func_t)(zpool_handle_t *, nvlist_t *, boolean_t);
 libzfs_handle_t *g_zfshdl;
 list_t g_pool_list;	/* list of unavailable pools at initialization */
 list_t g_device_list;	/* list of disks with asynchronous label request */
+tpool_t *g_tpool;
 boolean_t g_enumeration_done;
-pthread_t g_zfs_tid;
+pthread_t g_zfs_tid;	/* zfs_enum_pools() thread */
 
 typedef struct unavailpool {
 	zpool_handle_t	*uap_zhp;
-	pthread_t	uap_enable_tid;	/* dataset enable thread if activated */
 	list_node_t	uap_node;
 } unavailpool_t;
 
@@ -135,7 +135,6 @@ zfs_unavail_pool(zpool_handle_t *zhp, void *data)
 		unavailpool_t *uap;
 		uap = malloc(sizeof (unavailpool_t));
 		uap->uap_zhp = zhp;
-		uap->uap_enable_tid = 0;
 		list_insert_tail((list_t *)data, uap);
 	} else {
 		zpool_close(zhp);
@@ -512,19 +511,14 @@ zfs_iter_vdev(zpool_handle_t *zhp, nvlist_t *nvl, void *data)
 	(dp->dd_func)(zhp, nvl, dp->dd_islabeled);
 }
 
-static void *
+void
 zfs_enable_ds(void *arg)
 {
 	unavailpool_t *pool = (unavailpool_t *)arg;
 
-	assert(pool->uap_enable_tid = pthread_self());
-
 	(void) zpool_enable_datasets(pool->uap_zhp, NULL, 0);
 	zpool_close(pool->uap_zhp);
-	pool->uap_zhp = NULL;
-
-	/* Note: zfs_slm_fini() will cleanup this pool entry on exit */
-	return (NULL);
+	free(pool);
 }
 
 static int
@@ -559,15 +553,13 @@ zfs_iter_pool(zpool_handle_t *zhp, void *data)
 		for (pool = list_head(&g_pool_list); pool != NULL;
 		    pool = list_next(&g_pool_list, pool)) {
 
-			if (pool->uap_enable_tid != 0)
-				continue;	/* entry already processed */
 			if (strcmp(zpool_get_name(zhp),
 			    zpool_get_name(pool->uap_zhp)))
 				continue;
 			if (zfs_toplevel_state(zhp) >= VDEV_STATE_DEGRADED) {
-				/* send to a background thread; keep on list */
-				(void) pthread_create(&pool->uap_enable_tid,
-				    NULL, zfs_enable_ds, pool);
+				list_remove(&g_pool_list, pool);
+				(void) tpool_dispatch(g_tpool, zfs_enable_ds,
+				    pool);
 				break;
 			}
 		}
@@ -857,7 +849,7 @@ zfs_enum_pools(void *arg)
 int
 zfs_slm_init()
 {
-	if ((g_zfshdl = __libzfs_init()) == NULL)
+	if ((g_zfshdl = libzfs_init()) == NULL)
 		return (-1);
 
 	/*
@@ -869,7 +861,7 @@ zfs_slm_init()
 
 	if (pthread_create(&g_zfs_tid, NULL, zfs_enum_pools, NULL) != 0) {
 		list_destroy(&g_pool_list);
-		__libzfs_fini(g_zfshdl);
+		libzfs_fini(g_zfshdl);
 		return (-1);
 	}
 
@@ -887,19 +879,15 @@ zfs_slm_fini()
 
 	/* wait for zfs_enum_pools thread to complete */
 	(void) pthread_join(g_zfs_tid, NULL);
+	/* destroy the thread pool */
+	if (g_tpool != NULL) {
+		tpool_wait(g_tpool);
+		tpool_destroy(g_tpool);
+	}
 
 	while ((pool = (list_head(&g_pool_list))) != NULL) {
-		/*
-		 * each pool entry has two possibilities
-		 * 1. was made available (so wait for zfs_enable_ds thread)
-		 * 2. still unavailable (just close the pool)
-		 */
-		if (pool->uap_enable_tid)
-			(void) pthread_join(pool->uap_enable_tid, NULL);
-		else if (pool->uap_zhp != NULL)
-			zpool_close(pool->uap_zhp);
-
 		list_remove(&g_pool_list, pool);
+		zpool_close(pool->uap_zhp);
 		free(pool);
 	}
 	list_destroy(&g_pool_list);
@@ -910,7 +898,7 @@ zfs_slm_fini()
 	}
 	list_destroy(&g_device_list);
 
-	__libzfs_fini(g_zfshdl);
+	libzfs_fini(g_zfshdl);
 }
 
 void

--- a/cmd/zed/agents/zfs_retire.c
+++ b/cmd/zed/agents/zfs_retire.c
@@ -176,6 +176,8 @@ replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
 	nvlist_t **spares;
 	uint_t s, nspares;
 	char *dev_name;
+	zprop_source_t source;
+	int ashift;
 
 	config = zpool_get_config(zhp, NULL);
 	if (nvlist_lookup_nvlist(config, ZPOOL_CONFIG_VDEV_TREE,
@@ -188,6 +190,11 @@ replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
 	if (nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_SPARES,
 	    &spares, &nspares) != 0)
 		return;
+
+	/*
+	 * lookup "ashift" pool property, we may need it for the replacement
+	 */
+	ashift = zpool_get_prop_int(zhp, ZPOOL_PROP_ASHIFT, &source);
 
 	replacement = fmd_nvl_alloc(hdl, FMD_SLEEP);
 
@@ -206,6 +213,11 @@ replace_with_spare(fmd_hdl_t *hdl, zpool_handle_t *zhp, nvlist_t *vdev)
 		if (nvlist_lookup_string(spares[s], ZPOOL_CONFIG_PATH,
 		    &spare_name) != 0)
 			continue;
+
+		/* if set, add the "ashift" pool property to the spare nvlist */
+		if (source != ZPROP_SRC_DEFAULT)
+			(void) nvlist_add_uint64(spares[s],
+			    ZPOOL_CONFIG_ASHIFT, ashift);
 
 		(void) nvlist_add_nvlist_array(replacement,
 		    ZPOOL_CONFIG_CHILDREN, &spares[s], 1);
@@ -483,7 +495,7 @@ _zfs_retire_init(fmd_hdl_t *hdl)
 	zfs_retire_data_t *zdp;
 	libzfs_handle_t *zhdl;
 
-	if ((zhdl = __libzfs_init()) == NULL)
+	if ((zhdl = libzfs_init()) == NULL)
 		return;
 
 	if (fmd_hdl_register(hdl, FMD_API_VERSION, &fmd_info) != 0) {
@@ -504,7 +516,7 @@ _zfs_retire_fini(fmd_hdl_t *hdl)
 
 	if (zdp != NULL) {
 		zfs_retire_clear_data(hdl, zdp);
-		__libzfs_fini(zdp->zrd_hdl);
+		libzfs_fini(zdp->zrd_hdl);
 		fmd_hdl_free(hdl, zdp, sizeof (zfs_retire_data_t));
 	}
 }

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -464,7 +464,7 @@ tags = ['functional', 'exec']
 
 [tests/functional/fault]
 tests = ['auto_online_001_pos', 'auto_replace_001_pos', 'auto_spare_001_pos',
-    'auto_spare_002_pos.ksh']
+    'auto_spare_002_pos', 'auto_spare_ashift', 'auto_spare_multiple']
 tags = ['functional', 'fault']
 
 [tests/functional/features/async_destroy]

--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -353,16 +353,35 @@ function insert_disk #disk scsi_host
 
 #
 # Load scsi_debug module with specified parameters
+# $blksz can be either one of: < 512b | 512e | 4Kn >
 #
-function load_scsi_debug # dev_size_mb add_host num_tgts max_luns
+function load_scsi_debug # dev_size_mb add_host num_tgts max_luns blksz
 {
 	typeset devsize=$1
 	typeset hosts=$2
 	typeset tgts=$3
 	typeset luns=$4
+	typeset blksz=$5
 
 	[[ -z $devsize ]] || [[ -z $hosts ]] || [[ -z $tgts ]] || \
-	    [[ -z $luns ]] && log_fail "Arguments invalid or missing"
+	    [[ -z $luns ]] || [[ -z $blksz ]] && \
+	    log_fail "Arguments invalid or missing"
+
+	case "$5" in
+		'512b')
+			typeset sector=512
+			typeset blkexp=0
+		;;
+		'512e')
+			typeset sector=512
+			typeset blkexp=3
+		;;
+		'4Kn')
+			typeset sector=4096
+			typeset blkexp=0
+		;;
+		*) log_fail "Unsupported blksz value: $5" ;;
+	esac
 
 	if is_linux; then
 		modprobe -n scsi_debug
@@ -375,13 +394,24 @@ function load_scsi_debug # dev_size_mb add_host num_tgts max_luns
 			log_fail "scsi_debug module already installed"
 		else
 			log_must modprobe scsi_debug dev_size_mb=$devsize \
-			    add_host=$hosts num_tgts=$tgts max_luns=$luns
+			    add_host=$hosts num_tgts=$tgts max_luns=$luns \
+			    sector_size=$sector physblk_exp=$blkexp
 			block_device_wait
 			lsscsi | egrep scsi_debug > /dev/null
 			if (($? == 1)); then
 				log_fail "scsi_debug module install failed"
 			fi
 		fi
+	fi
+}
+
+#
+# Unload scsi_debug module, if needed.
+#
+function unload_scsi_debug
+{
+	if lsmod | grep scsi_debug >/dev/null; then
+		log_must modprobe -r scsi_debug
 	fi
 }
 

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3158,11 +3158,23 @@ function zed_stop
 	if [[ -f ${ZEDLET_DIR}/zed.pid ]]; then
 		zedpid=$(cat ${ZEDLET_DIR}/zed.pid)
 		kill $zedpid
-		wait $zedpid
+		while ps -p $zedpid > /dev/null; do
+			sleep 1
+		done
 		rm -f ${ZEDLET_DIR}/zed.pid
 	fi
-
 	return 0
+}
+
+#
+# Drain all zevents
+#
+function zed_events_drain
+{
+	while [ $(zpool events -H | wc -l) -ne 0 ]; do
+		sleep 1
+		zpool events -c >/dev/null
+	done
 }
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/cleanup.ksh
@@ -27,7 +27,7 @@ if is_linux; then
 	for SDDEVICE in $(get_debug_device); do
 		unplug $SDDEVICE
 	done
-	modprobe -r scsi_debug
+	unload_scsi_debug
 fi
 
 log_pass

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/setup.ksh
@@ -22,7 +22,7 @@ verify_runnable "global"
 
 # Create scsi_debug devices for the reopen tests
 if is_linux; then
-	load_scsi_debug $SDSIZE $SDHOSTS $SDTGTS $SDLUNS
+	load_scsi_debug $SDSIZE $SDHOSTS $SDTGTS $SDLUNS '512b'
 else
 	log_unsupported "scsi debug module unsupported"
 fi

--- a/tests/zfs-tests/tests/functional/fault/Makefile.am
+++ b/tests/zfs-tests/tests/functional/fault/Makefile.am
@@ -6,4 +6,6 @@ dist_pkgdata_SCRIPTS = \
 	auto_online_001_pos.ksh \
 	auto_replace_001_pos.ksh \
 	auto_spare_001_pos.ksh \
-	auto_spare_002_pos.ksh
+	auto_spare_002_pos.ksh \
+	auto_spare_ashift.ksh \
+	auto_spare_multiple.ksh

--- a/tests/zfs-tests/tests/functional/fault/auto_online_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_online_001_pos.ksh
@@ -54,9 +54,8 @@ fi
 
 function cleanup
 {
-	#online last disk before fail
-	insert_disk $offline_disk $host
-	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	destroy_pool $TESTPOOL
+	unload_scsi_debug
 }
 
 log_assert "Testing automated auto-online FMA test"
@@ -65,8 +64,8 @@ log_onexit cleanup
 
 # If using the default loop devices, need a scsi_debug device for auto-online
 if is_loop_device $DISK1; then
-	SD=$(lsscsi | nawk '/scsi_debug/ {print $6; exit}')
-	SDDEVICE=$(echo $SD | nawk -F / '{print $3}')
+	load_scsi_debug $SDSIZE $SDHOSTS $SDTGTS $SDLUNS '512b'
+	SDDEVICE=$(get_debug_device)
 	SDDEVICE_ID=$(get_persistent_disk_name $SDDEVICE)
 	autoonline_disks="$SDDEVICE"
 else

--- a/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_replace_001_pos.ksh
@@ -57,27 +57,23 @@ fi
 
 function setup
 {
-	lsmod | egrep scsi_debug > /dev/null
-	if (($? == 1)); then
-		load_scsi_debug $SDSIZE $SDHOSTS $SDTGTS $SDLUNS
-	fi
+	load_scsi_debug $SDSIZE $SDHOSTS $SDTGTS $SDLUNS '512b'
+	SD=$(get_debug_device)
+	SDDEVICE_ID=$(get_persistent_disk_name $SD)
 	# Register vdev_id alias rule for scsi_debug device to create a
 	# persistent path
-	SD=$(lsscsi | nawk '/scsi_debug/ {print $6; exit}' \
-	    | nawk -F / '{print $3}')
-	SDDEVICE_ID=$(get_persistent_disk_name $SD)
 	log_must eval "echo "alias scsidebug /dev/disk/by-id/$SDDEVICE_ID" \
 	    >> $VDEVID_CONF"
 	block_device_wait
-
-	SDDEVICE=$(udevadm info -q all -n $DEV_DSKDIR/$SD | egrep ID_VDEV \
-	    | nawk '{print $2; exit}' | nawk -F = '{print $2; exit}')
+	SDDEVICE=$(udevadm info -q all -n $DEV_DSKDIR/$SD \
+	    | awk -F'=' '/ID_VDEV=/{print $2; exit}')
 	[[ -z $SDDEVICE ]] && log_fail "vdev rule was not registered properly"
 }
 
 function cleanup
 {
-	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	destroy_pool $TESTPOOL
+	unload_scsi_debug
 }
 
 log_assert "Testing automated auto-replace FMA test"
@@ -112,7 +108,7 @@ log_must zpool export -F $TESTPOOL
 # Offline disk
 remove_disk $SD
 block_device_wait
-log_must modprobe -r scsi_debug
+unload_scsi_debug
 
 # Reimport pool with drive missing
 log_must zpool import $TESTPOOL

--- a/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_spare_001_pos.ksh
@@ -42,13 +42,16 @@ verify_runnable "both"
 function cleanup
 {
 	log_must zinject -c all
-	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	destroy_pool $TESTPOOL
 	rm -f $VDEV_FILES $SPARE_FILE
 }
 
 log_assert "Testing automated auto-spare FMA test"
 
 log_onexit cleanup
+
+# Clear events from previous runs
+zed_events_drain
 
 TESTFILE="/$TESTPOOL/$TESTFS/testfile"
 

--- a/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_spare_002_pos.ksh
@@ -42,13 +42,16 @@ verify_runnable "both"
 function cleanup
 {
 	log_must zinject -c all
-	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	destroy_pool $TESTPOOL
 	rm -f $VDEV_FILES $SPARE_FILE
 }
 
 log_assert "Testing automated auto-spare FMA test"
 
 log_onexit cleanup
+
+# Clear events from previous runs
+zed_events_drain
 
 TESTFILE="/$TESTPOOL/$TESTFS/testfile"
 
@@ -65,7 +68,13 @@ for type in "mirror" "raidz" "raidz2"; do
 	log_must dd if=/dev/urandom of=$TESTFILE bs=1M count=16
 
 	# 4. Inject CHECKSUM ERRORS on read with a zinject error handler
+	# NOTE: checksum events are ratelimited to max 5 per second, ZED needs
+	#       10 to kick in a spare
 	log_must zinject -d $FAULT_FILE -e corrupt -f 50 -T read $TESTPOOL
+	log_must cp $TESTFILE /dev/null
+	log_must sleep 1
+	log_must cp $TESTFILE /dev/null
+	log_must sleep 1
 	log_must cp $TESTFILE /dev/null
 
 	# 5. Verify the ZED kicks in a hot spare and expected pool/device status

--- a/tests/zfs-tests/tests/functional/fault/auto_spare_ashift.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_spare_ashift.ksh
@@ -1,0 +1,101 @@
+#!/bin/ksh -p
+
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Intel Corporation. All rights reserved.
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+. $STF_SUITE/tests/functional/fault/fault.cfg
+
+#
+# DESCRIPTION:
+# Testing Fault Management Agent ZED Logic - Automated Auto-Spare Test when
+# drive is faulted and a custom ashift value needs to be provided to replace it.
+#
+# STRATEGY:
+# 1. Create a pool from 512b devices and set "ashift" pool property accordingly
+# 2. Add one 512e spare device (4Kn would generate IO errors on replace)
+# 3. Inject IO errors with a zinject error handler
+# 4. Start a scrub
+# 5. Verify the ZED kicks in the hot spare and expected pool/device status
+# 6. Clear the fault
+# 7. Verify the hot spare is available and expected pool/device status
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zinject -c all
+	destroy_pool $TESTPOOL
+	unload_scsi_debug
+	rm -f $SAFE_DEVICE $FAIL_DEVICE
+}
+
+log_assert "ZED should replace a device using the configured ashift property"
+log_onexit cleanup
+
+# Clear events from previous runs
+zed_events_drain
+
+SAFE_DEVICE="$TEST_BASE_DIR/safe-dev"
+FAIL_DEVICE="$TEST_BASE_DIR/fail-dev"
+
+# 1. Create a pool from 512b devices and set "ashift" pool property accordingly
+for vdev in $SAFE_DEVICE $FAIL_DEVICE; do
+	truncate -s $SPA_MINDEVSIZE $vdev
+done
+log_must zpool create -f $TESTPOOL mirror $SAFE_DEVICE $FAIL_DEVICE
+# NOTE: file VDEVs should be added as 512b devices, verify this "just in case"
+for vdev in $SAFE_DEVICE $FAIL_DEVICE; do
+	verify_eq "9" "$(zdb -e -l $vdev | awk '/ashift: /{print $2}')" "ashift"
+done
+log_must zpool set ashift=9 $TESTPOOL
+
+# 2. Add one 512e spare device (4Kn would generate IO errors on replace)
+# NOTE: must be larger than the existing 512b devices, add 32m of fudge
+load_scsi_debug $(($SPA_MINDEVSIZE/1024/1024+32)) $SDHOSTS $SDTGTS $SDLUNS '512e'
+SPARE_DEVICE=$(get_debug_device)
+log_must_busy zpool add $TESTPOOL spare $SPARE_DEVICE
+
+# 3. Inject IO errors with a zinject error handler
+log_must zinject -d $FAIL_DEVICE -e io -T all -f 100 $TESTPOOL
+
+# 4. Start a scrub
+log_must zpool scrub $TESTPOOL
+
+# 5. Verify the ZED kicks in a hot spare and expected pool/device status
+log_note "Wait for ZED to auto-spare"
+log_must wait_vdev_state $TESTPOOL $FAIL_DEVICE "FAULTED" 60
+log_must wait_vdev_state $TESTPOOL $SPARE_DEVICE "ONLINE" 60
+log_must wait_hotspare_state $TESTPOOL $SPARE_DEVICE "INUSE"
+log_must check_state $TESTPOOL "" "DEGRADED"
+
+# 6. Clear the fault
+log_must zinject -c all
+log_must zpool clear $TESTPOOL $FAIL_DEVICE
+
+# 7. Verify the hot spare is available and expected pool/device status
+log_must wait_vdev_state $TESTPOOL $FAIL_DEVICE "ONLINE" 60
+log_must wait_hotspare_state $TESTPOOL $SPARE_DEVICE "AVAIL"
+log_must is_pool_resilvered $TESTPOOL
+log_must check_state $TESTPOOL "" "ONLINE"
+
+log_pass "ZED successfully replaces a device using the configured ashift property"

--- a/tests/zfs-tests/tests/functional/fault/auto_spare_multiple.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_spare_multiple.ksh
@@ -1,0 +1,152 @@
+#!/bin/ksh -p
+
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Intel Corporation. All rights reserved.
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/fault/fault.cfg
+
+#
+# DESCRIPTION:
+# Testing Fault Management Agent ZED Logic - Automated Auto-Spare Test when
+# multiple drives are faulted.
+#
+# STRATEGY:
+# 1. Create a pool with two hot spares
+# 2. Inject IO ERRORS with a zinject error handler on the first device
+# 3. Start a scrub
+# 4. Verify the ZED kicks in a hot spare and expected pool/device status
+# 5. Inject IO ERRORS on a second device
+# 6. Start a scrub
+# 7. Verify the ZED kicks in a second hot spare
+# 8. Clear the fault on both devices
+# 9. Verify the hot spares are available and expected pool/device status
+# 10. Rinse and repeat, this time faulting both devices at the same time
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zinject -c all
+	destroy_pool $TESTPOOL
+	rm -f $DATA_DEVS $SPARE_DEVS
+}
+
+log_assert "ZED should be able to handle multiple faulted devices"
+log_onexit cleanup
+
+# Clear events from previous runs
+zed_events_drain
+
+FAULT_DEV1="$TEST_BASE_DIR/fault-dev1"
+FAULT_DEV2="$TEST_BASE_DIR/fault-dev2"
+SAFE_DEV1="$TEST_BASE_DIR/safe-dev1"
+SAFE_DEV2="$TEST_BASE_DIR/safe-dev2"
+DATA_DEVS="$FAULT_DEV1 $FAULT_DEV2 $SAFE_DEV1 $SAFE_DEV2"
+SPARE_DEV1="$TEST_BASE_DIR/spare-dev1"
+SPARE_DEV2="$TEST_BASE_DIR/spare-dev2"
+SPARE_DEVS="$SPARE_DEV1 $SPARE_DEV2"
+
+for type in "mirror" "raidz" "raidz2" "raidz3"; do
+	# 1. Create a pool with two hot spares
+	truncate -s $SPA_MINDEVSIZE $DATA_DEVS $SPARE_DEVS
+	log_must zpool create -f $TESTPOOL $type $DATA_DEVS spare $SPARE_DEVS
+
+	# 2. Inject IO ERRORS with a zinject error handler on the first device
+	log_must zinject -d $FAULT_DEV1 -e io -T all -f 100 $TESTPOOL
+
+	# 3. Start a scrub
+	log_must zpool scrub $TESTPOOL
+
+	# 4. Verify the ZED kicks in a hot spare and expected pool/device status
+	log_note "Wait for ZED to auto-spare"
+	log_must wait_vdev_state $TESTPOOL $FAULT_DEV1 "FAULTED" 60
+	log_must wait_vdev_state $TESTPOOL $SPARE_DEV1 "ONLINE" 60
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV1 "INUSE"
+	log_must check_state $TESTPOOL "" "DEGRADED"
+
+	# 5. Inject IO ERRORS on a second device
+	log_must zinject -d $FAULT_DEV2 -e io -T all -f 100 $TESTPOOL
+
+	# 6. Start a scrub
+	while is_pool_scrubbing $TESTPOOL || is_pool_resilvering $TESTPOOL; do
+		sleep 1
+	done
+	log_must zpool scrub $TESTPOOL
+
+	# 7. Verify the ZED kicks in a second hot spare
+	log_note "Wait for ZED to auto-spare"
+	log_must wait_vdev_state $TESTPOOL $FAULT_DEV2 "FAULTED" 60
+	log_must wait_vdev_state $TESTPOOL $SPARE_DEV2 "ONLINE" 60
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV2 "INUSE"
+	log_must check_state $TESTPOOL "" "DEGRADED"
+
+	# 8. Clear the fault on both devices
+	log_must zinject -c all
+	log_must zpool clear $TESTPOOL $FAULT_DEV1
+	log_must zpool clear $TESTPOOL $FAULT_DEV2
+
+	# 9. Verify the hot spares are available and expected pool/device status
+	log_must wait_vdev_state $TESTPOOL $FAULT_DEV1 "ONLINE" 60
+	log_must wait_vdev_state $TESTPOOL $FAULT_DEV2 "ONLINE" 60
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV1 "AVAIL"
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV2 "AVAIL"
+	log_must check_state $TESTPOOL "" "ONLINE"
+
+	# Cleanup
+	cleanup
+done
+
+# Rinse and repeat, this time faulting both devices at the same time
+# NOTE: "raidz" is exluded since it cannot survive 2 faulted devices
+# NOTE: "mirror" is a 4-way mirror here and should survive this test
+for type in "mirror" "raidz2" "raidz3"; do
+	# 1. Create a pool with two hot spares
+	truncate -s $SPA_MINDEVSIZE $DATA_DEVS $SPARE_DEVS
+	log_must zpool create -f $TESTPOOL $type $DATA_DEVS spare $SPARE_DEVS
+
+	# 2. Inject IO ERRORS with a zinject error handler on two devices
+	log_must eval "zinject -d $FAULT_DEV1 -e io -T all -f 100 $TESTPOOL &"
+	log_must eval "zinject -d $FAULT_DEV2 -e io -T all -f 100 $TESTPOOL &"
+
+	# 3. Start a scrub
+	log_must zpool scrub $TESTPOOL
+
+	# 4. Verify the ZED kicks in two hot spares and expected pool/device status
+	log_note "Wait for ZED to auto-spare"
+	log_must wait_vdev_state $TESTPOOL $FAULT_DEV1 "FAULTED" 60
+	log_must wait_vdev_state $TESTPOOL $FAULT_DEV2 "FAULTED" 60
+	log_must wait_vdev_state $TESTPOOL $SPARE_DEV1 "ONLINE" 60
+	log_must wait_vdev_state $TESTPOOL $SPARE_DEV2 "ONLINE" 60
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV1 "INUSE"
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV2 "INUSE"
+	log_must check_state $TESTPOOL "" "DEGRADED"
+
+	# 5. Clear the fault on both devices
+	log_must zinject -c all
+	log_must zpool clear $TESTPOOL $FAULT_DEV1
+	log_must zpool clear $TESTPOOL $FAULT_DEV2
+
+	# Cleanup
+	cleanup
+done
+
+log_pass "ZED successfully handles multiple faulted devices"

--- a/tests/zfs-tests/tests/functional/fault/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/fault/cleanup.ksh
@@ -33,14 +33,4 @@ cleanup_devices $DISKS
 zed_stop
 zed_cleanup
 
-SDDEVICE=$(get_debug_device)
-
-# Offline disk and remove scsi_debug module
-if is_linux; then
-	if [ -n "$SDDEVICE" ]; then
-		remove_disk $SDDEVICE
-	fi
-	modprobe -r scsi_debug
-fi
-
 log_pass

--- a/tests/zfs-tests/tests/functional/fault/setup.ksh
+++ b/tests/zfs-tests/tests/functional/fault/setup.ksh
@@ -31,8 +31,4 @@ verify_runnable "global"
 zed_setup
 zed_start
 
-# Create a scsi_debug device to be used with auto-online (if using loop devices)
-# and auto-replace regardless of other devices
-load_scsi_debug $SDSIZE $SDHOSTS $SDTGTS $SDLUNS
-
 log_pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

 * Teach ZED to handle spares using configured ashift ("auto_spare_ashift.ksh")
 * Add new test case to verify ZED can handle multiple faults ("auto_spare_multiple.ksh")
 * Fix `zed_stop()` in "libtest.shlib"

TODO:

 * Use libtpool in ZED (originally used in the Illumos/FMA code)
 * Fix "auto_spare_002_pos.ksh" on the Ubuntu builders
 * Fix ZED crashing on startup (race condition in libzfs when used in multi-threaded context)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If the zpool "ashift" property is set then ZED should use its value when kicking in a hotspare; with this change 512e disks can be used as spares for VDEVs that were created with ashift=9, even if ZFS
natively detects them as 4K block devices.

https://github.com/zfsonlinux/zfs/issues/2562#issuecomment-343725217

Consider a ZFS mirror of "old" 512b devices (i'm using file vdevs just for testing):

```
root@linux:~# zpool status
  pool: testpool
 state: ONLINE
  scan: none requested
config:

	NAME            STATE     READ WRITE CKSUM
	testpool        ONLINE       0     0     0
	  mirror-0      ONLINE       0     0     0
	    /var/tmp/1  ONLINE       0     0     0
	    /var/tmp/2  ONLINE       0     0     0

errors: No known data errors
root@linux:~# zdb -C | grep ashift
            ashift: 9
```

When one of the "old" disks start failing we want to keep the storage redundant, so we add a "new" 512e spare disk to the pool (`scsi_debug` device):

```
root@linux:~# zpool status
  pool: testpool
 state: ONLINE
  scan: none requested
config:

	NAME            STATE     READ WRITE CKSUM
	testpool        ONLINE       0     0     0
	  mirror-0      ONLINE       0     0     0
	    /var/tmp/1  ONLINE       0     0     0
	    /var/tmp/2  ONLINE       0     0     0
	spares
	  sda           AVAIL   

errors: No known data errors
root@linux:~# 
```

Now one of the disk start failing: ZED detects this but is unable to kick in the hot spare. From `strace -f -e trace=ioctl zed -Ffv`:

```
Diagnosis Engine: error event 'ereport.fs.zfs.io'
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = -1 ENOMEM (Cannot allocate memory)
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
Diagnosis Engine: error event 'ereport.fs.zfs.io'
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = -1 ENOMEM (Cannot allocate memory)
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
Diagnosis Engine: error event 'ereport.fs.zfs.io'
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = -1 ENOMEM (Cannot allocate memory)
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
Diagnosis Engine: error event 'ereport.fs.zfs.io'
[pid  1915] ioctl(5, 0x5a81Process 2671 attached
Diagnosis Engine: timer fired (0x7fc35801cc90)
Diagnosis Engine: solving fault 'fault.fs.zfs.vdev.io'

zed_fault_event:
	uuid: b70bd35e-6f5b-4f7b-a452-3d54f87a6cf6
	class: fault.fs.zfs.vdev.io
	code: ZFS-8000-FD
	certainty: 100
	scheme: zfs
	pool: 3817828698539407965
	vdev: 9204350677508924462 

Retire Agent: zfs_retire_recv: 'list.suspect'
 <unfinished ...>
[pid  1917] ioctl(5, 0x5a04, 0x7fc3663bc720) = -1 EEXIST (File exists)
[pid  1917] ioctl(5, 0x5a05, 0x7fc3663bc6e0) = 0
[pid  1917] ioctl(5, 0x5a27, 0x7fc3663bc6e0) = 0
Retire Agent: matched vdev 9204350677508924462
[pid  1917] ioctl(5, 0x5a0d <unfinished ...>
[pid  1915] <... ioctl resumed> , 0x7fff48ee7e30) = 0
Diagnosis Engine: case solved (b70bd35e-6f5b-4f7b-a452-3d54f87a6cf6)
Diagnosis Engine: removing timer (0x7fc35801cc90)
[pid  2671] +++ exited with 0 +++
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
[pid  1917] <... ioctl resumed> , 0x7fc3663bc7c0) = 0
[pid  1915] ioctl(5, 0x5a81Retire Agent: zpool_vdev_fault: vdev 9204350677508924462 on 'testpool'
, 0x7fff48ee7e30) = 0
Retire Agent: zpool_vdev_replace '/var/tmp/1' with spare 'sda1'
[pid  1917] ioctl(5, 0x5a0e <unfinished ...>
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
[pid  1915] ioctl(5, 0x5a81 <unfinished ...>
[pid  1917] <... ioctl resumed> , 0x7fc3663bc750) = -1 EDOM (Numerical argument out of domain)
Diagnosis Engine: resource event 'resource.fs.zfs.statechange'
Retire Agent: zfs_retire_recv: 'resource.fs.zfs.statechange'
```

The pool remains without redundancy, because we attempted to replace the failing device with a disk providing a different sector size:

```
Retire Agent: zpool_vdev_replace '/var/tmp/1' with spare 'sda1'
[pid  1917] ioctl(5, 0x5a0e <unfinished ...>
[pid  1915] ioctl(5, 0x5a81, 0x7fff48ee7e30) = 0
[pid  1915] ioctl(5, 0x5a81 <unfinished ...>
[pid  1917] <... ioctl resumed> , 0x7fc3663bc750) = -1 EDOM (Numerical argument out of domain)
```

We need to provide a custom `ashift` value to replace the disk:

```
root@linux:~# zpool status
  pool: testpool
 state: DEGRADED
status: One or more devices are faulted in response to persistent errors.
	Sufficient replicas exist for the pool to continue functioning in a
	degraded state.
action: Replace the faulted device, or use 'zpool clear' to mark the device
	repaired.
  scan: scrub repaired 0B in 0h0m with 0 errors on Sun Nov 12 19:30:20 2017
config:

	NAME            STATE     READ WRITE CKSUM
	testpool        DEGRADED     0     0     0
	  mirror-0      DEGRADED     0     0     0
	    /var/tmp/1  FAULTED      5   257     0  too many errors
	    /var/tmp/2  ONLINE       0     0     0
	spares
	  sda           AVAIL   

errors: No known data errors
root@linux:~# zpool remove testpool sda
root@linux:~# zpool replace testpool /var/tmp/1 sda
cannot replace /var/tmp/1 with sda: new device has a different optimal sector size; use the option '-o ashift=N' to override the optimal size
root@linux:~# zpool replace testpool /var/tmp/1 sda -o ashift=9
root@linux:~# zpool status
  pool: testpool
 state: ONLINE
  scan: resilvered 84K in 0h0m with 0 errors on Sun Nov 12 19:34:21 2017
config:

	NAME            STATE     READ WRITE CKSUM
	testpool        ONLINE       0     0     0
	  mirror-0      ONLINE       0     0     0
	    sda         ONLINE       0     0     0
	    /var/tmp/2  ONLINE       0     0     0

errors: No known data errors
root@linux:~# 
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Test added to the ZTS. Full disclosure, the test panics my test builder:

```
/usr/share/zfs/test-runner/bin/test-runner.py  -c /usr/share/zfs/runfiles/issue-2562.run -T functional -i /usr/share/zfs/zfs-tests -I 1
Test: /usr/share/zfs/zfs-tests/tests/functional/fault/setup (run as root) [00:03] [PASS]
Test: /usr/share/zfs/zfs-tests/tests/functional/fault/auto_online_001_pos (run as root) [00:27] [PASS]
Test: /usr/share/zfs/zfs-tests/tests/functional/fault/auto_replace_001_pos (run as root) [00:25] [PASS]
Test: /usr/share/zfs/zfs-tests/tests/functional/fault/auto_spare_001_pos (run as root) [02:05] [PASS]
Test: /usr/share/zfs/zfs-tests/tests/functional/fault/auto_spare_002_pos (run as root) [01:12] [PASS]
[  319.563452] BUG: unable to handle kernel paging request at ffffffffa0905000
[  319.564723] IP: [<ffffffffa0000f34>] scsi_device_put+0x14/0x60 [scsi_mod]
[  319.566016] PGD 1816067 PUD 1817063 PMD cfead067 PTE 0
[  319.566137] Oops: 0000 [#1] SMP 
[  319.566137] Modules linked in: scsi_debug sd_mod crc_t10dif crct10dif_generic dm_mod loop nfsd auth_rpcgss oid_registry nfs_acl nfs lockd fscache sunrpc zfs(PO) zunicode(PO) crc32_pclmul aesni_intel zcommon(PO) aes_x86_64 lrw gf128mul glue_helper ablk_helper cryptd ppdev znvpair(PO) pcspkr zavl(PO) psmouse icp(PO) serio_raw spl(O) evdev parport_pc joydev parport i2c_piix4 processor pvpanic virtio_console i2c_core thermal_sys virtio_balloon button autofs4 ext4 crc16 mbcache jbd2 hid_generic usbhid hid sg sr_mod cdrom ata_generic virtio_scsi virtio_blk virtio_net crct10dif_pclmul crct10dif_common crc32c_intel floppy ata_piix ahci libahci xhci_hcd usbcore usb_common virtio_pci virtio_ring virtio libata scsi_mod [last unloaded: scsi_debug]
[  319.566137] CPU: 0 PID: 20555 Comm: systemd-udevd Tainted: P           O  3.16.0-4-amd64 #1 Debian 3.16.43-2+deb8u5
[  319.566137] Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
[  319.566137] task: ffff8800c6b923d0 ti: ffff8800d2088000 task.ti: ffff8800d2088000
[  319.566137] RIP: 0010:[<ffffffffa0000f34>]  [<ffffffffa0000f34>] scsi_device_put+0x14/0x60 [scsi_mod]
[  319.566137] RSP: 0018:ffff8800d208be68  EFLAGS: 00010292
[  319.566137] RAX: ffffffffa0905000 RBX: ffff8800c778a000 RCX: ffff880147542600
[  319.566137] RDX: 000000000000003e RSI: 0000000000000000 RDI: ffff8801515f1800
[  319.566137] RBP: ffff8801515f1800 R08: ffff8800c74e74e8 R09: ffff8800c74e7cf8
[  319.566137] R10: ffff8800c7581710 R11: 0000000000000000 R12: ffff8800c778a400
[  319.566137] R13: ffff8800dad61398 R14: 000000000002005d R15: 0000000000000000
[  319.566137] FS:  00007f95cd873880(0000) GS:ffff880158400000(0000) knlGS:0000000000000000
[  319.566137] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  319.566137] CR2: ffffffffa0905000 CR3: 00000000c77fb000 CR4: 00000000000006f0
[  319.566137] Stack:
[  319.566137]  ffff8800c778a000 ffff8801515f1800 ffffffffa08ef7cb ffff8800dad61380
[  319.566137]  0000000000000010 ffffffff811e021d ffff8800c7581700 0000000000000010
[  319.566137]  ffff8800d963d2f8 ffff880150835960 ffff8800db92ce58 ffff8800d963d2f8
[  319.566137] Call Trace:
[  319.566137]  [<ffffffffa08ef7cb>] ? scsi_disk_put+0x2b/0x40 [sd_mod]
[  319.566137]  [<ffffffff811e021d>] ? __blkdev_put+0x15d/0x1a0
[  319.566137]  [<ffffffff811e0c71>] ? blkdev_close+0x21/0x30
[  319.566137]  [<ffffffff811ac86a>] ? __fput+0xca/0x1d0
[  319.566137]  [<ffffffff8108679c>] ? task_work_run+0x8c/0xb0
[  319.566137]  [<ffffffff81013ef9>] ? do_notify_resume+0x69/0xa0
[  319.566137]  [<ffffffff8151a74a>] ? int_signal+0x12/0x17
[  319.566137] Code: 5b 5d 41 5c 41 5d 41 5e 41 5f c3 66 66 66 2e 0f 1f 84 00 00 00 00 00 e8 fb b9 51 e1 55 48 89 fd 53 48 8b 07 48 8b 80 c0 00 00 00 <48> 8b 18 48 85 db 74 0d 48 89 df e8 3c 79 0d e1 48 85 c0 75 17 
[  319.566137] RIP  [<ffffffffa0000f34>] scsi_device_put+0x14/0x60 [scsi_mod]
[  319.566137]  RSP <ffff8800d208be68>
[  319.566137] CR2: ffffffffa0905000
[  319.566137] ---[ end trace 8e14e9438119b8bd ]---
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
