### PR TITLE
Preserve itx alloc size for zio_data_buf_free()

### DIFF
--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -395,6 +395,7 @@ typedef struct itx {
 	uint8_t		itx_sync;	/* synchronous transaction */
 	zil_callback_t	itx_callback;   /* Called when the itx is persistent */
 	void		*itx_callback_data; /* User data for the callback */
+	size_t		itx_size;	/* allocated itx structure size */
 	uint64_t	itx_oid;	/* object id */
 	lr_t		itx_lr;		/* common part of log record */
 	/* followed by type-specific part of lr_xx_t and its immediate data */

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1254,17 +1254,20 @@ cont:
 itx_t *
 zil_itx_create(uint64_t txtype, size_t lrsize)
 {
+	size_t itxsize;
 	itx_t *itx;
 
 	lrsize = P2ROUNDUP_TYPED(lrsize, sizeof (uint64_t), size_t);
+	itxsize = offsetof(itx_t, itx_lr) + lrsize;
 
-	itx = zio_data_buf_alloc(offsetof(itx_t, itx_lr) + lrsize);
+	itx = zio_data_buf_alloc(itxsize);
 	itx->itx_lr.lrc_txtype = txtype;
 	itx->itx_lr.lrc_reclen = lrsize;
 	itx->itx_lr.lrc_seq = 0;	/* defensive */
 	itx->itx_sync = B_TRUE;		/* default is synchronous */
 	itx->itx_callback = NULL;
 	itx->itx_callback_data = NULL;
+	itx->itx_size = itxsize;
 
 	return (itx);
 }
@@ -1272,7 +1275,7 @@ zil_itx_create(uint64_t txtype, size_t lrsize)
 void
 zil_itx_destroy(itx_t *itx)
 {
-	zio_data_buf_free(itx, offsetof(itx_t, itx_lr)+itx->itx_lr.lrc_reclen);
+	zio_data_buf_free(itx, itx->itx_size);
 }
 
 /*


### PR DESCRIPTION
### Description

Using zio_data_buf_alloc() to allocate the itx's may be unsafe
because the itx->itx_lr.lrc_reclen field is not constant from
allocation to free.  This size is used by zio_data_buf_free() to
determine which cache the object should be returned to, a change
in size may result in the wrong cache being selected.

Avoid this issue entirely by storing the allocation size in the
itx as itx->itx_size.  Additionally, switch to using vmem_alloc()
to perform the allocation.  For the vast majority of allocations
which are <64k this will internally map to kmem_alloc() and will
therefore not impact performance.

### Motivation and Context

Potential issue identified by inspection while testing #6566.

### How Has This Been Tested?

```
$ ./scripts/zfs-tests.sh -vx -T slog
...
Test: tests/functional/slog/setup (run as root) [00:01] [PASS]
Test: tests/functional/slog/slog_001_pos (run as root) [00:45] [PASS]
Test: tests/functional/slog/slog_002_pos (run as root) [00:48] [PASS]
Test: tests/functional/slog/slog_003_pos (run as root) [01:42] [PASS]
Test: tests/functional/slog/slog_004_pos (run as root) [00:50] [PASS]
Test: tests/functional/slog/slog_005_pos (run as root) [00:24] [PASS]
Test: tests/functional/slog/slog_006_pos (run as root) [04:48] [PASS]
Test: tests/functional/slog/slog_007_pos (run as root) [01:56] [PASS]
Test: tests/functional/slog/slog_008_neg (run as root) [00:03] [PASS]
Test: tests/functional/slog/slog_009_neg (run as root) [00:13] [PASS]
Test: tests/functional/slog/slog_010_neg (run as root) [00:01] [PASS]
Test: tests/functional/slog/slog_011_neg (run as root) [00:44] [PASS]
Test: tests/functional/slog/slog_012_neg (run as root) [00:44] [PASS]
Test: tests/functional/slog/slog_013_pos (run as root) [00:00] [SKIP]
Test: tests/functional/slog/slog_014_pos (run as root) [01:34] [PASS]
Test: tests/functional/slog/slog_replay_fs (run as root) [00:14] [PASS]
Test: tests/functional/slog/slog_replay_volume (run as root) [00:21] [PASS]
Test: tests/functional/slog/cleanup (run as root) [00:01] [PASS]

Results Summary
SKIP	   1
PASS	  17
```

Submitted PR for a full run of the ZTS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
