### PR TITLE
Disable zvol_ENOSPC_001_pos on 32-bit systems

### DIFF
--- a/tests/zfs-tests/tests/functional/zvol/zvol_ENOSPC/zvol_ENOSPC_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_ENOSPC/zvol_ENOSPC_001_pos.ksh
@@ -47,6 +47,11 @@
 
 verify_runnable "global"
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/5848
+if is_32bit; then
+	log_unsupported "Test case runs slowly on 32 bit"
+fi
+
 function cleanup
 {
 	rm -rf $TESTDIR/*


### PR DESCRIPTION
### Description

Occasionally observed failure of zvol_ENOSPC_001_pos due to the
test case taking to long to complete.  Disable the test case until
it can be improved.

### Motivation and Context

Issue #5848,
Disable known harmless issues which can distract from real problems.

### How Has This Been Tested?

Buildbot

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
