### PR TITLE
Add dbuf hash and dbuf cache kstats

### DIFF
--- a/cmd/dbufstat/dbufstat.py
+++ b/cmd/dbufstat/dbufstat.py
@@ -31,10 +31,11 @@
 import sys
 import getopt
 import errno
+import re
 
 bhdr = ["pool", "objset", "object", "level", "blkid", "offset", "dbsize"]
 bxhdr = ["pool", "objset", "object", "level", "blkid", "offset", "dbsize",
-         "meta", "state", "dbholds", "list", "atype", "flags",
+         "meta", "state", "dbholds", "dbc", "list", "atype", "flags",
          "count", "asize", "access", "mru", "gmru", "mfu", "gmfu", "l2",
          "l2_dattr", "l2_asize", "l2_comp", "aholds", "dtype", "btype",
          "data_bs", "meta_bs", "bsize", "lvls", "dholds", "blocks", "dsize"]
@@ -45,7 +46,7 @@ dxhdr = ["pool", "objset", "object", "dtype", "btype", "data_bs", "meta_bs",
          "bsize", "lvls", "dholds", "blocks", "dsize", "cached", "direct",
          "indirect", "bonus", "spill"]
 dincompat = ["level", "blkid", "offset", "dbsize", "meta", "state", "dbholds",
-             "list", "atype", "flags", "count", "asize", "access",
+             "dbc", "list", "atype", "flags", "count", "asize", "access",
              "mru", "gmru", "mfu", "gmfu", "l2", "l2_dattr", "l2_asize",
              "l2_comp", "aholds"]
 
@@ -53,7 +54,7 @@ thdr = ["pool", "objset", "dtype", "cached"]
 txhdr = ["pool", "objset", "dtype", "cached", "direct", "indirect",
          "bonus", "spill"]
 tincompat = ["object", "level", "blkid", "offset", "dbsize", "meta", "state",
-             "dbholds", "list", "atype", "flags", "count", "asize",
+             "dbc", "dbholds", "list", "atype", "flags", "count", "asize",
              "access", "mru", "gmru", "mfu", "gmfu", "l2", "l2_dattr",
              "l2_asize", "l2_comp", "aholds", "btype", "data_bs", "meta_bs",
              "bsize", "lvls", "dholds", "blocks", "dsize"]
