### PR TITLE
Fix NFS sticky bit permission denied error

### DIFF
--- a/module/zfs/zfs_dir.c
+++ b/module/zfs/zfs_dir.c
@@ -1126,7 +1126,7 @@ top:
  *
  *	you own the directory,
  *	you own the entry,
- *	the entry is a plain file and you have write access,
+ *	you have write access to the entry,
  *	or you are privileged (checked in secpolicy...).
  *
  * The function returns 0 if remove access is granted.
@@ -1151,8 +1151,7 @@ zfs_sticky_remove_access(znode_t *zdp, znode_t *zp, cred_t *cr)
 	    cr, ZFS_OWNER);
 
 	if ((uid = crgetuid(cr)) == downer || uid == fowner ||
-	    (S_ISDIR(ZTOI(zp)->i_mode) &&
-	    zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr) == 0))
+	    zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr) == 0)
 		return (0);
 	else
 		return (secpolicy_vnode_remove(cr));


### PR DESCRIPTION
### Description

When zfs_sticky_remove_access() was originally adapted for Linux
a typo was made which altered the desired behavior.  As described
in the block comment, permission should be granted when the entry
is a regular file and you have write access.  S_ISREG should have
been used here instead of S_ISDIR.

### Motivation and Context

Issue #6889.

### How Has This Been Tested?

Locally using the test case provided in this https://github.com/zfsonlinux/zfs/issues/6889#issuecomment-346393383.  A test case was not added since this issue is only reproducible over NFS and the ZTS currently does not provide the needed infrastructure to support this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
