### PR TITLE
ZTS: Fix create-o_ashift test case

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2788,16 +2788,16 @@ dump_label(const char *dev)
 		exit(1);
 	}
 
-	if (ioctl(fd, BLKFLSBUF) != 0)
-		(void) printf("failed to invalidate cache '%s' : %s\n", path,
-		    strerror(errno));
-
 	if (fstat64_blk(fd, &statbuf) != 0) {
 		(void) printf("failed to stat '%s': %s\n", path,
 		    strerror(errno));
 		(void) close(fd);
 		exit(1);
 	}
+
+	if (S_ISBLK(statbuf.st_mode) && ioctl(fd, BLKFLSBUF) != 0)
+		(void) printf("failed to invalidate cache '%s' : %s\n", path,
+		    strerror(errno));
 
 	avl_create(&config_tree, cksum_record_compare,
 	    sizeof (cksum_record_t), offsetof(cksum_record_t, link));

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/create-o_ashift.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/create-o_ashift.ksh
@@ -42,54 +42,47 @@
 
 verify_runnable "global"
 
-# See issue: https://github.com/zfsonlinux/zfs/issues/6924
-if is_linux; then
-	log_unsupported "Test case occasionally fails"
-fi
-
 function cleanup
 {
-	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	destroy_pool $TESTPOOL
 	log_must rm -f $disk
 }
 
 #
-# Commit the specified number of TXGs to the provided pool
-# We use 'zpool sync' here because we can't force it via sync(1) like on illumos
-# $1 pool name
-# $2 number of txg syncs
+# Fill the uberblock ring in every <device> label: we do this by committing
+# TXGs to the provided <pool> until every slot contains a valid uberblock.
+# NOTE: We use 'zpool sync' here because we can't force it via sync(1) like on
+# illumos
 #
-function txg_sync
+function write_device_uberblocks # <device> <pool>
 {
-	typeset pool=$1
-	typeset -i count=$2
-	typeset -i i=0;
+	typeset device=$1
+	typeset pool=$2
 
-	while [ $i -lt $count ]
+	while [ "$(zdb -quuul $device | grep -c 'invalid')" -ne 0 ]
 	do
-		log_must sync_pool $pool true
-		((i = i + 1))
+		sync_pool $pool true
 	done
 }
 
 #
-# Verify device $1 labels contains $2 valid uberblocks in every label
-# $1 device
-# $2 uberblocks count
+# Verify every label on <device> contains <count> (valid) uberblocks
 #
-function verify_device_uberblocks
+function verify_device_uberblocks # <device> <count>
 {
 	typeset device=$1
 	typeset ubcount=$2
 
 	zdb -quuul $device | egrep '^(\s+)?Uberblock' |
-	    egrep -v 'invalid$' | awk \
-	    -v ubcount=$ubcount '{ uberblocks[$0]++; }
-	    END { for (i in uberblocks) {
-		count++;
-		if (uberblocks[i] != 4) { exit 1; }
-	    }
-	    if (count != ubcount) { exit 1; } }'
+	    awk -v ubcount=$ubcount 'BEGIN { count=0 } { uberblocks[$0]++; }
+	    END {
+	        for (i in uberblocks) {
+	            if (i ~ /invalid/) { continue; }
+	            if (uberblocks[i] != 4) { exit 1; }
+	            count++;
+	        }
+	        if (count != ubcount) { exit 1; }
+	    }'
 
 	return $?
 }
@@ -115,8 +108,7 @@ do
 		log_fail "Pool was created without setting ashift value to "\
 		    "$ashift (current = $pprop)"
 	fi
-	# force 128 txg sync to fill the uberblock ring
-	txg_sync $TESTPOOL 128
+	write_device_uberblocks $disk $TESTPOOL
 	verify_device_uberblocks $disk ${ubcount[$i]}
 	if [[ $? -ne 0 ]]
 	then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

The function that fills the uberblock ring buffer on every device label has been reworked to avoid occasional failures caused by a race condition that prevents 'zpool sync' from writing some uberblock
sequentially: this happens when the pool sync ioctl dispatch code calls `txg_wait_synced()` while we're already waiting for a TXG to sync.

### Root Cause Analysis

On a local builder i added some `zfs_dbgmsg()` calls and modified `zfs_ioc_pool_sync()` to call `txg_wait_synced(spa_get_dsl(spa), spa_last_synced_txg(spa) + 1)` just to help troubleshooting.

The resulting dbgmsg log shows why we skip writing uberblock [7]: we call `txg_wait_synced()` (after having dirtied `spa->spa_root_vdev`) while someone is already waiting for `txg=7` to sync: since `spa_last_synced_txg=5` we will only be writing uberblock [6] in this `zfs_ioc_pool_sync()` cycle, and because the test script was only going to `zpool sync -f $TESTPOOL` 128 times we won't have another chance to write uberblock [7].

