### PR TITLE
Fix 4.14 CONFIG_GCC_PLUGIN_RANDSTRUCT build

### DIFF
--- a/module/icp/io/aes.c
+++ b/module/icp/io/aes.c
@@ -132,16 +132,16 @@ static int aes_decrypt_atomic(crypto_provider_handle_t, crypto_session_id_t,
     crypto_data_t *, crypto_spi_ctx_template_t, crypto_req_handle_t);
 
 static crypto_cipher_ops_t aes_cipher_ops = {
-	aes_encrypt_init,
-	aes_encrypt,
-	aes_encrypt_update,
-	aes_encrypt_final,
-	aes_encrypt_atomic,
-	aes_decrypt_init,
-	aes_decrypt,
-	aes_decrypt_update,
-	aes_decrypt_final,
-	aes_decrypt_atomic
+	.encrypt_init = aes_encrypt_init,
+	.encrypt = aes_encrypt,
+	.encrypt_update = aes_encrypt_update,
+	.encrypt_final = aes_encrypt_final,
+	.encrypt_atomic = aes_encrypt_atomic,
+	.decrypt_init = aes_decrypt_init,
+	.decrypt = aes_decrypt,
+	.decrypt_update = aes_decrypt_update,
+	.decrypt_final = aes_decrypt_final,
+	.decrypt_atomic = aes_decrypt_atomic
 };
 
 static int aes_mac_atomic(crypto_provider_handle_t, crypto_session_id_t,
@@ -152,12 +152,12 @@ static int aes_mac_verify_atomic(crypto_provider_handle_t, crypto_session_id_t,
     crypto_spi_ctx_template_t, crypto_req_handle_t);
 
 static crypto_mac_ops_t aes_mac_ops = {
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	aes_mac_atomic,
-	aes_mac_verify_atomic
+	.mac_init = NULL,
+	.mac = NULL,
+	.mac_update = NULL,
+	.mac_final = NULL,
+	.mac_atomic = aes_mac_atomic,
+	.mac_verify_atomic = aes_mac_verify_atomic
 };
 
 static int aes_create_ctx_template(crypto_provider_handle_t,
@@ -166,8 +166,8 @@ static int aes_create_ctx_template(crypto_provider_handle_t,
 static int aes_free_context(crypto_ctx_t *);
 
 static crypto_ctx_ops_t aes_ctx_ops = {
-	aes_create_ctx_template,
-	aes_free_context
+	.create_ctx_template = aes_create_ctx_template,
+	.free_context = aes_free_context
 };
 
 static crypto_ops_t aes_crypto_ops = {{{{{

--- a/module/icp/io/sha1_mod.c
+++ b/module/icp/io/sha1_mod.c
@@ -115,12 +115,12 @@ static int sha1_digest_atomic(crypto_provider_handle_t, crypto_session_id_t,
     crypto_req_handle_t);
 
 static crypto_digest_ops_t sha1_digest_ops = {
-	sha1_digest_init,
-	sha1_digest,
-	sha1_digest_update,
-	NULL,
-	sha1_digest_final,
-	sha1_digest_atomic
+	.digest_init = sha1_digest_init,
+	.digest = sha1_digest,
+	.digest_update = sha1_digest_update,
+	.digest_key = NULL,
+	.digest_final = sha1_digest_final,
+	.digest_atomic = sha1_digest_atomic
 };
 
 static int sha1_mac_init(crypto_ctx_t *, crypto_mechanism_t *, crypto_key_t *,
@@ -136,12 +136,12 @@ static int sha1_mac_verify_atomic(crypto_provider_handle_t, crypto_session_id_t,
     crypto_spi_ctx_template_t, crypto_req_handle_t);
 
 static crypto_mac_ops_t sha1_mac_ops = {
-	sha1_mac_init,
-	NULL,
-	sha1_mac_update,
-	sha1_mac_final,
-	sha1_mac_atomic,
-	sha1_mac_verify_atomic
+	.mac_init = sha1_mac_init,
+	.mac = NULL,
+	.mac_update = sha1_mac_update,
+	.mac_final = sha1_mac_final,
+	.mac_atomic = sha1_mac_atomic,
+	.mac_verify_atomic = sha1_mac_verify_atomic
 };
 
 static int sha1_create_ctx_template(crypto_provider_handle_t,
@@ -150,8 +150,8 @@ static int sha1_create_ctx_template(crypto_provider_handle_t,
 static int sha1_free_context(crypto_ctx_t *);
 
 static crypto_ctx_ops_t sha1_ctx_ops = {
-	sha1_create_ctx_template,
-	sha1_free_context
+	.create_ctx_template = sha1_create_ctx_template,
+	.free_context = sha1_free_context
 };
 
 static crypto_ops_t sha1_crypto_ops = {{{{{

--- a/module/icp/io/sha2_mod.c
+++ b/module/icp/io/sha2_mod.c
@@ -143,12 +143,12 @@ static int sha2_digest_atomic(crypto_provider_handle_t, crypto_session_id_t,
     crypto_req_handle_t);
 
 static crypto_digest_ops_t sha2_digest_ops = {
-	sha2_digest_init,
-	sha2_digest,
-	sha2_digest_update,
-	NULL,
-	sha2_digest_final,
-	sha2_digest_atomic
+	.digest_init = sha2_digest_init,
+	.digest = sha2_digest,
+	.digest_update = sha2_digest_update,
+	.digest_key = NULL,
+	.digest_final = sha2_digest_final,
+	.digest_atomic = sha2_digest_atomic
 };
 
 static int sha2_mac_init(crypto_ctx_t *, crypto_mechanism_t *, crypto_key_t *,
@@ -164,12 +164,12 @@ static int sha2_mac_verify_atomic(crypto_provider_handle_t, crypto_session_id_t,
     crypto_spi_ctx_template_t, crypto_req_handle_t);
 
 static crypto_mac_ops_t sha2_mac_ops = {
-	sha2_mac_init,
-	NULL,
-	sha2_mac_update,
-	sha2_mac_final,
-	sha2_mac_atomic,
-	sha2_mac_verify_atomic
+	.mac_init = sha2_mac_init,
+	.mac = NULL,
+	.mac_update = sha2_mac_update,
+	.mac_final = sha2_mac_final,
+	.mac_atomic = sha2_mac_atomic,
+	.mac_verify_atomic = sha2_mac_verify_atomic
 };
 
 static int sha2_create_ctx_template(crypto_provider_handle_t,
@@ -178,8 +178,8 @@ static int sha2_create_ctx_template(crypto_provider_handle_t,
 static int sha2_free_context(crypto_ctx_t *);
 
 static crypto_ctx_ops_t sha2_ctx_ops = {
-	sha2_create_ctx_template,
-	sha2_free_context
+	.create_ctx_template = sha2_create_ctx_template,
+	.free_context = sha2_free_context
 };
 
 static crypto_ops_t sha2_crypto_ops = {{{{{

--- a/module/icp/io/skein_mod.c
+++ b/module/icp/io/skein_mod.c
@@ -88,12 +88,12 @@ static int skein_digest_atomic(crypto_provider_handle_t, crypto_session_id_t,
     crypto_req_handle_t);
 
 static crypto_digest_ops_t skein_digest_ops = {
-	skein_digest_init,
-	skein_digest,
-	skein_update,
-	NULL,
-	skein_final,
-	skein_digest_atomic
+	.digest_init = skein_digest_init,
+	.digest = skein_digest,
+	.digest_update = skein_update,
+	.digest_key = NULL,
+	.digest_final = skein_final,
+	.digest_atomic = skein_digest_atomic
 };
 
 static int skein_mac_init(crypto_ctx_t *, crypto_mechanism_t *, crypto_key_t *,
@@ -103,12 +103,12 @@ static int skein_mac_atomic(crypto_provider_handle_t, crypto_session_id_t,
     crypto_spi_ctx_template_t, crypto_req_handle_t);
 
 static crypto_mac_ops_t skein_mac_ops = {
-	skein_mac_init,
-	NULL,
-	skein_update,	/* using regular digest update is OK here */
-	skein_final,	/* using regular digest final is OK here */
-	skein_mac_atomic,
-	NULL
+	.mac_init = skein_mac_init,
+	.mac = NULL,
+	.mac_update = skein_update, /* using regular digest update is OK here */
+	.mac_final = skein_final,   /* using regular digest final is OK here */
+	.mac_atomic = skein_mac_atomic,
+	.mac_verify_atomic = NULL
 };
 
 static int skein_create_ctx_template(crypto_provider_handle_t,
@@ -117,8 +117,8 @@ static int skein_create_ctx_template(crypto_provider_handle_t,
 static int skein_free_context(crypto_ctx_t *);
 
 static crypto_ctx_ops_t skein_ctx_ops = {
-	skein_create_ctx_template,
-	skein_free_context
+	.create_ctx_template = skein_create_ctx_template,
+	.free_context = skein_free_context
 };
 
 static crypto_ops_t skein_crypto_ops = {{{{{

--- a/module/icp/os/modconf.c
+++ b/module/icp/os/modconf.c
@@ -36,7 +36,9 @@ static int mod_infonull(void *, struct modlinkage *, int *);
  * Cryptographic Modules
  */
 struct mod_ops mod_cryptoops = {
-	mod_null, mod_null, mod_infonull
+	.modm_install = mod_null,
+	.modm_remove = mod_null,
+	.modm_info = mod_infonull
 };
 
 /*

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -2807,11 +2807,11 @@ nvs_native_nvpair(nvstream_t *nvs, nvpair_t *nvp, size_t *size)
 }
 
 static const nvs_ops_t nvs_native_ops = {
-	nvs_native_nvlist,
-	nvs_native_nvpair,
-	nvs_native_nvp_op,
-	nvs_native_nvp_size,
-	nvs_native_nvl_fini
+	.nvs_nvlist = nvs_native_nvlist,
+	.nvs_nvpair = nvs_native_nvpair,
+	.nvs_nvp_op = nvs_native_nvp_op,
+	.nvs_nvp_size = nvs_native_nvp_size,
+	.nvs_nvl_fini = nvs_native_nvl_fini
 };
 
 static int
@@ -3294,11 +3294,11 @@ nvs_xdr_nvpair(nvstream_t *nvs, nvpair_t *nvp, size_t *size)
 }
 
 static const struct nvs_ops nvs_xdr_ops = {
-	nvs_xdr_nvlist,
-	nvs_xdr_nvpair,
-	nvs_xdr_nvp_op,
-	nvs_xdr_nvp_size,
-	nvs_xdr_nvl_fini
+	.nvs_nvlist = nvs_xdr_nvlist,
+	.nvs_nvpair = nvs_xdr_nvpair,
+	.nvs_nvp_op = nvs_xdr_nvp_op,
+	.nvs_nvp_size = nvs_xdr_nvp_size,
+	.nvs_nvl_fini = nvs_xdr_nvl_fini
 };
 
 static int

--- a/module/nvpair/nvpair_alloc_fixed.c
+++ b/module/nvpair/nvpair_alloc_fixed.c
@@ -110,11 +110,11 @@ nv_fixed_reset(nv_alloc_t *nva)
 }
 
 const nv_alloc_ops_t nv_fixed_ops_def = {
-	nv_fixed_init,	/* nv_ao_init() */
-	NULL,		/* nv_ao_fini() */
-	nv_fixed_alloc,	/* nv_ao_alloc() */
-	nv_fixed_free,	/* nv_ao_free() */
-	nv_fixed_reset	/* nv_ao_reset() */
+	.nv_ao_init = nv_fixed_init,
+	.nv_ao_fini = NULL,
+	.nv_ao_alloc = nv_fixed_alloc,
+	.nv_ao_free = nv_fixed_free,
+	.nv_ao_reset = nv_fixed_reset
 };
 
 const nv_alloc_ops_t *nv_fixed_ops = &nv_fixed_ops_def;

--- a/module/nvpair/nvpair_alloc_spl.c
+++ b/module/nvpair/nvpair_alloc_spl.c
@@ -53,27 +53,27 @@ nv_free_spl(nv_alloc_t *nva, void *buf, size_t size)
 }
 
 const nv_alloc_ops_t spl_sleep_ops_def = {
-	NULL,			/* nv_ao_init() */
-	NULL,			/* nv_ao_fini() */
-	nv_alloc_sleep_spl,	/* nv_ao_alloc() */
-	nv_free_spl,		/* nv_ao_free() */
-	NULL			/* nv_ao_reset() */
+	.nv_ao_init = NULL,
+	.nv_ao_fini = NULL,
+	.nv_ao_alloc = nv_alloc_sleep_spl,
+	.nv_ao_free = nv_free_spl,
+	.nv_ao_reset = NULL
 };
 
 const nv_alloc_ops_t spl_pushpage_ops_def = {
-	NULL,			/* nv_ao_init() */
-	NULL,			/* nv_ao_fini() */
-	nv_alloc_pushpage_spl,	/* nv_ao_alloc() */
-	nv_free_spl,		/* nv_ao_free() */
-	NULL			/* nv_ao_reset() */
+	.nv_ao_init = NULL,
+	.nv_ao_fini = NULL,
+	.nv_ao_alloc = nv_alloc_pushpage_spl,
+	.nv_ao_free = nv_free_spl,
+	.nv_ao_reset = NULL
 };
 
 const nv_alloc_ops_t spl_nosleep_ops_def = {
-	NULL,			/* nv_ao_init() */
-	NULL,			/* nv_ao_fini() */
-	nv_alloc_nosleep_spl,	/* nv_ao_alloc() */
-	nv_free_spl,		/* nv_ao_free() */
-	NULL			/* nv_ao_reset() */
+	.nv_ao_init = NULL,
+	.nv_ao_fini = NULL,
+	.nv_ao_alloc = nv_alloc_nosleep_spl,
+	.nv_ao_free = nv_free_spl,
+	.nv_ao_reset = NULL
 };
 
 nv_alloc_t nv_alloc_sleep_def = {

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -794,11 +794,11 @@ i_fm_free(nv_alloc_t *nva, void *buf, size_t size)
 }
 
 const nv_alloc_ops_t fm_mem_alloc_ops = {
-	NULL,
-	NULL,
-	i_fm_alloc,
-	i_fm_free,
-	NULL
+	.nv_ao_init = NULL,
+	.nv_ao_fini = NULL,
+	.nv_ao_alloc = i_fm_alloc,
+	.nv_ao_free = i_fm_free,
+	.nv_ao_reset = NULL
 };
 
 /*

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -168,8 +168,8 @@ vdev_mirror_map_free(zio_t *zio)
 }
 
 static const zio_vsd_ops_t vdev_mirror_vsd_ops = {
-	vdev_mirror_map_free,
-	zio_vsd_default_cksum_report
+	.vsd_free = vdev_mirror_map_free,
+	.vsd_cksum_report = zio_vsd_default_cksum_report
 };
 
 static int

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -318,8 +318,8 @@ vdev_raidz_cksum_report(zio_t *zio, zio_cksum_report_t *zcr, void *arg)
 }
 
 static const zio_vsd_ops_t vdev_raidz_vsd_ops = {
-	vdev_raidz_map_free_vsd,
-	vdev_raidz_cksum_report
+	.vsd_free = vdev_raidz_map_free_vsd,
+	.vsd_cksum_report = vdev_raidz_cksum_report
 };
 
 /*

--- a/module/zfs/zfs_acl.c
+++ b/module/zfs/zfs_acl.c
@@ -174,18 +174,18 @@ zfs_ace_v0_data(void *acep, void **datap)
 }
 
 static acl_ops_t zfs_acl_v0_ops = {
-	zfs_ace_v0_get_mask,
-	zfs_ace_v0_set_mask,
-	zfs_ace_v0_get_flags,
-	zfs_ace_v0_set_flags,
-	zfs_ace_v0_get_type,
-	zfs_ace_v0_set_type,
-	zfs_ace_v0_get_who,
-	zfs_ace_v0_set_who,
-	zfs_ace_v0_size,
-	zfs_ace_v0_abstract_size,
-	zfs_ace_v0_mask_off,
-	zfs_ace_v0_data
+	.ace_mask_get = zfs_ace_v0_get_mask,
+	.ace_mask_set = zfs_ace_v0_set_mask,
+	.ace_flags_get = zfs_ace_v0_get_flags,
+	.ace_flags_set = zfs_ace_v0_set_flags,
+	.ace_type_get = zfs_ace_v0_get_type,
+	.ace_type_set = zfs_ace_v0_set_type,
+	.ace_who_get = zfs_ace_v0_get_who,
+	.ace_who_set = zfs_ace_v0_set_who,
+	.ace_size = zfs_ace_v0_size,
+	.ace_abstract_size = zfs_ace_v0_abstract_size,
+	.ace_mask_off = zfs_ace_v0_mask_off,
+	.ace_data = zfs_ace_v0_data
 };
 
 static uint16_t
@@ -310,18 +310,18 @@ zfs_ace_fuid_data(void *acep, void **datap)
 }
 
 static acl_ops_t zfs_acl_fuid_ops = {
-	zfs_ace_fuid_get_mask,
-	zfs_ace_fuid_set_mask,
-	zfs_ace_fuid_get_flags,
-	zfs_ace_fuid_set_flags,
-	zfs_ace_fuid_get_type,
-	zfs_ace_fuid_set_type,
-	zfs_ace_fuid_get_who,
-	zfs_ace_fuid_set_who,
-	zfs_ace_fuid_size,
-	zfs_ace_fuid_abstract_size,
-	zfs_ace_fuid_mask_off,
-	zfs_ace_fuid_data
+	.ace_mask_get = zfs_ace_fuid_get_mask,
+	.ace_mask_set = zfs_ace_fuid_set_mask,
+	.ace_flags_get = zfs_ace_fuid_get_flags,
+	.ace_flags_set = zfs_ace_fuid_set_flags,
+	.ace_type_get = zfs_ace_fuid_get_type,
+	.ace_type_set = zfs_ace_fuid_set_type,
+	.ace_who_get = zfs_ace_fuid_get_who,
+	.ace_who_set = zfs_ace_fuid_set_who,
+	.ace_size = zfs_ace_fuid_size,
+	.ace_abstract_size = zfs_ace_fuid_abstract_size,
+	.ace_mask_off = zfs_ace_fuid_mask_off,
+	.ace_data = zfs_ace_fuid_data
 };
 
 /*


### PR DESCRIPTION
Fix build errors with gcc 7.2.0 on Gentoo with kernel 4.14
built with CONFIG_GCC_PLUGIN_RANDSTRUCT=y such as:

module/nvpair/nvpair.c:2810:2:error:
positional initialization of field in ?struct? declared with
'designated_init' attribute [-Werror=designated-init]
  nvs_native_nvlist,
  ^~~~~~~~~~~~~~~~~

Signed-off-by: Mark Wright <gienah@gentoo.org>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

Specify the struct member that is being initialized.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixes build errors with gcc 7.2.0 on Gentoo with kernel 4.14.2 built with
CONFIG_GCC_PLUGIN_RANDSTRUCT=y such as:
```
/var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/module/nvpair/nvpair.c:2810:2:error: positional initialization of field in ‘struct’ declared with ‘designated_init’ attribute [-Werror=designated-init]
  nvs_native_nvlist,
  ^~~~~~~~~~~~~~~~~
/var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/module/nvpair/nvpair.c:2810:2: note: (near initialization for ‘nvs_native_ops’)
/var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/module/nvpair/nvpair.c:2810:2:error: invalid initializer
/var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/module/nvpair/nvpair.c:2810:2: note: (near initialization for ‘nvs_native_ops.<anonymous>’)
/var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/module/nvpair/nvpair.c:2811:2:error: positional initialization of field in ‘struct’ declared with ‘designated_init’ attribute [-Werror=designated-init]
  nvs_native_nvpair,
  ^~~~~~~~~~~~~~~~~
```

<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

I built sys-fs/zfs-kmod-9999 patched with these changes, then booted
my Gentoo machine running on zfs with the changes using
sys-kernel/gentoo-sources-4.14.2 built with 
CONFIG_GCC_PLUGIN_RANDSTRUCT=y

<!--- Include details of your testing environment, and the tests you ran to -->
```
argus ~ # uname -a
Linux argus 4.14.2-gentoo #1 SMP Mon Nov 27 10:17:35 AEDT 2017 x86_64 Intel(R) Core(TM) i7 CPU X 940 @ 2.13GHz GenuineIntel GNU/Linux
argus ~ # grep CONFIG_GCC_PLUGIN_RANDSTRUCT /usr/src/linux-4.14.2-gentoo/.config
CONFIG_GCC_PLUGIN_RANDSTRUCT=y
CONFIG_GCC_PLUGIN_RANDSTRUCT_PERFORMANCE=y
argus ~ # 
```

<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
