### PR TITLE
Update for cppcheck v1.80

### DIFF
--- a/.github/suppressions.txt
+++ b/.github/suppressions.txt
@@ -1,4 +1,3 @@
-nullPointer:./module/zfs/zfs_vnops.c:839
 preprocessorErrorDirective:./module/zfs/vdev_raidz_math_avx512f.c:243
 preprocessorErrorDirective:./module/zfs/vdev_raidz_math_sse2.c:266
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,10 +72,10 @@ lint: cppcheck paxcheck
 
 cppcheck:
 	@if type cppcheck > /dev/null 2>&1; then \
-		cppcheck --quiet --force --error-exitcode=2 \
+		cppcheck --quiet --force --error-exitcode=2 --inline-suppr \
 			--suppressions-list=.github/suppressions.txt \
-			-UHAVE_SSE2 -UHAVE_AVX512F \
-			${top_srcdir}; \
+			-UHAVE_SSE2 -UHAVE_AVX512F -UHAVE_UIO_ZEROCOPY \
+			-UHAVE_DNLC ${top_srcdir}; \
 	fi
 
 paxcheck:

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -493,19 +493,9 @@ int
 sa_enable_share(sa_share_t share, char *protocol)
 {
 	sa_share_impl_t impl_share = (sa_share_impl_t)share;
-	int rc, ret;
-	boolean_t found_protocol;
+	int rc, ret = SA_OK;
+	boolean_t found_protocol = B_FALSE;
 	sa_fstype_t *fstype;
-
-#ifdef DEBUG
-	fprintf(stderr, "sa_enable_share: share->sharepath=%s, protocol=%s\n",
-	    impl_share->sharepath, protocol);
-#endif
-
-	assert(impl_share->handle != NULL);
-
-	ret = SA_OK;
-	found_protocol = B_FALSE;
 
 	fstype = fstypes;
 	while (fstype != NULL) {
@@ -534,17 +524,9 @@ int
 sa_disable_share(sa_share_t share, char *protocol)
 {
 	sa_share_impl_t impl_share = (sa_share_impl_t)share;
-	int rc, ret;
-	boolean_t found_protocol;
+	int rc, ret = SA_OK;
+	boolean_t found_protocol = B_FALSE;
 	sa_fstype_t *fstype;
-
-#ifdef DEBUG
-	fprintf(stderr, "sa_disable_share: share->sharepath=%s, protocol=%s\n",
-	    impl_share->sharepath, protocol);
-#endif
-
-	ret = SA_OK;
-	found_protocol = B_FALSE;
 
 	fstype = fstypes;
 	while (fstype != NULL) {
@@ -696,11 +678,6 @@ sa_parse_legacy_options(sa_group_t group, char *options, char *proto)
 {
 	sa_fstype_t *fstype;
 
-#ifdef DEBUG
-	fprintf(stderr, "sa_parse_legacy_options: options=%s, proto=%s\n",
-	    options, proto);
-#endif
-
 	fstype = fstypes;
 	while (fstype != NULL) {
 		if (strcmp(fstype->name, proto) != 0) {
@@ -786,12 +763,6 @@ sa_zfs_process_share(sa_handle_t handle, sa_group_t group, sa_share_t share,
 {
 	sa_handle_impl_t impl_handle = (sa_handle_impl_t)handle;
 	sa_share_impl_t impl_share = (sa_share_impl_t)share;
-
-#ifdef DEBUG
-	fprintf(stderr, "sa_zfs_process_share: mountpoint=%s, proto=%s, "
-	    "shareopts=%s, sourcestr=%s, dataset=%s\n", mountpoint, proto,
-	    shareopts, sourcestr, dataset);
-#endif
 
 	return (process_share(impl_handle, impl_share, mountpoint, NULL,
 	    proto, shareopts, NULL, dataset, B_FALSE));

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -2306,8 +2306,10 @@ static void
 get_source(zfs_handle_t *zhp, zprop_source_t *srctype, char *source,
     char *statbuf, size_t statlen)
 {
-	if (statbuf == NULL || *srctype == ZPROP_SRC_TEMPORARY)
+	if (statbuf == NULL ||
+	    srctype == NULL || *srctype == ZPROP_SRC_TEMPORARY) {
 		return;
+	}
 
 	if (source == NULL) {
 		*srctype = ZPROP_SRC_NONE;

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -310,7 +310,7 @@ zpool_label_disk_wait(char *path, int timeout_ms)
 		dev = udev_device_new_from_subsystem_sysname(udev,
 		    "block", sysname);
 		if ((dev != NULL) && udev_device_is_ready(dev)) {
-			struct udev_list_entry *links, *link;
+			struct udev_list_entry *links, *link = NULL;
 
 			ret = 0;
 			links = udev_device_get_devlinks_list_entry(dev);

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -250,7 +250,7 @@ abd_alloc_pages(abd_t *abd, size_t size)
 	struct list_head pages;
 	struct sg_table table;
 	struct scatterlist *sg;
-	struct page *page, *tmp_page;
+	struct page *page, *tmp_page = NULL;
 	gfp_t gfp = __GFP_NOWARN | GFP_NOIO;
 	gfp_t gfp_comp = (gfp | __GFP_NORETRY | __GFP_COMP) & ~__GFP_RECLAIM;
 	int max_order = MIN(zfs_abd_scatter_max_order, MAX_ORDER - 1);
@@ -334,12 +334,12 @@ abd_alloc_pages(abd_t *abd, size_t size)
 static void
 abd_alloc_pages(abd_t *abd, size_t size)
 {
-	struct scatterlist *sg;
+	struct scatterlist *sg = NULL;
 	struct sg_table table;
 	struct page *page;
 	gfp_t gfp = __GFP_NOWARN | GFP_NOIO;
 	int nr_pages = abd_chunkcnt_for_bytes(size);
-	int i;
+	int i = 0;
 
 	while (sg_alloc_table(&table, nr_pages, gfp)) {
 		ABDSTAT_BUMP(abdstat_scatter_sg_table_retry);
@@ -370,11 +370,11 @@ abd_alloc_pages(abd_t *abd, size_t size)
 static void
 abd_free_pages(abd_t *abd)
 {
-	struct scatterlist *sg;
+	struct scatterlist *sg = NULL;
 	struct sg_table table;
 	struct page *page;
 	int nr_pages = ABD_SCATTER(abd).abd_nents;
-	int order, i;
+	int order, i = 0;
 
 	if (abd->abd_flags & ABD_FLAG_MULTI_ZONE)
 		ABDSTAT_BUMPDOWN(abdstat_scatter_page_multi_zone);
@@ -543,8 +543,8 @@ abd_verify(abd_t *abd)
 		ASSERT3P(abd->abd_u.abd_linear.abd_buf, !=, NULL);
 	} else {
 		size_t n;
-		int i;
-		struct scatterlist *sg;
+		int i = 0;
+		struct scatterlist *sg = NULL;
 
 		ASSERT3U(ABD_SCATTER(abd).abd_nents, >, 0);
 		ASSERT3U(ABD_SCATTER(abd).abd_offset, <,
@@ -747,8 +747,8 @@ abd_get_offset_impl(abd_t *sabd, size_t off, size_t size)
 		abd->abd_u.abd_linear.abd_buf =
 		    (char *)sabd->abd_u.abd_linear.abd_buf + off;
 	} else {
-		int i;
-		struct scatterlist *sg;
+		int i = 0;
+		struct scatterlist *sg = NULL;
 		size_t new_offset = sabd->abd_u.abd_scatter.abd_offset + off;
 
 		abd = abd_alloc_struct();

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -836,6 +836,7 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 			    aiov->iov_base != abuf->b_data)) {
 				ASSERT(xuio);
 				dmu_write(zfsvfs->z_os, zp->z_id, woff,
+				    /* cppcheck-suppress nullPointer */
 				    aiov->iov_len, aiov->iov_base, tx);
 				dmu_return_arcbuf(abuf);
 				xuio_stat_wbuf_copied();

--- a/module/zfs/zpl_xattr.c
+++ b/module/zfs/zpl_xattr.c
@@ -333,7 +333,7 @@ zpl_xattr_get_sa(struct inode *ip, const char *name, void *value, size_t size)
 	if (error)
 		return (error);
 
-	if (!size)
+	if (size == 0 || value == NULL)
 		return (nv_size);
 
 	if (size < nv_size)

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -202,7 +202,7 @@ static zvol_state_t *
 zvol_find_by_name_hash(const char *name, uint64_t hash, int mode)
 {
 	zvol_state_t *zv;
-	struct hlist_node *p;
+	struct hlist_node *p = NULL;
 
 	mutex_enter(&zvol_state_lock);
 	hlist_for_each(p, ZVOL_HT_HEAD(hash)) {


### PR DESCRIPTION
### Description

Resolve new warnings and errors from cppcheck v1.80.

* [lib/libshare/libshare.c:543]: (warning)
  Possible null pointer dereference: protocol
* [lib/libzfs/libzfs_dataset.c:2323]: (warning)
  Possible null pointer dereference: srctype
* [lib/libzfs/libzfs_import.c:318]: (error)
  Uninitialized variable: link
* [module/zfs/abd.c:353]: (error) Uninitialized variable: sg
* [module/zfs/abd.c:353]: (error) Uninitialized variable: i
* [module/zfs/abd.c:385]: (error) Uninitialized variable: sg
* [module/zfs/abd.c:385]: (error) Uninitialized variable: i
* [module/zfs/abd.c:553]: (error) Uninitialized variable: i
* [module/zfs/abd.c:553]: (error) Uninitialized variable: sg
* [module/zfs/abd.c:763]: (error) Uninitialized variable: i
* [module/zfs/abd.c:763]: (error) Uninitialized variable: sg
* [module/zfs/abd.c:305]: (error) Uninitialized variable: tmp_page
* [module/zfs/zpl_xattr.c:342]: (warning)
   Possible null pointer dereference: value
* [module/zfs/zvol.c:208]: (error) Uninitialized variable: p

Convert the following suppression to inline.

* [module/zfs/zfs_vnops.c:840]: (error)
  Possible null pointer dereference: aiov

Exclude HAVE_UIO_ZEROCOPY and HAVE_DNLC from analysis since
these macro's will never be defined until this functionality
is implemented.

### Motivation and Context

Preparation for upgrading buildbot to use cppcheck v1.80.

### How Has This Been Tested?

`make lint` locally with cppcheck v1.72 and v1.80.  No warnings or errors reported.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.