### PR TITLE
Allow to limit zed's syslog chattiness

### DIFF
--- a/cmd/zed/zed.d/all-syslog.sh
+++ b/cmd/zed/zed.d/all-syslog.sh
@@ -5,6 +5,18 @@
 [ -f "${ZED_ZEDLET_DIR}/zed.rc" ] && . "${ZED_ZEDLET_DIR}/zed.rc"
 . "${ZED_ZEDLET_DIR}/zed-functions.sh"
 
+if [ -n "${ZED_SYSLOG_SUBCLASS_INCLUDE}" ]; then
+    case "${ZEVENT_SUBCLASS}" in
+    ${ZED_SYSLOG_SUBCLASS_INCLUDE}) ;;
+    *) exit 0;;
+    esac
+elif [ -n "${ZED_SYSLOG_SUBCLASS_EXCLUDE}" ]; then
+    case "${ZEVENT_SUBCLASS}" in
+    ${ZED_SYSLOG_SUBCLASS_EXCLUDE}) exit 0;;
+    *) ;;
+    esac
+fi
+
 zed_log_msg "eid=${ZEVENT_EID}" "class=${ZEVENT_SUBCLASS}" \
     "${ZEVENT_POOL_GUID:+"pool_guid=${ZEVENT_POOL_GUID}"}" \
     "${ZEVENT_VDEV_PATH:+"vdev_path=${ZEVENT_VDEV_PATH}"}" \

--- a/cmd/zed/zed.d/zed.rc
+++ b/cmd/zed/zed.d/zed.rc
@@ -97,3 +97,14 @@ ZED_USE_ENCLOSURE_LEDS=1
 #
 #ZED_SYSLOG_TAG="zed"
 
+##
+# Which set of event subclasses to log
+# By default, events from all subclasses are logged.
+# If ZED_SYSLOG_SUBCLASS_INCLUDE is set, only subclasses
+# matching the pattern are logged. Use the pipe symbol (|)
+# or shell wildcards (*, ?) to match multiple subclasses.
+# Otherwise, if ZED_SYSLOG_SUBCLASS_EXCLUDE is set, the
+# matching subclasses are excluded from logging.
+#ZED_SYSLOG_SUBCLASS_INCLUDE="checksum|scrub_*|vdev.*"
+#ZED_SYSLOG_SUBCLASS_EXCLUDE="statechange|config_*|history_event"
+


### PR DESCRIPTION
### Description

Some usage patterns like send/recv of replication streams can
produce a large number of events. In such a case, the current
all-syslog.sh zedlet will hold up to its name, and flood the
logs with mostly redundant information. To mitigate this
situation, this changeset introduces two new variables
ZED_SYSLOG_SUBCLASS_INCLUDE and ZED_SYSLOG_SUBCLASS_EXCLUDE
to zed.rc that give more control over which event classes end
up in the syslog.

Signed-off-by: Daniel Kobras <d.kobras@science-computing.de>
Closes: #6886

### Motivation and Context
It seems that each time a dataset that also uses =zfs-auto-snapshot= is replicated, a =history_event= for the =com.sun:auto-snapshot-desc= property in each snapshot is logged. This easily spams the logs with thousands of redundant, and rather useless messages as described in #6886, so adding a facility to trim down the noise without disabling the syslog feature altogether seems to be in order.

### How Has This Been Tested?
Tested on EL7.4 with ZoL 0.7.2.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
