### PR TITLE
Fix ARC pointer overrun

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3155,17 +3155,19 @@ arc_buf_destroy_impl(arc_buf_t *buf)
 		ASSERT(hdr->b_l1hdr.b_bufcnt > 0);
 		hdr->b_l1hdr.b_bufcnt -= 1;
 
-		if (ARC_BUF_ENCRYPTED(buf))
+		if (ARC_BUF_ENCRYPTED(buf)) {
 			hdr->b_crypt_hdr.b_ebufcnt -= 1;
 
-		/*
-		 * If we have no more encrypted buffers and we've already
-		 * gotten a copy of the decrypted data we can free b_rabd to
-		 * save some space.
-		 */
-		if (hdr->b_crypt_hdr.b_ebufcnt == 0 && HDR_HAS_RABD(hdr) &&
-		    hdr->b_l1hdr.b_pabd != NULL && !HDR_IO_IN_PROGRESS(hdr)) {
-			arc_hdr_free_abd(hdr, B_TRUE);
+			/*
+			 * If we have no more encrypted buffers and we've
+			 * already gotten a copy of the decrypted data we can
+			 * free b_rabd to save some space.
+			 */
+			if (hdr->b_crypt_hdr.b_ebufcnt == 0 &&
+			    HDR_HAS_RABD(hdr) && hdr->b_l1hdr.b_pabd != NULL &&
+			    !HDR_IO_IN_PROGRESS(hdr)) {
+				arc_hdr_free_abd(hdr, B_TRUE);
+			}
 		}
 	}
 


### PR DESCRIPTION
Only access the `b_crypt_hdr` field of an ARC header if the content
is encrypted.

Signed-off-by: DHE <git@dehacked.net>

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
ARC buffer header sizes vary depending on whether or not they are encrypted. We are accessing a crypto-only field on an unverified header.

### Motivation and Context
<pre>
=================================================================
==23684==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x614000000dfc at pc 0x7fbf9726c695 bp 0x7ffc9d238d10 sp 0x7ffc9d238d08
READ of size 4 at 0x614000000dfc thread T0
    #0 0x7fbf9726c694 in arc_buf_destroy_impl ../../module/zfs/arc.c:3166
    #1 0x7fbf9726d9e5 in arc_hdr_destroy ../../module/zfs/arc.c:3719
    #2 0x7fbf9727a490 in arc_buf_destroy ../../module/zfs/arc.c:3754
    #3 0x7fbf972c0eb5 in dbuf_new_size ../../module/zfs/dbuf.c:1538
    #4 0x7fbf97354d2d in dnode_set_blksz ../../module/zfs/dnode.c:1637
    #5 0x7fbf972e731b in dmu_object_set_blocksize ../../module/zfs/dmu.c:2020
    #6 0x7fbf9759cd55 in zap_lockdir_impl ../../module/zfs/zap_micro.c:552
    #7 0x7fbf9759e0e2 in zap_lockdir ../../module/zfs/zap_micro.c:589
    #8 0x7fbf975a017a in zap_add ../../module/zfs/zap_micro.c:1223
    #9 0x7fbf97472def in spa_create ../../module/zfs/spa.c:4184
...

0x614000000dfc is located 12 bytes to the right of 432-byte region [0x614000000c40,0x614000000df0)
allocated by thread T0 here:
...
    #3 0x7fbf97263ad6 in arc_hdr_alloc ../../module/zfs/arc.c:3310
</pre>

### How Has This Been Tested?
gcc 7.x's `-fsanitize=address`. Otherwise, Buildbots plz

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
