### PR TITLE
Use zfs-import.target in contrib/dracut

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -89,15 +89,21 @@ install() {
 	printf "\x${DD}\x${CC}\x${BB}\x${AA}" > "${initdir}/etc/hostid"
 
 	if dracut_module_included "systemd"; then
-		mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
+		mkdir -p "${initdir}/$systemdsystemunitdir/zfs-import.target.wants"
 		for _item in scan cache ; do
 			dracut_install @systemdunitdir@/zfs-import-$_item.service
-			if ! [ -L "${initdir}/$systemdsystemunitdir/initrd.target.wants"/zfs-import-$_item.service ]; then
-				ln -s ../zfs-import-$_item.service "${initdir}/$systemdsystemunitdir/initrd.target.wants"/zfs-import-$_item.service
+			if ! [ -L "${initdir}/$systemdsystemunitdir/zfs-import.target.wants"/zfs-import-$_item.service ]; then
+				ln -s ../zfs-import-$_item.service "${initdir}/$systemdsystemunitdir/zfs-import.target.wants"/zfs-import-$_item.service
 				type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-import-$_item.service
 			fi
 		done
 		dracut_install systemd-ask-password
 		dracut_install systemd-tty-ask-password-agent
+		mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
+		dracut_install @systemdunitdir@/zfs-import.target
+		if ! [ -L "${initdir}/$systemdsystemunitdir/initrd.target.wants"/zfs-import.target ]; then
+			ln -s ../zfs-import.target "${initdir}/$systemdsystemunitdir/initrd.target.wants"/zfs-import.target
+			type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-import.target
+		fi
 	fi
 }

--- a/contrib/dracut/90zfs/zfs-generator.sh.in
+++ b/contrib/dracut/90zfs/zfs-generator.sh.in
@@ -41,8 +41,7 @@ echo "zfs-generator: writing extension for sysroot.mount to $GENERATOR_DIR"/sysr
 {
     echo "[Unit]"
     echo "Before=initrd-root-fs.target"
-    echo "After=zfs-import-scan.service"
-    echo "After=zfs-import-cache.service"
+    echo "After=zfs-import.target"
     echo "[Mount]"
     if [ "${root}" = "zfs:AUTO" ] ; then
       echo "PassEnvironment=BOOTFS"


### PR DESCRIPTION
### Description
The new zfs-import.target should be used in place of the zfs-import-*.service units in `contrib/dracut`.

### Motivation and Context
PR #6764 added `zfs-import.target` to simplify dependency on pool importing. #6822 did some cleanup. The recent #6955 (re: #6953) added RPM support for enabling this units. That bug report has prompted me to grep the code base for zfs-import. The last remaining code section to be updated is under `control/dracut/90zfs`.

This PR is  a **work in progress**. I don't think dracut users are exposed to any bug presently, because `sysroot.mount` is still ordered `After=zfs-import-*.service`

Two files are affected:
1. `zfs-generator.sh.in` is straightforwardly modified to order `sysroot.mount` `After=zfs-import.target` (instead of each `zfs-import-*.service`). 
2. `module-setup.sh.in` is also modified. **I need input, because I don't know how precisely dracut works.** `zfs-import.target` (and each `zfs-import-*.service`) is `dracut_install`-ed (and *unconditionally* `mark_hostonly`-ed). Do we need to build a `zfs-import.target.wants` directory with `zfs-import-*.service` links? Or will that be inherited from the host system?

### How Has This Been Tested?
This has NOT been tested. This is a place to centralize discussion about these changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
