### PR TITLE
Fix 'zpool add' handling of nested interior VDEVs

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -861,9 +861,11 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 
 				/*
 				 * If this is a replacing or spare vdev, then
-				 * get the real first child of the vdev.
+				 * get the real first child of the vdev: do this
+				 * in a loop because replacing and spare vdevs
+				 * can be nested.
 				 */
-				if (strcmp(childtype,
+				while (strcmp(childtype,
 				    VDEV_TYPE_REPLACING) == 0 ||
 				    strcmp(childtype, VDEV_TYPE_SPARE) == 0) {
 					nvlist_t **rchild;

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -257,7 +257,7 @@ tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
     'zpool_add_004_pos', 'zpool_add_005_pos', 'zpool_add_006_pos',
     'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg',
     'zpool_add_010_pos',
-    'add-o_ashift', 'add_prop_ashift']
+    'add-o_ashift', 'add_prop_ashift', 'add_nested_replacing_spare']
 tags = ['functional', 'cli_root', 'zpool_add']
 
 [tests/functional/cli_root/zpool_attach]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/Makefile.am
@@ -15,4 +15,5 @@ dist_pkgdata_SCRIPTS = \
 	zpool_add_009_neg.ksh \
 	zpool_add_010_pos.ksh \
 	add-o_ashift.ksh \
-	add_prop_ashift.ksh
+	add_prop_ashift.ksh \
+	add_nested_replacing_spare.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/add_nested_replacing_spare.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/add_nested_replacing_spare.ksh
@@ -1,0 +1,111 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_create/zpool_create.shlib
+
+#
+# DESCRIPTION:
+#	'zpool add' works with nested replacing/spare vdevs
+#
+# STRATEGY:
+#	1. Create a redundant pool with a spare device
+#	2. Manually fault a device, wait for the hot-spare and then replace it:
+#	   this creates a situation where replacing and spare vdevs are nested.
+#	3. Verify 'zpool add' is able to add new devices to the pool.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	zed_stop
+	zed_cleanup
+	log_must zinject -c all
+	destroy_pool $TESTPOOL
+	log_must rm -f $DATA_DEVS $SPARE_DEVS
+}
+
+log_assert "'zpool add' works with nested replacing/spare vdevs"
+log_onexit cleanup
+
+FAULT_DEV="$TEST_BASE_DIR/fault-dev"
+SAFE_DEV1="$TEST_BASE_DIR/safe-dev1"
+SAFE_DEV2="$TEST_BASE_DIR/safe-dev2"
+SAFE_DEV3="$TEST_BASE_DIR/safe-dev3"
+SAFE_DEVS="$SAFE_DEV1 $SAFE_DEV2 $SAFE_DEV3"
+REPLACE_DEV="$TEST_BASE_DIR/replace-dev"
+ADD_DEV="$TEST_BASE_DIR/add-dev"
+DATA_DEVS="$FAULT_DEV $SAFE_DEVS $REPLACE_DEV $ADD_DEV"
+SPARE_DEV1="$TEST_BASE_DIR/spare-dev1"
+SPARE_DEV2="$TEST_BASE_DIR/spare-dev2"
+SPARE_DEVS="$SPARE_DEV1 $SPARE_DEV2"
+
+# We need ZED running to work with spares
+zed_setup
+zed_start
+# Clear events from previous runs
+zed_events_drain
+
+for type in "mirror" "raidz1" "raidz2" "raidz3"
+do
+	# 1. Create a redundant pool with a spare device
+	truncate -s $SPA_MINDEVSIZE $DATA_DEVS $SPARE_DEVS
+	log_must zpool create $TESTPOOL $type $FAULT_DEV $SAFE_DEVS
+	log_must zpool add $TESTPOOL spare $SPARE_DEV1
+
+	# 2.1 Fault a device, verify the spare is kicked in
+	log_must zinject -d $FAULT_DEV -e nxio -T all -f 100 $TESTPOOL
+	log_must zpool scrub $TESTPOOL
+	log_must wait_vdev_state $TESTPOOL $FAULT_DEV "UNAVAIL" 60
+	log_must wait_vdev_state $TESTPOOL $SPARE_DEV1 "ONLINE" 60
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV1 "INUSE"
+	log_must check_state $TESTPOOL "" "DEGRADED"
+
+	# 2.2 Replace the faulted device: this creates a replacing vdev inside a
+	#     spare vdev
+	log_must zpool replace $TESTPOOL $FAULT_DEV $REPLACE_DEV
+	log_must wait_vdev_state $TESTPOOL $REPLACE_DEV "ONLINE" 60
+	zpool status | awk -v poolname="$TESTPOOL" -v type="$type" 'BEGIN {s=""}
+	    $1 ~ poolname {c=4}; (c && c--) { s=s$1":" }
+	    END { if (s != poolname":"type"-0:spare-0:replacing-0:") exit 1; }'
+	if [[ $? -ne 0 ]]; then
+		log_fail "Pool does not contain nested replacing/spare vdevs"
+	fi
+
+	# 3. Verify 'zpool add' is able to add new devices
+	log_must zpool add $TESTPOOL spare $SPARE_DEV2
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV2 "AVAIL"
+	log_must zpool add -f $TESTPOOL $ADD_DEV
+	log_must wait_vdev_state $TESTPOOL $ADD_DEV "ONLINE" 60
+
+	# Cleanup
+	log_must zinject -c all
+	destroy_pool $TESTPOOL
+	log_must rm -f $DATA_DEVS $SPARE_DEVS
+done
+
+log_pass "'zpool add' works with nested replacing/spare vdevs"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
When replacing a faulted device which was previously handled by a spare multiple levels of nested interior VDEVs will be present in the pool configuration: this is safe and allowed, but `get_replication()` needs to handle this situation gracefully to let zpool add new devices to the pool otherwise we will suffer the following failure:

