### PR TITLE
Fix 'zfs get {user|group}objused@' functionality

### DIFF
--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -740,7 +740,7 @@ zfs_userspace_one(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
 		return (0);
 
 	if (type == ZFS_PROP_USEROBJUSED || type == ZFS_PROP_GROUPOBJUSED) {
-		strlcpy(buf, DMU_OBJACCT_PREFIX, DMU_OBJACCT_PREFIX_LEN);
+		strlcpy(buf, DMU_OBJACCT_PREFIX, DMU_OBJACCT_PREFIX_LEN + 1);
 		offset = DMU_OBJACCT_PREFIX_LEN;
 	}
 

--- a/tests/zfs-tests/tests/functional/userquota/groupspace_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/groupspace_003_pos.ksh
@@ -30,6 +30,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
 . $STF_SUITE/tests/functional/userquota/userquota_common.kshlib
 
 #
@@ -56,10 +57,15 @@ function cleanup
 function group_object_count
 {
 	typeset fs=$1
-	typeset user=$2
-	typeset cnt=$(zfs groupspace -oname,objused $fs | grep $user |
-			awk '{print $2}')
-	echo $cnt
+	typeset group=$2
+	typeset -i groupspacecnt=$(zfs groupspace -oname,objused $fs |
+	    awk /$group/'{print $2}')
+	typeset -i zfsgetcnt=$(zfs get -H -ovalue groupobjused@$group $fs)
+
+	# 'zfs groupspace' and 'zfs get groupobjused@' should be equal
+	verify_eq "$groupspacecnt" "$zfsgetcnt" "groupobjused@$group"
+
+	echo $groupspacecnt
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/userquota/userspace_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/userquota/userspace_003_pos.ksh
@@ -30,6 +30,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/math.shlib
 . $STF_SUITE/tests/functional/userquota/userquota_common.kshlib
 
 #
@@ -58,9 +59,14 @@ function user_object_count
 {
 	typeset fs=$1
 	typeset user=$2
-	typeset cnt=$(zfs userspace -oname,objused $fs |
+	typeset -i userspacecnt=$(zfs userspace -oname,objused $fs |
 	    awk /$user/'{print $2}')
-	echo $cnt
+	typeset -i zfsgetcnt=$(zfs get -H -ovalue userobjused@$user $fs)
+
+	# 'zfs userspace' and 'zfs get userobjused@' should be equal
+	verify_eq "$userspacecnt" "$zfsgetcnt" "userobjused@$user"
+
+	echo $userspacecnt
 }
 
 log_onexit cleanup


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Fix a regression accidentally introduced in 1b81ab4 that prevents `zfs get {user|group}objused@` from correctly reporting the requested value.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #6904 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Updated "userspace_003_pos.ksh" and "groupspace_003_pos.ksh" scripts.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
