### PR TITLE
Disable vdev_zaps_004_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_004_pos.ksh
@@ -31,6 +31,11 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/vdev_zaps/vdev_zaps.kshlib
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/6935
+if is_linux; then
+	log_unsupported "Test case occasionally fails"
+fi
+
 log_assert "Per-vdev ZAPs are transferred properly on attach/detach"
 
 DISK=${DISKS%% *}


### PR DESCRIPTION
### Description

Occasionally observed failure of vdev_zaps_004_pos due to the test
case not being 100% reliable.  In order to prevent false positives
disable this test case until it can be made reliable.

### Motivation and Context

Issue #6935

### How Has This Been Tested?

Buildbot

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
