### PR TITLE
Fix multihost stale cache file import

### DIFF
--- a/tests/zfs-tests/tests/functional/mmp/mmp.cfg
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.cfg
@@ -30,6 +30,8 @@ export TXG_TIMEOUT_DEFAULT=5
 
 export MMP_POOL=mmppool
 export MMP_DIR=$TEST_BASE_DIR/mmp
+export MMP_CACHE=$MMP_DIR/zpool.cache
+export MMP_ZTEST_LOG=$MMP_DIR/ztest.log
 export MMP_HISTORY=100
 export MMP_HISTORY_OFF=0
 

--- a/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -97,21 +97,24 @@ function mmp_pool_create # pool dir
 {
 	typeset pool=${1:-$MMP_POOL}
 	typeset dir=${2:-$MMP_DIR}
-	typeset opts="-T120 -M -k0 -f $dir -E -p $pool"
+	typeset opts="-VVVVV -T120 -M -k0 -f $dir -E -p $pool"
 
 	log_must mkdir -p $dir
+	log_must rm -f $dir/*
 	log_must truncate -s $MINVDEVSIZE $dir/vdev1 $dir/vdev2
 
 	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $HOSTID1
-	log_must zpool create -f $pool mirror $dir/vdev1 $dir/vdev2
+	log_must zpool create -f -o cachefile=$MMP_CACHE $pool \
+	    mirror $dir/vdev1 $dir/vdev2
 	log_must zpool set multihost=on $pool
+	log_must mv $MMP_CACHE ${MMP_CACHE}.stale
 	log_must zpool export $pool
 	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $HOSTID2
 
 	log_note "Starting ztest in the background as hostid $HOSTID1"
-	log_must eval "ZFS_HOSTID=$HOSTID1 ztest $opts >/dev/null 2>&1 &"
+	log_must eval "ZFS_HOSTID=$HOSTID1 ztest $opts >$MMP_ZTEST_LOG 2>&1 &"
 
 	while ! is_pool_imported "$pool" "-d $dir"; do
 		log_must pgrep ztest
@@ -134,7 +137,7 @@ function mmp_pool_destroy # pool dir
 		destroy_pool $pool
         fi
 
-	rm -Rf $dir
+	log_must rm -f $dir/*
 	mmp_clear_hostid
 }
 

--- a/tests/zfs-tests/tests/functional/mmp/mmp_active_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_active_import.ksh
@@ -41,7 +41,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	mmp_pool_destroy $MMP_DIR $MMP_POOL
+	mmp_pool_destroy $MMP_POOL $MMP_DIR
 	log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_DEFAULT
 	log_must mmp_clear_hostid
 }
@@ -60,9 +60,17 @@ log_must is_pool_imported $MMP_POOL "-d $MMP_DIR"
 
 # 3. Verify 'zpool import [-f] $MMP_POOL' cannot import the pool.
 MMP_IMPORTED_MSG="Cannot import '$MMP_POOL': pool is imported"
+
 log_must try_pool_import $MMP_POOL "-d $MMP_DIR" "$MMP_IMPORTED_MSG"
 for i in {1..10}; do
 	log_must try_pool_import $MMP_POOL "-f -d $MMP_DIR" "$MMP_IMPORTED_MSG"
+done
+
+log_must try_pool_import $MMP_POOL "-c ${MMP_CACHE}.stale" "$MMP_IMPORTED_MSG"
+
+for i in {1..10}; do
+	log_must try_pool_import $MMP_POOL "-f -c ${MMP_CACHE}.stale" \
+	    "$MMP_IMPORTED_MSG"
 done
 
 # 4. Kill ztest to make pool eligible for import.  Poll with 'zpool status'.


### PR DESCRIPTION
### Description

When the multihost property is enabled it should be impossible to
import an active pool even using the force (-f) option.  This patch
prevents a forced import from succeeding when importing with a
stale cache file.

The root cause of the problem is that the kernel modules trusted
the hostid provided in configuration.  This is always correct when
the configuration is generated by scanning for the pool.  However,
when using an existing cache file the hostid could be stale which
would result in the activity check being skipped.

Resolve the issue by always using the hostid read from the label
configuration where the best uberblock was found.

### Motivation and Context

Issue #6933

### How Has This Been Tested?

The `mmp_active_import` test case was extended to try importing an active pool using a cache file.

```
$  ./scripts/zfs-tests.sh -vx -T mmp
...
/home/behlendo/src/git/zfs/tests/test-runner/bin/test-runner.py  -c /home/behlendo/src/git/zfs/tests/runfiles/linux.run -T mmp -i /home/behlendo/src/git/zfs/tests/zfs-tests -I 1
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/setup (run as root) [00:00] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/mmp_on_thread (run as root) [00:08] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/mmp_on_uberblocks (run as root) [00:11] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/mmp_on_off (run as root) [00:14] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/mmp_interval (run as root) [00:00] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/mmp_active_import (run as root) [01:37] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import (run as root) [00:29] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/mmp_exported_import (run as root) [00:11] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/mmp_write_uberblocks (run as root) [00:04] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval (run as root) [00:02] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/mmp/cleanup (run as root) [00:00] [PASS]

Results Summary
PASS	  11

Running Time:	00:02:59
Percent passed:	100.0%
Log directory:	/var/tmp/test_results/20171215T174452
```


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
