### PR TITLE
Enable zfs-import.target in systemd preset

### DIFF
--- a/etc/systemd/system/50-zfs.preset.in
+++ b/etc/systemd/system/50-zfs.preset.in
@@ -1,6 +1,7 @@
 # ZFS is enabled by default
 enable zfs-import-cache.service
 disable zfs-import-scan.service
+enable zfs-import.target
 enable zfs-mount.service
 enable zfs-share.service
 enable zfs-zed.service


### PR DESCRIPTION
Cherry picked line from PR #6822, this enables the new target introduced in PR #6764.

### How Has This Been Tested?
Cherry picked line from master, included by @behlendorf in Fedora and EPEL 0.7.4-2 release. Built and installed myself.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