@@ -70,9 +71,10 @@ cols = {
     "meta":       [4,    -1, "is this buffer metadata?"],
     "state":      [5,    -1, "state of buffer (read, cached, etc)"],
     "dbholds":    [7,  1000, "number of holds on buffer"],
+    "dbc":        [3,    -1, "in dbuf cache"],
     "list":       [4,    -1, "which ARC list contains this buffer"],
     "atype":      [7,    -1, "ARC header type (data or metadata)"],
-    "flags":      [8,    -1, "ARC read flags"],
+    "flags":      [9,    -1, "ARC read flags"],
     "count":      [5,    -1, "ARC data count"],
     "asize":      [7,  1024, "size of this ARC buffer"],
     "access":     [10,   -1, "time this ARC buffer was last accessed"],
@@ -104,8 +106,8 @@ cols = {
 hdr = None
 xhdr = None
 sep = "  "  # Default separator is 2 spaces
-cmd = ("Usage: dbufstat.py [-bdhrtvx] [-i file] [-f fields] [-o file] "
-       "[-s string]\n")
+cmd = ("Usage: dbufstat.py [-bdhnrtvx] [-i file] [-f fields] [-o file] "
+       "[-s string] [-F filter]\n")
 raw = 0
 
 
@@ -151,6 +153,7 @@ def usage():
     sys.stderr.write("\t -b : Print table of information for each dbuf\n")
     sys.stderr.write("\t -d : Print table of information for each dnode\n")
     sys.stderr.write("\t -h : Print this help message\n")
+    sys.stderr.write("\t -n : Exclude header from output\n")
     sys.stderr.write("\t -r : Print raw values\n")
     sys.stderr.write("\t -t : Print table of information for each dnode type"
                      "\n")
@@ -162,11 +165,13 @@ def usage():
     sys.stderr.write("\t -o : Redirect output to the specified file\n")
     sys.stderr.write("\t -s : Override default field separator with custom "
                      "character or string\n")
+    sys.stderr.write("\t -F : Filter output by value or regex\n")
     sys.stderr.write("\nExamples:\n")
     sys.stderr.write("\tdbufstat.py -d -o /tmp/d.log\n")
     sys.stderr.write("\tdbufstat.py -t -s \",\" -o /tmp/t.log\n")
     sys.stderr.write("\tdbufstat.py -v\n")
     sys.stderr.write("\tdbufstat.py -d -f pool,object,objset,dsize,cached\n")
+    sys.stderr.write("\tdbufstat.py -bx -F dbc=1,objset=54,pool=testpool\n")
     sys.stderr.write("\n")
 
     sys.exit(1)
@@ -409,12 +414,32 @@ def update_dict(d, k, line, labels):
     return d
 
 
-def print_dict(d):
-    print_header()
+def skip_line(vals, filters):
+    '''
+    Determines if a line should be skipped during printing
+    based on a set of filters
+    '''
+    if len(filters) == 0:
+        return False
+
+    for key in vals:
+        if key in filters:
+            val = prettynum(cols[key][0], cols[key][1], vals[key]).strip()
+            # we want a full match here
+            if re.match("(?:" + filters[key] + r")\Z", val) is None:
+                return True
+
+    return False
+
+
+def print_dict(d, filters, noheader):
+    if not noheader:
+        print_header()
     for pool in list(d.keys()):
         for objset in list(d[pool].keys()):
             for v in list(d[pool][objset].values()):
-                print_values(v)
+                if not skip_line(v, filters):
+                    print_values(v)
 
 
 def dnodes_build_dict(filehandle):
@@ -455,7 +480,7 @@ def types_build_dict(filehandle):
     return types
 
 
-def buffers_print_all(filehandle):
+def buffers_print_all(filehandle, filters, noheader):
     labels = dict()
 
     # First 3 lines are header information, skip the first two
@@ -466,11 +491,14 @@ def buffers_print_all(filehandle):
     for i, v in enumerate(next(filehandle).split()):
         labels[v] = i
 
-    print_header()
+    if not noheader:
+        print_header()
 
     # The rest of the file is buffer information
     for line in filehandle:
-        print_values(parse_line(line.split(), labels))
+        vals = parse_line(line.split(), labels)
+        if not skip_line(vals, filters):
+            print_values(vals)
 
 
 def main():
@@ -487,11 +515,13 @@ def main():
     tflag = False
     vflag = False
     xflag = False
+    nflag = False
+    filters = dict()
 
     try:
         opts, args = getopt.getopt(
             sys.argv[1:],
-            "bdf:hi:o:rs:tvx",
+            "bdf:hi:o:rs:tvxF:n",
             [
                 "buffers",
                 "dnodes",
@@ -502,7 +532,8 @@ def main():
                 "seperator",
                 "types",
                 "verbose",
-                "extended"
+                "extended",
+                "filter"
             ]
         )
     except getopt.error:
@@ -532,6 +563,35 @@ def main():
             vflag = True
         if opt in ('-x', '--extended'):
             xflag = True
+        if opt in ('-n', '--noheader'):
+            nflag = True
+        if opt in ('-F', '--filter'):
+            fils = [x.strip() for x in arg.split(",")]
+
+            for fil in fils:
+                f = [x.strip() for x in fil.split("=")]
+
+                if len(f) != 2:
+                    sys.stderr.write("Invalid filter '%s'.\n" % fil)
+                    sys.exit(1)
+
+                if f[0] not in cols:
+                    sys.stderr.write("Invalid field '%s' in filter.\n" % f[0])
+                    sys.exit(1)
+
+                if f[0] in filters:
+                    sys.stderr.write("Field '%s' specified multiple times in "
+                                     "filter.\n" % f[0])
+                    sys.exit(1)
+
+                try:
+                    re.compile("(?:" + f[1] + r")\Z")
+                except re.error:
+                    sys.stderr.write("Invalid regex for field '%s' in "
+                                     "filter.\n" % f[0])
+                    sys.exit(1)
+
+                filters[f[0]] = f[1]
 
     if hflag or (xflag and desired_cols):
         usage()
@@ -594,13 +654,13 @@ def main():
             sys.exit(1)
 
     if bflag:
-        buffers_print_all(sys.stdin)
+        buffers_print_all(sys.stdin, filters, nflag)
 
     if dflag:
-        print_dict(dnodes_build_dict(sys.stdin))
+        print_dict(dnodes_build_dict(sys.stdin), filters, nflag)
 
     if tflag:
-        print_dict(types_build_dict(sys.stdin))
+        print_dict(types_build_dict(sys.stdin), filters, nflag)
 
 
 if __name__ == '__main__':

--- a/configure.ac
+++ b/configure.ac
@@ -175,6 +175,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/Makefile
 	tests/zfs-tests/tests/functional/acl/Makefile
 	tests/zfs-tests/tests/functional/acl/posix/Makefile
+	tests/zfs-tests/tests/functional/arc/Makefile
 	tests/zfs-tests/tests/functional/atime/Makefile
 	tests/zfs-tests/tests/functional/bootfs/Makefile
 	tests/zfs-tests/tests/functional/cache/Makefile

--- a/module/zfs/dbuf_stats.c
+++ b/module/zfs/dbuf_stats.c
@@ -46,14 +46,14 @@ static int
 dbuf_stats_hash_table_headers(char *buf, size_t size)
 {
 	(void) snprintf(buf, size,
-	    "%-88s | %-124s | %s\n"
-	    "%-16s %-8s %-8s %-8s %-8s %-8s %-8s %-5s %-5s %5s | "
-	    "%-5s %-5s %-8s %-6s %-8s %-12s "
-	    "%-6s %-6s %-6s %-6s %-6s %-8s %-8s %-8s %-5s | "
-	    "%-6s %-6s %-8s %-8s %-6s %-6s %-5s %-8s %-8s\n",
+	    "%-96s | %-119s | %s\n"
+	    "%-16s %-8s %-8s %-8s %-8s %-10s %-8s %-5s %-5s %-7s %3s | "
+	    "%-5s %-5s %-9s %-6s %-8s %-12s "
+	    "%-6s %-6s %-6s %-6s %-6s %-8s %-8s %-8s %-6s | "
+	    "%-6s %-6s %-8s %-8s %-6s %-6s %-6s %-8s %-8s\n",
 	    "dbuf", "arcbuf", "dnode", "pool", "objset", "object", "level",
-	    "blkid", "offset", "dbsize", "meta", "state", "dbholds", "list",
-	    "atype", "flags", "count", "asize", "access",
+	    "blkid", "offset", "dbsize", "meta", "state", "dbholds", "dbc",
+	    "list", "atype", "flags", "count", "asize", "access",
 	    "mru", "gmru", "mfu", "gmfu", "l2", "l2_dattr", "l2_asize",
 	    "l2_comp", "aholds", "dtype", "btype", "data_bs", "meta_bs",
 	    "bsize", "lvls", "dholds", "blocks", "dsize");
@@ -75,10 +75,10 @@ __dbuf_stats_hash_table_data(char *buf, size_t size, dmu_buf_impl_t *db)
 	__dmu_object_info_from_dnode(dn, &doi);
 
 	nwritten = snprintf(buf, size,
-	    "%-16s %-8llu %-8lld %-8lld %-8lld %-8llu %-8llu %-5d %-5d %-5lu | "
-	    "%-5d %-5d 0x%-6x %-6lu %-8llu %-12llu "
-	    "%-6lu %-6lu %-6lu %-6lu %-6lu %-8llu %-8llu %-8d %-5lu | "
-	    "%-6d %-6d %-8lu %-8lu %-6llu %-6lu %-5lu %-8llu %-8llu\n",
+	    "%-16s %-8llu %-8lld %-8lld %-8lld %-10llu %-8llu %-5d %-5d "
+	    "%-7lu %-3d | %-5d %-5d 0x%-7x %-6lu %-8llu %-12llu "
+	    "%-6lu %-6lu %-6lu %-6lu %-6lu %-8llu %-8llu %-8d %-6lu | "
+	    "%-6d %-6d %-8lu %-8lu %-6llu %-6lu %-6lu %-8llu %-8llu\n",
 	    /* dmu_buf_impl_t */
 	    spa_name(dn->dn_objset->os_spa),
 	    (u_longlong_t)dmu_objset_id(db->db_objset),
@@ -90,6 +90,7 @@ __dbuf_stats_hash_table_data(char *buf, size_t size, dmu_buf_impl_t *db)
 	    !!dbuf_is_metadata(db),
 	    db->db_state,
 	    (ulong_t)refcount_count(&db->db_holds),
+	    multilist_link_active(&db->db_cache_link),
 	    /* arc_buf_info_t */
 	    abi.abi_state_type,
 	    abi.abi_state_contents,

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -27,6 +27,10 @@ tags = ['functional']
 tests = ['posix_003_pos']
 tags = ['functional', 'acl', 'posix']
 
+[tests/functional/arc]
+tests = ['dbufstats_001_pos', 'dbufstats_002_pos']
+tags = ['functional', 'arc']
+
 [tests/functional/atime]
 tests = ['atime_001_pos', 'atime_002_neg', 'atime_003_pos']
 tags = ['functional', 'atime']

--- a/tests/zfs-tests/tests/functional/Makefile.am
+++ b/tests/zfs-tests/tests/functional/Makefile.am
@@ -1,5 +1,6 @@
 SUBDIRS = \
 	acl \
+	arc \
 	atime \
 	bootfs \
 	cache \

--- a/tests/zfs-tests/tests/functional/arc/Makefile.am
+++ b/tests/zfs-tests/tests/functional/arc/Makefile.am
@@ -1,0 +1,6 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/arc
+dist_pkgdata_SCRIPTS = \
+	cleanup.ksh \
+	setup.ksh \
+	dbufstats_001_pos.ksh \
+	dbufstats_002_pos.ksh

--- a/tests/zfs-tests/tests/functional/arc/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/arc/cleanup.ksh
@@ -1,4 +1,4 @@
-#! /bin/ksh -p
+#!/bin/ksh -p
 #
 # CDDL HEADER START
 #
@@ -21,23 +21,9 @@
 #
 
 #
-# Copyright (c) 2015 by Lawrence Livermore National Security, LLC.
-# All rights reserved.
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
 #
 
 . $STF_SUITE/include/libtest.shlib
 
-set -A args  "" "-b" "-d" "-r" "-v" "-s \",\"" "-x" "-n"
-
-log_assert "dbufstat.py generates output and doesn't return an error code"
-
-typeset -i i=0
-while [[ $i -lt ${#args[*]} ]]; do
-        log_must eval "dbufstat.py ${args[i]} > /dev/null"
-        ((i = i + 1))
-done
-
-# A simple test of dbufstat.py filter functionality
-log_must eval "dbufstat.py -F object=10,dbc=1,pool=$TESTPOOL > /dev/null"
-
-log_pass "dbufstat.py generates output and doesn't return an error code"
+default_cleanup

--- a/tests/zfs-tests/tests/functional/arc/dbufstats_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/arc/dbufstats_001_pos.ksh
@@ -1,0 +1,83 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+
+#
+# DESCRIPTION:
+# Ensure stats presented in /proc/spl/kstat/zfs/dbufstats are correct
+# based on /proc/spl/kstat/zfs/dbufs.
+#
+# STRATEGY:
+# 1. Generate a file with random data in it
+# 2. Store output from dbufs kstat
+# 3. Store output from dbufstats kstat
+# 4. Compare stats presented in dbufstats with stat generated using
+#    dbufstat.py and the dbufs kstat output
+#
+
+DBUFSTATS_FILE=$(mktemp $TEST_BASE_DIR/dbufstats.out.XXXXXX)
+DBUFS_FILE=$(mktemp $TEST_BASE_DIR/dbufs.out.XXXXXX)
+
+function cleanup
+{
+	log_must rm -f $TESTDIR/file $DBUFS_FILE $DBUFSTATS_FILE
+}
+
+function testdbufstat # stat_name dbufstat_filter
+{
+        name=$1
+        filter=""
+
+        [[ -n "$2" ]] && filter="-F $2"
+
+        verify_eq \
+	    $(grep -w "$name" "$DBUFSTATS_FILE" | awk '{ print $3 }') \
+	    $(dbufstat.py -bxn -i "$DBUFS_FILE" "$filter" | wc -l) \
+	    "$name"
+}
+
+verify_runnable "both"
+
+log_assert "dbufstats produces correct statistics"
+
+log_onexit cleanup
+
+log_must file_write -o create -f "$TESTDIR/file" -b 1048576 -c 20 -d R
+log_must zpool sync
+
+log_must eval "cat /proc/spl/kstat/zfs/dbufs > $DBUFS_FILE"
+log_must eval "cat /proc/spl/kstat/zfs/dbufstats > $DBUFSTATS_FILE"
+
+for level in {0..11}; do
+	testdbufstat "cache_level_$level" "dbc=1,level=$level"
+done
+
+testdbufstat "cache_count" "dbc=1"
+testdbufstat "hash_elements" ""
+
+log_pass "dbufstats produces correct statistics passed"

--- a/tests/zfs-tests/tests/functional/arc/dbufstats_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/arc/dbufstats_002_pos.ksh
@@ -1,0 +1,80 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
+
+#
+# DESCRIPTION:
+# Ensure that dbufs move from mru to mfu as expected.
+#
+# STRATEGY:
+# 1. Set dbuf cache size to a small size (10M for this test)
+# 2. Generate a file with random data (small enough to fit in cache)
+# 3. zpool sync to remove dbufs from anon list in ARC
+# 4. Obtain the object ID using linux stat command
+# 5. Ensure that all dbufs are on the mru list in the ARC
+# 6. Generate another random file large enough to flush dbuf cache
+# 7. cat the first generated file
+# 8. Ensure that at least some dbufs moved to the mfu list in the ARC
+#
+
+DBUFS_FILE=$(mktemp $TEST_BASE_DIR/dbufs.out.XXXXXX)
+
+function cleanup
+{
+	log_must rm -f $TESTDIR/file $TESTDIR/file2 $DBUFS_FILE
+}
+
+verify_runnable "both"
+
+log_assert "dbufs move from mru to mfu list"
+
+log_onexit cleanup
+
+log_must file_write -o create -f "$TESTDIR/file" -b 1048576 -c 1 -d R
+log_must zpool sync
+
+objid=$(stat --format="%i" "$TESTDIR/file")
+log_note "Object ID for $TESTDIR/file is $objid"
+
+log_must eval "cat /proc/spl/kstat/zfs/dbufs > $DBUFS_FILE"
+dbuf=$(dbufstat.py -bxn -i "$DBUFS_FILE" -F "object=$objid" | wc -l)
+mru=$(dbufstat.py -bxn -i "$DBUFS_FILE" -F "object=$objid,list=1" | wc -l)
+mfu=$(dbufstat.py -bxn -i "$DBUFS_FILE" -F "object=$objid,list=3" | wc -l)
+log_note "dbuf count is $dbuf, mru count is $mru, mfu count is $mfu"
+verify_ne "0" "$mru" "mru count"
+verify_eq "0" "$mfu" "mfu count"
+
+log_must eval "cat $TESTDIR/file > /dev/null"
+log_must eval "cat /proc/spl/kstat/zfs/dbufs > $DBUFS_FILE"
+dbuf=$(dbufstat.py -bxn -i "$DBUFS_FILE" -F "object=$objid" | wc -l)
+mru=$(dbufstat.py -bxn -i "$DBUFS_FILE" -F "object=$objid,list=1" | wc -l)
+mfu=$(dbufstat.py -bxn -i "$DBUFS_FILE" -F "object=$objid,list=3" | wc -l)
+log_note "dbuf count is $dbuf, mru count is $mru, mfu count is $mfu"
+verify_ne "0" "$mfu" "mfu count"
+
+log_pass "dbufs move from mru to mfu list passed"

--- a/tests/zfs-tests/tests/functional/arc/setup.ksh
+++ b/tests/zfs-tests/tests/functional/arc/setup.ksh
@@ -1,4 +1,4 @@
-#! /bin/ksh -p
+#!/bin/ksh -p
 #
 # CDDL HEADER START
 #
@@ -21,23 +21,10 @@
 #
 
 #
-# Copyright (c) 2015 by Lawrence Livermore National Security, LLC.
-# All rights reserved.
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
 #
 
 . $STF_SUITE/include/libtest.shlib
 
-set -A args  "" "-b" "-d" "-r" "-v" "-s \",\"" "-x" "-n"
-
-log_assert "dbufstat.py generates output and doesn't return an error code"
-
-typeset -i i=0
-while [[ $i -lt ${#args[*]} ]]; do
-        log_must eval "dbufstat.py ${args[i]} > /dev/null"
-        ((i = i + 1))
-done
-
-# A simple test of dbufstat.py filter functionality
-log_must eval "dbufstat.py -F object=10,dbc=1,pool=$TESTPOOL > /dev/null"
-
-log_pass "dbufstat.py generates output and doesn't return an error code"
+DISK=${DISKS%% *}
+default_setup $DISK


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Introduce kstats about the dbuf hash and dbuf cache
to make it easier to inspect state. This should help
with debugging and understanding of these portions
of the codebase.

Correct format of dbuf kstat file.

Introduce a dbc column to dbufs kstat to indicate if
a dbuf is in the dbuf cache.

Introduce field filtering in the dbufstat python script.

I will also be introducing some basic test cases to test the new dbufstats kstat and other basic scenarios.

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Gain a better understanding how dbufs are cached and provide another useful tool for users/developer.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Locally on a VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