```
1513516280   txg.c:657:txg_wait_synced(): txg=7 quiesce_txg=5 sync_txg=7
1513516280   txg.c:661:txg_wait_synced(): broadcasting sync more tx_synced=4 waiting=7 dp=ffff8800db1e6000
1513516280   vdev_label.c:1250:vdev_uberblock_sync():  [5] -> 
1513516280   vdev_label.c:200:vdev_label_write():  -> 0
1513516280   vdev_label.c:210:vdev_label_write():  <- 0
1513516280   vdev_label.c:200:vdev_label_write():  -> 1
1513516280   vdev_label.c:210:vdev_label_write():  <- 1
1513516280   vdev_label.c:200:vdev_label_write():  -> 2
1513516280   vdev_label.c:210:vdev_label_write():  <- 2
1513516280   vdev_label.c:200:vdev_label_write():  -> 3
1513516280   vdev_label.c:210:vdev_label_write():  <- 3
1513516280   zfs_ioctl.c:6025:zfs_ioc_pool_sync():  -> (spa_last_synced_txg = 5) 
1513516280   txg.c:661:txg_wait_synced(): broadcasting sync more tx_synced=5 waiting=7 dp=ffff8800db1e6000
1513516280   txg.c:657:txg_wait_synced(): txg=6 quiesce_txg=7 sync_txg=7
1513516280   txg.c:661:txg_wait_synced(): broadcasting sync more tx_synced=5 waiting=7 dp=ffff8800db1e6000
1513516280   vdev_label.c:200:vdev_label_write():  -> 0
1513516280   vdev_label.c:210:vdev_label_write():  <- 0
1513516280   vdev_label.c:200:vdev_label_write():  -> 2
1513516280   vdev_label.c:210:vdev_label_write():  <- 2
1513516280   vdev_label.c:1250:vdev_uberblock_sync():  [6] -> 
1513516280   vdev_label.c:200:vdev_label_write():  -> 0
1513516280   vdev_label.c:210:vdev_label_write():  <- 0
1513516280   vdev_label.c:200:vdev_label_write():  -> 1
1513516280   vdev_label.c:210:vdev_label_write():  <- 1
1513516280   vdev_label.c:200:vdev_label_write():  -> 2
1513516280   vdev_label.c:210:vdev_label_write():  <- 2
1513516280   vdev_label.c:200:vdev_label_write():  -> 3
1513516280   vdev_label.c:210:vdev_label_write():  <- 3
1513516280   vdev_label.c:1256:vdev_uberblock_sync():  [6] <- 
1513516280   vdev_label.c:200:vdev_label_write():  -> 1
1513516280   vdev_label.c:210:vdev_label_write():  <- 1
1513516280   vdev_label.c:200:vdev_label_write():  -> 3
1513516280   vdev_label.c:210:vdev_label_write():  <- 3
1513516280   txg.c:661:txg_wait_synced(): broadcasting sync more tx_synced=6 waiting=7 dp=ffff8800db1e6000
1513516280   txg.c:661:txg_wait_synced(): broadcasting sync more tx_synced=6 waiting=7 dp=ffff8800db1e6000
1513516280   zfs_ioctl.c:6029:zfs_ioc_pool_sync():  <- (spa_last_synced_txg = 7)
1513516280   zfs_ioctl.c:6025:zfs_ioc_pool_sync():  -> (spa_last_synced_txg = 7) 
1513516280   txg.c:657:txg_wait_synced(): txg=8 quiesce_txg=8 sync_txg=8
1513516280   txg.c:661:txg_wait_synced(): broadcasting sync more tx_synced=7 waiting=8 dp=ffff8800db1e6000
1513516280   vdev_label.c:200:vdev_label_write():  -> 0
1513516280   vdev_label.c:210:vdev_label_write():  <- 0
1513516280   vdev_label.c:200:vdev_label_write():  -> 2
1513516280   vdev_label.c:210:vdev_label_write():  <- 2
1513516280   vdev_label.c:1250:vdev_uberblock_sync():  [8] -> 
1513516280   vdev_label.c:200:vdev_label_write():  -> 0
1513516280   vdev_label.c:210:vdev_label_write():  <- 0
1513516280   vdev_label.c:200:vdev_label_write():  -> 1
1513516280   vdev_label.c:210:vdev_label_write():  <- 1
1513516280   vdev_label.c:200:vdev_label_write():  -> 2
1513516280   vdev_label.c:210:vdev_label_write():  <- 2
1513516280   vdev_label.c:200:vdev_label_write():  -> 3
1513516280   vdev_label.c:210:vdev_label_write():  <- 3
1513516280   vdev_label.c:1256:vdev_uberblock_sync():  [8] <- 
1513516280   vdev_label.c:200:vdev_label_write():  -> 1
1513516280   vdev_label.c:210:vdev_label_write():  <- 1
1513516280   vdev_label.c:200:vdev_label_write():  -> 3
1513516280   vdev_label.c:210:vdev_label_write():  <- 3
1513516280   zfs_ioctl.c:6029:zfs_ioc_pool_sync():  <- (spa_last_synced_txg = 8)
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #6924

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
