### PR TITLE
Suppress incorrect objtool warnings

### DIFF
--- a/config/kernel-objtool.m4
+++ b/config/kernel-objtool.m4
@@ -12,7 +12,30 @@ AC_DEFUN([ZFS_AC_KERNEL_OBJTOOL], [
 		#endif
 	],[
 		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_KERNEL_OBJTOOL, 1, [kernel does stack verification])
+		AC_DEFINE(HAVE_KERNEL_OBJTOOL, 1,
+		    [kernel does stack verification])
+
+		ZFS_AC_KERNEL_STACK_FRAME_NON_STANDARD
+	],[
+		AC_MSG_RESULT(no)
+	])
+])
+
+dnl #
+dnl # 4.6 API added STACK_FRAME_NON_STANDARD macro
+dnl #
+AC_DEFUN([ZFS_AC_KERNEL_STACK_FRAME_NON_STANDARD], [
+	AC_MSG_CHECKING([whether STACK_FRAME_NON_STANDARD is defined])
+	ZFS_LINUX_TRY_COMPILE([
+		#include <linux/frame.h>
+	],[
+		#if !defined(STACK_FRAME_NON_STANDARD)
+		CTASSERT(1);
+		#endif
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_STACK_FRAME_NON_STANDARD, 1,
+		   [STACK_FRAME_NON_STANDARD is defined])
 	],[
 		AC_MSG_RESULT(no)
 	])

--- a/include/sys/Makefile.am
+++ b/include/sys/Makefile.am
@@ -35,6 +35,7 @@ COMMON_H = \
 	$(top_srcdir)/include/sys/dsl_userhold.h \
 	$(top_srcdir)/include/sys/edonr.h \
 	$(top_srcdir)/include/sys/efi_partition.h \
+	$(top_srcdir)/include/sys/frame.h \
 	$(top_srcdir)/include/sys/hkdf.h \
 	$(top_srcdir)/include/sys/metaslab.h \
 	$(top_srcdir)/include/sys/metaslab_impl.h \

--- a/include/sys/frame.h
+++ b/include/sys/frame.h
@@ -1,0 +1,36 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (C) 2017 by Lawrence Livermore National Security, LLC.
+ */
+
+#ifndef _SYS_FRAME_H
+#define	_SYS_FRAME_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#if defined(__KERNEL__) && defined(HAVE_STACK_FRAME_NON_STANDARD)
+#include <linux/frame.h>
+#else
+#define	STACK_FRAME_NON_STANDARD(func)
+#endif
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _SYS_FRAME_H */

--- a/module/zcommon/zfs_fletcher_avx512.c
+++ b/module/zcommon/zfs_fletcher_avx512.c
@@ -26,6 +26,7 @@
 
 #include <linux/simd_x86.h>
 #include <sys/byteorder.h>
+#include <sys/frame.h>
 #include <sys/spa_checksum.h>
 #include <zfs_fletcher.h>
 #include <strings.h>
@@ -107,6 +108,7 @@ fletcher_4_avx512f_native(fletcher_4_ctx_t *ctx, const void *buf, uint64_t size)
 
 	kfpu_end();
 }
+STACK_FRAME_NON_STANDARD(fletcher_4_avx512f_native);
 
 static void
 fletcher_4_avx512f_byteswap(fletcher_4_ctx_t *ctx, const void *buf,
@@ -150,6 +152,7 @@ fletcher_4_avx512f_byteswap(fletcher_4_ctx_t *ctx, const void *buf,
 
 	kfpu_end();
 }
+STACK_FRAME_NON_STANDARD(fletcher_4_avx512f_byteswap);
 
 static boolean_t
 fletcher_4_avx512f_valid(void)

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -120,6 +120,11 @@ $(MODULE)-objs += dsl_destroy.o
 $(MODULE)-objs += dsl_userhold.o
 $(MODULE)-objs += qat_compress.o
 
+# Suppress incorrect warnings from versions of objtool which are not
+# aware of x86 EVEX prefix instructions used for AVX512.
+OBJECT_FILES_NON_STANDARD_vdev_raidz_math_avx512bw.o := y
+OBJECT_FILES_NON_STANDARD_vdev_raidz_math_avx512f.o := y
+
 $(MODULE)-$(CONFIG_X86) += vdev_raidz_math_sse2.o
 $(MODULE)-$(CONFIG_X86) += vdev_raidz_math_ssse3.o
 $(MODULE)-$(CONFIG_X86) += vdev_raidz_math_avx2.o


### PR DESCRIPTION
### Description

Suppress incorrect warnings from versions of objtool which are not
aware of x86 EVEX prefix instructions used for AVX512.

>  module/zfs/vdev_raidz_math_avx512bw.o: warning:
>  objtool: <func+offset>: can't find jump dest instruction at .text

### Motivation and Context

Understand and resolve all warnings.

### How Has This Been Tested?

Local build with CONFIG_STACK_VALIDATION and CONFIG_FRAME_POINTER enabled.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
