### PR TITLE
vdev_id: new slot type SES.

### DIFF
--- a/cmd/vdev_id/vdev_id
+++ b/cmd/vdev_id/vdev_id
@@ -276,6 +276,23 @@ sas_handler() {
 		d=$(eval echo \${$i})
 		SLOT=`echo $d | sed -e 's/^.*://'`
 		;;
+	"ses")
+		# look for this SAS path in all SCSI Enclosure Services
+		# (SES) enclosures
+		sas_address=`cat $end_device_dir/sas_address 2>/dev/null`
+		enclosures=`lsscsi -g | \
+			sed -n -e '/enclosu/s/^.* \([^ ][^ ]*\) *$/\1/p'`
+		for enclosure in $enclosures; do
+			set -- $(sg_ses -p aes $enclosure | \
+				awk "/device slot number:/{slot=\$12} \
+					/SAS address: $sas_address/\
+					{print slot}")
+			SLOT=$1
+			if [ -n "$SLOT" ] ; then
+				break
+			fi
+		done
+		;;
 	esac
 	if [ -z "$SLOT" ] ; then
 		return

--- a/man/man5/vdev_id.conf.5
+++ b/man/man5/vdev_id.conf.5
@@ -90,7 +90,7 @@ internally uses this value to determine which HBA or switch port a
 device is connected to.  The default is 4.
 
 .TP
-\fIslot\fR <bay|phy|port|id|lun>
+\fIslot\fR <bay|phy|port|id|lun|ses>
 Specifies from which element of a SAS identifier the slot number is
 taken.  The default is bay.
 
@@ -103,6 +103,12 @@ taken.  The default is bay.
 \fIid\fR - use the scsi id as the slot number.
 
 \fIlun\fR - use the scsi lun as the slot number.
+
+\fIses\fR - use the SCSI Enclosure Services (SES) enclosure device slot number,
+as reported by
+.BR sg_ses (8).
+This is intended for use only on systems where \fIbay\fR is unsupported,
+noting that \fIport\fR and \fIid\fR may be unstable across disk replacement.
 .SH EXAMPLES
 A non-multipath configuration with direct-attached SAS enclosures and an
 arbitrary slot re-mapping.


### PR DESCRIPTION
### Description
This extends vdev_id to support a new slot type, `SES`, for SCSI Enclosure Services.

With slot type `SES`, the disk slot numbers are determined by using the device slot number reported by `sg_ses` for the device with matching SAS address.

### Motivation and Context
This is primarily of use on systems with a deficient driver omitting support for bay_identifier in /sys/devices.  For example, HP's hpsa driver used with their H241 cards doesn't support bay_identifier, instead returning invalid argument.  The reason for this can be found in the source code for that driver, which has the following
```
hpsa_sas_get_bay_identifier(struct sas_rphy *rphy)
{
	return -ENXIO;
}
```
Oh dear.

In my testing, I found that the existing slot types of `port` and `id` were not stable across disk replacement, so an alternative was required.

### How Has This Been Tested?
This has been tested on all our ZFS fileservers, which now produce a satisfactory bay identifier when udev is triggered to run the vdev_id script.  These servers include:
- HP DL385 Gen 7 using LSI 9201-16e HBA card and HP D6000/MDS600 external storage
- HP DL380 Gen 8 using HP H221 HBA card and HP D2700/D6000 external storage
- HP DL380 Gen 9 using HP H241 HBA card and HP D3700 external storage.

The combination of DL380 Gen 9, H241, and older D2700 external storage does not seem to support SCSI Enclosure Services.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
