### PR TITLE
Call commit callbacks from the tail of the list

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -748,11 +748,16 @@ void dmu_tx_mark_netfree(dmu_tx_t *tx);
  * to stable storage and will also be called if the dmu_tx is aborted.
  * If there is any error which prevents the transaction from being committed to
  * disk, the callback will be called with a value of error != 0.
+ *
+ * When multiple callbacks are registered to the transaction, the callbacks
+ * will be called in reverse order to let Lustre, the only user of commit
+ * callback currently, take the fast path of its commit callback handling.
  */
 typedef void dmu_tx_callback_func_t(void *dcb_data, int error);
 
 void dmu_tx_callback_register(dmu_tx_t *tx, dmu_tx_callback_func_t *dcb_func,
     void *dcb_data);
+void dmu_tx_do_callbacks(list_t *cb_list, int error);
 
 /*
  * Free up the data blocks for a defined range of a file.  If size is

--- a/include/sys/dmu_tx.h
+++ b/include/sys/dmu_tx.h
@@ -145,10 +145,6 @@ uint64_t dmu_tx_get_txg(dmu_tx_t *tx);
 struct dsl_pool *dmu_tx_pool(dmu_tx_t *tx);
 void dmu_tx_wait(dmu_tx_t *tx);
 
-void dmu_tx_callback_register(dmu_tx_t *tx, dmu_tx_callback_func_t *dcb_func,
-    void *dcb_data);
-void dmu_tx_do_callbacks(list_t *cb_list, int error);
-
 /*
  * These routines are defined in dmu_spa.h, and are called by the SPA.
  */

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -1197,7 +1197,7 @@ dmu_tx_do_callbacks(list_t *cb_list, int error)
 {
 	dmu_tx_callback_t *dcb;
 
-	while ((dcb = list_head(cb_list)) != NULL) {
+	while ((dcb = list_tail(cb_list)) != NULL) {
 		list_remove(cb_list, dcb);
 		dcb->dcb_func(dcb->dcb_data, error);
 		kmem_free(dcb, sizeof (dmu_tx_callback_t));


### PR DESCRIPTION
Our zfs backed Lustre MDT had soft lockups while under heavy metadata
workload:
[ 3597.867291] NMI watchdog: BUG: soft lockup - CPU#20 stuck for 22s! [tx_commit_cb:67888]
[ 3597.867329] Modules linked in: osp(OE) mdd(OE) lod(OE) mdt(OE) lfsck(OE) mgs(OE) mgc(OE) osd_zfs(OE) lquota(OE) fid(OE) fld(OE) ptlrpc(OE) obdclass(OE) ko2iblnd(OE) lnet(OE) libcfs(OE) bonding rdma_ucm(OE) ib_ucm(OE) rdma_cm(OE) iw_cm(OE) ib_ipoib(OE) ib_cm(OE) ib_uverbs(OE) ib_umad(OE) mlx4_en(OE) mlx4_ib(OE) mlx4_core(OE) dm_mirror dm_region_hash dm_log sb_edac zfs(POE) edac_core intel_powerclamp coretemp zunicode(POE) zavl(POE) intel_rapl icp(POE) iosf_mbi kvm_intel zcommon(POE) znvpair(POE) spl(OE) kvm iTCO_wdt iTCO_vendor_support irqbypass dm_round_robin crc32_pclmul ghash_clmulni_intel sg ipmi_si hpilo hpwdt aesni_intel ipmi_devintf lrw gf128mul glue_helper ipmi_msghandler ioatdma ablk_helper pcspkr i2c_i801 wmi cryptd nfsd dm_multipath lpc_ich shpchp dca acpi_cpufreq acpi_power_meter dm_mod
[ 3597.867344]  auth_rpcgss nfs_acl lockd grace sunrpc knem(OE) ip_tables xfs libcrc32c mlx5_ib(OE) ib_core(OE) sd_mod crc_t10dif crct10dif_generic mgag200 i2c_algo_bit drm_kms_helper syscopyarea sysfillrect sysimgblt fb_sys_fops ttm drm tg3 mlx5_core(OE) devlink mlx_compat(OE) crct10dif_pclmul ptp crct10dif_common serio_raw crc32c_intel i2c_core pps_core hpsa(OE) scsi_transport_sas
[ 3597.867346] CPU: 20 PID: 67888 Comm: tx_commit_cb Tainted: P           OE  ------------   3.10.0-693.2.2.el7.x86_64 #1
[ 3597.867348] Hardware name: HP ProLiant DL360 Gen9/ProLiant DL360 Gen9, BIOS P89 04/25/2017
[ 3597.867349] task: ffff889c3d6f1fa0 ti: ffff8898b7dec000 task.ti: ffff8898b7dec000
[ 3597.867357] RIP: 0010:[<ffffffff810fa326>]  [<ffffffff810fa326>] native_queued_spin_lock_slowpath+0x116/0x1e0
[ 3597.867358] RSP: 0018:ffff8898b7defcd0  EFLAGS: 00000246
[ 3597.867358] RAX: 0000000000000000 RBX: 000000010001a588 RCX: 0000000000a10000
[ 3597.867359] RDX: ffff88befed97880 RSI: 0000000000c10001 RDI: ffff885e58a78138
[ 3597.867359] RBP: ffff8898b7defcd0 R08: ffff88befec97880 R09: 0000000000000000
[ 3597.867360] R10: 00000000ea2b3a01 R11: ffffea017ba8acc0 R12: ffff885efbf32f40
[ 3597.867361] R13: ffff88bebc38a48d R14: 0000000000016d39 R15: ffffffff811de591
[ 3597.867361] FS:  0000000000000000(0000) GS:ffff88befec80000(0000) knlGS:0000000000000000
[ 3597.867362] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[ 3597.867362] CR2: 00007fda2a9a2090 CR3: 0000005eef36d000 CR4: 00000000003407e0
[ 3597.867363] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
[ 3597.867363] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
[ 3597.867364] Stack:
[ 3597.867365]  ffff8898b7defce0 ffffffff8169e61f ffff8898b7defcf0 ffffffff816abb70
[ 3597.867366]  ffff8898b7defd68 ffffffffc136314e ffff885e58a78138 ffff885c6376a650
[ 3597.867367]  ffff8898b7defd10 ffff8898b7defd10 0000000000000000 0000000000000000
[ 3597.867367] Call Trace:
[ 3597.867375]  [<ffffffff8169e61f>] queued_spin_lock_slowpath+0xb/0xf
[ 3597.867378]  [<ffffffff816abb70>] _raw_spin_lock+0x20/0x30
[ 3597.867445]  [<ffffffffc136314e>] ptlrpc_commit_replies+0x7e/0x380 [ptlrpc]
[ 3597.867481]  [<ffffffffc13af3a2>] tgt_cb_last_committed+0x2c2/0x3d0 [ptlrpc]
[ 3597.867489]  [<ffffffffc114773b>] osd_trans_commit_cb+0x14b/0x490 [osd_zfs]
[ 3597.867529]  [<ffffffffc0b91ba4>] dmu_tx_do_callbacks+0x44/0x70 [zfs]
[ 3597.867554]  [<ffffffffc0bdd224>] txg_do_callbacks+0x14/0x30 [zfs]
[ 3597.867561]  [<ffffffffc02c3ed6>] taskq_thread+0x246/0x470 [spl]
[ 3597.867564]  [<ffffffff810c4810>] ? wake_up_state+0x20/0x20
[ 3597.867568]  [<ffffffffc02c3c90>] ? taskq_thread_spawn+0x60/0x60 [spl]
[ 3597.867571]  [<ffffffff810b098f>] kthread+0xcf/0xe0
[ 3597.867573]  [<ffffffff810b08c0>] ? insert_kthread_work+0x40/0x40
[ 3597.867576]  [<ffffffff816b4f58>] ret_from_fork+0x58/0x90
[ 3597.867577]  [<ffffffff810b08c0>] ? insert_kthread_work+0x40/0x40
[ 3597.867588] Code: 0d 48 98 83 e2 30 48 81 c2 80 78 01 00 48 03 14 c5 e0 fd b0 81 4c 89 02 41 8b 40 08 85 c0 75 0f 0f 1f 44 00 00 f3 90 41 8b 40 08 <85> c0 74 f6 4d 8b 08 4d 85 c9 74 04 41 0f 18 09 8b 17 0f b7 c2

This patch makes zfs commit callbacks work on highest transaction
number first, saving the subsequent calls to ptlrpc_commit_replies
in Lustre, which makes the problem go away.

A similar issue for ext4/ldiskfs is described on:
https://jira.hpdd.intel.com/browse/LU-6527

Signed-off-by: Li Dongyang <dongyang.li@anu.edu.au>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
