### PR TITLE
Handle invalid options in arc_summary

### DIFF
--- a/cmd/arc_summary/arc_summary.py
+++ b/cmd/arc_summary/arc_summary.py
@@ -977,9 +977,15 @@ def main():
     global show_tunable_descriptions
     global alternate_tunable_layout
 
-    opts, args = getopt.getopt(
-        sys.argv[1:], "adp:h", ["alternate", "description", "page=", "help"]
-    )
+    try:
+        opts, args = getopt.getopt(
+            sys.argv[1:],
+            "adp:h", ["alternate", "description", "page=", "help"]
+        )
+    except getopt.error as e:
+        sys.stderr.write("Error: %s\n" % e.msg)
+        usage()
+        sys.exit(1)
 
     args = {}
     for opt, arg in opts:
@@ -991,7 +997,7 @@ def main():
             args['p'] = arg
         if opt in ('-h', '--help'):
             usage()
-            sys.exit()
+            sys.exit(0)
 
     Kstat = get_Kstat()
 
@@ -1006,7 +1012,7 @@ def main():
         except IndexError:
             sys.stderr.write('the argument to -p must be between 1 and ' +
                              str(len(unSub)) + '\n')
-            sys.exit()
+            sys.exit(1)
     else:
         pages = unSub
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -408,7 +408,7 @@ tests = ['zdb_001_neg', 'zfs_001_neg', 'zfs_allow_001_neg',
     'zpool_offline_001_neg', 'zpool_online_001_neg', 'zpool_remove_001_neg',
     'zpool_replace_001_neg', 'zpool_scrub_001_neg', 'zpool_set_001_neg',
     'zpool_status_001_neg', 'zpool_upgrade_001_neg', 'arcstat_001_pos',
-    'arc_summary_001_pos', 'dbufstat_001_pos']
+    'arc_summary_001_pos', 'arc_summary_002_neg', 'dbufstat_001_pos']
 user =
 tags = ['functional', 'cli_user', 'misc']
 

--- a/tests/zfs-tests/tests/functional/cli_user/misc/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/Makefile.am
@@ -46,4 +46,5 @@ dist_pkgdata_SCRIPTS = \
 	zpool_upgrade_001_neg.ksh \
 	arcstat_001_pos.ksh \
 	arc_summary_001_pos.ksh \
+	arc_summary_002_neg.ksh \
 	dbufstat_001_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_user/misc/arc_summary_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/arc_summary_002_neg.ksh
@@ -1,0 +1,38 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2015 by Lawrence Livermore National Security, LLC.
+# All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+typeset args=("-x" "-r" "-5" "-p 7" "--err" "-@")
+
+log_assert "arc_summary.py generates an error code with invalid options"
+
+for arg in "${args[@]}"; do
+        log_mustnot eval "arc_summary.py $arg > /dev/null"
+done
+
+log_pass "arc_summary.py generates an error code with invalid options"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

If an invalid option is provided to arc_summary.py we handle any error thrown from the getopt Python module and print the usage help message.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I accidentally mistyped an invalid option while i was spending some quality time with arc_summary and Python to try and understand why it doesn't let us trap EPIPE exceptions (#6969):

```
root@linux:# arc_summary.py -s
Traceback (most recent call last):
  File "./cmd/arc_summary/arc_summary.py", line 1020, in <module>
    main()
  File "./cmd/arc_summary/arc_summary.py", line 981, in main
    sys.argv[1:], "adp:h", ["alternate", "description", "page=", "help"]
  File "/usr/lib/python2.7/getopt.py", line 90, in getopt
    opts, args = do_shorts(opts, args[0][1:], shortopts, args[1:])
  File "/usr/lib/python2.7/getopt.py", line 190, in do_shorts
    if short_has_arg(opt, shortopts):
  File "/usr/lib/python2.7/getopt.py", line 206, in short_has_arg
    raise GetoptError('option -%s not recognized' % opt, opt)
getopt.GetoptError: option -s not recognized
```

with patch applied:

```
root@linux:# arc_summary.py -s
Error: option -s not recognized
Usage: arc_summary.py [-h] [-a] [-d] [-p PAGE]

	 -h, --help           : Print this help message and exit
	 -a, --alternate      : Show an alternate sysctl layout
	 -d, --description    : Show the sysctl descriptions
	 -p PAGE, --page=PAGE : Select a single output page to display,
	                        should be an integer between 1 and 6

Examples:
	arc_summary.py -a
	arc_summary.py -p 4
	arc_summary.py -ad
	arc_summary.py --page=2
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on local builder (Debian 8). A new test was also added to ZFS Test Suite, i don't know it's actually useful, i can drop it from this PR if needed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
