### PR TITLE
zpool(8): Fix "zpool import -t"

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1429,7 +1429,7 @@ about pool recovery mode, see the
 .Fl X
 option, above. WARNING: This option can be extremely hazardous to the
 health of your pool and should only be used as a last resort.
-.It Fl s
+.It Fl t
 Used with
 .Sy newpool .
 Specifies that


### PR DESCRIPTION
Signed-off-by: DHE <git@dehacked.net>

### Description
`zpool import -t` was accidentally relabeled as `zpool import -s` (duplicate for `-s`) during the mdoc conversion (cda0317e4d2a1277b328e4fc42ee3699bbe46c12)

### Motivation and Context
Bad documentation

### How Has This Been Tested?
Bisection to identify when it went bad

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux code style requirements.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
