### PR TITLE
Fix ARC hit rate

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -263,6 +263,7 @@ void arc_buf_destroy(arc_buf_t *buf, void *tag);
 void arc_buf_info(arc_buf_t *buf, arc_buf_info_t *abi, int state_index);
 uint64_t arc_buf_size(arc_buf_t *buf);
 uint64_t arc_buf_lsize(arc_buf_t *buf);
+void arc_buf_access(arc_buf_t *buf);
 void arc_release(arc_buf_t *buf, void *tag);
 int arc_released(arc_buf_t *buf);
 void arc_buf_sigsegv(int sig, siginfo_t *si, void *unused);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -449,8 +449,13 @@ typedef struct arc_stats {
 	 */
 	kstat_named_t arcstat_mutex_miss;
 	/*
+	 * Number of buffers skipped when updating the access state due to the
+	 * header having already been released after acquiring the hash lock.
+	 */
+	kstat_named_t arcstat_access_skip;
+	/*
 	 * Number of buffers skipped because they have I/O in progress, are
-	 * indrect prefetch buffers that have not lived long enough, or are
+	 * indirect prefetch buffers that have not lived long enough, or are
 	 * not from the spa we're trying to evict from.
 	 */
 	kstat_named_t arcstat_evict_skip;
@@ -688,6 +693,7 @@ static arc_stats_t arc_stats = {
 	{ "mfu_ghost_hits",		KSTAT_DATA_UINT64 },
 	{ "deleted",			KSTAT_DATA_UINT64 },
 	{ "mutex_miss",			KSTAT_DATA_UINT64 },
+	{ "access_skip",		KSTAT_DATA_UINT64 },
 	{ "evict_skip",			KSTAT_DATA_UINT64 },
 	{ "evict_not_enough",		KSTAT_DATA_UINT64 },
 	{ "evict_l2_cached",		KSTAT_DATA_UINT64 },
@@ -5609,6 +5615,50 @@ arc_access(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 		cmn_err(CE_PANIC, "invalid arc state 0x%p",
 		    hdr->b_l1hdr.b_state);
 	}
+}
+
+/*
+ * This routine is called by dbuf_hold() to update the arc_access() state
+ * which otherwise would be skipped for entries in the dbuf cache.
+ */
+void
+arc_buf_access(arc_buf_t *buf)
+{
+	mutex_enter(&buf->b_evict_lock);
+	arc_buf_hdr_t *hdr = buf->b_hdr;
+
+	/*
+	 * Avoid taking the hash_lock when possible as an optimization.
+	 * The header must be checked again under the hash_lock in order
+	 * to handle the case where it is concurrently being released.
+	 */
+	if (hdr->b_l1hdr.b_state == arc_anon || HDR_EMPTY(hdr)) {
+		mutex_exit(&buf->b_evict_lock);
+		return;
+	}
+
+	kmutex_t *hash_lock = HDR_LOCK(hdr);
+	mutex_enter(hash_lock);
+
+	if (hdr->b_l1hdr.b_state == arc_anon || HDR_EMPTY(hdr)) {
+		mutex_exit(hash_lock);
+		mutex_exit(&buf->b_evict_lock);
+		ARCSTAT_BUMP(arcstat_access_skip);
+		return;
+	}
+
+	mutex_exit(&buf->b_evict_lock);
+
+	ASSERT(hdr->b_l1hdr.b_state == arc_mru ||
+	    hdr->b_l1hdr.b_state == arc_mfu);
+
+	DTRACE_PROBE1(arc__hit, arc_buf_hdr_t *, hdr);
+	arc_access(hdr, hash_lock);
+	mutex_exit(hash_lock);
+
+	ARCSTAT_BUMP(arcstat_hits);
+	ARCSTAT_CONDSTAT(!HDR_PREFETCH(hdr) && !HDR_PRESCIENT_PREFETCH(hdr),
+	    demand, prefetch, !HDR_ISTYPE_METADATA(hdr), data, metadata, hits);
 }
 
 /* a generic arc_read_done_func_t which you can use */

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2821,8 +2821,10 @@ __dbuf_hold_impl(struct dbuf_hold_impl_data *dh)
 		return (SET_ERROR(ENOENT));
 	}
 
-	if (dh->dh_db->db_buf != NULL)
+	if (dh->dh_db->db_buf != NULL) {
+		arc_buf_access(dh->dh_db->db_buf);
 		ASSERT3P(dh->dh_db->db.db_data, ==, dh->dh_db->db_buf->b_data);
+	}
 
 	ASSERT(dh->dh_db->db_buf == NULL || arc_referenced(dh->dh_db->db_buf));
 


### PR DESCRIPTION
### Description

When the compressed ARC feature was added in commit d3c2ae1 the method of reference counting in the ARC was modified.  As part of this accounting change the `arc_buf_add_ref()` function was removed entirely.

This would have been fine but the `arc_buf_add_ref()` function served a second undocumented purpose of updating the ARC access information when taking a hold on a dbuf.  Without this logic in place a cached dbuf would not migrate its associated `arc_buf_hdr_t` to the MFU list.  This negatively impacts the ARC hit rate, particularly on systems with a small ARC.

This change reinstates the missing call to `arc_access()` from `dbuf_hold()` by implementing a new `arc_buf_access()` function.

### Motivation and Context

As reported in #6171 a significant drop in the ARC hit rate was reported by users upgrading to the 0.7.x releases. 

### How Has This Been Tested?

Manually with the following trivial test case which reads a file twice.  After the first read the file size should be reflected in the arcstat `mru_size`.  After the second read the file size should have been migrated to the arcstat `mfu_size`.

Notice that when testing without the patch the `mfu_size` doesn't increase on the second read.

```
$ zfs mount -a
$ grep -E 'mru_size|mfu_size' /proc/spl/kstat/zfs/arcstats
mru_size                        4    412672
mfu_size                        4    739328

$ cat /tank/file >/dev/null
 grep -E 'mru_size|mfu_size' /proc/spl/kstat/zfs/arcstats
mru_size                        4    21483008
mfu_size                        4    786432

$ cat /tank/file >/dev/null
 grep -E 'mru_size|mfu_size' /proc/spl/kstat/zfs/arcstats
mru_size                        4    21483008
mfu_size                        4    786432
```

After applying this patch the behavior is once again as expected.  This matches the long standing behavior from the zfs-0.6.5.x releases.

```
$ zfs mount -a
$ grep -E 'mru_size|mfu_size' /proc/spl/kstat/zfs/arcstats
mru_size                        4    415232
mfu_size                        4    737792

$  cat /tank/file >/dev/null
$ grep -E 'mru_size|mfu_size' /proc/spl/kstat/zfs/arcstats
mru_size                        4    21384192
mfu_size                        4    889856

$ cat /tank/file >/dev/null
$ grep -E 'mru_size|mfu_size' /proc/spl/kstat/zfs/arcstats
mru_size                        4    1084928
mfu_size                        4    21198336
```

Additional testing included a full local run of the ZTS.

@grwilson since this code was also dropped from OpenZFS I believe it suffers from a similar regression.  Can you please review this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