```
root@linux:~# zpool status
  pool: testpool
 state: DEGRADED
  scan: resilvered 20.1M in 0 days 00:00:07 with 0 errors on Tue Dec 26 18:47:37 2017
config:

	NAME                         STATE     READ WRITE CKSUM
	testpool                     DEGRADED     0     0     0
	  mirror-0                   DEGRADED     0     0     0
	    /var/tmp/file-vdev1      ONLINE       0     0     0
	    spare-1                  DEGRADED     0     0     0
	      replacing-0            DEGRADED     0     0     0
	        /var/tmp/file-vdev2  UNAVAIL      0     0     0  cannot open
	        /var/tmp/file-vdev3  ONLINE       0     0     0
	      /var/tmp/file-spare1   ONLINE       0     0     0
	spares
	  /var/tmp/file-spare1       INUSE     currently in use

errors: No known data errors
root@linux:~# zpool add $POOLNAME spare $TMPDIR/file-spare2
nvlist_lookup_string(cnv, ZPOOL_CONFIG_PATH, &path) == 0
ASSERT at zpool_vdev.c:884:get_replication()Aborted (core dumped)
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/6678

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on local builder, script added to the ZTS; `zpool add` is now able to handle the following situation:

```
root@linux:/usr/src/zfs# zpool status
  pool: testpool
 state: DEGRADED
status: One or more devices has experienced an unrecoverable error.  An
	attempt was made to correct the error.  Applications are unaffected.
action: Determine if the device needs to be replaced, and clear the errors
	using 'zpool clear' or replace the device with 'zpool replace'.
   see: http://zfsonlinux.org/msg/ZFS-8000-9P
  scan: resilvered 20.2M in 0 days 00:00:00 with 0 errors on Tue Dec 26 18:41:38 2017
config:

	NAME                                                STATE     READ WRITE CKSUM
	testpool                                            DEGRADED     0     0     0
	  mirror-0                                          DEGRADED     0     0     0
	    /var/tmp/file-vdev1                             ONLINE       0     0     0
	    spare-1                                         DEGRADED   261     0     0
	      replacing-0                                   DEGRADED     0     0     0
	        /var/tmp/file-vdev2                         UNAVAIL      0     0     0  cannot open
	        spare-1                                     DEGRADED     0     0     0
	          replacing-0                               DEGRADED     0     0     0
	            /var/tmp/file-vdev3                     UNAVAIL      0     0     0  cannot open
	            spare-1                                 DEGRADED     0     0     0
	              replacing-0                           DEGRADED     0     0     0
	                /var/tmp/file-vdev4                 UNAVAIL      0     0     0  cannot open
	                spare-1                             DEGRADED     0     0     0
	                  replacing-0                       DEGRADED     0     0     0
	                    /var/tmp/file-vdev5             UNAVAIL      0     0     0  cannot open
	                    spare-1                         DEGRADED     0     0     0
	                      replacing-0                   DEGRADED     0     0     0
	                        /var/tmp/file-vdev6         UNAVAIL      0     0     0  cannot open
	                        spare-1                     DEGRADED     0     0     0
	                          /var/tmp/file-vdev7       UNAVAIL      0     0     0  cannot open
	                          /var/tmp/file-spare6      ONLINE       0     0     0
	                        spare-2                     DEGRADED     0     0     0
	                          replacing-0               DEGRADED     0     0     0
	                            /var/tmp/file-vdev8     UNAVAIL      0     0     0  cannot open
	                            spare-1                 DEGRADED     0     0     0
	                              /var/tmp/file-vdev9   UNAVAIL      0     0     0  cannot open
	                              /var/tmp/file-spare8  ONLINE       0     0     0
	                            /var/tmp/file-vdev10    ONLINE       0     0     0
	                          /var/tmp/file-spare7      ONLINE       0     0     0
	                      /var/tmp/file-spare5          ONLINE       0     0     0
	                  /var/tmp/file-spare4              ONLINE       0     0     0
	              /var/tmp/file-spare3                  ONLINE       0     0     0
	          /var/tmp/file-spare2                      ONLINE       0     0     0
	      /var/tmp/file-spare1                          ONLINE       0     0   261
	spares
	  /var/tmp/file-spare1                              INUSE     currently in use
	  /var/tmp/file-spare2                              INUSE     currently in use
	  /var/tmp/file-spare3                              INUSE     currently in use
	  /var/tmp/file-spare4                              INUSE     currently in use
	  /var/tmp/file-spare5                              INUSE     currently in use
	  /var/tmp/file-spare6                              INUSE     currently in use
	  /var/tmp/file-spare7                              INUSE     currently in use
	  /var/tmp/file-spare8                              INUSE     currently in use
	  /var/tmp/file-spare9                              AVAIL   

errors: No known data errors
root@linux:/usr/src/zfs# truncate -s 512m $TMPDIR/file-spare-new
root@linux:/usr/src/zfs# zpool add $POOLNAME spare $TMPDIR/file-spare-new
root@linux:/usr/src/zfs# echo $?
0
root@linux:/usr/src/zfs# 
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
