### PR TITLE
Disable automatic dependencies in zfs-test package

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -180,11 +180,12 @@ Requires:       lsscsi
 Requires:       mdadm
 Requires:       bc
 Requires:       ksh
-Requires:	fio
-Requires:	acl
-Requires:	sudo
-Requires:	sysstat
-Requires:	rng-tools
+Requires:       fio
+Requires:       acl
+Requires:       sudo
+Requires:       sysstat
+Requires:       rng-tools
+AutoReqProv:    no
 
 %description test
 This package contains test infrastructure and support scripts for


### PR DESCRIPTION
### Description

All of the ZTS test scripts specify /bin/ksh as the interpreter.
Unfortunately, as of Fedora 27 only /usr/bin/ksh is provided by
the package manager.  Rather than change all the scripts to
accommodate the latest Fedora disable automatic dependencies
for the zfs-test package.  Functionally this will not cause
any problems since /bin is a symlink to /usr/bin.

### Motivation and Context

Fix Fedora 27 automated testing.

### How Has This Been Tested?

Locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
