### PR TITLE
Enable QAT support in zfs-dkms RPM

### DIFF
--- a/scripts/dkms.mkconf
+++ b/scripts/dkms.mkconf
@@ -30,6 +30,7 @@ PRE_BUILD="configure
   --with-spl=\${source_tree}/spl-\${PACKAGE_VERSION}
   --with-spl-obj=\${dkms_tree}/spl/\${PACKAGE_VERSION}/\${kernelver}/\${arch}
   --with-spl-timeout=300
+  --with-qat=\${ICP_ROOT}
   \$(
     [[ -r \${PACKAGE_CONFIG} ]] \\
     && source \${PACKAGE_CONFIG} \\

--- a/scripts/dkms.mkconf
+++ b/scripts/dkms.mkconf
@@ -32,6 +32,12 @@ PRE_BUILD="configure
   --with-spl-timeout=300
   --with-qat=\${ICP_ROOT}
   \$(
+    [[ -n \${ICP_ROOT} ]] && \\
+    {
+      echo --with-qat=\${ICP_ROOT}
+    }
+  )
+  \$(
     [[ -r \${PACKAGE_CONFIG} ]] \\
     && source \${PACKAGE_CONFIG} \\
     && shopt -q -s extglob \\


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Enable QAT accelerated gzip compression in zfs-dkms RPM package when
environment variant ICP_ROOT is set to QAT drive source code
folder and QAT hardware presence.
Otherwise, switch back to default gzip compression.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
QAT accelerated gzip compression is only supported when user specific the QAT driver source code path in building zfs from source code. 
By adding this new patch, ZFS user can enable QAT support by set ICP_ROOT to local QAT driver source code path before installing the ZFS-DKMS RPM package.  

<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested the ZFS-DKMS package on CentOS7 with/without ICP_ROOT is set.
Tested the ZFS-DKMS package on CentOS7 with/without QAT driver.
Tested the ZFS-kmod package on CentOS7 without QAT driver.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
