### PR TITLE
OpenZFS 8794 - cstyle generates warnings with recent perl

### DIFF
--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -383,7 +383,7 @@ line: while (<$filehandle>) {
 
 	# is this the beginning or ending of a function?
 	# (not if "struct foo\n{\n")
-	if (/^{$/ && $prev =~ /\)\s*(const\s*)?(\/\*.*\*\/\s*)?\\?$/) {
+	if (/^\{$/ && $prev =~ /\)\s*(const\s*)?(\/\*.*\*\/\s*)?\\?$/) {
 		$in_function = 1;
 		$in_declaration = 1;
 		$in_function_header = 0;
@@ -391,7 +391,7 @@ line: while (<$filehandle>) {
 		$prev = $line;
 		next line;
 	}
-	if (/^}\s*(\/\*.*\*\/\s*)*$/) {
+	if (/^\}\s*(\/\*.*\*\/\s*)*$/) {
 		if ($prev =~ /^\s*return\s*;/) {
 			err_prev("unneeded return at end of function");
 		}
@@ -401,7 +401,7 @@ line: while (<$filehandle>) {
 		next line;
 	}
 	if ($in_function_header && ! /^    (\w|\.)/ ) {
-		if (/^{}$/ # empty functions
+		if (/^\{\}$/ # empty functions
 		|| /;/ #run function with multiline arguments
 		|| /#/ #preprocessor commands
 		|| /^[^\s\\]*\(.*\)$/ #functions without ; at the end
@@ -431,7 +431,7 @@ line: while (<$filehandle>) {
 			$function_header_full_indent = 1;
 		}
 	}
-	if ($in_function_header && /^{$/) {
+	if ($in_function_header && /^\{$/) {
 		$in_function_header = 0;
 		$function_header_full_indent = 0;
 		$in_function = 1;
@@ -440,7 +440,7 @@ line: while (<$filehandle>) {
 		$in_function_header = 0;
 		$function_header_full_indent = 0;
 	}
-	if ($in_function_header && /{$/ ) {
+	if ($in_function_header && /\{$/ ) {
 		if ($picky) {
 			err("opening brace on same line as function header");
 		}
@@ -670,14 +670,14 @@ line: while (<$filehandle>) {
 	if (/\S\{/ && !/\{\{/) {
 		err("missing space before left brace");
 	}
-	if ($in_function && /^\s+{/ &&
+	if ($in_function && /^\s+\{/ &&
 	    ($prev =~ /\)\s*$/ || $prev =~ /\bstruct\s+\w+$/)) {
 		err("left brace starting a line");
 	}
-	if (/}(else|while)/) {
+	if (/\}(else|while)/) {
 		err("missing space after right brace");
 	}
-	if (/}\s\s+(else|while)/) {
+	if (/\}\s\s+(else|while)/) {
 		err("extra space after right brace");
 	}
 	if (/\b_VOID\b|\bVOID\b|\bSTATIC\b/) {
@@ -730,18 +730,18 @@ line: while (<$filehandle>) {
 	if ($heuristic) {
 		# cannot check this everywhere due to "struct {\n...\n} foo;"
 		if ($in_function && !$in_declaration &&
-		    /}./ && !/}\s+=/ && !/{.*}[;,]$/ && !/}(\s|)*$/ &&
-		    !/} (else|while)/ && !/}}/) {
+		    /\}./ && !/\}\s+=/ && !/\{.*\}[;,]$/ && !/\}(\s|)*$/ &&
+		    !/\} (else|while)/ && !/\}\}/) {
 			err("possible bad text following right brace");
 		}
 		# cannot check this because sub-blocks in
 		# the middle of code are ok
-		if ($in_function && /^\s+{/) {
+		if ($in_function && /^\s+\{/) {
 			err("possible left brace starting a line");
 		}
 	}
 	if (/^\s*else\W/) {
-		if ($prev =~ /^\s*}$/) {
+		if ($prev =~ /^\s*\}$/) {
 			err_prefix($prev,
 			    "else and right brace should be on same line");
 		}
@@ -827,8 +827,8 @@ process_indent($)
 
 	# skip over enumerations, array definitions, initializers, etc.
 	if ($cont_off <= 0 && !/^\s*$special/ &&
-	    (/(?:(?:\b(?:enum|struct|union)\s*[^\{]*)|(?:\s+=\s*)){/ ||
-	    (/^\s*{/ && $prev =~ /=\s*(?:\/\*.*\*\/\s*)*$/))) {
+	    (/(?:(?:\b(?:enum|struct|union)\s*[^\{]*)|(?:\s+=\s*))\{/ ||
+	    (/^\s*\{/ && $prev =~ /=\s*(?:\/\*.*\*\/\s*)*$/))) {
 		$cont_in = 0;
 		$cont_off = tr/{/{/ - tr/}/}/;
 		return;
@@ -851,14 +851,14 @@ process_indent($)
 		return		if (/^\s*\}?$/);
 		return		if (/^\s*\}?\s*else\s*\{?$/);
 		return		if (/^\s*do\s*\{?$/);
-		return		if (/{$/);
-		return		if (/}[,;]?$/);
+		return		if (/\{$/);
+		return		if (/\}[,;]?$/);
 
 		# Allow macros on their own lines
 		return		if (/^\s*[A-Z_][A-Z_0-9]*$/);
 
 		# cases we don't deal with, generally non-kosher
-		if (/{/) {
+		if (/\{/) {
 			err("stuff after {");
 			return;
 		}
@@ -927,7 +927,7 @@ process_indent($)
 			#
 			next		if (@cont_paren != 0);
 			if ($cont_special) {
-				if ($rest =~ /^\s*{?$/) {
+				if ($rest =~ /^\s*\{?$/) {
 					$cont_in = 0;
 					last;
 				}


### PR DESCRIPTION
### Description
OpenZFS 8794 - cstyle generates warnings with recent perl

Authored by: Dominik Hassler <hadfl@omniosce.org>
Reviewed by: Andy Fiddaman <andy@omniosce.org>
Reviewed by: Igor Kozhukhov <igor@dilos.org>
Reviewed by: Toomas Soome <tsoome@me.com>
Approved by: Dan McDonald <danmcd@joyent.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/8794
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/578f67364c

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->


<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keep current on patch ports.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Locally on a CentOS 7 VM.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
