### PR TITLE
Issue #5360: Add /usr/bin/env to COPY_EXEC_LIST in initramfs hooks.

### DIFF
--- a/contrib/initramfs/hooks/zfs.in
+++ b/contrib/initramfs/hooks/zfs.in
@@ -20,6 +20,7 @@ COPY_FILE_LIST="$COPY_FILE_LIST @udevruledir@/69-vdev.rules"
 
 # These prerequisites are provided by the base system.
 COPY_EXEC_LIST="$COPY_EXEC_LIST /usr/bin/dirname /bin/hostname /sbin/blkid"
+COPY_EXEC_LIST="$COPY_EXEC_LIST /usr/bin/env"
 
 # Explicitly specify all kernel modules because automatic dependency resolution
 # is unreliable on many systems.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
5dc1ff29ec385bc58d76e76bb367d4391c6ee155 changed the user space program to mount a zfs snapshot from /bin/sh to /usr/bin/env.  If the executable is not present in the initramfs then snapshots cannot be automounted.  The commit adds /usr/bin/env to the list of executables included in the initramfs image.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With zfs 0.6.4 our system booted without intervention when it copied the root filesystem image from a snapshot to memory.  After upgrading to 0.7.1 (ubuntu daily ppa) this was no longer the case until /usr/bin/env was included in the initramfs image.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/zfsonlinux/zfs/issues/5360

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
We use a custom initramfs hook script which has `copy_exec /usr/bin/env`.  This is the equivalent in the master repository which we anticipate adopting in the near future.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
