### PR TITLE
zhack: fix getopt return type

### DIFF
--- a/cmd/zhack/zhack.c
+++ b/cmd/zhack/zhack.c
@@ -268,7 +268,7 @@ zhack_feature_enable_sync(void *arg, dmu_tx_t *tx)
 static void
 zhack_do_feature_enable(int argc, char **argv)
 {
-	char c;
+	int c;
 	char *desc, *target;
 	spa_t *spa;
 	objset_t *mos;
@@ -363,7 +363,7 @@ feature_decr_sync(void *arg, dmu_tx_t *tx)
 static void
 zhack_do_feature_ref(int argc, char **argv)
 {
-	char c;
+	int c;
 	char *target;
 	boolean_t decr = B_FALSE;
 	spa_t *spa;
@@ -483,7 +483,7 @@ main(int argc, char **argv)
 	char *path[MAX_NUM_PATHS];
 	const char *subcommand;
 	int rv = 0;
-	char c;
+	int c;
 
 	g_importargs.path = path;
 


### PR DESCRIPTION
This fixes zhack's command processing on ARM.  (where char is unsigned, and so, in promotion to an int, will never compare equal to -1.)

Signed-off-by: Nathaniel Wesley Filardo <nwf@cs.jhu.edu>

### How Has This Been Tested?
Tested by running `./cmd/zhack/zhack feature stat testpool` before and after.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
