### PR TITLE
[buildbot][pt2] zfs master 18.11.2017 (0.7.3) + openzfs 8585 + pr6568 + zfetch prefetch + ARC fixes (incl. commit callbacks from tail of list)

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2226,6 +2226,8 @@ dump_dir(objset_t *os)
 		max_slot_used = object + dnode_slots - 1;
 	}
 
+	ASSERT3U(object_count, ==, usedobjs);
+
 	(void) printf("\n");
 
 	(void) printf("    Dnode slots:\n");
@@ -2243,8 +2245,6 @@ dump_dir(objset_t *os)
 		(void) fprintf(stderr, "dmu_object_next() = %d\n", error);
 		abort();
 	}
-
-	ASSERT3U(object_count, ==, usedobjs);
 }
 
 static void
@@ -3089,7 +3089,7 @@ zdb_blkptr_done(zio_t *zio)
 	abd_free(zio->io_abd);
 
 	mutex_enter(&spa->spa_scrub_lock);
-	spa->spa_load_verify_ios--;
+	spa->spa_scrub_inflight--;
 	cv_broadcast(&spa->spa_scrub_io_cv);
 
 	if (ioerr && !(zio->io_flags & ZIO_FLAG_SPECULATIVE)) {
@@ -3160,9 +3160,9 @@ zdb_blkptr_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 			flags |= ZIO_FLAG_SPECULATIVE;
 
 		mutex_enter(&spa->spa_scrub_lock);
-		while (spa->spa_load_verify_ios > max_inflight)
+		while (spa->spa_scrub_inflight > max_inflight)
 			cv_wait(&spa->spa_scrub_io_cv, &spa->spa_scrub_lock);
-		spa->spa_load_verify_ios++;
+		spa->spa_scrub_inflight++;
 		mutex_exit(&spa->spa_scrub_lock);
 
 		zio_nowait(zio_read(NULL, spa, bp, abd, size,

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -2144,14 +2144,15 @@ ztest_get_done(zgd_t *zgd, int error)
 	ztest_object_unlock(zd, object);
 
 	if (error == 0 && zgd->zgd_bp)
-		zil_add_block(zgd->zgd_zilog, zgd->zgd_bp);
+		zil_lwb_add_block(zgd->zgd_lwb, zgd->zgd_bp);
 
 	umem_free(zgd, sizeof (*zgd));
 	umem_free(zzp, sizeof (*zzp));
 }
 
 static int
-ztest_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
+ztest_get_data(void *arg, lr_write_t *lr, char *buf, struct lwb *lwb,
+    zio_t *zio)
 {
 	ztest_ds_t *zd = arg;
 	objset_t *os = zd->zd_os;
@@ -2165,6 +2166,10 @@ ztest_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 	zgd_t *zgd;
 	int error;
 	ztest_zgd_private_t *zgd_private;
+
+	ASSERT3P(lwb, !=, NULL);
+	ASSERT3P(zio, !=, NULL);
+	ASSERT3U(size, !=, 0);
 
 	ztest_object_lock(zd, object, RL_READER);
 	error = dmu_bonus_hold(os, object, FTAG, &db);
@@ -2186,7 +2191,7 @@ ztest_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio)
 	db = NULL;
 
 	zgd = umem_zalloc(sizeof (*zgd), UMEM_NOFAIL);
-	zgd->zgd_zilog = zd->zd_zilog;
+	zgd->zgd_lwb = lwb;
 	zgd_private = umem_zalloc(sizeof (ztest_zgd_private_t), UMEM_NOFAIL);
 	zgd_private->z_zd = zd;
 	zgd_private->z_object = object;

--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -66,11 +66,11 @@ typedef struct arc_prune arc_prune_t;
  * while transforming data into its desired format - specifically, when
  * decrypting, the key may not be present, or the HMAC may not be correct
  * which signifies deliberate tampering with the on-disk state
- * (assuming that the checksum was correct). If any error occurs, the "buf"
- * parameter will be NULL.
+ * (assuming that the checksum was correct). The "error" parameter will be
+ * nonzero in this case, even if there is no associated zio.
  */
-typedef void arc_read_done_func_t(zio_t *zio, const zbookmark_phys_t *zb,
-    const blkptr_t *bp, arc_buf_t *buf, void *private);
+typedef void arc_read_done_func_t(zio_t *zio, int error, arc_buf_t *buf,
+    void *private);
 typedef void arc_write_done_func_t(zio_t *zio, arc_buf_t *buf, void *private);
 typedef void arc_prune_func_t(int64_t bytes, void *private);
 
@@ -106,45 +106,44 @@ typedef enum arc_flags
 	ARC_FLAG_CACHED			= 1 << 3,	/* I/O was in cache */
 	ARC_FLAG_L2CACHE		= 1 << 4,	/* cache in L2ARC */
 	ARC_FLAG_PREDICTIVE_PREFETCH	= 1 << 5,	/* I/O from zfetch */
-	ARC_FLAG_PRESCIENT_PREFETCH	= 1 << 6,	/* long min lifespan */
 
 	/*
 	 * Private ARC flags.  These flags are private ARC only flags that
 	 * will show up in b_flags in the arc_hdr_buf_t. These flags should
 	 * only be set by ARC code.
 	 */
-	ARC_FLAG_IN_HASH_TABLE		= 1 << 7,	/* buffer is hashed */
-	ARC_FLAG_IO_IN_PROGRESS		= 1 << 8,	/* I/O in progress */
-	ARC_FLAG_IO_ERROR		= 1 << 9,	/* I/O failed for buf */
-	ARC_FLAG_INDIRECT		= 1 << 10,	/* indirect block */
+	ARC_FLAG_IN_HASH_TABLE		= 1 << 6,	/* buffer is hashed */
+	ARC_FLAG_IO_IN_PROGRESS		= 1 << 7,	/* I/O in progress */
+	ARC_FLAG_IO_ERROR		= 1 << 8,	/* I/O failed for buf */
+	ARC_FLAG_INDIRECT		= 1 << 9,	/* indirect block */
 	/* Indicates that block was read with ASYNC priority. */
-	ARC_FLAG_PRIO_ASYNC_READ	= 1 << 11,
-	ARC_FLAG_L2_WRITING		= 1 << 12,	/* write in progress */
-	ARC_FLAG_L2_EVICTED		= 1 << 13,	/* evicted during I/O */
-	ARC_FLAG_L2_WRITE_HEAD		= 1 << 14,	/* head of write list */
+	ARC_FLAG_PRIO_ASYNC_READ	= 1 << 10,
+	ARC_FLAG_L2_WRITING		= 1 << 11,	/* write in progress */
+	ARC_FLAG_L2_EVICTED		= 1 << 12,	/* evicted during I/O */
+	ARC_FLAG_L2_WRITE_HEAD		= 1 << 13,	/* head of write list */
 	/*
 	 * Encrypted or authenticated on disk (may be plaintext in memory).
 	 * This header has b_crypt_hdr allocated. Does not include indirect
 	 * blocks with checksums of MACs which will also have their X
 	 * (encrypted) bit set in the bp.
 	 */
-	ARC_FLAG_PROTECTED		= 1 << 15,
+	ARC_FLAG_PROTECTED		= 1 << 14,
 	/* data has not been authenticated yet */
-	ARC_FLAG_NOAUTH			= 1 << 16,
+	ARC_FLAG_NOAUTH			= 1 << 15,
 	/* indicates that the buffer contains metadata (otherwise, data) */
-	ARC_FLAG_BUFC_METADATA		= 1 << 17,
+	ARC_FLAG_BUFC_METADATA		= 1 << 16,
 
 	/* Flags specifying whether optional hdr struct fields are defined */
-	ARC_FLAG_HAS_L1HDR		= 1 << 18,
-	ARC_FLAG_HAS_L2HDR		= 1 << 19,
+	ARC_FLAG_HAS_L1HDR		= 1 << 17,
+	ARC_FLAG_HAS_L2HDR		= 1 << 18,
 
 	/*
 	 * Indicates the arc_buf_hdr_t's b_pdata matches the on-disk data.
 	 * This allows the l2arc to use the blkptr's checksum to verify
 	 * the data without having to store the checksum in the hdr.
 	 */
-	ARC_FLAG_COMPRESSED_ARC		= 1 << 20,
-	ARC_FLAG_SHARED_DATA		= 1 << 21,
+	ARC_FLAG_COMPRESSED_ARC		= 1 << 19,
+	ARC_FLAG_SHARED_DATA		= 1 << 20,
 
 	/*
 	 * The arc buffer's compression mode is stored in the top 7 bits of the

--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -262,6 +262,7 @@ void arc_buf_destroy(arc_buf_t *buf, void *tag);
 void arc_buf_info(arc_buf_t *buf, arc_buf_info_t *abi, int state_index);
 uint64_t arc_buf_size(arc_buf_t *buf);
 uint64_t arc_buf_lsize(arc_buf_t *buf);
+void arc_buf_access(arc_buf_t *buf);
 void arc_release(arc_buf_t *buf, void *tag);
 int arc_released(arc_buf_t *buf);
 void arc_buf_sigsegv(int sig, siginfo_t *si, void *unused);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -982,7 +982,7 @@ uint64_t dmu_tx_get_txg(dmu_tx_t *tx);
  * {zfs,zvol,ztest}_get_done() args
  */
 typedef struct zgd {
-	struct zilog	*zgd_zilog;
+	struct lwb	*zgd_lwb;
 	struct blkptr	*zgd_bp;
 	dmu_buf_t	*zgd_db;
 	struct rl	*zgd_rl;

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -748,11 +748,16 @@ void dmu_tx_mark_netfree(dmu_tx_t *tx);
  * to stable storage and will also be called if the dmu_tx is aborted.
  * If there is any error which prevents the transaction from being committed to
  * disk, the callback will be called with a value of error != 0.
+ *
+ * When multiple callbacks are registered to the transaction, the callbacks
+ * will be called in reverse order to let Lustre, the only user of commit
+ * callback currently, take the fast path of its commit callback handling.
  */
 typedef void dmu_tx_callback_func_t(void *dcb_data, int error);
 
 void dmu_tx_callback_register(dmu_tx_t *tx, dmu_tx_callback_func_t *dcb_func,
     void *dcb_data);
+void dmu_tx_do_callbacks(list_t *cb_list, int error);
 
 /*
  * Free up the data blocks for a defined range of a file.  If size is

--- a/include/sys/dmu_tx.h
+++ b/include/sys/dmu_tx.h
@@ -145,10 +145,6 @@ uint64_t dmu_tx_get_txg(dmu_tx_t *tx);
 struct dsl_pool *dmu_tx_pool(dmu_tx_t *tx);
 void dmu_tx_wait(dmu_tx_t *tx);
 
-void dmu_tx_callback_register(dmu_tx_t *tx, dmu_tx_callback_func_t *dcb_func,
-    void *dcb_data);
-void dmu_tx_do_callbacks(list_t *cb_list, int error);
-
 /*
  * These routines are defined in dmu_spa.h, and are called by the SPA.
  */

--- a/include/sys/dmu_zfetch.h
+++ b/include/sys/dmu_zfetch.h
@@ -31,34 +31,44 @@
 #define	_DMU_ZFETCH_H
 
 #include <sys/zfs_context.h>
+#include <sys/range_tree.h>
 
 #ifdef	__cplusplus
 extern "C" {
 #endif
 
-extern unsigned long	zfetch_array_rd_sz;
-
 struct dnode;				/* so we can reference dnode */
 
-typedef struct zstream {
-	uint64_t	zs_blkid;	/* expect next access at this blkid */
-	uint64_t	zs_pf_blkid;	/* next block to prefetch */
+typedef struct zfetch_access_info {
+	uint64_t	zai_req_start;
+	uint64_t	zai_req_end;
+	uint64_t	zai_pf_min_blk;
+	uint64_t	zai_pf_max_blk;
+	uint64_t	zai_st_min_blk;
+	uint64_t	zai_st_max_blk;
 
-	/*
-	 * We will next prefetch the L1 indirect block of this level-0
-	 * block id.
-	 */
-	uint64_t	zs_ipf_blkid;
+	unsigned	zai_left_pf_seg;
+	unsigned	zai_left_pf_space;
+	unsigned	zai_right_pf_seg;
+	unsigned	zai_right_pf_space;
 
-	kmutex_t	zs_lock;	/* protects stream */
-	hrtime_t	zs_atime;	/* time last prefetch issued */
-	list_node_t	zs_node;	/* link for zf_stream */
-} zstream_t;
+	unsigned	zai_left_st_seg;
+	unsigned	zai_left_st_space;
+	unsigned	zai_right_st_seg;
+	unsigned	zai_right_st_space;
+} zfetch_access_info_t;
 
 typedef struct zfetch {
-	krwlock_t	zf_rwlock;	/* protects zfetch structure */
-	list_t		zf_stream;	/* list of zstream_t's */
-	struct dnode	*zf_dnode;	/* dnode that owns this zfetch */
+	kmutex_t		zf_lock;    /* protects zfetch structure */
+	struct dnode		*zf_dnode;  /* dnode that owns this zfetch */
+	hrtime_t		zf_atime;   /* time last prefetch issued */
+	uint64_t		zf_lastblkid;
+	/* range tree of prefetched blkid */
+	struct range_tree	zf_demand_tree;
+	/* range tree of prefetched blkid */
+	struct range_tree	zf_pf_tree;
+
+	zfetch_access_info_t	zf_zai;
 } zfetch_t;
 
 void		zfetch_init(void);

--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -80,7 +80,6 @@ typedef struct zfs_blkstat {
 
 typedef struct zfs_all_blkstats {
 	zfs_blkstat_t	zab_type[DN_MAX_LEVELS + 1][DMU_OT_TOTAL + 1];
-	kmutex_t	zab_lock;
 } zfs_all_blkstats_t;
 
 

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -108,56 +108,22 @@ typedef enum dsl_scan_flags {
  */
 typedef struct dsl_scan {
 	struct dsl_pool *scn_dp;
+
+	boolean_t scn_suspending;
 	uint64_t scn_restart_txg;
 	uint64_t scn_done_txg;
 	uint64_t scn_sync_start_time;
-	uint64_t scn_issued_before_pass;
+	zio_t *scn_zio_root;
 
 	/* for freeing blocks */
 	boolean_t scn_is_bptree;
 	boolean_t scn_async_destroying;
 	boolean_t scn_async_stalled;
+	uint64_t scn_visited_this_txg;
 
-	/* flags and stats for controlling scan state */
-	boolean_t scn_is_sorted;	/* doing sequential scan */
-	boolean_t scn_clearing;		/* scan is issuing sequential extents */
-	boolean_t scn_checkpointing;	/* scan is issuing all queued extents */
-	boolean_t scn_suspending;	/* scan is suspending until next txg */
-	uint64_t scn_last_checkpoint;	/* time of last checkpoint */
-
-	/* members for thread synchronization */
-	zio_t *scn_zio_root;		/* root zio for waiting on IO */
-	taskq_t *scn_taskq;		/* task queue for issuing extents */
-
-	/* for controlling scan prefetch, protected by spa_scrub_lock */
-	boolean_t scn_prefetch_stop;	/* prefetch should stop */
-	zbookmark_phys_t scn_prefetch_bookmark;	/* prefetch start bookmark */
-	avl_tree_t scn_prefetch_queue;	/* priority queue of prefetch IOs */
-	uint64_t scn_maxinflight_bytes; /* max bytes in flight for pool */
-
-	/* per txg statistics */
-	uint64_t scn_visited_this_txg;	/* total bps visited this txg */
-	uint64_t scn_holes_this_txg;
-	uint64_t scn_lt_min_this_txg;
-	uint64_t scn_gt_max_this_txg;
-	uint64_t scn_ddt_contained_this_txg;
-	uint64_t scn_objsets_visited_this_txg;
-	uint64_t scn_avg_seg_size_this_txg;
-	uint64_t scn_segs_this_txg;
-	uint64_t scn_avg_zio_size_this_txg;
-	uint64_t scn_zios_this_txg;
-
-	/* members needed for syncing scan status to disk */
-	dsl_scan_phys_t scn_phys;	/* on disk representation of scan */
-	dsl_scan_phys_t scn_phys_cached;
-	avl_tree_t scn_queue;		/* queue of datasets to scan */
-	uint64_t scn_bytes_pending;	/* outstanding data to issue */
+	dsl_scan_phys_t scn_phys;
 } dsl_scan_t;
 
-typedef struct dsl_scan_io_queue dsl_scan_io_queue_t;
-
-void scan_init(void);
-void scan_fini(void);
 int dsl_scan_init(struct dsl_pool *dp, uint64_t txg);
 void dsl_scan_fini(struct dsl_pool *dp);
 void dsl_scan_sync(struct dsl_pool *, dmu_tx_t *);
@@ -176,9 +142,6 @@ void dsl_scan_ds_clone_swapped(struct dsl_dataset *ds1, struct dsl_dataset *ds2,
     struct dmu_tx *tx);
 boolean_t dsl_scan_active(dsl_scan_t *scn);
 boolean_t dsl_scan_is_paused_scrub(const dsl_scan_t *scn);
-void dsl_scan_freed(spa_t *spa, const blkptr_t *bp);
-void dsl_scan_io_queue_destroy(dsl_scan_io_queue_t *queue);
-void dsl_scan_io_queue_vdev_xfer(vdev_t *svd, vdev_t *tvd);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -859,19 +859,17 @@ typedef struct pool_scan_stat {
 	uint64_t	pss_start_time;	/* scan start time */
 	uint64_t	pss_end_time;	/* scan end time */
 	uint64_t	pss_to_examine;	/* total bytes to scan */
-	uint64_t	pss_examined;	/* total bytes located by scanner */
+	uint64_t	pss_examined;	/* total examined bytes	*/
 	uint64_t	pss_to_process; /* total bytes to process */
 	uint64_t	pss_processed;	/* total processed bytes */
 	uint64_t	pss_errors;	/* scan errors	*/
 
 	/* values not stored on disk */
-	uint64_t	pss_pass_exam; /* examined bytes per scan pass */
-	uint64_t	pss_pass_issued; /* issued bytes per scan pass */
+	uint64_t	pss_pass_exam;	/* examined bytes per scan pass */
 	uint64_t	pss_pass_start;	/* start time of a scan pass */
 	uint64_t	pss_pass_scrub_pause; /* pause time of a scurb pass */
 	/* cumulative time scrub spent paused, needed for rate calculation */
 	uint64_t	pss_pass_scrub_spent_paused;
-	uint64_t	pss_issued;	/* total bytes checked by scanner */
 } pool_scan_stat_t;
 
 typedef enum dsl_scan_state {

--- a/include/sys/range_tree.h
+++ b/include/sys/range_tree.h
@@ -75,9 +75,14 @@ typedef void range_tree_func_t(void *arg, uint64_t start, uint64_t size);
 
 void range_tree_init(void);
 void range_tree_fini(void);
+
+void range_tree_initialize(range_tree_t *rt, range_tree_ops_t *ops, void *arg,
+    kmutex_t *lp);
 range_tree_t *range_tree_create(range_tree_ops_t *ops, void *arg, kmutex_t *lp);
+void range_tree_deinitialize(range_tree_t *rt);
 void range_tree_destroy(range_tree_t *rt);
 boolean_t range_tree_contains(range_tree_t *rt, uint64_t start, uint64_t size);
+boolean_t range_tree_overlaps(range_tree_t *rt, uint64_t start, uint64_t size);
 uint64_t range_tree_space(range_tree_t *rt);
 void range_tree_verify(range_tree_t *rt, uint64_t start, uint64_t size);
 void range_tree_swap(range_tree_t **rtsrc, range_tree_t **rtdst);
@@ -86,9 +91,16 @@ void range_tree_stat_verify(range_tree_t *rt);
 void range_tree_add(void *arg, uint64_t start, uint64_t size);
 void range_tree_remove(void *arg, uint64_t start, uint64_t size);
 void range_tree_clear(range_tree_t *rt, uint64_t start, uint64_t size);
+void range_tree_set(range_tree_t *rt, uint64_t start, uint64_t size);
 
 void range_tree_vacate(range_tree_t *rt, range_tree_func_t *func, void *arg);
 void range_tree_walk(range_tree_t *rt, range_tree_func_t *func, void *arg);
+
+void range_tree_range_walk(range_tree_t *rt, uint64_t start, uint64_t end,
+    range_tree_func_t *func, void *arg);
+
+uint64_t range_tree_space_start(range_tree_t *rt);
+uint64_t range_tree_space_end(range_tree_t *rt);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/range_tree.h
+++ b/include/sys/range_tree.h
@@ -44,13 +44,8 @@ typedef struct range_tree_ops range_tree_ops_t;
 typedef struct range_tree {
 	avl_tree_t	rt_root;	/* offset-ordered segment AVL tree */
 	uint64_t	rt_space;	/* sum of all segments in the map */
-	uint64_t	rt_gap;		/* allowable inter-segment gap */
 	range_tree_ops_t *rt_ops;
-
-	/* rt_avl_compare should only be set if rt_arg is an AVL tree */
 	void		*rt_arg;
-	int (*rt_avl_compare)(const void *, const void *);
-
 
 	/*
 	 * The rt_histogram maintains a histogram of ranges. Each bucket,
@@ -66,7 +61,6 @@ typedef struct range_seg {
 	avl_node_t	rs_pp_node;	/* AVL picker-private node */
 	uint64_t	rs_start;	/* starting offset of this segment */
 	uint64_t	rs_end;		/* ending offset (non-inclusive) */
-	uint64_t	rs_fill;	/* actual fill if gap mode is on */
 } range_seg_t;
 
 struct range_tree_ops {
@@ -81,37 +75,20 @@ typedef void range_tree_func_t(void *arg, uint64_t start, uint64_t size);
 
 void range_tree_init(void);
 void range_tree_fini(void);
-range_tree_t *range_tree_create_impl(range_tree_ops_t *ops, void *arg,
-    int (*avl_compare) (const void *, const void *), kmutex_t *lp,
-    uint64_t gap);
 range_tree_t *range_tree_create(range_tree_ops_t *ops, void *arg, kmutex_t *lp);
 void range_tree_destroy(range_tree_t *rt);
 boolean_t range_tree_contains(range_tree_t *rt, uint64_t start, uint64_t size);
-range_seg_t *range_tree_find(range_tree_t *rt, uint64_t start, uint64_t size);
-void range_tree_resize_segment(range_tree_t *rt, range_seg_t *rs,
-    uint64_t newstart, uint64_t newsize);
 uint64_t range_tree_space(range_tree_t *rt);
 void range_tree_verify(range_tree_t *rt, uint64_t start, uint64_t size);
 void range_tree_swap(range_tree_t **rtsrc, range_tree_t **rtdst);
 void range_tree_stat_verify(range_tree_t *rt);
-void range_tree_set_lock(range_tree_t *rt, kmutex_t *lp);
 
 void range_tree_add(void *arg, uint64_t start, uint64_t size);
 void range_tree_remove(void *arg, uint64_t start, uint64_t size);
-void range_tree_remove_fill(range_tree_t *rt, uint64_t start, uint64_t size);
-void range_tree_adjust_fill(range_tree_t *rt, range_seg_t *rs, int64_t delta);
 void range_tree_clear(range_tree_t *rt, uint64_t start, uint64_t size);
 
 void range_tree_vacate(range_tree_t *rt, range_tree_func_t *func, void *arg);
 void range_tree_walk(range_tree_t *rt, range_tree_func_t *func, void *arg);
-range_seg_t *range_tree_first(range_tree_t *rt);
-
-void rt_avl_create(range_tree_t *rt, void *arg);
-void rt_avl_destroy(range_tree_t *rt, void *arg);
-void rt_avl_add(range_tree_t *rt, range_seg_t *rs, void *arg);
-void rt_avl_remove(range_tree_t *rt, range_seg_t *rs, void *arg);
-void rt_avl_vacate(range_tree_t *rt, void *arg);
-extern struct range_tree_ops rt_avl_ops;
 
 #ifdef	__cplusplus
 }

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -185,9 +185,9 @@ struct spa {
 	uberblock_t	spa_ubsync;		/* last synced uberblock */
 	uberblock_t	spa_uberblock;		/* current uberblock */
 	boolean_t	spa_extreme_rewind;	/* rewind past deferred frees */
+	uint64_t	spa_last_io;		/* lbolt of last non-scan I/O */
 	kmutex_t	spa_scrub_lock;		/* resilver/scrub lock */
-	uint64_t	spa_scrub_inflight;	/* in-flight scrub bytes */
-	uint64_t	spa_load_verify_ios;	/* in-flight verification IOs */
+	uint64_t	spa_scrub_inflight;	/* in-flight scrub I/Os */
 	kcondvar_t	spa_scrub_io_cv;	/* scrub I/O completion */
 	uint8_t		spa_scrub_active;	/* active or suspended? */
 	uint8_t		spa_scrub_type;		/* type of scrub we're doing */
@@ -198,7 +198,6 @@ struct spa {
 	uint64_t	spa_scan_pass_scrub_pause; /* scrub pause time */
 	uint64_t	spa_scan_pass_scrub_spent_paused; /* total paused */
 	uint64_t	spa_scan_pass_exam;	/* examined bytes per pass */
-	uint64_t	spa_scan_pass_issued;	/* issued bytes per pass */
 	kmutex_t	spa_async_lock;		/* protect async state */
 	kthread_t	*spa_async_thread;	/* thread doing async task */
 	int		spa_async_suspended;	/* async tasks suspended */

--- a/include/sys/trace_zil.h
+++ b/include/sys/trace_zil.h
@@ -33,89 +33,181 @@
 #include <linux/tracepoint.h>
 #include <sys/types.h>
 
+#define	ZILOG_TP_STRUCT_ENTRY						    \
+		__field(uint64_t,	zl_lr_seq)			    \
+		__field(uint64_t,	zl_commit_lr_seq)		    \
+		__field(uint64_t,	zl_destroy_txg)			    \
+		__field(uint64_t,	zl_replaying_seq)		    \
+		__field(uint32_t,	zl_suspend)			    \
+		__field(uint8_t,	zl_suspending)			    \
+		__field(uint8_t,	zl_keep_first)			    \
+		__field(uint8_t,	zl_replay)			    \
+		__field(uint8_t,	zl_stop_sync)			    \
+		__field(uint8_t,	zl_logbias)			    \
+		__field(uint8_t,	zl_sync)			    \
+		__field(int,		zl_parse_error)			    \
+		__field(uint64_t,	zl_parse_blk_seq)		    \
+		__field(uint64_t,	zl_parse_lr_seq)		    \
+		__field(uint64_t,	zl_parse_blk_count)		    \
+		__field(uint64_t,	zl_parse_lr_count)		    \
+		__field(uint64_t,	zl_cur_used)			    \
+		__field(clock_t,	zl_replay_time)			    \
+		__field(uint64_t,	zl_replay_blks)
+
+#define	ZILOG_TP_FAST_ASSIGN						    \
+		__entry->zl_lr_seq		= zilog->zl_lr_seq;	    \
+		__entry->zl_commit_lr_seq	= zilog->zl_commit_lr_seq;  \
+		__entry->zl_destroy_txg	= zilog->zl_destroy_txg;	    \
+		__entry->zl_replaying_seq	= zilog->zl_replaying_seq;  \
+		__entry->zl_suspend		= zilog->zl_suspend;	    \
+		__entry->zl_suspending	= zilog->zl_suspending;		    \
+		__entry->zl_keep_first	= zilog->zl_keep_first;		    \
+		__entry->zl_replay		= zilog->zl_replay;	    \
+		__entry->zl_stop_sync	= zilog->zl_stop_sync;		    \
+		__entry->zl_logbias		= zilog->zl_logbias;	    \
+		__entry->zl_sync		= zilog->zl_sync;	    \
+		__entry->zl_parse_error	= zilog->zl_parse_error;	    \
+		__entry->zl_parse_blk_seq	= zilog->zl_parse_blk_seq;  \
+		__entry->zl_parse_lr_seq	= zilog->zl_parse_lr_seq;   \
+		__entry->zl_parse_blk_count	= zilog->zl_parse_blk_count;\
+		__entry->zl_parse_lr_count	= zilog->zl_parse_lr_count; \
+		__entry->zl_cur_used	= zilog->zl_cur_used;		    \
+		__entry->zl_replay_time	= zilog->zl_replay_time;	    \
+		__entry->zl_replay_blks	= zilog->zl_replay_blks;
+
+#define	ZILOG_TP_PRINTK_FMT						    \
+	"zl { lr_seq %llu commit_lr_seq %llu destroy_txg %llu "		    \
+	"replaying_seq %llu suspend %u suspending %u keep_first %u "	    \
+	"replay %u stop_sync %u logbias %u sync %u "			    \
+	"parse_error %u parse_blk_seq %llu parse_lr_seq %llu "		    \
+	"parse_blk_count %llu parse_lr_count %llu "			    \
+	"cur_used %llu replay_time %lu replay_blks %llu }"
+
+#define	ZILOG_TP_PRINTK_ARGS						    \
+	    __entry->zl_lr_seq, __entry->zl_commit_lr_seq,		    \
+	    __entry->zl_destroy_txg, __entry->zl_replaying_seq,		    \
+	    __entry->zl_suspend, __entry->zl_suspending,		    \
+	    __entry->zl_keep_first, __entry->zl_replay,			    \
+	    __entry->zl_stop_sync, __entry->zl_logbias, __entry->zl_sync,   \
+	    __entry->zl_parse_error, __entry->zl_parse_blk_seq,		    \
+	    __entry->zl_parse_lr_seq, __entry->zl_parse_blk_count,	    \
+	    __entry->zl_parse_lr_count, __entry->zl_cur_used,		    \
+	    __entry->zl_replay_time, __entry->zl_replay_blks
+
+#define	ITX_TP_STRUCT_ENTRY						    \
+		__field(itx_wr_state_t,	itx_wr_state)			    \
+		__field(uint8_t,	itx_sync)			    \
+		__field(zil_callback_t,	itx_callback)			    \
+		__field(void *,		itx_callback_data)		    \
+		__field(uint64_t,	itx_oid)			    \
+									    \
+		__field(uint64_t,	lrc_txtype)			    \
+		__field(uint64_t,	lrc_reclen)			    \
+		__field(uint64_t,	lrc_txg)			    \
+		__field(uint64_t,	lrc_seq)
+
+#define	ITX_TP_FAST_ASSIGN						    \
+		__entry->itx_wr_state		= itx->itx_wr_state;	    \
+		__entry->itx_sync		= itx->itx_sync;	    \
+		__entry->itx_callback		= itx->itx_callback;	    \
+		__entry->itx_callback_data	= itx->itx_callback_data;   \
+		__entry->itx_oid		= itx->itx_oid;		    \
+									    \
+		__entry->lrc_txtype		= itx->itx_lr.lrc_txtype;   \
+		__entry->lrc_reclen		= itx->itx_lr.lrc_reclen;   \
+		__entry->lrc_txg		= itx->itx_lr.lrc_txg;	    \
+		__entry->lrc_seq		= itx->itx_lr.lrc_seq;
+
+#define	ITX_TP_PRINTK_FMT						    \
+	"itx { wr_state %u sync %u callback %p callback_data %p oid %llu"   \
+	" { txtype %llu reclen %llu txg %llu seq %llu } }"
+
+#define	ITX_TP_PRINTK_ARGS						    \
+	    __entry->itx_wr_state, __entry->itx_sync, __entry->itx_callback,\
+	    __entry->itx_callback_data, __entry->itx_oid,		    \
+	    __entry->lrc_txtype, __entry->lrc_reclen, __entry->lrc_txg,	    \
+	    __entry->lrc_seq
+
+#define	ZCW_TP_STRUCT_ENTRY						    \
+		__field(lwb_t *,	zcw_lwb)			    \
+		__field(boolean_t,	zcw_done)			    \
+		__field(int,		zcw_zio_error)			    \
+
+#define	ZCW_TP_FAST_ASSIGN						    \
+		__entry->zcw_lwb		= zcw->zcw_lwb;		    \
+		__entry->zcw_done		= zcw->zcw_done;	    \
+		__entry->zcw_zio_error		= zcw->zcw_zio_error;
+
+#define	ZCW_TP_PRINTK_FMT						    \
+	"zcw { lwb %p done %u error %u }"
+
+#define	ZCW_TP_PRINTK_ARGS						    \
+	    __entry->zcw_lwb, __entry->zcw_done, __entry->zcw_zio_error
+
 /*
- * Generic support for one argument tracepoints of the form:
+ * Generic support for two argument tracepoints of the form:
  *
- * DTRACE_PROBE1(...,
- *     zilog_t *, ...);
+ * DTRACE_PROBE2(...,
+ *     zilog_t *, ...,
+ *     itx_t *, ...);
  */
 /* BEGIN CSTYLED */
-DECLARE_EVENT_CLASS(zfs_zil_class,
-	TP_PROTO(zilog_t *zilog),
-	TP_ARGS(zilog),
+DECLARE_EVENT_CLASS(zfs_zil_process_itx_class,
+	TP_PROTO(zilog_t *zilog, itx_t *itx),
+	TP_ARGS(zilog, itx),
 	TP_STRUCT__entry(
-	    __field(uint64_t,	zl_lr_seq)
-	    __field(uint64_t,	zl_commit_lr_seq)
-	    __field(uint64_t,	zl_destroy_txg)
-	    __field(uint64_t,	zl_replaying_seq)
-	    __field(uint32_t,	zl_suspend)
-	    __field(uint8_t,	zl_suspending)
-	    __field(uint8_t,	zl_keep_first)
-	    __field(uint8_t,	zl_replay)
-	    __field(uint8_t,	zl_stop_sync)
-	    __field(uint8_t,	zl_writer)
-	    __field(uint8_t,	zl_logbias)
-	    __field(uint8_t,	zl_sync)
-	    __field(int,	zl_parse_error)
-	    __field(uint64_t,	zl_parse_blk_seq)
-	    __field(uint64_t,	zl_parse_lr_seq)
-	    __field(uint64_t,	zl_parse_blk_count)
-	    __field(uint64_t,	zl_parse_lr_count)
-	    __field(uint64_t,	zl_next_batch)
-	    __field(uint64_t,	zl_com_batch)
-	    __field(uint64_t,	zl_cur_used)
-	    __field(clock_t,	zl_replay_time)
-	    __field(uint64_t,	zl_replay_blks)
+	    ZILOG_TP_STRUCT_ENTRY
+	    ITX_TP_STRUCT_ENTRY
 	),
 	TP_fast_assign(
-	    __entry->zl_lr_seq		= zilog->zl_lr_seq;
-	    __entry->zl_commit_lr_seq	= zilog->zl_commit_lr_seq;
-	    __entry->zl_destroy_txg	= zilog->zl_destroy_txg;
-	    __entry->zl_replaying_seq	= zilog->zl_replaying_seq;
-	    __entry->zl_suspend		= zilog->zl_suspend;
-	    __entry->zl_suspending	= zilog->zl_suspending;
-	    __entry->zl_keep_first	= zilog->zl_keep_first;
-	    __entry->zl_replay		= zilog->zl_replay;
-	    __entry->zl_stop_sync	= zilog->zl_stop_sync;
-	    __entry->zl_writer		= zilog->zl_writer;
-	    __entry->zl_logbias		= zilog->zl_logbias;
-	    __entry->zl_sync		= zilog->zl_sync;
-	    __entry->zl_parse_error	= zilog->zl_parse_error;
-	    __entry->zl_parse_blk_seq	= zilog->zl_parse_blk_seq;
-	    __entry->zl_parse_lr_seq	= zilog->zl_parse_lr_seq;
-	    __entry->zl_parse_blk_count	= zilog->zl_parse_blk_count;
-	    __entry->zl_parse_lr_count	= zilog->zl_parse_lr_count;
-	    __entry->zl_next_batch	= zilog->zl_next_batch;
-	    __entry->zl_com_batch	= zilog->zl_com_batch;
-	    __entry->zl_cur_used	= zilog->zl_cur_used;
-	    __entry->zl_replay_time	= zilog->zl_replay_time;
-	    __entry->zl_replay_blks	= zilog->zl_replay_blks;
+	    ZILOG_TP_FAST_ASSIGN
+	    ITX_TP_FAST_ASSIGN
 	),
-	TP_printk("zl { lr_seq %llu commit_lr_seq %llu destroy_txg %llu "
-	    "replaying_seq %llu suspend %u suspending %u keep_first %u "
-	    "replay %u stop_sync %u writer %u logbias %u sync %u "
-	    "parse_error %u parse_blk_seq %llu parse_lr_seq %llu "
-	    "parse_blk_count %llu parse_lr_count %llu next_batch %llu "
-	    "com_batch %llu cur_used %llu replay_time %lu replay_blks %llu }",
-	    __entry->zl_lr_seq, __entry->zl_commit_lr_seq,
-	    __entry->zl_destroy_txg, __entry->zl_replaying_seq,
-	    __entry->zl_suspend, __entry->zl_suspending, __entry->zl_keep_first,
-	    __entry->zl_replay, __entry->zl_stop_sync, __entry->zl_writer,
-	    __entry->zl_logbias, __entry->zl_sync, __entry->zl_parse_error,
-	    __entry->zl_parse_blk_seq, __entry->zl_parse_lr_seq,
-	    __entry->zl_parse_blk_count, __entry->zl_parse_lr_count,
-	    __entry->zl_next_batch, __entry->zl_com_batch, __entry->zl_cur_used,
-	    __entry->zl_replay_time, __entry->zl_replay_blks)
+	TP_printk(
+	    ZILOG_TP_PRINTK_FMT " " ITX_TP_PRINTK_FMT,
+	    ZILOG_TP_PRINTK_ARGS, ITX_TP_PRINTK_ARGS)
 );
 /* END CSTYLED */
 
 /* BEGIN CSTYLED */
-#define	DEFINE_ZIL_EVENT(name) \
-DEFINE_EVENT(zfs_zil_class, name, \
-	TP_PROTO(zilog_t *zilog), \
-	TP_ARGS(zilog))
-DEFINE_ZIL_EVENT(zfs_zil__cw1);
-DEFINE_ZIL_EVENT(zfs_zil__cw2);
+#define	DEFINE_ZIL_PROCESS_ITX_EVENT(name) \
+DEFINE_EVENT(zfs_zil_process_itx_class, name, \
+	TP_PROTO(zilog_t *zilog, itx_t *itx), \
+	TP_ARGS(zilog, itx))
+DEFINE_ZIL_PROCESS_ITX_EVENT(zfs_zil__process__commit__itx);
+DEFINE_ZIL_PROCESS_ITX_EVENT(zfs_zil__process__normal__itx);
+/* END CSTYLED */
+
+/*
+ * Generic support for two argument tracepoints of the form:
+ *
+ * DTRACE_PROBE2(...,
+ *     zilog_t *, ...,
+ *     zil_commit_waiter_t *, ...);
+ */
+/* BEGIN CSTYLED */
+DECLARE_EVENT_CLASS(zfs_zil_commit_io_error_class,
+	TP_PROTO(zilog_t *zilog, zil_commit_waiter_t *zcw),
+	TP_ARGS(zilog, zcw),
+	TP_STRUCT__entry(
+	    ZILOG_TP_STRUCT_ENTRY
+	    ZCW_TP_STRUCT_ENTRY
+	),
+	TP_fast_assign(
+	    ZILOG_TP_FAST_ASSIGN
+	    ZCW_TP_FAST_ASSIGN
+	),
+	TP_printk(
+	    ZILOG_TP_PRINTK_FMT " " ZCW_TP_PRINTK_FMT,
+	    ZILOG_TP_PRINTK_ARGS, ZCW_TP_PRINTK_ARGS)
+);
+
+/* BEGIN CSTYLED */
+#define	DEFINE_ZIL_COMMIT_IO_ERROR_EVENT(name) \
+DEFINE_EVENT(zfs_zil_commit_io_error_class, name, \
+	TP_PROTO(zilog_t *zilog, zil_commit_waiter_t *zcw), \
+	TP_ARGS(zilog, zcw))
+DEFINE_ZIL_COMMIT_IO_ERROR_EVENT(zfs_zil__commit__io__error);
 /* END CSTYLED */
 
 #endif /* _TRACE_ZIL_H */

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -198,13 +198,6 @@ struct vdev {
 	uint64_t	vdev_max_async_write_queue_depth;
 
 	/*
-	 * Protects the vdev_scan_io_queue field itself as well as the
-	 * structure's contents (when present).
-	 */
-	kmutex_t			vdev_scan_io_queue_lock;
-	struct dsl_scan_io_queue	*vdev_scan_io_queue;
-
-	/*
 	 * Leaf vdev state.
 	 */
 	range_tree_t	*vdev_dtl[DTL_TYPES]; /* dirty time logs	*/

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -40,6 +40,7 @@ extern "C" {
 
 struct dsl_pool;
 struct dsl_dataset;
+struct lwb;
 
 /*
  * Intent log format:
@@ -140,6 +141,7 @@ typedef enum zil_create {
 /*
  * Intent log transaction types and record structures
  */
+#define	TX_COMMIT		0	/* Commit marker (no on-disk state) */
 #define	TX_CREATE		1	/* Create file */
 #define	TX_MKDIR		2	/* Make directory */
 #define	TX_MKXATTR		3	/* Make XATTR directory */
@@ -464,7 +466,8 @@ typedef int zil_parse_blk_func_t(zilog_t *zilog, blkptr_t *bp, void *arg,
 typedef int zil_parse_lr_func_t(zilog_t *zilog, lr_t *lr, void *arg,
     uint64_t txg);
 typedef int zil_replay_func_t(void *arg1, void *arg2, boolean_t byteswap);
-typedef int zil_get_data_t(void *arg, lr_write_t *lr, char *dbuf, zio_t *zio);
+typedef int zil_get_data_t(void *arg, lr_write_t *lr, char *dbuf,
+    struct lwb *lwb, zio_t *zio);
 
 extern int zil_parse(zilog_t *zilog, zil_parse_blk_func_t *parse_blk_func,
     zil_parse_lr_func_t *parse_lr_func, void *arg, uint64_t txg,
@@ -502,7 +505,8 @@ extern void	zil_clean(zilog_t *zilog, uint64_t synced_txg);
 extern int	zil_suspend(const char *osname, void **cookiep);
 extern void	zil_resume(void *cookie);
 
-extern void	zil_add_block(zilog_t *zilog, const blkptr_t *bp);
+extern void	zil_lwb_add_block(struct lwb *lwb, const blkptr_t *bp);
+extern void	zil_lwb_add_txg(struct lwb *lwb, uint64_t txg);
 extern int	zil_bp_tree_add(zilog_t *zilog, const blkptr_t *bp);
 
 extern void	zil_set_sync(zilog_t *zilog, uint64_t syncval);

--- a/include/sys/zil_impl.h
+++ b/include/sys/zil_impl.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -36,7 +36,30 @@ extern "C" {
 #endif
 
 /*
- * Log write buffer.
+ * Possbile states for a given lwb structure. An lwb will start out in
+ * the "closed" state, and then transition to the "opened" state via a
+ * call to zil_lwb_write_open(). After the lwb is "open", it can
+ * transition into the "issued" state via zil_lwb_write_issue(). After
+ * the lwb's zio completes, and the vdev's are flushed, the lwb will
+ * transition into the "done" state via zil_lwb_write_done(), and the
+ * structure eventually freed.
+ */
+typedef enum {
+    LWB_STATE_CLOSED,
+    LWB_STATE_OPENED,
+    LWB_STATE_ISSUED,
+    LWB_STATE_DONE,
+    LWB_NUM_STATES
+} lwb_state_t;
+
+/*
+ * Log write block (lwb)
+ *
+ * Prior to an lwb being issued to disk via zil_lwb_write_issue(), it
+ * will be protected by the zilog's "zl_writer_lock". Basically, prior
+ * to it being issued, it will only be accessed by the thread that's
+ * holding the "zl_writer_lock". After the lwb is issued, the zilog's
+ * "zl_lock" is used to protect the lwb against concurrent access.
  */
 typedef struct lwb {
 	zilog_t		*lwb_zilog;	/* back pointer to log struct */
@@ -45,12 +68,44 @@ typedef struct lwb {
 	boolean_t	lwb_slog;	/* lwb_blk is on SLOG device */
 	int		lwb_nused;	/* # used bytes in buffer */
 	int		lwb_sz;		/* size of block and buffer */
+	lwb_state_t	lwb_state;	/* the state of this lwb */
 	char		*lwb_buf;	/* log write buffer */
-	zio_t		*lwb_zio;	/* zio for this buffer */
+	zio_t		*lwb_write_zio;	/* zio for the lwb buffer */
+	zio_t		*lwb_root_zio;	/* root zio for lwb write and flushes */
 	dmu_tx_t	*lwb_tx;	/* tx for log block allocation */
 	uint64_t	lwb_max_txg;	/* highest txg in this lwb */
 	list_node_t	lwb_node;	/* zilog->zl_lwb_list linkage */
+	list_t		lwb_itxs;	/* list of itx's */
+	list_t		lwb_waiters;	/* list of zil_commit_waiter's */
+	avl_tree_t	lwb_vdev_tree;	/* vdevs to flush after lwb write */
+	kmutex_t	lwb_vdev_lock;	/* protects lwb_vdev_tree */
+	hrtime_t	lwb_issued_timestamp; /* when was the lwb issued? */
 } lwb_t;
+
+/*
+ * ZIL commit waiter.
+ *
+ * This structure is allocated each time zil_commit() is called, and is
+ * used by zil_commit() to communicate with other parts of the ZIL, such
+ * that zil_commit() can know when it safe for it return. For more
+ * details, see the comment above zil_commit().
+ *
+ * The "zcw_lock" field is used to protect the commit waiter against
+ * concurrent access. This lock is often acquired while already holding
+ * the zilog's "zl_writer_lock" or "zl_lock"; see the functions
+ * zil_process_commit_list() and zil_lwb_flush_vdevs_done() as examples
+ * of this. Thus, one must be careful not to acquire the
+ * "zl_writer_lock" or "zl_lock" when already holding the "zcw_lock";
+ * e.g. see the zil_commit_waiter_timeout() function.
+ */
+typedef struct zil_commit_waiter {
+	kcondvar_t	zcw_cv;		/* signalled when "done" */
+	kmutex_t	zcw_lock;	/* protects fields of this struct */
+	list_node_t	zcw_node;	/* linkage in lwb_t:lwb_waiter list */
+	lwb_t		*zcw_lwb;	/* back pointer to lwb when linked */
+	boolean_t	zcw_done;	/* B_TRUE when "done", else B_FALSE */
+	int		zcw_zio_error;	/* contains the zio io_error value */
+} zil_commit_waiter_t;
 
 /*
  * Intent log transaction lists
@@ -94,20 +149,20 @@ struct zilog {
 	const zil_header_t *zl_header;	/* log header buffer */
 	objset_t	*zl_os;		/* object set we're logging */
 	zil_get_data_t	*zl_get_data;	/* callback to get object content */
-	zio_t		*zl_root_zio;	/* log writer root zio */
+	lwb_t		*zl_last_lwb_opened; /* most recent lwb opened */
+	hrtime_t	zl_last_lwb_latency; /* zio latency of last lwb done */
 	uint64_t	zl_lr_seq;	/* on-disk log record sequence number */
 	uint64_t	zl_commit_lr_seq; /* last committed on-disk lr seq */
 	uint64_t	zl_destroy_txg;	/* txg of last zil_destroy() */
 	uint64_t	zl_replayed_seq[TXG_SIZE]; /* last replayed rec seq */
 	uint64_t	zl_replaying_seq; /* current replay seq number */
 	uint32_t	zl_suspend;	/* log suspend count */
-	kcondvar_t	zl_cv_writer;	/* log writer thread completion */
 	kcondvar_t	zl_cv_suspend;	/* log suspend completion */
 	uint8_t		zl_suspending;	/* log is currently suspending */
 	uint8_t		zl_keep_first;	/* keep first log block in destroy */
 	uint8_t		zl_replay;	/* replaying records while set */
 	uint8_t		zl_stop_sync;	/* for debugging */
-	uint8_t		zl_writer;	/* boolean: write setup in progress */
+	kmutex_t	zl_writer_lock;	/* single writer, per ZIL, at a time */
 	uint8_t		zl_logbias;	/* latency or throughput */
 	uint8_t		zl_sync;	/* synchronous or asynchronous */
 	int		zl_parse_error;	/* last zil_parse() error */
@@ -115,15 +170,10 @@ struct zilog {
 	uint64_t	zl_parse_lr_seq; /* highest lr seq on last parse */
 	uint64_t	zl_parse_blk_count; /* number of blocks parsed */
 	uint64_t	zl_parse_lr_count; /* number of log records parsed */
-	uint64_t	zl_next_batch;	/* next batch number */
-	uint64_t	zl_com_batch;	/* committed batch number */
-	kcondvar_t	zl_cv_batch[2];	/* batch condition variables */
 	itxg_t		zl_itxg[TXG_SIZE]; /* intent log txg chains */
 	list_t		zl_itx_commit_list; /* itx list to be committed */
 	uint64_t	zl_cur_used;	/* current commit log size used */
 	list_t		zl_lwb_list;	/* in-flight log write list */
-	kmutex_t	zl_vdev_lock;	/* protects zl_vdev_tree */
-	avl_tree_t	zl_vdev_tree;	/* vdevs to flush in zil_commit() */
 	avl_tree_t	zl_bp_tree;	/* track bps during log parse */
 	clock_t		zl_replay_time;	/* lbolt of when replay started */
 	uint64_t	zl_replay_blks;	/* number of log blocks replayed */
@@ -131,6 +181,7 @@ struct zilog {
 	uint_t		zl_prev_blks[ZIL_PREV_BLKS]; /* size - sector rounded */
 	uint_t		zl_prev_rotor;	/* rotor for zl_prev[] */
 	txg_node_t	zl_dirty_link;	/* protected by dp_dirty_zilogs list */
+	uint64_t	zl_dirty_max_txg; /* highest txg used to dirty zilog */
 };
 
 typedef struct zil_bp_node {

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -596,6 +596,7 @@ extern enum zio_checksum zio_checksum_dedup_select(spa_t *spa,
 extern enum zio_compress zio_compress_select(spa_t *spa,
     enum zio_compress child, enum zio_compress parent);
 
+extern void zio_cancel(zio_t *zio);
 extern void zio_suspend(spa_t *spa, zio_t *zio);
 extern int zio_resume(spa_t *spa);
 extern void zio_resume_wait(spa_t *spa);

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -76,6 +76,7 @@ do {									\
 		    (u_longlong_t)__left, #OP, (u_longlong_t)__right);	\
 } while (0)
 
+#define	VERIFY3B(x, y, z)	VERIFY3_IMPL(x, y, z, boolean_t)
 #define	VERIFY3S(x, y, z)	VERIFY3_IMPL(x, y, z, int64_t)
 #define	VERIFY3U(x, y, z)	VERIFY3_IMPL(x, y, z, uint64_t)
 #define	VERIFY3P(x, y, z)	VERIFY3_IMPL(x, y, z, uintptr_t)
@@ -94,6 +95,7 @@ do {									\
 	__compile_time_assertion__ ## y[(x) ? 1 : -1]
 
 #ifdef NDEBUG
+#define	ASSERT3B(x, y, z)	((void)0)
 #define	ASSERT3S(x, y, z)	((void)0)
 #define	ASSERT3U(x, y, z)	((void)0)
 #define	ASSERT3P(x, y, z)	((void)0)
@@ -104,6 +106,7 @@ do {									\
 #define	IMPLY(A, B)		((void)0)
 #define	EQUIV(A, B)		((void)0)
 #else
+#define	ASSERT3B(x, y, z)	VERIFY3B(x, y, z)
 #define	ASSERT3S(x, y, z)	VERIFY3S(x, y, z)
 #define	ASSERT3U(x, y, z)	VERIFY3U(x, y, z)
 #define	ASSERT3P(x, y, z)	VERIFY3P(x, y, z)

--- a/lib/libspl/include/sys/time.h
+++ b/lib/libspl/include/sys/time.h
@@ -51,14 +51,22 @@
 #endif
 
 #ifndef MSEC2NSEC
-#define	MSEC2NSEC(m)    ((hrtime_t)(m) * (NANOSEC / MILLISEC))
+#define	MSEC2NSEC(m)	((hrtime_t)(m) * (NANOSEC / MILLISEC))
 #endif
 
 #ifndef NSEC2MSEC
-#define	NSEC2MSEC(n)    ((n) / (NANOSEC / MILLISEC))
+#define	NSEC2MSEC(n)	((n) / (NANOSEC / MILLISEC))
 #endif
 
-#ifndef	NSEC2SEC
+#ifndef USEC2NSEC
+#define	USEC2NSEC(m)	((hrtime_t)(m) * (NANOSEC / MICROSEC))
+#endif
+
+#ifndef NSEC2USEC
+#define	NSEC2USEC(n)	((n) / (NANOSEC / MICROSEC))
+#endif
+
+#ifndef NSEC2SEC
 #define	NSEC2SEC(n)	((n) / (NANOSEC / SEC))
 #endif
 

--- a/lib/libzfs/libzfs_status.c
+++ b/lib/libzfs/libzfs_status.c
@@ -214,7 +214,7 @@ check_status(nvlist_t *config, boolean_t isimport, zpool_errata_t *erratap)
 	 */
 	(void) nvlist_lookup_uint64_array(nvroot, ZPOOL_CONFIG_SCAN_STATS,
 	    (uint64_t **)&ps, &psc);
-	if (ps != NULL && ps->pss_func == POOL_SCAN_RESILVER &&
+	if (ps && ps->pss_func == POOL_SCAN_RESILVER &&
 	    ps->pss_state == DSS_SCANNING)
 		return (ZPOOL_STATUS_RESILVERING);
 

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1,6 +1,5 @@
 '\" te
 .\" Copyright (c) 2013 by Turbo Fredriksson <turbo@bayour.com>. All rights reserved.
-.\" Copyright (c) 2017 Datto Inc.
 .\" The contents of this file are subject to the terms of the Common Development
 .\" and Distribution License (the "License").  You may not use this file except
 .\" in compliance with the License. You can obtain a copy of the license at
@@ -13,7 +12,7 @@
 .\" CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
-.TH ZFS-MODULE-PARAMETERS 5 "Oct 28, 2017"
+.TH ZFS-MODULE-PARAMETERS 5 "Oct 28, 2017" 
 .SH NAME
 zfs\-module\-parameters \- ZFS module parameters
 .SH DESCRIPTION
@@ -488,7 +487,7 @@ Default value: \fB10\fR.
 .ad
 .RS 12n
 If set to a non zero value, it will replace the arc_grow_retry value with this value.
-The arc_grow_retry value (default 5) is the number of seconds the ARC will wait before
+The arc_grow_retry value (default 5) is the number of seconds the ARC will wait before 
 trying to resume growth after a memory pressure event.
 .sp
 Default value: \fB0\fR.
@@ -606,7 +605,7 @@ Default value: \fB10,000\fR.
 .RS 12n
 Define the strategy for ARC meta data buffer eviction (meta reclaim strategy).
 A value of 0 (META_ONLY) will evict only the ARC meta data buffers.
-A value of 1 (BALANCED) indicates that additional data buffers may be evicted if
+A value of 1 (BALANCED) indicates that additional data buffers may be evicted if 
 that is required to in order to evict the required number of meta data buffers.
 .sp
 Default value: \fB1\fR.
@@ -627,24 +626,11 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
-\fBzfs_arc_min_prefetch_ms\fR (int)
+\fBzfs_arc_min_prefetch_lifespan\fR (int)
 .ad
 .RS 12n
-Minimum time prefetched blocks are locked in the ARC, specified in ms.
-A value of \fB0\fR will default to 1 second.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_arc_min_prescient_prefetch_ms\fR (int)
-.ad
-.RS 12n
-Minimum time "prescient prefetched" blocks are locked in the ARC, specified
-in ms. These blocks are meant to be prefetched fairly aggresively ahead of
-the code that may use them. A value of \fB0\fR will default to 6 seconds.
+Minimum time prefetched blocks are locked in the ARC, specified in jiffies.
+A value of 0 will default to 1 second.
 .sp
 Default value: \fB0\fR.
 .RE
@@ -693,7 +679,7 @@ Default value: \fB8\fR.
 .RS 12n
 If set to a non zero value, this will update arc_p_min_shift (default 4)
 with the new value.
-arc_p_min_shift is used to shift of arc_c for calculating both min and max
+arc_p_min_shift is used to shift of arc_c for calculating both min and max 
 max arc_p
 .sp
 Default value: \fB0\fR.
@@ -1674,6 +1660,19 @@ Use \fB1\fR for yes and \fB0\fR for no (default).
 .sp
 .ne 2
 .na
+\fBzfs_resilver_delay\fR (int)
+.ad
+.RS 12n
+Number of ticks to delay prior to issuing a resilver I/O operation when
+a non-resilver or non-scrub I/O operation has occurred within the past
+\fBzfs_scan_idle\fR ticks.
+.sp
+Default value: \fB2\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_resilver_min_time_ms\fR (int)
 .ad
 .RS 12n
@@ -1686,7 +1685,21 @@ Default value: \fB3,000\fR.
 .sp
 .ne 2
 .na
-\fBzfs_scrub_min_time_ms\fR (int)
+\fBzfs_scan_idle\fR (int)
+.ad
+.RS 12n
+Idle window in clock ticks.  During a scrub or a resilver, if
+a non-scrub or non-resilver I/O operation has occurred during this
+window, the next scrub or resilver operation is delayed by, respectively
+\fBzfs_scrub_delay\fR or \fBzfs_resilver_delay\fR ticks.
+.sp
+Default value: \fB50\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_scan_min_time_ms\fR (int)
 .ad
 .RS 12n
 Scrubs are processed by the sync thread. While scrubbing it will spend
@@ -1698,120 +1711,14 @@ Default value: \fB1,000\fR.
 .sp
 .ne 2
 .na
-\fBzfs_scan_checkpoint_intval\fR (int)
+\fBzfs_scrub_delay\fR (int)
 .ad
 .RS 12n
-To preserve progress across reboots the sequential scan algorithm periodically
-needs to stop metadata scanning and issue all the verifications I/Os to disk.
-The frequency of this flushing is determined by the
-\fBfBzfs_scan_checkpoint_intval\fR tunable.
+Number of ticks to delay prior to issuing a scrub I/O operation when
+a non-scrub or non-resilver I/O operation has occurred within the past
+\fBzfs_scan_idle\fR ticks.
 .sp
-Default value: \fB7200\fR seconds (every 2 hours).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_fill_weight\fR (int)
-.ad
-.RS 12n
-This tunable affects how scrub and resilver I/O segments are ordered. A higher
-number indicates that we care more about how filled in a segment is, while a
-lower number indicates we care more about the size of the extent without
-considering the gaps within a segment. This value is only tunable upon module
-insertion. Changing the value afterwards will have no affect on scrub or
-resilver performance.
-.sp
-Default value: \fB3\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_issue_strategy\fR (int)
-.ad
-.RS 12n
-Determines the order that data will be verified while scrubbing or resilvering.
-If set to \fB1\fR, data will be verified as sequentially as possible, given the
-amount of memory reserved for scrubbing (see \fBzfs_scan_mem_lim_fact\fR). This
-may improve scrub performance if the pool's data is very fragmented. If set to
-\fB2\fR, the largest mostly-contiguous chunk of found data will be verified
-first. By deferring scrubbing of small segments, we may later find adjacent data
-to coalesce and increase the segment size. If set to \fB0\fR, zfs will use
-strategy \fB1\fR during normal verification and strategy \fB2\fR while taking a
-checkpoint.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_legacy\fR (int)
-.ad
-.RS 12n
-A value of 0 indicates that scrubs and resilvers will gather metadata in
-memory before issuing sequential I/O. A value of 1 indicates that the legacy
-algorithm will be used where I/O is initiated as soon as it is discovered.
-Changing this value to 0 will not affect scrubs or resilvers that are already
-in progress.
-.sp
-Default value: \fB0\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_max_ext_gap\fR (int)
-.ad
-.RS 12n
-Indicates the largest gap in bytes between scrub / resilver I/Os that will still
-be considered sequential for sorting purposes. Changing this value will not
-affect scrubs or resilvers that are already in progress.
-.sp
-Default value: \fB2097152 (2 MB)\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_mem_lim_fact\fR (int)
-.ad
-.RS 12n
-Maximum fraction of RAM used for I/O sorting by sequential scan algorithm.
-This tunable determines the hard limit for I/O sorting memory usage.
-When the hard limit is reached we stop scanning metadata and start issuing
-data verification I/O. This is done until we get below the soft limit.
-.sp
-Default value: \fB20\fR which is 5% of RAM (1/20).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_mem_lim_soft_fact\fR (int)
-.ad
-.RS 12n
-The fraction of the hard limit used to determined the soft limit for I/O sorting
-by the sequential scan algorithm. When we cross this limit from bellow no action
-is taken. When we cross this limit from above it is because we are issuing
-verification I/O. In this case (unless the metadata scan is done) we stop
-issuing verification I/O and start scanning metadata again until we get to the
-hard limit.
-.sp
-Default value: \fB20\fR which is 5% of the hard limit (1/20).
-.RE
-
-.sp
-.ne 2
-.na
-\fBzfs_scan_vdev_limit\fR (int)
-.ad
-.RS 12n
-Maximum amount of data that can be concurrently issued at once for scrubs and
-resilvers per leaf device, given in bytes.
-.sp
-Default value: \fB41943040\fR.
+Default value: \fB4\fR.
 .RE
 
 .sp
@@ -1868,6 +1775,18 @@ This controls the number of threads used by the dp_sync_taskq.  The default
 value of 75% will create a maximum of one thread per cpu.
 .sp
 Default value: \fB75\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_top_maxinflight\fR (int)
+.ad
+.RS 12n
+Max concurrent I/Os per top-level vdev (mirrors or raidz arrays) allowed during
+scrub or resilver operations.
+.sp
+Default value: \fB32\fR.
 .RE
 
 .sp

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -357,8 +357,7 @@ int			arc_no_grow_shift = 5;
  * minimum lifespan of a prefetch block in clock ticks
  * (initialized in arc_init())
  */
-static int		arc_min_prefetch_ms;
-static int		arc_min_prescient_prefetch_ms;
+static int		arc_min_prefetch_lifespan;
 
 /*
  * If this percent of memory is free, don't throttle.
@@ -408,8 +407,7 @@ unsigned long zfs_arc_dnode_limit_percent = 10;
  * These tunables are Linux specific
  */
 unsigned long zfs_arc_sys_free = 0;
-int zfs_arc_min_prefetch_ms = 0;
-int zfs_arc_min_prescient_prefetch_ms = 0;
+int zfs_arc_min_prefetch_lifespan = 0;
 int zfs_arc_p_aggressive_disable = 1;
 int zfs_arc_p_dampener_disable = 1;
 int zfs_arc_meta_prune = 10000;
@@ -665,7 +663,6 @@ typedef struct arc_stats {
 	kstat_named_t arcstat_meta_min;
 	kstat_named_t arcstat_sync_wait_for_async;
 	kstat_named_t arcstat_demand_hit_predictive_prefetch;
-	kstat_named_t arcstat_demand_hit_prescient_prefetch;
 	kstat_named_t arcstat_need_free;
 	kstat_named_t arcstat_sys_free;
 	kstat_named_t arcstat_raw_size;
@@ -765,7 +762,6 @@ static arc_stats_t arc_stats = {
 	{ "arc_meta_min",		KSTAT_DATA_UINT64 },
 	{ "sync_wait_for_async",	KSTAT_DATA_UINT64 },
 	{ "demand_hit_predictive_prefetch", KSTAT_DATA_UINT64 },
-	{ "demand_hit_prescient_prefetch", KSTAT_DATA_UINT64 },
 	{ "arc_need_free",		KSTAT_DATA_UINT64 },
 	{ "arc_sys_free",		KSTAT_DATA_UINT64 },
 	{ "arc_raw_size",		KSTAT_DATA_UINT64 }
@@ -865,8 +861,6 @@ static taskq_t *arc_prune_taskq;
 #define	HDR_IO_IN_PROGRESS(hdr)	((hdr)->b_flags & ARC_FLAG_IO_IN_PROGRESS)
 #define	HDR_IO_ERROR(hdr)	((hdr)->b_flags & ARC_FLAG_IO_ERROR)
 #define	HDR_PREFETCH(hdr)	((hdr)->b_flags & ARC_FLAG_PREFETCH)
-#define	HDR_PRESCIENT_PREFETCH(hdr)	\
-	((hdr)->b_flags & ARC_FLAG_PRESCIENT_PREFETCH)
 #define	HDR_COMPRESSION_ENABLED(hdr)	\
 	((hdr)->b_flags & ARC_FLAG_COMPRESSED_ARC)
 
@@ -3786,8 +3780,6 @@ arc_evict_hdr(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 {
 	arc_state_t *evicted_state, *state;
 	int64_t bytes_evicted = 0;
-	int min_lifetime = HDR_PRESCIENT_PREFETCH(hdr) ?
-	    arc_min_prescient_prefetch_ms : arc_min_prefetch_ms;
 
 	ASSERT(MUTEX_HELD(hash_lock));
 	ASSERT(HDR_HAS_L1HDR(hdr));
@@ -3841,7 +3833,8 @@ arc_evict_hdr(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 	/* prefetch buffers have a minimum lifespan */
 	if (HDR_IO_IN_PROGRESS(hdr) ||
 	    ((hdr->b_flags & (ARC_FLAG_PREFETCH | ARC_FLAG_INDIRECT)) &&
-	    ddi_get_lbolt() - hdr->b_l1hdr.b_arc_access < min_lifetime * hz)) {
+	    ddi_get_lbolt() - hdr->b_l1hdr.b_arc_access <
+	    arc_min_prefetch_lifespan)) {
 		ARCSTAT_BUMP(arcstat_evict_skip);
 		return (bytes_evicted);
 	}
@@ -5501,15 +5494,13 @@ arc_access(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 		 * - move the buffer to the head of the list if this is
 		 *   another prefetch (to make it less likely to be evicted).
 		 */
-		if (HDR_PREFETCH(hdr) || HDR_PRESCIENT_PREFETCH(hdr)) {
+		if (HDR_PREFETCH(hdr)) {
 			if (refcount_count(&hdr->b_l1hdr.b_refcnt) == 0) {
 				/* link protected by hash lock */
 				ASSERT(multilist_link_active(
 				    &hdr->b_l1hdr.b_arc_node));
 			} else {
-				arc_hdr_clear_flags(hdr,
-				    ARC_FLAG_PREFETCH |
-				    ARC_FLAG_PRESCIENT_PREFETCH);
+				arc_hdr_clear_flags(hdr, ARC_FLAG_PREFETCH);
 				atomic_inc_32(&hdr->b_l1hdr.b_mru_hits);
 				ARCSTAT_BUMP(arcstat_mru_hits);
 			}
@@ -5543,13 +5534,10 @@ arc_access(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 		 * MFU state.
 		 */
 
-		if (HDR_PREFETCH(hdr) || HDR_PRESCIENT_PREFETCH(hdr)) {
+		if (HDR_PREFETCH(hdr)) {
 			new_state = arc_mru;
-			if (refcount_count(&hdr->b_l1hdr.b_refcnt) > 0) {
-				arc_hdr_clear_flags(hdr,
-				    ARC_FLAG_PREFETCH |
-				    ARC_FLAG_PRESCIENT_PREFETCH);
-			}
+			if (refcount_count(&hdr->b_l1hdr.b_refcnt) > 0)
+				arc_hdr_clear_flags(hdr, ARC_FLAG_PREFETCH);
 			DTRACE_PROBE1(new_state__mru, arc_buf_hdr_t *, hdr);
 		} else {
 			new_state = arc_mfu;
@@ -5571,7 +5559,11 @@ arc_access(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 		 * If it was a prefetch, we will explicitly move it to
 		 * the head of the list now.
 		 */
-
+		if ((HDR_PREFETCH(hdr)) != 0) {
+			ASSERT(refcount_is_zero(&hdr->b_l1hdr.b_refcnt));
+			/* link protected by hash_lock */
+			ASSERT(multilist_link_active(&hdr->b_l1hdr.b_arc_node));
+		}
 		atomic_inc_32(&hdr->b_l1hdr.b_mfu_hits);
 		ARCSTAT_BUMP(arcstat_mfu_hits);
 		hdr->b_l1hdr.b_arc_access = ddi_get_lbolt();
@@ -5583,11 +5575,12 @@ arc_access(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 		 * MFU state.
 		 */
 
-		if (HDR_PREFETCH(hdr) || HDR_PRESCIENT_PREFETCH(hdr)) {
+		if (HDR_PREFETCH(hdr)) {
 			/*
 			 * This is a prefetch access...
 			 * move this block back to the MRU state.
 			 */
+			ASSERT0(refcount_count(&hdr->b_l1hdr.b_refcnt));
 			new_state = arc_mru;
 		}
 
@@ -5614,25 +5607,20 @@ arc_access(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 /* a generic arc_read_done_func_t which you can use */
 /* ARGSUSED */
 void
-arc_bcopy_func(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
-    arc_buf_t *buf, void *arg)
+arc_bcopy_func(zio_t *zio, int error, arc_buf_t *buf, void *arg)
 {
-	if (buf == NULL)
-		return;
-
-	bcopy(buf->b_data, arg, arc_buf_size(buf));
+	if (error == 0)
+		bcopy(buf->b_data, arg, arc_buf_size(buf));
 	arc_buf_destroy(buf, arg);
 }
 
 /* a generic arc_read_done_func_t */
-/* ARGSUSED */
 void
-arc_getbuf_func(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
-    arc_buf_t *buf, void *arg)
+arc_getbuf_func(zio_t *zio, int error, arc_buf_t *buf, void *arg)
 {
 	arc_buf_t **bufp = arg;
-
-	if (buf == NULL) {
+	if (error != 0) {
+		arc_buf_destroy(buf, arg);
 		*bufp = NULL;
 	} else {
 		*bufp = buf;
@@ -5666,6 +5654,7 @@ arc_read_done(zio_t *zio)
 	arc_callback_t	*callback_list;
 	arc_callback_t	*acb;
 	boolean_t	freeable = B_FALSE;
+	boolean_t	no_zio_error = (zio->io_error == 0);
 
 	/*
 	 * The hdr was inserted into hash-table and removed from lists
@@ -5712,7 +5701,7 @@ arc_read_done(zio_t *zio)
 		}
 	}
 
-	if (zio->io_error == 0) {
+	if (no_zio_error) {
 		/* byteswap if necessary */
 		if (BP_SHOULD_BYTESWAP(zio->io_bp)) {
 			if (BP_GET_LEVEL(zio->io_bp) > 0) {
@@ -5733,8 +5722,7 @@ arc_read_done(zio_t *zio)
 	callback_list = hdr->b_l1hdr.b_acb;
 	ASSERT3P(callback_list, !=, NULL);
 
-	if (hash_lock && zio->io_error == 0 &&
-	    hdr->b_l1hdr.b_state == arc_anon) {
+	if (hash_lock && no_zio_error && hdr->b_l1hdr.b_state == arc_anon) {
 		/*
 		 * Only call arc_access on anonymous buffers.  This is because
 		 * if we've issued an I/O for an evicted buffer, we've already
@@ -5755,19 +5743,13 @@ arc_read_done(zio_t *zio)
 		if (!acb->acb_done)
 			continue;
 
+		/* This is a demand read since prefetches don't use callbacks */
 		callback_cnt++;
-
-		if (zio->io_error != 0)
-			continue;
 
 		int error = arc_buf_alloc_impl(hdr, zio->io_spa,
 		    acb->acb_dsobj, acb->acb_private, acb->acb_encrypted,
-		    acb->acb_compressed, acb->acb_noauth, B_TRUE,
+		    acb->acb_compressed, acb->acb_noauth, no_zio_error,
 		    &acb->acb_buf);
-		if (error != 0) {
-			arc_buf_destroy(acb->acb_buf, acb->acb_private);
-			acb->acb_buf = NULL;
-		}
 
 		/*
 		 * Assert non-speculative zios didn't fail because an
@@ -5790,8 +5772,9 @@ arc_read_done(zio_t *zio)
 			}
 		}
 
-		if (zio->io_error == 0)
+		if (no_zio_error) {
 			zio->io_error = error;
+		}
 	}
 	hdr->b_l1hdr.b_acb = NULL;
 	arc_hdr_clear_flags(hdr, ARC_FLAG_IO_IN_PROGRESS);
@@ -5801,7 +5784,7 @@ arc_read_done(zio_t *zio)
 	ASSERT(refcount_is_zero(&hdr->b_l1hdr.b_refcnt) ||
 	    callback_list != NULL);
 
-	if (zio->io_error == 0) {
+	if (no_zio_error) {
 		arc_hdr_verify(hdr, zio->io_bp);
 	} else {
 		arc_hdr_set_flags(hdr, ARC_FLAG_IO_ERROR);
@@ -5835,8 +5818,8 @@ arc_read_done(zio_t *zio)
 	/* execute each callback and free its structure */
 	while ((acb = callback_list) != NULL) {
 		if (acb->acb_done) {
-			acb->acb_done(zio, &zio->io_bookmark, zio->io_bp,
-			    acb->acb_buf, acb->acb_private);
+			acb->acb_done(zio, zio->io_error, acb->acb_buf,
+			    acb->acb_private);
 		}
 
 		if (acb->acb_zio_dummy != NULL) {
@@ -5993,25 +5976,12 @@ top:
 				arc_hdr_clear_flags(hdr,
 				    ARC_FLAG_PREDICTIVE_PREFETCH);
 			}
-
-			if (hdr->b_flags & ARC_FLAG_PRESCIENT_PREFETCH) {
-				ARCSTAT_BUMP(
-				    arcstat_demand_hit_prescient_prefetch);
-				arc_hdr_clear_flags(hdr,
-				    ARC_FLAG_PRESCIENT_PREFETCH);
-			}
-
 			ASSERT(!BP_IS_EMBEDDED(bp) || !BP_IS_HOLE(bp));
 
 			/* Get a buf with the desired data in it. */
 			rc = arc_buf_alloc_impl(hdr, spa, zb->zb_objset,
 			    private, encrypted_read, compressed_read,
 			    noauth_read, B_TRUE, &buf);
-			if (rc != 0) {
-				arc_buf_destroy(buf, private);
-				buf = NULL;
-			}
-
 			ASSERT((zio_flags & ZIO_FLAG_SPECULATIVE) || rc == 0);
 		} else if (*arc_flags & ARC_FLAG_PREFETCH &&
 		    refcount_count(&hdr->b_l1hdr.b_refcnt) == 0) {
@@ -6019,8 +5989,6 @@ top:
 		}
 		DTRACE_PROBE1(arc__hit, arc_buf_hdr_t *, hdr);
 		arc_access(hdr, hash_lock);
-		if (*arc_flags & ARC_FLAG_PRESCIENT_PREFETCH)
-			arc_hdr_set_flags(hdr, ARC_FLAG_PRESCIENT_PREFETCH);
 		if (*arc_flags & ARC_FLAG_L2CACHE)
 			arc_hdr_set_flags(hdr, ARC_FLAG_L2CACHE);
 		mutex_exit(hash_lock);
@@ -6030,7 +5998,7 @@ top:
 		    data, metadata, hits);
 
 		if (done)
-			done(NULL, zb, bp, buf, private);
+			done(NULL, rc, buf, private);
 	} else {
 		uint64_t lsize = BP_GET_LSIZE(bp);
 		uint64_t psize = BP_GET_PSIZE(bp);
@@ -6146,8 +6114,6 @@ top:
 		if (*arc_flags & ARC_FLAG_PREFETCH &&
 		    refcount_is_zero(&hdr->b_l1hdr.b_refcnt))
 			arc_hdr_set_flags(hdr, ARC_FLAG_PREFETCH);
-		if (*arc_flags & ARC_FLAG_PRESCIENT_PREFETCH)
-			arc_hdr_set_flags(hdr, ARC_FLAG_PRESCIENT_PREFETCH);
 		if (*arc_flags & ARC_FLAG_L2CACHE)
 			arc_hdr_set_flags(hdr, ARC_FLAG_L2CACHE);
 		if (BP_IS_AUTHENTICATED(bp))
@@ -7259,15 +7225,9 @@ arc_tuning_update(void)
 	if (zfs_arc_p_min_shift)
 		arc_p_min_shift = zfs_arc_p_min_shift;
 
-	/* Valid range: 1 - N ms */
-	if (zfs_arc_min_prefetch_ms)
-		arc_min_prefetch_ms = zfs_arc_min_prefetch_ms;
-
-	/* Valid range: 1 - N ms */
-	if (zfs_arc_min_prescient_prefetch_ms) {
-		arc_min_prescient_prefetch_ms =
-		    zfs_arc_min_prescient_prefetch_ms;
-	}
+	/* Valid range: 1 - N ticks */
+	if (zfs_arc_min_prefetch_lifespan)
+		arc_min_prefetch_lifespan = zfs_arc_min_prefetch_lifespan;
 
 	/* Valid range: 0 - 100 */
 	if ((zfs_arc_lotsfree_percent >= 0) &&
@@ -7410,8 +7370,7 @@ arc_init(void)
 	cv_init(&arc_reclaim_waiters_cv, NULL, CV_DEFAULT, NULL);
 
 	/* Convert seconds to clock ticks */
-	arc_min_prefetch_ms = 1;
-	arc_min_prescient_prefetch_ms = 6;
+	arc_min_prefetch_lifespan = 1 * hz;
 
 #ifdef _KERNEL
 	/*
@@ -9049,12 +9008,8 @@ MODULE_PARM_DESC(zfs_arc_average_blocksize, "Target average block size");
 module_param(zfs_compressed_arc_enabled, int, 0644);
 MODULE_PARM_DESC(zfs_compressed_arc_enabled, "Disable compressed arc buffers");
 
-module_param(zfs_arc_min_prefetch_ms, int, 0644);
-MODULE_PARM_DESC(zfs_arc_min_prefetch_ms, "Min life of prefetch block in ms");
-
-module_param(zfs_arc_min_prescient_prefetch_ms, int, 0644);
-MODULE_PARM_DESC(zfs_arc_min_prescient_prefetch_ms,
-	"Min life of prescient prefetched block in ms");
+module_param(zfs_arc_min_prefetch_lifespan, int, 0644);
+MODULE_PARM_DESC(zfs_arc_min_prefetch_lifespan, "Min life of prefetch block");
 
 module_param(l2arc_write_max, ulong, 0644);
 MODULE_PARM_DESC(l2arc_write_max, "Max write bytes per interval");

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -447,8 +447,13 @@ typedef struct arc_stats {
 	 */
 	kstat_named_t arcstat_mutex_miss;
 	/*
+	 * Number of buffers skipped when updating the access state due to the
+	 * header having already been released after acquiring the hash lock.
+	 */
+	kstat_named_t arcstat_access_skip;
+	/*
 	 * Number of buffers skipped because they have I/O in progress, are
-	 * indrect prefetch buffers that have not lived long enough, or are
+	 * indirect prefetch buffers that have not lived long enough, or are
 	 * not from the spa we're trying to evict from.
 	 */
 	kstat_named_t arcstat_evict_skip;
@@ -685,6 +690,7 @@ static arc_stats_t arc_stats = {
 	{ "mfu_ghost_hits",		KSTAT_DATA_UINT64 },
 	{ "deleted",			KSTAT_DATA_UINT64 },
 	{ "mutex_miss",			KSTAT_DATA_UINT64 },
+	{ "access_skip",		KSTAT_DATA_UINT64 },
 	{ "evict_skip",			KSTAT_DATA_UINT64 },
 	{ "evict_not_enough",		KSTAT_DATA_UINT64 },
 	{ "evict_l2_cached",		KSTAT_DATA_UINT64 },
@@ -5602,6 +5608,50 @@ arc_access(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 		cmn_err(CE_PANIC, "invalid arc state 0x%p",
 		    hdr->b_l1hdr.b_state);
 	}
+}
+
+/*
+ * This routine is called by dbuf_hold() to update the arc_access() state
+ * which otherwise would be skipped for entries in the dbuf cache.
+ */
+void
+arc_buf_access(arc_buf_t *buf)
+{
+	mutex_enter(&buf->b_evict_lock);
+	arc_buf_hdr_t *hdr = buf->b_hdr;
+
+	/*
+	 * Avoid taking the hash_lock when possible as an optimization.
+	 * The header must be checked again under the hash_lock in order
+	 * to handle the case where it is concurrently being released.
+	 */
+	if (hdr->b_l1hdr.b_state == arc_anon || HDR_EMPTY(hdr)) {
+		mutex_exit(&buf->b_evict_lock);
+		return;
+	}
+
+	kmutex_t *hash_lock = HDR_LOCK(hdr);
+	mutex_enter(hash_lock);
+
+	if (hdr->b_l1hdr.b_state == arc_anon || HDR_EMPTY(hdr)) {
+		mutex_exit(hash_lock);
+		mutex_exit(&buf->b_evict_lock);
+		ARCSTAT_BUMP(arcstat_access_skip);
+		return;
+	}
+
+	mutex_exit(&buf->b_evict_lock);
+
+	ASSERT(hdr->b_l1hdr.b_state == arc_mru ||
+	    hdr->b_l1hdr.b_state == arc_mfu);
+
+	DTRACE_PROBE1(arc__hit, arc_buf_hdr_t *, hdr);
+	arc_access(hdr, hash_lock);
+	mutex_exit(hash_lock);
+
+	ARCSTAT_BUMP(arcstat_hits);
+	ARCSTAT_CONDSTAT(!HDR_PREFETCH(hdr),
+	    demand, prefetch, !HDR_ISTYPE_METADATA(hdr), data, metadata, hits);
 }
 
 /* a generic arc_read_done_func_t which you can use */

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2811,8 +2811,10 @@ __dbuf_hold_impl(struct dbuf_hold_impl_data *dh)
 		return (SET_ERROR(ENOENT));
 	}
 
-	if (dh->dh_db->db_buf != NULL)
+	if (dh->dh_db->db_buf != NULL) {
+		arc_buf_access(dh->dh_db->db_buf);
 		ASSERT3P(dh->dh_db->db.db_data, ==, dh->dh_db->db_buf->b_data);
+	}
 
 	ASSERT(dh->dh_db->db_buf == NULL || arc_referenced(dh->dh_db->db_buf));
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -973,8 +973,7 @@ dbuf_whichblock(const dnode_t *dn, const int64_t level, const uint64_t offset)
 }
 
 static void
-dbuf_read_done(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
-    arc_buf_t *buf, void *vdb)
+dbuf_read_done(zio_t *zio, int err, arc_buf_t *buf, void *vdb)
 {
 	dmu_buf_impl_t *db = vdb;
 
@@ -988,22 +987,19 @@ dbuf_read_done(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 	ASSERT(db->db.db_data == NULL);
 	if (db->db_level == 0 && db->db_freed_in_flight) {
 		/* we were freed in flight; disregard any error */
-		if (buf == NULL) {
-			buf = arc_alloc_buf(db->db_objset->os_spa,
-			    db, DBUF_GET_BUFC_TYPE(db), db->db.db_size);
-		}
 		arc_release(buf, db);
 		bzero(buf->b_data, db->db.db_size);
 		arc_buf_freeze(buf);
 		db->db_freed_in_flight = FALSE;
 		dbuf_set_data(db, buf);
 		db->db_state = DB_CACHED;
-	} else if (buf != NULL) {
+	} else if (err == 0) {
 		dbuf_set_data(db, buf);
 		db->db_state = DB_CACHED;
 	} else {
 		ASSERT(db->db_blkid != DMU_BONUS_BLKID);
 		ASSERT3P(db->db_buf, ==, NULL);
+		arc_buf_destroy(buf, db);
 		db->db_state = DB_UNCACHED;
 	}
 	cv_broadcast(&db->db_changed);
@@ -2516,8 +2512,7 @@ dbuf_issue_final_prefetch(dbuf_prefetch_arg_t *dpa, blkptr_t *bp)
  * prefetch if the next block down is our target.
  */
 static void
-dbuf_prefetch_indirect_done(zio_t *zio, const zbookmark_phys_t *zb,
-    const blkptr_t *iobp, arc_buf_t *abuf, void *private)
+dbuf_prefetch_indirect_done(zio_t *zio, int err, arc_buf_t *abuf, void *private)
 {
 	dbuf_prefetch_arg_t *dpa = private;
 
@@ -2556,18 +2551,13 @@ dbuf_prefetch_indirect_done(zio_t *zio, const zbookmark_phys_t *zb,
 		dbuf_rele(db, FTAG);
 	}
 
-	if (abuf == NULL) {
-		kmem_free(dpa, sizeof (*dpa));
-		return;
-	}
-
 	dpa->dpa_curlevel--;
+
 	uint64_t nextblkid = dpa->dpa_zb.zb_blkid >>
 	    (dpa->dpa_epbs * (dpa->dpa_curlevel - dpa->dpa_zb.zb_level));
 	blkptr_t *bp = ((blkptr_t *)abuf->b_data) +
 	    P2PHASE(nextblkid, 1ULL << dpa->dpa_epbs);
-
-	if (BP_IS_HOLE(bp)) {
+	if (BP_IS_HOLE(bp) || err != 0) {
 		kmem_free(dpa, sizeof (*dpa));
 	} else if (dpa->dpa_curlevel == dpa->dpa_zb.zb_level) {
 		ASSERT3U(nextblkid, ==, dpa->dpa_zb.zb_blkid);

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -1172,25 +1172,13 @@ ddt_sync_table(ddt_t *ddt, dmu_tx_t *tx, uint64_t txg)
 void
 ddt_sync(spa_t *spa, uint64_t txg)
 {
-	dsl_scan_t *scn = spa->spa_dsl_pool->dp_scan;
 	dmu_tx_t *tx;
-	zio_t *rio;
+	zio_t *rio = zio_root(spa, NULL, NULL,
+	    ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE);
 
 	ASSERT(spa_syncing_txg(spa) == txg);
 
 	tx = dmu_tx_create_assigned(spa->spa_dsl_pool, txg);
-
-	rio = zio_root(spa, NULL, NULL,
-	    ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE);
-
-	/*
-	 * This function may cause an immediate scan of ddt blocks (see
-	 * the comment above dsl_scan_ddt() for details). We set the
-	 * scan's root zio here so that we can wait for any scan IOs in
-	 * addition to the regular ddt IOs.
-	 */
-	ASSERT3P(scn->scn_zio_root, ==, NULL);
-	scn->scn_zio_root = rio;
 
 	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
 		ddt_t *ddt = spa->spa_ddt[c];
@@ -1201,7 +1189,6 @@ ddt_sync(spa_t *spa, uint64_t txg)
 	}
 
 	(void) zio_wait(rio);
-	scn->scn_zio_root = NULL;
 
 	dmu_tx_commit(tx);
 }

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -530,7 +530,7 @@ dmu_buf_hold_array_by_dnode(dnode_t *dn, uint64_t offset, uint64_t length,
 	}
 
 	if ((flags & DMU_READ_NO_PREFETCH) == 0 &&
-	    DNODE_META_IS_CACHEABLE(dn) && length <= zfetch_array_rd_sz) {
+	    DNODE_META_IS_CACHEABLE(dn)) {
 		dmu_zfetch(&dn->dn_zfetch, blkid, nblks,
 		    read && DNODE_IS_CACHEABLE(dn));
 	}

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1783,6 +1783,13 @@ dmu_sync_late_arrival(zio_t *pio, objset_t *os, dmu_sync_cb_t *done, zgd_t *zgd,
 		return (SET_ERROR(EIO));
 	}
 
+	/*
+	 * In order to prevent the zgd's lwb from being free'd prior to
+	 * dmu_sync_late_arrival_done() being called, we have to ensure
+	 * the lwb's "max txg" takes this tx's txg into account.
+	 */
+	zil_lwb_add_txg(zgd->zgd_lwb, dmu_tx_get_txg(tx));
+
 	dsa = kmem_alloc(sizeof (dmu_sync_arg_t), KM_SLEEP);
 	dsa->dsa_dr = NULL;
 	dsa->dsa_done = done;

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -520,8 +520,7 @@ traverse_prefetcher(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 {
 	prefetch_data_t *pfd = arg;
 	int zio_flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE;
-	arc_flags_t aflags = ARC_FLAG_NOWAIT | ARC_FLAG_PREFETCH |
-	    ARC_FLAG_PRESCIENT_PREFETCH;
+	arc_flags_t aflags = ARC_FLAG_NOWAIT | ARC_FLAG_PREFETCH;
 
 	ASSERT(pfd->pd_bytes_fetched >= 0);
 	if (bp == NULL)

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -1197,7 +1197,7 @@ dmu_tx_do_callbacks(list_t *cb_list, int error)
 {
 	dmu_tx_callback_t *dcb;
 
-	while ((dcb = list_head(cb_list)) != NULL) {
+	while ((dcb = list_tail(cb_list)) != NULL) {
 		list_remove(cb_list, dcb);
 		dcb->dcb_func(dcb->dcb_data, error);
 		kmem_free(dcb, sizeof (dmu_tx_callback_t));

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -732,7 +732,7 @@ dnode_move_impl(dnode_t *odn, dnode_t *ndn)
 	ASSERT(!RW_LOCK_HELD(&odn->dn_struct_rwlock));
 	ASSERT(MUTEX_NOT_HELD(&odn->dn_mtx));
 	ASSERT(MUTEX_NOT_HELD(&odn->dn_dbufs_mtx));
-	ASSERT(!RW_LOCK_HELD(&odn->dn_zfetch.zf_rwlock));
+	// ASSERT(!RW_LOCK_HELD(&odn->dn_zfetch.zf_rwlock));
 
 	/* Copy fields. */
 	ndn->dn_objset = odn->dn_objset;
@@ -793,9 +793,7 @@ dnode_move_impl(dnode_t *odn, dnode_t *ndn)
 	ndn->dn_newuid = odn->dn_newuid;
 	ndn->dn_newgid = odn->dn_newgid;
 	ndn->dn_id_flags = odn->dn_id_flags;
-	dmu_zfetch_init(&ndn->dn_zfetch, NULL);
-	list_move_tail(&ndn->dn_zfetch.zf_stream, &odn->dn_zfetch.zf_stream);
-	ndn->dn_zfetch.zf_dnode = odn->dn_zfetch.zf_dnode;
+	dmu_zfetch_init(&ndn->dn_zfetch, odn->dn_zfetch.zf_dnode);
 
 	/*
 	 * Update back pointers. Updating the handle fixes the back pointer of
@@ -816,7 +814,7 @@ dnode_move_impl(dnode_t *odn, dnode_t *ndn)
 	    offsetof(dmu_buf_impl_t, db_link));
 	odn->dn_dbufs_count = 0;
 	odn->dn_bonus = NULL;
-	odn->dn_zfetch.zf_dnode = NULL;
+	dmu_zfetch_fini(&odn->dn_zfetch);
 
 	/*
 	 * Set the low bit of the objset pointer to ensure that dnode_move()

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -390,10 +390,8 @@ dsl_pool_close(dsl_pool_t *dp)
 	mutex_destroy(&dp->dp_lock);
 	cv_destroy(&dp->dp_spaceavail_cv);
 	taskq_destroy(dp->dp_iput_taskq);
-	if (dp->dp_blkstats) {
-		mutex_destroy(&dp->dp_blkstats->zab_lock);
+	if (dp->dp_blkstats)
 		vmem_free(dp->dp_blkstats, sizeof (zfs_all_blkstats_t));
-	}
 	kmem_free(dp, sizeof (dsl_pool_t));
 }
 

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -50,140 +50,32 @@
 #include <sys/sa_impl.h>
 #include <sys/zfeature.h>
 #include <sys/abd.h>
-#include <sys/range_tree.h>
 #ifdef _KERNEL
 #include <sys/zfs_vfsops.h>
 #endif
-
-/*
- * Grand theory statement on scan queue sorting
- *
- * Scanning is implemented by recursively traversing all indirection levels
- * in an object and reading all blocks referenced from said objects. This
- * results in us approximately traversing the object from lowest logical
- * offset to the highest. For best performance, we would want the logical
- * blocks to be physically contiguous. However, this is frequently not the
- * case with pools given the allocation patterns of copy-on-write filesystems.
- * So instead, we put the I/Os into a reordering queue and issue them in a
- * way that will most benefit physical disks (LBA-order).
- *
- * Queue management:
- *
- * Ideally, we would want to scan all metadata and queue up all block I/O
- * prior to starting to issue it, because that allows us to do an optimal
- * sorting job. This can however consume large amounts of memory. Therefore
- * we continuously monitor the size of the queues and constrain them to 5%
- * (zfs_scan_mem_lim_fact) of physmem. If the queues grow larger than this
- * limit, we clear out a few of the largest extents at the head of the queues
- * to make room for more scanning. Hopefully, these extents will be fairly
- * large and contiguous, allowing us to approach sequential I/O throughput
- * even without a fully sorted tree.
- *
- * Metadata scanning takes place in dsl_scan_visit(), which is called from
- * dsl_scan_sync() every spa_sync(). If we have either fully scanned all
- * metadata on the pool, or we need to make room in memory because our
- * queues are too large, dsl_scan_visit() is postponed and
- * scan_io_queues_run() is called from dsl_scan_sync() instead. This implies
- * that metadata scanning and queued I/O issuing are mutually exclusive. This
- * allows us to provide maximum sequential I/O throughput for the majority of
- * I/O's issued since sequential I/O performance is significantly negatively
- * impacted if it is interleaved with random I/O.
- *
- * Implementation Notes
- *
- * One side effect of the queued scanning algorithm is that the scanning code
- * needs to be notified whenever a block is freed. This is needed to allow
- * the scanning code to remove these I/Os from the issuing queue. Additionally,
- * we do not attempt to queue gang blocks to be issued sequentially since this
- * is very hard to do and would have an extremely limitted performance benefit.
- * Instead, we simply issue gang I/Os as soon as we find them using the legacy
- * algorithm.
- *
- * Backwards compatibility
- *
- * This new algorithm is backwards compatible with the legacy on-disk data
- * structures (and therefore does not require a new feature flag).
- * Periodically during scanning (see zfs_scan_checkpoint_intval), the scan
- * will stop scanning metadata (in logical order) and wait for all outstanding
- * sorted I/O to complete. Once this is done, we write out a checkpoint
- * bookmark, indicating that we have scanned everything logically before it.
- * If the pool is imported on a machine without the new sorting algorithm,
- * the scan simply resumes from the last checkpoint using the legacy algorithm.
- */
 
 typedef int (scan_cb_t)(dsl_pool_t *, const blkptr_t *,
     const zbookmark_phys_t *);
 
 static scan_cb_t dsl_scan_scrub_cb;
+static void dsl_scan_cancel_sync(void *, dmu_tx_t *);
+static void dsl_scan_sync_state(dsl_scan_t *, dmu_tx_t *);
+static boolean_t dsl_scan_restarting(dsl_scan_t *, dmu_tx_t *);
 
-static int scan_ds_queue_compare(const void *a, const void *b);
-static int scan_prefetch_queue_compare(const void *a, const void *b);
-static void scan_ds_queue_clear(dsl_scan_t *scn);
-static boolean_t scan_ds_queue_contains(dsl_scan_t *scn, uint64_t dsobj,
-    uint64_t *txg);
-static void scan_ds_queue_insert(dsl_scan_t *scn, uint64_t dsobj, uint64_t txg);
-static void scan_ds_queue_remove(dsl_scan_t *scn, uint64_t dsobj);
-static void scan_ds_queue_sync(dsl_scan_t *scn, dmu_tx_t *tx);
+int zfs_top_maxinflight = 32;		/* maximum I/Os per top-level */
+int zfs_resilver_delay = 2;		/* number of ticks to delay resilver */
+int zfs_scrub_delay = 4;		/* number of ticks to delay scrub */
+int zfs_scan_idle = 50;			/* idle window in clock ticks */
 
-extern int zfs_vdev_async_write_active_min_dirty_percent;
-
-/*
- * By default zfs will check to ensure it is not over the hard memory
- * limit before each txg. If finer-grained control of this is needed
- * this value can be set to 1 to enable checking before scanning each
- * block.
- */
-int zfs_scan_strict_mem_lim = B_FALSE;
-
-/*
- * Maximum number of parallelly executed bytes per leaf vdev. We attempt
- * to strike a balance here between keeping the vdev queues full of I/Os
- * at all times and not overflowing the queues to cause long latency,
- * which would cause long txg sync times. No matter what, we will not
- * overload the drives with I/O, since that is protected by
- * zfs_vdev_scrub_max_active.
- */
-unsigned long zfs_scan_vdev_limit = 4 << 20;
-
-int zfs_scan_issue_strategy = 0;
-int zfs_scan_legacy = B_FALSE; /* don't queue & sort zios, go direct */
-uint64_t zfs_scan_max_ext_gap = 2 << 20; /* in bytes */
-
-/*
- * fill_weight is non-tunable at runtime, so we copy it at module init from
- * zfs_scan_fill_weight. Runtime adjustments to zfs_scan_fill_weight would
- * break queue sorting.
- */
-int zfs_scan_fill_weight = 3;
-static uint64_t fill_weight;
-
-/* See dsl_scan_should_clear() for details on the memory limit tunables */
-uint64_t zfs_scan_mem_lim_min = 16 << 20;	/* bytes */
-uint64_t zfs_scan_mem_lim_soft_max = 128 << 20;	/* bytes */
-int zfs_scan_mem_lim_fact = 20;		/* fraction of physmem */
-int zfs_scan_mem_lim_soft_fact = 20;	/* fraction of mem lim above */
-
-int zfs_scrub_min_time_ms = 1000; /* min millisecs to scrub per txg */
+int zfs_scan_min_time_ms = 1000; /* min millisecs to scrub per txg */
 int zfs_free_min_time_ms = 1000; /* min millisecs to free per txg */
 int zfs_resilver_min_time_ms = 3000; /* min millisecs to resilver per txg */
-int zfs_scan_checkpoint_intval = 7200; /* in seconds */
 int zfs_no_scrub_io = B_FALSE; /* set to disable scrub i/o */
 int zfs_no_scrub_prefetch = B_FALSE; /* set to disable scrub prefetch */
 enum ddt_class zfs_scrub_ddt_class_max = DDT_CLASS_DUPLICATE;
+int dsl_scan_delay_completion = B_FALSE; /* set to delay scan completion */
 /* max number of blocks to free in a single TXG */
 unsigned long zfs_free_max_blocks = 100000;
-
-/*
- * We wait a few txgs after importing a pool to begin scanning so that
- * the import / mounting code isn't held up by scrub / resilver IO.
- * Unfortunately, it is a bit difficult to determine exactly how long
- * this will take since userspace will trigger fs mounts asynchronously
- * and the kernel will create zvol minors asynchronously. As a result,
- * the value provided here is a bit arbitrary, but represents a
- * reasonable estimate of how many txgs it will take to finish fully
- * importing a pool
- */
-#define	SCAN_IMPORT_WAIT_TXGS 		5
 
 #define	DSL_SCAN_IS_SCRUB_RESILVER(scn) \
 	((scn)->scn_phys.scn_func == POOL_SCAN_SCRUB || \
@@ -200,163 +92,6 @@ static scan_cb_t *scan_funcs[POOL_SCAN_FUNCS] = {
 	dsl_scan_scrub_cb,	/* POOL_SCAN_SCRUB */
 	dsl_scan_scrub_cb,	/* POOL_SCAN_RESILVER */
 };
-
-/* In core node for the scn->scn_queue. Represents a dataset to be scanned */
-typedef struct {
-	uint64_t	sds_dsobj;
-	uint64_t	sds_txg;
-	avl_node_t	sds_node;
-} scan_ds_t;
-
-/*
- * This controls what conditions are placed on dsl_scan_sync_state():
- * SYNC_OPTIONAL) write out scn_phys iff scn_bytes_pending == 0
- * SYNC_MANDATORY) write out scn_phys always. scn_bytes_pending must be 0.
- * SYNC_CACHED) if scn_bytes_pending == 0, write out scn_phys. Otherwise
- *	write out the scn_phys_cached version.
- * See dsl_scan_sync_state for details.
- */
-typedef enum {
-	SYNC_OPTIONAL,
-	SYNC_MANDATORY,
-	SYNC_CACHED
-} state_sync_type_t;
-
-/*
- * This struct represents the minimum information needed to reconstruct a
- * zio for sequential scanning. This is useful because many of these will
- * accumulate in the sequential IO queues before being issued, so saving
- * memory matters here.
- */
-typedef struct scan_io {
-	/* fields from blkptr_t */
-	uint64_t		sio_offset;
-	uint64_t		sio_blk_prop;
-	uint64_t		sio_phys_birth;
-	uint64_t		sio_birth;
-	zio_cksum_t		sio_cksum;
-	uint32_t		sio_asize;
-
-	/* fields from zio_t */
-	int			sio_flags;
-	zbookmark_phys_t	sio_zb;
-
-	/* members for queue sorting */
-	union {
-		avl_node_t	sio_addr_node; /* link into issueing queue */
-		list_node_t	sio_list_node; /* link for issuing to disk */
-	} sio_nodes;
-} scan_io_t;
-
-struct dsl_scan_io_queue {
-	dsl_scan_t	*q_scn; /* associated dsl_scan_t */
-	vdev_t		*q_vd; /* top-level vdev that this queue represents */
-
-	/* trees used for sorting I/Os and extents of I/Os */
-	range_tree_t	*q_exts_by_addr;
-	avl_tree_t	q_exts_by_size;
-	avl_tree_t	q_sios_by_addr;
-
-	/* members for zio rate limiting */
-	uint64_t	q_maxinflight_bytes;
-	uint64_t	q_inflight_bytes;
-	kcondvar_t	q_zio_cv; /* used under vd->vdev_scan_io_queue_lock */
-
-	/* per txg statistics */
-	uint64_t	q_total_seg_size_this_txg;
-	uint64_t	q_segs_this_txg;
-	uint64_t	q_total_zio_size_this_txg;
-	uint64_t	q_zios_this_txg;
-};
-
-/* private data for dsl_scan_prefetch_cb() */
-typedef struct scan_prefetch_ctx {
-	refcount_t spc_refcnt;		/* refcount for memory management */
-	dsl_scan_t *spc_scn;		/* dsl_scan_t for the pool */
-	boolean_t spc_root;		/* is this prefetch for an objset? */
-	uint8_t spc_indblkshift;	/* dn_indblkshift of current dnode */
-	uint16_t spc_datablkszsec;	/* dn_idatablkszsec of current dnode */
-} scan_prefetch_ctx_t;
-
-/* private data for dsl_scan_prefetch() */
-typedef struct scan_prefetch_issue_ctx {
-	avl_node_t spic_avl_node;	/* link into scn->scn_prefetch_queue */
-	scan_prefetch_ctx_t *spic_spc;	/* spc for the callback */
-	blkptr_t spic_bp;		/* bp to prefetch */
-	zbookmark_phys_t spic_zb;	/* bookmark to prefetch */
-} scan_prefetch_issue_ctx_t;
-
-static void scan_exec_io(dsl_pool_t *dp, const blkptr_t *bp, int zio_flags,
-    const zbookmark_phys_t *zb, dsl_scan_io_queue_t *queue);
-static void scan_io_queue_insert_impl(dsl_scan_io_queue_t *queue,
-    scan_io_t *sio);
-
-static dsl_scan_io_queue_t *scan_io_queue_create(vdev_t *vd);
-static void scan_io_queues_destroy(dsl_scan_t *scn);
-
-static kmem_cache_t *sio_cache;
-
-void
-scan_init(void)
-{
-	/*
-	 * This is used in ext_size_compare() to weight segments
-	 * based on how sparse they are. This cannot be changed
-	 * mid-scan and the tree comparison functions don't currently
-	 * have a mechansim for passing additional context to the
-	 * compare functions. Thus we store this value globally and
-	 * we only allow it to be set at module intiailization time
-	 */
-	fill_weight = zfs_scan_fill_weight;
-
-	sio_cache = kmem_cache_create("sio_cache",
-	    sizeof (scan_io_t), 0, NULL, NULL, NULL, NULL, NULL, 0);
-}
-
-void
-scan_fini(void)
-{
-	kmem_cache_destroy(sio_cache);
-}
-
-static inline boolean_t
-dsl_scan_is_running(const dsl_scan_t *scn)
-{
-	return (scn->scn_phys.scn_state == DSS_SCANNING);
-}
-
-boolean_t
-dsl_scan_resilvering(dsl_pool_t *dp)
-{
-	return (dsl_scan_is_running(dp->dp_scan) &&
-	    dp->dp_scan->scn_phys.scn_func == POOL_SCAN_RESILVER);
-}
-
-static inline void
-sio2bp(const scan_io_t *sio, blkptr_t *bp, uint64_t vdev_id)
-{
-	bzero(bp, sizeof (*bp));
-	DVA_SET_ASIZE(&bp->blk_dva[0], sio->sio_asize);
-	DVA_SET_VDEV(&bp->blk_dva[0], vdev_id);
-	DVA_SET_OFFSET(&bp->blk_dva[0], sio->sio_offset);
-	bp->blk_prop = sio->sio_blk_prop;
-	bp->blk_phys_birth = sio->sio_phys_birth;
-	bp->blk_birth = sio->sio_birth;
-	bp->blk_fill = 1;	/* we always only work with data pointers */
-	bp->blk_cksum = sio->sio_cksum;
-}
-
-static inline void
-bp2sio(const blkptr_t *bp, scan_io_t *sio, int dva_i)
-{
-	/* we discard the vdev id, since we can deduce it from the queue */
-	sio->sio_offset = DVA_GET_OFFSET(&bp->blk_dva[dva_i]);
-	sio->sio_asize = DVA_GET_ASIZE(&bp->blk_dva[dva_i]);
-	sio->sio_blk_prop = bp->blk_prop;
-	sio->sio_phys_birth = bp->blk_phys_birth;
-	sio->sio_birth = bp->blk_birth;
-	sio->sio_cksum = bp->blk_cksum;
-}
 
 int
 dsl_scan_init(dsl_pool_t *dp, uint64_t txg)
@@ -378,13 +113,6 @@ dsl_scan_init(dsl_pool_t *dp, uint64_t txg)
 	scn->scn_async_destroying = spa_feature_is_active(dp->dp_spa,
 	    SPA_FEATURE_ASYNC_DESTROY);
 
-	bcopy(&scn->scn_phys, &scn->scn_phys_cached, sizeof (scn->scn_phys));
-	avl_create(&scn->scn_queue, scan_ds_queue_compare, sizeof (scan_ds_t),
-	    offsetof(scan_ds_t, sds_node));
-	avl_create(&scn->scn_prefetch_queue, scan_prefetch_queue_compare,
-	    sizeof (scan_prefetch_issue_ctx_t),
-	    offsetof(scan_prefetch_issue_ctx_t, spic_avl_node));
-
 	err = zap_lookup(dp->dp_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
 	    "scrub_func", sizeof (uint64_t), 1, &f);
 	if (err == 0) {
@@ -395,7 +123,7 @@ dsl_scan_init(dsl_pool_t *dp, uint64_t txg)
 		scn->scn_restart_txg = txg;
 		zfs_dbgmsg("old-style scrub was in progress; "
 		    "restarting new-style scrub in txg %llu",
-		    (longlong_t)scn->scn_restart_txg);
+		    scn->scn_restart_txg);
 
 		/*
 		 * Load the queue obj from the old location so that it
@@ -429,7 +157,7 @@ dsl_scan_init(dsl_pool_t *dp, uint64_t txg)
 				    scn->scn_async_destroying) {
 					spa->spa_errata =
 					    ZPOOL_ERRATA_ZOL_2094_ASYNC_DESTROY;
-					return (EOVERFLOW);
+					return (SET_ERROR(EOVERFLOW));
 				}
 
 				bcopy(zaptmp, &scn->scn_phys,
@@ -449,14 +177,7 @@ dsl_scan_init(dsl_pool_t *dp, uint64_t txg)
 		else if (err)
 			return (err);
 
-		/*
-		 * We might be restarting after a reboot, so jump the issued
-		 * counter to how far we've scanned. We know we're consistent
-		 * up to here.
-		 */
-		scn->scn_issued_before_pass = scn->scn_phys.scn_examined;
-
-		if (dsl_scan_is_running(scn) &&
+		if (scn->scn_phys.scn_state == DSS_SCANNING &&
 		    spa_prev_software_version(dp->dp_spa) < SPA_VERSION_SCAN) {
 			/*
 			 * A new-type scrub was in progress on an old
@@ -468,24 +189,8 @@ dsl_scan_init(dsl_pool_t *dp, uint64_t txg)
 			scn->scn_restart_txg = txg;
 			zfs_dbgmsg("new-style scrub was modified "
 			    "by old software; restarting in txg %llu",
-			    (longlong_t)scn->scn_restart_txg);
+			    scn->scn_restart_txg);
 		}
-	}
-
-	/* reload the queue into the in-core state */
-	if (scn->scn_phys.scn_queue_obj != 0) {
-		zap_cursor_t zc;
-		zap_attribute_t za;
-
-		for (zap_cursor_init(&zc, dp->dp_meta_objset,
-		    scn->scn_phys.scn_queue_obj);
-		    zap_cursor_retrieve(&zc, &za) == 0;
-		    (void) zap_cursor_advance(&zc)) {
-			scan_ds_queue_insert(scn,
-			    zfs_strtonum(za.za_name, NULL),
-			    za.za_first_integer);
-		}
-		zap_cursor_fini(&zc);
 	}
 
 	spa_scan_stat_init(spa);
@@ -495,106 +200,9 @@ dsl_scan_init(dsl_pool_t *dp, uint64_t txg)
 void
 dsl_scan_fini(dsl_pool_t *dp)
 {
-	if (dp->dp_scan != NULL) {
-		dsl_scan_t *scn = dp->dp_scan;
-
-		if (scn->scn_taskq != NULL)
-			taskq_destroy(scn->scn_taskq);
-		scan_ds_queue_clear(scn);
-		avl_destroy(&scn->scn_queue);
-		avl_destroy(&scn->scn_prefetch_queue);
-
+	if (dp->dp_scan) {
 		kmem_free(dp->dp_scan, sizeof (dsl_scan_t));
 		dp->dp_scan = NULL;
-	}
-}
-
-static boolean_t
-dsl_scan_restarting(dsl_scan_t *scn, dmu_tx_t *tx)
-{
-	return (scn->scn_restart_txg != 0 &&
-	    scn->scn_restart_txg <= tx->tx_txg);
-}
-
-boolean_t
-dsl_scan_scrubbing(const dsl_pool_t *dp)
-{
-	dsl_scan_phys_t *scn_phys = &dp->dp_scan->scn_phys;
-
-	return (scn_phys->scn_state == DSS_SCANNING &&
-	    scn_phys->scn_func == POOL_SCAN_SCRUB);
-}
-
-boolean_t
-dsl_scan_is_paused_scrub(const dsl_scan_t *scn)
-{
-	return (dsl_scan_scrubbing(scn->scn_dp) &&
-	    scn->scn_phys.scn_flags & DSF_SCRUB_PAUSED);
-}
-
-/*
- * Writes out a persistent dsl_scan_phys_t record to the pool directory.
- * Because we can be running in the block sorting algorithm, we do not always
- * want to write out the record, only when it is "safe" to do so. This safety
- * condition is achieved by making sure that the sorting queues are empty
- * (scn_bytes_pending == 0). When this condition is not true, the sync'd state
- * is inconsistent with how much actual scanning progress has been made. The
- * kind of sync to be performed is specified by the sync_type argument. If the
- * sync is optional, we only sync if the queues are empty. If the sync is
- * mandatory, we do a hard ASSERT to make sure that the queues are empty. The
- * third possible state is a "cached" sync. This is done in response to:
- * 1) The dataset that was in the last sync'd dsl_scan_phys_t having been
- *	destroyed, so we wouldn't be able to restart scanning from it.
- * 2) The snapshot that was in the last sync'd dsl_scan_phys_t having been
- *	superseded by a newer snapshot.
- * 3) The dataset that was in the last sync'd dsl_scan_phys_t having been
- *	swapped with its clone.
- * In all cases, a cached sync simply rewrites the last record we've written,
- * just slightly modified. For the modifications that are performed to the
- * last written dsl_scan_phys_t, see dsl_scan_ds_destroyed,
- * dsl_scan_ds_snapshotted and dsl_scan_ds_clone_swapped.
- */
-static void
-dsl_scan_sync_state(dsl_scan_t *scn, dmu_tx_t *tx, state_sync_type_t sync_type)
-{
-	int i;
-	spa_t *spa = scn->scn_dp->dp_spa;
-
-	ASSERT(sync_type != SYNC_MANDATORY || scn->scn_bytes_pending == 0);
-	if (scn->scn_bytes_pending == 0) {
-		for (i = 0; i < spa->spa_root_vdev->vdev_children; i++) {
-			vdev_t *vd = spa->spa_root_vdev->vdev_child[i];
-			dsl_scan_io_queue_t *q = vd->vdev_scan_io_queue;
-
-			if (q == NULL)
-				continue;
-
-			mutex_enter(&vd->vdev_scan_io_queue_lock);
-			ASSERT3P(avl_first(&q->q_sios_by_addr), ==, NULL);
-			ASSERT3P(avl_first(&q->q_exts_by_size), ==, NULL);
-			ASSERT3P(range_tree_first(q->q_exts_by_addr), ==, NULL);
-			mutex_exit(&vd->vdev_scan_io_queue_lock);
-		}
-
-		if (scn->scn_phys.scn_queue_obj != 0)
-			scan_ds_queue_sync(scn, tx);
-		VERIFY0(zap_update(scn->scn_dp->dp_meta_objset,
-		    DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_SCAN, sizeof (uint64_t), SCAN_PHYS_NUMINTS,
-		    &scn->scn_phys, tx));
-		bcopy(&scn->scn_phys, &scn->scn_phys_cached,
-		    sizeof (scn->scn_phys));
-
-		if (scn->scn_checkpointing)
-			zfs_dbgmsg("finish scan checkpoint");
-
-		scn->scn_checkpointing = B_FALSE;
-		scn->scn_last_checkpoint = ddi_get_lbolt();
-	} else if (sync_type == SYNC_CACHED) {
-		VERIFY0(zap_update(scn->scn_dp->dp_meta_objset,
-		    DMU_POOL_DIRECTORY_OBJECT,
-		    DMU_POOL_SCAN, sizeof (uint64_t), SCAN_PHYS_NUMINTS,
-		    &scn->scn_phys_cached, tx));
 	}
 }
 
@@ -604,7 +212,7 @@ dsl_scan_setup_check(void *arg, dmu_tx_t *tx)
 {
 	dsl_scan_t *scn = dmu_tx_pool(tx)->dp_scan;
 
-	if (dsl_scan_is_running(scn))
+	if (scn->scn_phys.scn_state == DSS_SCANNING)
 		return (SET_ERROR(EBUSY));
 
 	return (0);
@@ -619,7 +227,7 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	dsl_pool_t *dp = scn->scn_dp;
 	spa_t *spa = dp->dp_spa;
 
-	ASSERT(!dsl_scan_is_running(scn));
+	ASSERT(scn->scn_phys.scn_state != DSS_SCANNING);
 	ASSERT(*funcp > POOL_SCAN_NONE && *funcp < POOL_SCAN_FUNCS);
 	bzero(&scn->scn_phys, sizeof (scn->scn_phys));
 	scn->scn_phys.scn_func = *funcp;
@@ -630,11 +238,8 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	scn->scn_phys.scn_start_time = gethrestime_sec();
 	scn->scn_phys.scn_errors = 0;
 	scn->scn_phys.scn_to_examine = spa->spa_root_vdev->vdev_stat.vs_alloc;
-	scn->scn_issued_before_pass = 0;
 	scn->scn_restart_txg = 0;
 	scn->scn_done_txg = 0;
-	scn->scn_last_checkpoint = 0;
-	scn->scn_checkpointing = B_FALSE;
 	spa_scan_stat_init(spa);
 
 	if (DSL_SCAN_IS_SCRUB_RESILVER(scn)) {
@@ -667,10 +272,8 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	if (dp->dp_blkstats == NULL) {
 		dp->dp_blkstats =
 		    vmem_alloc(sizeof (zfs_all_blkstats_t), KM_SLEEP);
-		mutex_init(&dp->dp_blkstats->zab_lock, NULL,
-		    MUTEX_DEFAULT, NULL);
 	}
-	bzero(&dp->dp_blkstats->zab_type, sizeof (dp->dp_blkstats->zab_type));
+	bzero(dp->dp_blkstats, sizeof (zfs_all_blkstats_t));
 
 	if (spa_version(spa) < SPA_VERSION_DSL_SCRUB)
 		ot = DMU_OT_ZAP_OTHER;
@@ -678,50 +281,11 @@ dsl_scan_setup_sync(void *arg, dmu_tx_t *tx)
 	scn->scn_phys.scn_queue_obj = zap_create(dp->dp_meta_objset,
 	    ot ? ot : DMU_OT_SCAN_QUEUE, DMU_OT_NONE, 0, tx);
 
-	bcopy(&scn->scn_phys, &scn->scn_phys_cached, sizeof (scn->scn_phys));
-
-	dsl_scan_sync_state(scn, tx, SYNC_MANDATORY);
+	dsl_scan_sync_state(scn, tx);
 
 	spa_history_log_internal(spa, "scan setup", tx,
 	    "func=%u mintxg=%llu maxtxg=%llu",
 	    *funcp, scn->scn_phys.scn_min_txg, scn->scn_phys.scn_max_txg);
-}
-
-/*
- * Called by the ZFS_IOC_POOL_SCAN ioctl to start a scrub or resilver.
- * Can also be called to resume a paused scrub.
- */
-int
-dsl_scan(dsl_pool_t *dp, pool_scan_func_t func)
-{
-	spa_t *spa = dp->dp_spa;
-	dsl_scan_t *scn = dp->dp_scan;
-
-	/*
-	 * Purge all vdev caches and probe all devices.  We do this here
-	 * rather than in sync context because this requires a writer lock
-	 * on the spa_config lock, which we can't do from sync context.  The
-	 * spa_scrub_reopen flag indicates that vdev_open() should not
-	 * attempt to start another scrub.
-	 */
-	spa_vdev_state_enter(spa, SCL_NONE);
-	spa->spa_scrub_reopen = B_TRUE;
-	vdev_reopen(spa->spa_root_vdev);
-	spa->spa_scrub_reopen = B_FALSE;
-	(void) spa_vdev_state_exit(spa, NULL, 0);
-
-	if (func == POOL_SCAN_SCRUB && dsl_scan_is_paused_scrub(scn)) {
-		/* got scrub start cmd, resume paused scrub */
-		int err = dsl_scrub_set_pause_resume(scn->scn_dp,
-		    POOL_SCRUB_NORMAL);
-		if (err == 0)
-			return (ECANCELED);
-
-		return (SET_ERROR(err));
-	}
-
-	return (dsl_sync_task(spa_name(spa), dsl_scan_setup_check,
-	    dsl_scan_setup_sync, &func, 0, ZFS_SPACE_CHECK_NONE));
 }
 
 /* ARGSUSED */
@@ -751,11 +315,10 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 	}
 
 	if (scn->scn_phys.scn_queue_obj != 0) {
-		VERIFY0(dmu_object_free(dp->dp_meta_objset,
+		VERIFY(0 == dmu_object_free(dp->dp_meta_objset,
 		    scn->scn_phys.scn_queue_obj, tx));
 		scn->scn_phys.scn_queue_obj = 0;
 	}
-	scan_ds_queue_clear(scn);
 
 	scn->scn_phys.scn_flags &= ~DSF_SCRUB_PAUSED;
 
@@ -763,22 +326,13 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 	 * If we were "restarted" from a stopped state, don't bother
 	 * with anything else.
 	 */
-	if (!dsl_scan_is_running(scn)) {
-		ASSERT(!scn->scn_is_sorted);
+	if (scn->scn_phys.scn_state != DSS_SCANNING)
 		return;
-	}
 
-	if (scn->scn_is_sorted) {
-		scan_io_queues_destroy(scn);
-		scn->scn_is_sorted = B_FALSE;
-
-		if (scn->scn_taskq != NULL) {
-			taskq_destroy(scn->scn_taskq);
-			scn->scn_taskq = NULL;
-		}
-	}
-
-	scn->scn_phys.scn_state = complete ? DSS_FINISHED : DSS_CANCELED;
+	if (complete)
+		scn->scn_phys.scn_state = DSS_FINISHED;
+	else
+		scn->scn_phys.scn_state = DSS_CANCELED;
 
 	if (dsl_scan_restarting(scn, tx))
 		spa_history_log_internal(spa, "scan aborted, restarting", tx,
@@ -791,6 +345,12 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 		    "errors=%llu", spa_get_errlog_size(spa));
 
 	if (DSL_SCAN_IS_SCRUB_RESILVER(scn)) {
+		mutex_enter(&spa->spa_scrub_lock);
+		while (spa->spa_scrub_inflight > 0) {
+			cv_wait(&spa->spa_scrub_io_cv,
+			    &spa->spa_scrub_lock);
+		}
+		mutex_exit(&spa->spa_scrub_lock);
 		spa->spa_scrub_started = B_FALSE;
 		spa->spa_scrub_active = B_FALSE;
 
@@ -819,8 +379,6 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 
 	if (spa->spa_errata == ZPOOL_ERRATA_ZOL_2094_SCRUB)
 		spa->spa_errata = 0;
-
-	ASSERT(!dsl_scan_is_running(scn));
 }
 
 /* ARGSUSED */
@@ -829,7 +387,7 @@ dsl_scan_cancel_check(void *arg, dmu_tx_t *tx)
 {
 	dsl_scan_t *scn = dmu_tx_pool(tx)->dp_scan;
 
-	if (!dsl_scan_is_running(scn))
+	if (scn->scn_phys.scn_state != DSS_SCANNING)
 		return (SET_ERROR(ENOENT));
 	return (0);
 }
@@ -841,7 +399,7 @@ dsl_scan_cancel_sync(void *arg, dmu_tx_t *tx)
 	dsl_scan_t *scn = dmu_tx_pool(tx)->dp_scan;
 
 	dsl_scan_done(scn, B_FALSE, tx);
-	dsl_scan_sync_state(scn, tx, SYNC_MANDATORY);
+	dsl_scan_sync_state(scn, tx);
 }
 
 int
@@ -849,6 +407,16 @@ dsl_scan_cancel(dsl_pool_t *dp)
 {
 	return (dsl_sync_task(spa_name(dp->dp_spa), dsl_scan_cancel_check,
 	    dsl_scan_cancel_sync, NULL, 3, ZFS_SPACE_CHECK_RESERVED));
+}
+
+boolean_t
+dsl_scan_is_paused_scrub(const dsl_scan_t *scn)
+{
+	if (dsl_scan_scrubbing(scn->scn_dp) &&
+	    scn->scn_phys.scn_flags & DSF_SCRUB_PAUSED)
+		return (B_TRUE);
+
+	return (B_FALSE);
 }
 
 static int
@@ -885,7 +453,7 @@ dsl_scrub_pause_resume_sync(void *arg, dmu_tx_t *tx)
 		/* can't pause a scrub when there is no in-progress scrub */
 		spa->spa_scan_pass_scrub_pause = gethrestime_sec();
 		scn->scn_phys.scn_flags |= DSF_SCRUB_PAUSED;
-		dsl_scan_sync_state(scn, tx, SYNC_CACHED);
+		dsl_scan_sync_state(scn, tx);
 	} else {
 		ASSERT3U(*cmd, ==, POOL_SCRUB_NORMAL);
 		if (dsl_scan_is_paused_scrub(scn)) {
@@ -898,7 +466,7 @@ dsl_scrub_pause_resume_sync(void *arg, dmu_tx_t *tx)
 			    gethrestime_sec() - spa->spa_scan_pass_scrub_pause;
 			spa->spa_scan_pass_scrub_pause = 0;
 			scn->scn_phys.scn_flags &= ~DSF_SCRUB_PAUSED;
-			dsl_scan_sync_state(scn, tx, SYNC_CACHED);
+			dsl_scan_sync_state(scn, tx);
 		}
 	}
 }
@@ -914,24 +482,24 @@ dsl_scrub_set_pause_resume(const dsl_pool_t *dp, pool_scrub_cmd_t cmd)
 	    ZFS_SPACE_CHECK_RESERVED));
 }
 
-
-/* start a new scan, or restart an existing one. */
-void
-dsl_resilver_restart(dsl_pool_t *dp, uint64_t txg)
+boolean_t
+dsl_scan_scrubbing(const dsl_pool_t *dp)
 {
-	if (txg == 0) {
-		dmu_tx_t *tx;
-		tx = dmu_tx_create_dd(dp->dp_mos_dir);
-		VERIFY(0 == dmu_tx_assign(tx, TXG_WAIT));
+	dsl_scan_t *scn = dp->dp_scan;
 
-		txg = dmu_tx_get_txg(tx);
-		dp->dp_scan->scn_restart_txg = txg;
-		dmu_tx_commit(tx);
-	} else {
-		dp->dp_scan->scn_restart_txg = txg;
-	}
-	zfs_dbgmsg("restarting resilver txg=%llu", (longlong_t)txg);
+	if (scn->scn_phys.scn_state == DSS_SCANNING &&
+	    scn->scn_phys.scn_func == POOL_SCAN_SCRUB)
+		return (B_TRUE);
+
+	return (B_FALSE);
 }
+
+static void dsl_scan_visitbp(blkptr_t *bp, const zbookmark_phys_t *zb,
+    dnode_phys_t *dnp, dsl_dataset_t *ds, dsl_scan_t *scn,
+    dmu_objset_type_t ostype, dmu_tx_t *tx);
+inline __attribute__((always_inline)) static void dsl_scan_visitdnode(
+    dsl_scan_t *, dsl_dataset_t *ds, dmu_objset_type_t ostype,
+    dnode_phys_t *dnp, uint64_t object, dmu_tx_t *tx);
 
 void
 dsl_free(dsl_pool_t *dp, uint64_t txg, const blkptr_t *bp)
@@ -946,169 +514,25 @@ dsl_free_sync(zio_t *pio, dsl_pool_t *dp, uint64_t txg, const blkptr_t *bpp)
 	zio_nowait(zio_free_sync(pio, dp->dp_spa, txg, bpp, pio->io_flags));
 }
 
-static int
-scan_ds_queue_compare(const void *a, const void *b)
+static uint64_t
+dsl_scan_ds_maxtxg(dsl_dataset_t *ds)
 {
-	const scan_ds_t *sds_a = a, *sds_b = b;
-
-	if (sds_a->sds_dsobj < sds_b->sds_dsobj)
-		return (-1);
-	if (sds_a->sds_dsobj == sds_b->sds_dsobj)
-		return (0);
-	return (1);
+	uint64_t smt = ds->ds_dir->dd_pool->dp_scan->scn_phys.scn_max_txg;
+	if (ds->ds_is_snapshot)
+		return (MIN(smt, dsl_dataset_phys(ds)->ds_creation_txg));
+	return (smt);
 }
 
 static void
-scan_ds_queue_clear(dsl_scan_t *scn)
+dsl_scan_sync_state(dsl_scan_t *scn, dmu_tx_t *tx)
 {
-	void *cookie = NULL;
-	scan_ds_t *sds;
-	while ((sds = avl_destroy_nodes(&scn->scn_queue, &cookie)) != NULL) {
-		kmem_free(sds, sizeof (*sds));
-	}
+	VERIFY0(zap_update(scn->scn_dp->dp_meta_objset,
+	    DMU_POOL_DIRECTORY_OBJECT,
+	    DMU_POOL_SCAN, sizeof (uint64_t), SCAN_PHYS_NUMINTS,
+	    &scn->scn_phys, tx));
 }
 
-static boolean_t
-scan_ds_queue_contains(dsl_scan_t *scn, uint64_t dsobj, uint64_t *txg)
-{
-	scan_ds_t srch, *sds;
-
-	srch.sds_dsobj = dsobj;
-	sds = avl_find(&scn->scn_queue, &srch, NULL);
-	if (sds != NULL && txg != NULL)
-		*txg = sds->sds_txg;
-	return (sds != NULL);
-}
-
-static void
-scan_ds_queue_insert(dsl_scan_t *scn, uint64_t dsobj, uint64_t txg)
-{
-	scan_ds_t *sds;
-	avl_index_t where;
-
-	sds = kmem_zalloc(sizeof (*sds), KM_SLEEP);
-	sds->sds_dsobj = dsobj;
-	sds->sds_txg = txg;
-
-	VERIFY3P(avl_find(&scn->scn_queue, sds, &where), ==, NULL);
-	avl_insert(&scn->scn_queue, sds, where);
-}
-
-static void
-scan_ds_queue_remove(dsl_scan_t *scn, uint64_t dsobj)
-{
-	scan_ds_t srch, *sds;
-
-	srch.sds_dsobj = dsobj;
-
-	sds = avl_find(&scn->scn_queue, &srch, NULL);
-	VERIFY(sds != NULL);
-	avl_remove(&scn->scn_queue, sds);
-	kmem_free(sds, sizeof (*sds));
-}
-
-static void
-scan_ds_queue_sync(dsl_scan_t *scn, dmu_tx_t *tx)
-{
-	dsl_pool_t *dp = scn->scn_dp;
-	spa_t *spa = dp->dp_spa;
-	dmu_object_type_t ot = (spa_version(spa) >= SPA_VERSION_DSL_SCRUB) ?
-	    DMU_OT_SCAN_QUEUE : DMU_OT_ZAP_OTHER;
-
-	ASSERT0(scn->scn_bytes_pending);
-	ASSERT(scn->scn_phys.scn_queue_obj != 0);
-
-	VERIFY0(dmu_object_free(dp->dp_meta_objset,
-	    scn->scn_phys.scn_queue_obj, tx));
-	scn->scn_phys.scn_queue_obj = zap_create(dp->dp_meta_objset, ot,
-	    DMU_OT_NONE, 0, tx);
-	for (scan_ds_t *sds = avl_first(&scn->scn_queue);
-	    sds != NULL; sds = AVL_NEXT(&scn->scn_queue, sds)) {
-		VERIFY0(zap_add_int_key(dp->dp_meta_objset,
-		    scn->scn_phys.scn_queue_obj, sds->sds_dsobj,
-		    sds->sds_txg, tx));
-	}
-}
-
-/*
- * Computes the memory limit state that we're currently in. A sorted scan
- * needs quite a bit of memory to hold the sorting queue, so we need to
- * reasonably constrain the size so it doesn't impact overall system
- * performance. We compute two limits:
- * 1) Hard memory limit: if the amount of memory used by the sorting
- *	queues on a pool gets above this value, we stop the metadata
- *	scanning portion and start issuing the queued up and sorted
- *	I/Os to reduce memory usage.
- *	This limit is calculated as a fraction of physmem (by default 5%).
- *	We constrain the lower bound of the hard limit to an absolute
- *	minimum of zfs_scan_mem_lim_min (default: 16 MiB). We also constrain
- *	the upper bound to 5% of the total pool size - no chance we'll
- *	ever need that much memory, but just to keep the value in check.
- * 2) Soft memory limit: once we hit the hard memory limit, we start
- *	issuing I/O to reduce queue memory usage, but we don't want to
- *	completely empty out the queues, since we might be able to find I/Os
- *	that will fill in the gaps of our non-sequential IOs at some point
- *	in the future. So we stop the issuing of I/Os once the amount of
- *	memory used drops below the soft limit (at which point we stop issuing
- *	I/O and start scanning metadata again).
- *
- *	This limit is calculated by subtracting a fraction of the hard
- *	limit from the hard limit. By default this fraction is 5%, so
- *	the soft limit is 95% of the hard limit. We cap the size of the
- *	difference between the hard and soft limits at an absolute
- *	maximum of zfs_scan_mem_lim_soft_max (default: 128 MiB) - this is
- *	sufficient to not cause too frequent switching between the
- *	metadata scan and I/O issue (even at 2k recordsize, 128 MiB's
- *	worth of queues is about 1.2 GiB of on-pool data, so scanning
- *	that should take at least a decent fraction of a second).
- */
-static boolean_t
-dsl_scan_should_clear(dsl_scan_t *scn)
-{
-	vdev_t *rvd = scn->scn_dp->dp_spa->spa_root_vdev;
-	uint64_t mlim_hard, mlim_soft, mused;
-	uint64_t alloc = metaslab_class_get_alloc(spa_normal_class(
-	    scn->scn_dp->dp_spa));
-
-	mlim_hard = MAX((physmem / zfs_scan_mem_lim_fact) * PAGESIZE,
-	    zfs_scan_mem_lim_min);
-	mlim_hard = MIN(mlim_hard, alloc / 20);
-	mlim_soft = mlim_hard - MIN(mlim_hard / zfs_scan_mem_lim_soft_fact,
-	    zfs_scan_mem_lim_soft_max);
-	mused = 0;
-	for (uint64_t i = 0; i < rvd->vdev_children; i++) {
-		vdev_t *tvd = rvd->vdev_child[i];
-		dsl_scan_io_queue_t *queue;
-
-		mutex_enter(&tvd->vdev_scan_io_queue_lock);
-		queue = tvd->vdev_scan_io_queue;
-		if (queue != NULL) {
-			/* #extents in exts_by_size = # in exts_by_addr */
-			mused += avl_numnodes(&queue->q_exts_by_size) *
-			    sizeof (range_seg_t) +
-			    avl_numnodes(&queue->q_sios_by_addr) *
-			    sizeof (scan_io_t);
-		}
-		mutex_exit(&tvd->vdev_scan_io_queue_lock);
-	}
-
-	dprintf("current scan memory usage: %llu bytes\n", (longlong_t)mused);
-
-	if (mused == 0)
-		ASSERT0(scn->scn_bytes_pending);
-
-	/*
-	 * If we are above our hard limit, we need to clear out memory.
-	 * If we are below our soft limit, we need to accumulate sequential IOs.
-	 * Otherwise, we should keep doing whatever we are currently doing.
-	 */
-	if (mused >= mlim_hard)
-		return (B_TRUE);
-	else if (mused < mlim_soft)
-		return (B_FALSE);
-	else
-		return (scn->scn_clearing);
-}
+extern int zfs_vdev_async_write_active_min_dirty_percent;
 
 static boolean_t
 dsl_scan_check_suspend(dsl_scan_t *scn, const zbookmark_phys_t *zb)
@@ -1129,32 +553,27 @@ dsl_scan_check_suspend(dsl_scan_t *scn, const zbookmark_phys_t *zb)
 
 	/*
 	 * We suspend if:
+	 *  - we have scanned for the maximum time: an entire txg
+	 *    timeout (default 5 sec)
+	 *  or
 	 *  - we have scanned for at least the minimum time (default 1 sec
 	 *    for scrub, 3 sec for resilver), and either we have sufficient
 	 *    dirty data that we are starting to write more quickly
-	 *    (default 30%), someone is explicitly waiting for this txg
-	 *    to complete, or we have used up all of the time in the txg
-	 *    timeout (default 5 sec).
+	 *    (default 30%), or someone is explicitly waiting for this txg
+	 *    to complete.
 	 *  or
 	 *  - the spa is shutting down because this pool is being exported
 	 *    or the machine is rebooting.
-	 *  or
-	 *  - the scan queue has reached its memory use limit
 	 */
-	uint64_t curr_time_ns = gethrtime();
-	uint64_t scan_time_ns = curr_time_ns - scn->scn_sync_start_time;
-	uint64_t sync_time_ns = curr_time_ns -
-	    scn->scn_dp->dp_spa->spa_sync_starttime;
-	int dirty_pct = scn->scn_dp->dp_dirty_total * 100 / zfs_dirty_data_max;
 	int mintime = (scn->scn_phys.scn_func == POOL_SCAN_RESILVER) ?
-	    zfs_resilver_min_time_ms : zfs_scrub_min_time_ms;
-
-	if ((NSEC2MSEC(scan_time_ns) > mintime &&
-	    (dirty_pct >= zfs_vdev_async_write_active_min_dirty_percent ||
-	    txg_sync_waiting(scn->scn_dp) ||
-	    NSEC2SEC(sync_time_ns) >= zfs_txg_timeout)) ||
-	    spa_shutting_down(scn->scn_dp->dp_spa) ||
-	    (zfs_scan_strict_mem_lim && dsl_scan_should_clear(scn))) {
+	    zfs_resilver_min_time_ms : zfs_scan_min_time_ms;
+	uint64_t elapsed_nanosecs = gethrtime() - scn->scn_sync_start_time;
+	int dirty_pct = scn->scn_dp->dp_dirty_total * 100 / zfs_dirty_data_max;
+	if (elapsed_nanosecs / NANOSEC >= zfs_txg_timeout ||
+	    (NSEC2MSEC(elapsed_nanosecs) > mintime &&
+	    (txg_sync_waiting(scn->scn_dp) ||
+	    dirty_pct >= zfs_vdev_async_write_active_min_dirty_percent)) ||
+	    spa_shutting_down(scn->scn_dp->dp_spa)) {
 		if (zb) {
 			dprintf("suspending at bookmark %llx/%llx/%llx/%llx\n",
 			    (longlong_t)zb->zb_objset,
@@ -1162,16 +581,12 @@ dsl_scan_check_suspend(dsl_scan_t *scn, const zbookmark_phys_t *zb)
 			    (longlong_t)zb->zb_level,
 			    (longlong_t)zb->zb_blkid);
 			scn->scn_phys.scn_bookmark = *zb;
-		} else {
-			dsl_scan_phys_t *scnp = &scn->scn_phys;
-
-			dprintf("suspending at at DDT bookmark "
-			    "%llx/%llx/%llx/%llx\n",
-			    (longlong_t)scnp->scn_ddt_bookmark.ddb_class,
-			    (longlong_t)scnp->scn_ddt_bookmark.ddb_type,
-			    (longlong_t)scnp->scn_ddt_bookmark.ddb_checksum,
-			    (longlong_t)scnp->scn_ddt_bookmark.ddb_cursor);
 		}
+		dprintf("suspending at DDT bookmark %llx/%llx/%llx/%llx\n",
+		    (longlong_t)scn->scn_phys.scn_ddt_bookmark.ddb_class,
+		    (longlong_t)scn->scn_phys.scn_ddt_bookmark.ddb_type,
+		    (longlong_t)scn->scn_phys.scn_ddt_bookmark.ddb_checksum,
+		    (longlong_t)scn->scn_phys.scn_ddt_bookmark.ddb_cursor);
 		scn->scn_suspending = B_TRUE;
 		return (B_TRUE);
 	}
@@ -1268,283 +683,32 @@ dsl_scan_zil(dsl_pool_t *dp, zil_header_t *zh)
 	zil_free(zilog);
 }
 
-/*
- * We compare scan_prefetch_issue_ctx_t's based on their bookmarks. The idea
- * here is to sort the AVL tree by the order each block will be needed.
- */
-static int
-scan_prefetch_queue_compare(const void *a, const void *b)
-{
-	const scan_prefetch_issue_ctx_t *spic_a = a, *spic_b = b;
-	const scan_prefetch_ctx_t *spc_a = spic_a->spic_spc;
-	const scan_prefetch_ctx_t *spc_b = spic_b->spic_spc;
-
-	return (zbookmark_compare(spc_a->spc_datablkszsec,
-	    spc_a->spc_indblkshift, spc_b->spc_datablkszsec,
-	    spc_b->spc_indblkshift, &spic_a->spic_zb, &spic_b->spic_zb));
-}
-
+/* ARGSUSED */
 static void
-scan_prefetch_ctx_rele(scan_prefetch_ctx_t *spc, void *tag)
+dsl_scan_prefetch(dsl_scan_t *scn, arc_buf_t *buf, blkptr_t *bp,
+    uint64_t objset, uint64_t object, uint64_t blkid)
 {
-	if (refcount_remove(&spc->spc_refcnt, tag) == 0) {
-		refcount_destroy(&spc->spc_refcnt);
-		kmem_free(spc, sizeof (scan_prefetch_ctx_t));
-	}
-}
-
-static scan_prefetch_ctx_t *
-scan_prefetch_ctx_create(dsl_scan_t *scn, dnode_phys_t *dnp, void *tag)
-{
-	scan_prefetch_ctx_t *spc;
-
-	spc = kmem_alloc(sizeof (scan_prefetch_ctx_t), KM_SLEEP);
-	refcount_create(&spc->spc_refcnt);
-	refcount_add(&spc->spc_refcnt, tag);
-	spc->spc_scn = scn;
-	if (dnp != NULL) {
-		spc->spc_datablkszsec = dnp->dn_datablkszsec;
-		spc->spc_indblkshift = dnp->dn_indblkshift;
-		spc->spc_root = B_FALSE;
-	} else {
-		spc->spc_datablkszsec = 0;
-		spc->spc_indblkshift = 0;
-		spc->spc_root = B_TRUE;
-	}
-
-	return (spc);
-}
-
-static void
-scan_prefetch_ctx_add_ref(scan_prefetch_ctx_t *spc, void *tag)
-{
-	refcount_add(&spc->spc_refcnt, tag);
-}
-
-static boolean_t
-dsl_scan_check_prefetch_resume(scan_prefetch_ctx_t *spc,
-    const zbookmark_phys_t *zb)
-{
-	zbookmark_phys_t *last_zb = &spc->spc_scn->scn_prefetch_bookmark;
-	dnode_phys_t tmp_dnp;
-	dnode_phys_t *dnp = (spc->spc_root) ? NULL : &tmp_dnp;
-
-	if (zb->zb_objset != last_zb->zb_objset)
-		return (B_TRUE);
-	if ((int64_t)zb->zb_object < 0)
-		return (B_FALSE);
-
-	tmp_dnp.dn_datablkszsec = spc->spc_datablkszsec;
-	tmp_dnp.dn_indblkshift = spc->spc_indblkshift;
-
-	if (zbookmark_subtree_completed(dnp, zb, last_zb))
-		return (B_TRUE);
-
-	return (B_FALSE);
-}
-
-static void
-dsl_scan_prefetch(scan_prefetch_ctx_t *spc, blkptr_t *bp, zbookmark_phys_t *zb)
-{
-	avl_index_t idx;
-	dsl_scan_t *scn = spc->spc_scn;
-	spa_t *spa = scn->scn_dp->dp_spa;
-	scan_prefetch_issue_ctx_t *spic;
+	zbookmark_phys_t czb;
+	arc_flags_t flags = ARC_FLAG_NOWAIT | ARC_FLAG_PREFETCH;
+	int zio_flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_SCAN_THREAD;
 
 	if (zfs_no_scrub_prefetch)
 		return;
 
-	if (BP_IS_HOLE(bp) || bp->blk_birth <= scn->scn_phys.scn_cur_min_txg ||
-	    (BP_GET_LEVEL(bp) == 0 && BP_GET_TYPE(bp) != DMU_OT_DNODE &&
-	    BP_GET_TYPE(bp) != DMU_OT_OBJSET))
+	if (BP_IS_HOLE(bp) || bp->blk_birth <= scn->scn_phys.scn_min_txg ||
+	    (BP_GET_LEVEL(bp) == 0 && BP_GET_TYPE(bp) != DMU_OT_DNODE))
 		return;
 
-	if (dsl_scan_check_prefetch_resume(spc, zb))
-		return;
-
-	scan_prefetch_ctx_add_ref(spc, scn);
-	spic = kmem_alloc(sizeof (scan_prefetch_issue_ctx_t), KM_SLEEP);
-	spic->spic_spc = spc;
-	spic->spic_bp = *bp;
-	spic->spic_zb = *zb;
-
-	/*
-	 * Add the IO to the queue of blocks to prefetch. This allows us to
-	 * prioritize blocks that we will need first for the main traversal
-	 * thread.
-	 */
-	mutex_enter(&spa->spa_scrub_lock);
-	if (avl_find(&scn->scn_prefetch_queue, spic, &idx) != NULL) {
-		/* this block is already queued for prefetch */
-		kmem_free(spic, sizeof (scan_prefetch_issue_ctx_t));
-		scan_prefetch_ctx_rele(spc, scn);
-		mutex_exit(&spa->spa_scrub_lock);
-		return;
+	if (BP_IS_PROTECTED(bp)) {
+		ASSERT3U(BP_GET_TYPE(bp), ==, DMU_OT_DNODE);
+		ASSERT3U(BP_GET_LEVEL(bp), ==, 0);
+		zio_flags |= ZIO_FLAG_RAW;
 	}
 
-	avl_insert(&scn->scn_prefetch_queue, spic, idx);
-	cv_broadcast(&spa->spa_scrub_io_cv);
-	mutex_exit(&spa->spa_scrub_lock);
-}
+	SET_BOOKMARK(&czb, objset, object, BP_GET_LEVEL(bp), blkid);
 
-static void
-dsl_scan_prefetch_dnode(dsl_scan_t *scn, dnode_phys_t *dnp,
-    uint64_t objset, uint64_t object)
-{
-	int i;
-	zbookmark_phys_t zb;
-	scan_prefetch_ctx_t *spc;
-
-	if (dnp->dn_nblkptr == 0 && !(dnp->dn_flags & DNODE_FLAG_SPILL_BLKPTR))
-		return;
-
-	SET_BOOKMARK(&zb, objset, object, 0, 0);
-
-	spc = scan_prefetch_ctx_create(scn, dnp, FTAG);
-
-	for (i = 0; i < dnp->dn_nblkptr; i++) {
-		zb.zb_level = BP_GET_LEVEL(&dnp->dn_blkptr[i]);
-		zb.zb_blkid = i;
-		dsl_scan_prefetch(spc, &dnp->dn_blkptr[i], &zb);
-	}
-
-	if (dnp->dn_flags & DNODE_FLAG_SPILL_BLKPTR) {
-		zb.zb_level = 0;
-		zb.zb_blkid = DMU_SPILL_BLKID;
-		dsl_scan_prefetch(spc, DN_SPILL_BLKPTR(dnp), &zb);
-	}
-
-	scan_prefetch_ctx_rele(spc, FTAG);
-}
-
-void
-dsl_scan_prefetch_cb(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
-    arc_buf_t *buf, void *private)
-{
-	scan_prefetch_ctx_t *spc = private;
-	dsl_scan_t *scn = spc->spc_scn;
-	spa_t *spa = scn->scn_dp->dp_spa;
-
-	/* broadcast that the IO has completed for rate limitting purposes */
-	mutex_enter(&spa->spa_scrub_lock);
-	ASSERT3U(spa->spa_scrub_inflight, >=, BP_GET_PSIZE(bp));
-	spa->spa_scrub_inflight -= BP_GET_PSIZE(bp);
-	cv_broadcast(&spa->spa_scrub_io_cv);
-	mutex_exit(&spa->spa_scrub_lock);
-
-	/* if there was an error or we are done prefetching, just cleanup */
-	if (buf == NULL || scn->scn_suspending)
-		goto out;
-
-	if (BP_GET_LEVEL(bp) > 0) {
-		int i;
-		blkptr_t *cbp;
-		int epb = BP_GET_LSIZE(bp) >> SPA_BLKPTRSHIFT;
-		zbookmark_phys_t czb;
-
-		for (i = 0, cbp = buf->b_data; i < epb; i++, cbp++) {
-			SET_BOOKMARK(&czb, zb->zb_objset, zb->zb_object,
-			    zb->zb_level - 1, zb->zb_blkid * epb + i);
-			dsl_scan_prefetch(spc, cbp, &czb);
-		}
-	} else if (BP_GET_TYPE(bp) == DMU_OT_DNODE) {
-		dnode_phys_t *cdnp;
-		int i;
-		int epb = BP_GET_LSIZE(bp) >> DNODE_SHIFT;
-
-		for (i = 0, cdnp = buf->b_data; i < epb;
-		    i += cdnp->dn_extra_slots + 1,
-		    cdnp += cdnp->dn_extra_slots + 1) {
-			dsl_scan_prefetch_dnode(scn, cdnp,
-			    zb->zb_objset, zb->zb_blkid * epb + i);
-		}
-	} else if (BP_GET_TYPE(bp) == DMU_OT_OBJSET) {
-		objset_phys_t *osp = buf->b_data;
-
-		dsl_scan_prefetch_dnode(scn, &osp->os_meta_dnode,
-		    zb->zb_objset, DMU_META_DNODE_OBJECT);
-
-		if (OBJSET_BUF_HAS_USERUSED(buf)) {
-			dsl_scan_prefetch_dnode(scn,
-			    &osp->os_groupused_dnode, zb->zb_objset,
-			    DMU_GROUPUSED_OBJECT);
-			dsl_scan_prefetch_dnode(scn,
-			    &osp->os_userused_dnode, zb->zb_objset,
-			    DMU_USERUSED_OBJECT);
-		}
-	}
-
-out:
-	if (buf != NULL)
-		arc_buf_destroy(buf, private);
-	scan_prefetch_ctx_rele(spc, scn);
-}
-
-/* ARGSUSED */
-static void
-dsl_scan_prefetch_thread(void *arg)
-{
-	dsl_scan_t *scn = arg;
-	spa_t *spa = scn->scn_dp->dp_spa;
-	scan_prefetch_issue_ctx_t *spic;
-
-	/* loop until we are told to stop */
-	while (!scn->scn_prefetch_stop) {
-		arc_flags_t flags = ARC_FLAG_NOWAIT |
-		    ARC_FLAG_PRESCIENT_PREFETCH | ARC_FLAG_PREFETCH;
-		int zio_flags = ZIO_FLAG_CANFAIL | ZIO_FLAG_SCAN_THREAD;
-
-		mutex_enter(&spa->spa_scrub_lock);
-
-		/*
-		 * Wait until we have an IO to issue and are not above our
-		 * maximum in flight limit.
-		 */
-		while (!scn->scn_prefetch_stop &&
-		    (avl_numnodes(&scn->scn_prefetch_queue) == 0 ||
-		    spa->spa_scrub_inflight >= scn->scn_maxinflight_bytes)) {
-			cv_wait(&spa->spa_scrub_io_cv, &spa->spa_scrub_lock);
-		}
-
-		/* recheck if we should stop since we waited for the cv */
-		if (scn->scn_prefetch_stop) {
-			mutex_exit(&spa->spa_scrub_lock);
-			break;
-		}
-
-		/* remove the prefetch IO from the tree */
-		spic = avl_first(&scn->scn_prefetch_queue);
-		spa->spa_scrub_inflight += BP_GET_PSIZE(&spic->spic_bp);
-		avl_remove(&scn->scn_prefetch_queue, spic);
-
-		mutex_exit(&spa->spa_scrub_lock);
-
-		if (BP_IS_PROTECTED(&spic->spic_bp)) {
-			ASSERT(BP_GET_TYPE(&spic->spic_bp) == DMU_OT_DNODE ||
-			    BP_GET_TYPE(&spic->spic_bp) == DMU_OT_OBJSET);
-			ASSERT3U(BP_GET_LEVEL(&spic->spic_bp), ==, 0);
-			zio_flags |= ZIO_FLAG_RAW;
-		}
-
-		/* issue the prefetch asynchronously */
-		(void) arc_read(scn->scn_zio_root, scn->scn_dp->dp_spa,
-		    &spic->spic_bp, dsl_scan_prefetch_cb, spic->spic_spc,
-		    ZIO_PRIORITY_ASYNC_READ, zio_flags, &flags, &spic->spic_zb);
-
-		kmem_free(spic, sizeof (scan_prefetch_issue_ctx_t));
-	}
-
-	ASSERT(scn->scn_prefetch_stop);
-
-	/* free any prefetches we didn't get to complete */
-	mutex_enter(&spa->spa_scrub_lock);
-	while ((spic = avl_first(&scn->scn_prefetch_queue)) != NULL) {
-		avl_remove(&scn->scn_prefetch_queue, spic);
-		scan_prefetch_ctx_rele(spic->spic_spc, scn);
-		kmem_free(spic, sizeof (scan_prefetch_issue_ctx_t));
-	}
-	ASSERT0(avl_numnodes(&scn->scn_prefetch_queue));
-	mutex_exit(&spa->spa_scrub_lock);
+	(void) arc_read(scn->scn_zio_root, scn->scn_dp->dp_spa, bp,
+	    NULL, NULL, ZIO_PRIORITY_ASYNC_READ, zio_flags, &flags, &czb);
 }
 
 static boolean_t
@@ -1583,13 +747,6 @@ dsl_scan_check_resume(dsl_scan_t *scn, const dnode_phys_t *dnp,
 	return (B_FALSE);
 }
 
-static void dsl_scan_visitbp(blkptr_t *bp, const zbookmark_phys_t *zb,
-    dnode_phys_t *dnp, dsl_dataset_t *ds, dsl_scan_t *scn,
-    dmu_objset_type_t ostype, dmu_tx_t *tx);
-inline __attribute__((always_inline)) static void dsl_scan_visitdnode(
-    dsl_scan_t *, dsl_dataset_t *ds, dmu_objset_type_t ostype,
-    dnode_phys_t *dnp, uint64_t object, dmu_tx_t *tx);
-
 /*
  * Return nonzero on i/o error.
  * Return new buf to write out in *bufp.
@@ -1617,6 +774,10 @@ dsl_scan_recurse(dsl_scan_t *scn, dsl_dataset_t *ds, dmu_objset_type_t ostype,
 			return (err);
 		}
 		for (i = 0, cbp = buf->b_data; i < epb; i++, cbp++) {
+			dsl_scan_prefetch(scn, buf, cbp, zb->zb_objset,
+			    zb->zb_object, zb->zb_blkid * epb + i);
+		}
+		for (i = 0, cbp = buf->b_data; i < epb; i++, cbp++) {
 			zbookmark_phys_t czb;
 
 			SET_BOOKMARK(&czb, zb->zb_objset, zb->zb_object,
@@ -1629,7 +790,7 @@ dsl_scan_recurse(dsl_scan_t *scn, dsl_dataset_t *ds, dmu_objset_type_t ostype,
 	} else if (BP_GET_TYPE(bp) == DMU_OT_DNODE) {
 		arc_flags_t flags = ARC_FLAG_WAIT;
 		dnode_phys_t *cdnp;
-		int i;
+		int i, j;
 		int epb = BP_GET_LSIZE(bp) >> DNODE_SHIFT;
 		arc_buf_t *buf;
 
@@ -1643,6 +804,15 @@ dsl_scan_recurse(dsl_scan_t *scn, dsl_dataset_t *ds, dmu_objset_type_t ostype,
 		if (err) {
 			scn->scn_phys.scn_errors++;
 			return (err);
+		}
+		for (i = 0, cdnp = buf->b_data; i < epb;
+		    i += cdnp->dn_extra_slots + 1,
+		    cdnp += cdnp->dn_extra_slots + 1) {
+			for (j = 0; j < cdnp->dn_nblkptr; j++) {
+				blkptr_t *cbp = &cdnp->dn_blkptr[j];
+				dsl_scan_prefetch(scn, buf, cbp,
+				    zb->zb_objset, zb->zb_blkid * epb + i, j);
+			}
 		}
 		for (i = 0, cdnp = buf->b_data; i < epb;
 		    i += cdnp->dn_extra_slots + 1,
@@ -1673,8 +843,8 @@ dsl_scan_recurse(dsl_scan_t *scn, dsl_dataset_t *ds, dmu_objset_type_t ostype,
 			/*
 			 * We also always visit user/group accounting
 			 * objects, and never skip them, even if we are
-			 * suspending. This is necessary so that the
-			 * space deltas from this txg get integrated.
+			 * suspending.  This is necessary so that the space
+			 * deltas from this txg get integrated.
 			 */
 			dsl_scan_visitdnode(scn, ds, osp->os_type,
 			    &osp->os_groupused_dnode,
@@ -1724,13 +894,21 @@ dsl_scan_visitbp(blkptr_t *bp, const zbookmark_phys_t *zb,
     dmu_objset_type_t ostype, dmu_tx_t *tx)
 {
 	dsl_pool_t *dp = scn->scn_dp;
-	blkptr_t *bp_toread = NULL;
+	blkptr_t *bp_toread;
+
+	bp_toread = kmem_alloc(sizeof (blkptr_t), KM_SLEEP);
+	*bp_toread = *bp;
+
+	/* ASSERT(pbuf == NULL || arc_released(pbuf)); */
 
 	if (dsl_scan_check_suspend(scn, zb))
-		return;
+		goto out;
 
 	if (dsl_scan_check_resume(scn, dnp, zb))
-		return;
+		goto out;
+
+	if (BP_IS_HOLE(bp))
+		goto out;
 
 	scn->scn_visited_this_txg++;
 
@@ -1741,24 +919,14 @@ dsl_scan_visitbp(blkptr_t *bp, const zbookmark_phys_t *zb,
 	 * if required to debug an issue in dsl_scan_visitbp().
 	 *
 	 * dprintf_bp(bp,
-	 *     "visiting ds=%p/%llu zb=%llx/%llx/%llx/%llx bp=%p",
-	 *     ds, ds ? ds->ds_object : 0,
-	 *     zb->zb_objset, zb->zb_object, zb->zb_level, zb->zb_blkid,
-	 *     bp);
+	 *    "visiting ds=%p/%llu zb=%llx/%llx/%llx/%llx bp=%p",
+	 *    ds, ds ? ds->ds_object : 0,
+	 *    zb->zb_objset, zb->zb_object, zb->zb_level, zb->zb_blkid,
+	 *    bp);
 	 */
 
-	if (BP_IS_HOLE(bp)) {
-		scn->scn_holes_this_txg++;
-		return;
-	}
-
-	if (bp->blk_birth <= scn->scn_phys.scn_cur_min_txg) {
-		scn->scn_lt_min_this_txg++;
-		return;
-	}
-
-	bp_toread = kmem_alloc(sizeof (blkptr_t), KM_SLEEP);
-	*bp_toread = *bp;
+	if (bp->blk_birth <= scn->scn_phys.scn_cur_min_txg)
+		goto out;
 
 	if (dsl_scan_recurse(scn, ds, ostype, dnp, bp_toread, zb, tx) != 0)
 		goto out;
@@ -1770,7 +938,6 @@ dsl_scan_visitbp(blkptr_t *bp, const zbookmark_phys_t *zb,
 	 */
 	if (ddt_class_contains(dp->dp_spa,
 	    scn->scn_phys.scn_ddt_class_max, bp)) {
-		scn->scn_ddt_contained_this_txg++;
 		goto out;
 	}
 
@@ -1781,13 +948,9 @@ dsl_scan_visitbp(blkptr_t *bp, const zbookmark_phys_t *zb,
 	 * Don't scan it now unless we need to because something
 	 * under it was modified.
 	 */
-	if (BP_PHYSICAL_BIRTH(bp) > scn->scn_phys.scn_cur_max_txg) {
-		scn->scn_gt_max_this_txg++;
-		goto out;
+	if (BP_PHYSICAL_BIRTH(bp) <= scn->scn_phys.scn_cur_max_txg) {
+		scan_funcs[scn->scn_phys.scn_func](dp, bp, zb);
 	}
-
-	scan_funcs[scn->scn_phys.scn_func](dp, bp, zb);
-
 out:
 	kmem_free(bp_toread, sizeof (blkptr_t));
 }
@@ -1797,33 +960,26 @@ dsl_scan_visit_rootbp(dsl_scan_t *scn, dsl_dataset_t *ds, blkptr_t *bp,
     dmu_tx_t *tx)
 {
 	zbookmark_phys_t zb;
-	scan_prefetch_ctx_t *spc;
 
 	SET_BOOKMARK(&zb, ds ? ds->ds_object : DMU_META_OBJSET,
 	    ZB_ROOT_OBJECT, ZB_ROOT_LEVEL, ZB_ROOT_BLKID);
-
-	if (ZB_IS_ZERO(&scn->scn_phys.scn_bookmark)) {
-		SET_BOOKMARK(&scn->scn_prefetch_bookmark,
-		    zb.zb_objset, 0, 0, 0);
-	} else {
-		scn->scn_prefetch_bookmark = scn->scn_phys.scn_bookmark;
-	}
-
-	scn->scn_objsets_visited_this_txg++;
-
-	spc = scan_prefetch_ctx_create(scn, NULL, FTAG);
-	dsl_scan_prefetch(spc, bp, &zb);
-	scan_prefetch_ctx_rele(spc, FTAG);
-
-	dsl_scan_visitbp(bp, &zb, NULL, ds, scn, DMU_OST_NONE, tx);
+	dsl_scan_visitbp(bp, &zb, NULL,
+	    ds, scn, DMU_OST_NONE, tx);
 
 	dprintf_ds(ds, "finished scan%s", "");
 }
 
-static void
-ds_destroyed_scn_phys(dsl_dataset_t *ds, dsl_scan_phys_t *scn_phys)
+void
+dsl_scan_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
-	if (scn_phys->scn_bookmark.zb_objset == ds->ds_object) {
+	dsl_pool_t *dp = ds->ds_dir->dd_pool;
+	dsl_scan_t *scn = dp->dp_scan;
+	uint64_t mintxg;
+
+	if (scn->scn_phys.scn_state != DSS_SCANNING)
+		return;
+
+	if (scn->scn_phys.scn_bookmark.zb_objset == ds->ds_object) {
 		if (ds->ds_is_snapshot) {
 			/*
 			 * Note:
@@ -1835,57 +991,23 @@ ds_destroyed_scn_phys(dsl_dataset_t *ds, dsl_scan_phys_t *scn_phys)
 			 *    ignore it when we retraverse it in
 			 *    dsl_scan_visitds().
 			 */
-			scn_phys->scn_bookmark.zb_objset =
+			scn->scn_phys.scn_bookmark.zb_objset =
 			    dsl_dataset_phys(ds)->ds_next_snap_obj;
 			zfs_dbgmsg("destroying ds %llu; currently traversing; "
 			    "reset zb_objset to %llu",
 			    (u_longlong_t)ds->ds_object,
 			    (u_longlong_t)dsl_dataset_phys(ds)->
 			    ds_next_snap_obj);
-			scn_phys->scn_flags |= DSF_VISIT_DS_AGAIN;
+			scn->scn_phys.scn_flags |= DSF_VISIT_DS_AGAIN;
 		} else {
-			SET_BOOKMARK(&scn_phys->scn_bookmark,
+			SET_BOOKMARK(&scn->scn_phys.scn_bookmark,
 			    ZB_DESTROYED_OBJSET, 0, 0, 0);
 			zfs_dbgmsg("destroying ds %llu; currently traversing; "
 			    "reset bookmark to -1,0,0,0",
 			    (u_longlong_t)ds->ds_object);
 		}
-	}
-}
-
-/*
- * Invoked when a dataset is destroyed. We need to make sure that:
- *
- * 1) If it is the dataset that was currently being scanned, we write
- *	a new dsl_scan_phys_t and marking the objset reference in it
- *	as destroyed.
- * 2) Remove it from the work queue, if it was present.
- *
- * If the dataset was actually a snapshot, instead of marking the dataset
- * as destroyed, we instead substitute the next snapshot in line.
- */
-void
-dsl_scan_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
-{
-	dsl_pool_t *dp = ds->ds_dir->dd_pool;
-	dsl_scan_t *scn = dp->dp_scan;
-	uint64_t mintxg;
-
-	if (!dsl_scan_is_running(scn))
-		return;
-
-	ds_destroyed_scn_phys(ds, &scn->scn_phys);
-	ds_destroyed_scn_phys(ds, &scn->scn_phys_cached);
-
-	if (scan_ds_queue_contains(scn, ds->ds_object, &mintxg)) {
-		scan_ds_queue_remove(scn, ds->ds_object);
-		if (ds->ds_is_snapshot)
-			scan_ds_queue_insert(scn,
-			    dsl_dataset_phys(ds)->ds_next_snap_obj, mintxg);
-	}
-
-	if (zap_lookup_int_key(dp->dp_meta_objset, scn->scn_phys.scn_queue_obj,
-	    ds->ds_object, &mintxg) == 0) {
+	} else if (zap_lookup_int_key(dp->dp_meta_objset,
+	    scn->scn_phys.scn_queue_obj, ds->ds_object, &mintxg) == 0) {
 		ASSERT3U(dsl_dataset_phys(ds)->ds_num_children, <=, 1);
 		VERIFY3U(0, ==, zap_remove_int(dp->dp_meta_objset,
 		    scn->scn_phys.scn_queue_obj, ds->ds_object, tx));
@@ -1914,28 +1036,9 @@ dsl_scan_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 	 * dsl_scan_sync() should be called after this, and should sync
 	 * out our changed state, but just to be safe, do it here.
 	 */
-	dsl_scan_sync_state(scn, tx, SYNC_CACHED);
+	dsl_scan_sync_state(scn, tx);
 }
 
-static void
-ds_snapshotted_bookmark(dsl_dataset_t *ds, zbookmark_phys_t *scn_bookmark)
-{
-	if (scn_bookmark->zb_objset == ds->ds_object) {
-		scn_bookmark->zb_objset =
-		    dsl_dataset_phys(ds)->ds_prev_snap_obj;
-		zfs_dbgmsg("snapshotting ds %llu; currently traversing; "
-		    "reset zb_objset to %llu",
-		    (u_longlong_t)ds->ds_object,
-		    (u_longlong_t)dsl_dataset_phys(ds)->ds_prev_snap_obj);
-	}
-}
-
-/*
- * Called when a dataset is snapshotted. If we were currently traversing
- * this snapshot, we reset our bookmark to point at the newly created
- * snapshot. We also modify our work queue to remove the old snapshot and
- * replace with the new one.
- */
 void
 dsl_scan_ds_snapshotted(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
@@ -1943,22 +1046,20 @@ dsl_scan_ds_snapshotted(dsl_dataset_t *ds, dmu_tx_t *tx)
 	dsl_scan_t *scn = dp->dp_scan;
 	uint64_t mintxg;
 
-	if (!dsl_scan_is_running(scn))
+	if (scn->scn_phys.scn_state != DSS_SCANNING)
 		return;
 
 	ASSERT(dsl_dataset_phys(ds)->ds_prev_snap_obj != 0);
 
-	ds_snapshotted_bookmark(ds, &scn->scn_phys.scn_bookmark);
-	ds_snapshotted_bookmark(ds, &scn->scn_phys_cached.scn_bookmark);
-
-	if (scan_ds_queue_contains(scn, ds->ds_object, &mintxg)) {
-		scan_ds_queue_remove(scn, ds->ds_object);
-		scan_ds_queue_insert(scn,
-		    dsl_dataset_phys(ds)->ds_prev_snap_obj, mintxg);
-	}
-
-	if (zap_lookup_int_key(dp->dp_meta_objset, scn->scn_phys.scn_queue_obj,
-	    ds->ds_object, &mintxg) == 0) {
+	if (scn->scn_phys.scn_bookmark.zb_objset == ds->ds_object) {
+		scn->scn_phys.scn_bookmark.zb_objset =
+		    dsl_dataset_phys(ds)->ds_prev_snap_obj;
+		zfs_dbgmsg("snapshotting ds %llu; currently traversing; "
+		    "reset zb_objset to %llu",
+		    (u_longlong_t)ds->ds_object,
+		    (u_longlong_t)dsl_dataset_phys(ds)->ds_prev_snap_obj);
+	} else if (zap_lookup_int_key(dp->dp_meta_objset,
+	    scn->scn_phys.scn_queue_obj, ds->ds_object, &mintxg) == 0) {
 		VERIFY3U(0, ==, zap_remove_int(dp->dp_meta_objset,
 		    scn->scn_phys.scn_queue_obj, ds->ds_object, tx));
 		VERIFY(zap_add_int_key(dp->dp_meta_objset,
@@ -1969,34 +1070,9 @@ dsl_scan_ds_snapshotted(dsl_dataset_t *ds, dmu_tx_t *tx)
 		    (u_longlong_t)ds->ds_object,
 		    (u_longlong_t)dsl_dataset_phys(ds)->ds_prev_snap_obj);
 	}
-
-	dsl_scan_sync_state(scn, tx, SYNC_CACHED);
+	dsl_scan_sync_state(scn, tx);
 }
 
-static void
-ds_clone_swapped_bookmark(dsl_dataset_t *ds1, dsl_dataset_t *ds2,
-    zbookmark_phys_t *scn_bookmark)
-{
-	if (scn_bookmark->zb_objset == ds1->ds_object) {
-		scn_bookmark->zb_objset = ds2->ds_object;
-		zfs_dbgmsg("clone_swap ds %llu; currently traversing; "
-		    "reset zb_objset to %llu",
-		    (u_longlong_t)ds1->ds_object,
-		    (u_longlong_t)ds2->ds_object);
-	} else if (scn_bookmark->zb_objset == ds2->ds_object) {
-		scn_bookmark->zb_objset = ds1->ds_object;
-		zfs_dbgmsg("clone_swap ds %llu; currently traversing; "
-		    "reset zb_objset to %llu",
-		    (u_longlong_t)ds2->ds_object,
-		    (u_longlong_t)ds1->ds_object);
-	}
-}
-
-/*
- * Called when a parent dataset and its clone are swapped. If we were
- * currently traversing the dataset, we need to switch to traversing the
- * newly promoted parent.
- */
 void
 dsl_scan_ds_clone_swapped(dsl_dataset_t *ds1, dsl_dataset_t *ds2, dmu_tx_t *tx)
 {
@@ -2004,24 +1080,27 @@ dsl_scan_ds_clone_swapped(dsl_dataset_t *ds1, dsl_dataset_t *ds2, dmu_tx_t *tx)
 	dsl_scan_t *scn = dp->dp_scan;
 	uint64_t mintxg;
 
-	if (!dsl_scan_is_running(scn))
+	if (scn->scn_phys.scn_state != DSS_SCANNING)
 		return;
 
-	ds_clone_swapped_bookmark(ds1, ds2, &scn->scn_phys.scn_bookmark);
-	ds_clone_swapped_bookmark(ds1, ds2, &scn->scn_phys_cached.scn_bookmark);
-
-	if (scan_ds_queue_contains(scn, ds1->ds_object, &mintxg)) {
-		scan_ds_queue_remove(scn, ds1->ds_object);
-		scan_ds_queue_insert(scn, ds2->ds_object, mintxg);
-	}
-	if (scan_ds_queue_contains(scn, ds2->ds_object, &mintxg)) {
-		scan_ds_queue_remove(scn, ds2->ds_object);
-		scan_ds_queue_insert(scn, ds1->ds_object, mintxg);
+	if (scn->scn_phys.scn_bookmark.zb_objset == ds1->ds_object) {
+		scn->scn_phys.scn_bookmark.zb_objset = ds2->ds_object;
+		zfs_dbgmsg("clone_swap ds %llu; currently traversing; "
+		    "reset zb_objset to %llu",
+		    (u_longlong_t)ds1->ds_object,
+		    (u_longlong_t)ds2->ds_object);
+	} else if (scn->scn_phys.scn_bookmark.zb_objset == ds2->ds_object) {
+		scn->scn_phys.scn_bookmark.zb_objset = ds1->ds_object;
+		zfs_dbgmsg("clone_swap ds %llu; currently traversing; "
+		    "reset zb_objset to %llu",
+		    (u_longlong_t)ds2->ds_object,
+		    (u_longlong_t)ds1->ds_object);
 	}
 
 	if (zap_lookup_int_key(dp->dp_meta_objset, scn->scn_phys.scn_queue_obj,
 	    ds1->ds_object, &mintxg) == 0) {
 		int err;
+
 		ASSERT3U(mintxg, ==, dsl_dataset_phys(ds1)->ds_prev_snap_txg);
 		ASSERT3U(mintxg, ==, dsl_dataset_phys(ds2)->ds_prev_snap_txg);
 		VERIFY3U(0, ==, zap_remove_int(dp->dp_meta_objset,
@@ -2039,9 +1118,8 @@ dsl_scan_ds_clone_swapped(dsl_dataset_t *ds1, dsl_dataset_t *ds2, dmu_tx_t *tx)
 		    "replacing with %llu",
 		    (u_longlong_t)ds1->ds_object,
 		    (u_longlong_t)ds2->ds_object);
-	}
-	if (zap_lookup_int_key(dp->dp_meta_objset, scn->scn_phys.scn_queue_obj,
-	    ds2->ds_object, &mintxg) == 0) {
+	} else if (zap_lookup_int_key(dp->dp_meta_objset,
+	    scn->scn_phys.scn_queue_obj, ds2->ds_object, &mintxg) == 0) {
 		ASSERT3U(mintxg, ==, dsl_dataset_phys(ds1)->ds_prev_snap_txg);
 		ASSERT3U(mintxg, ==, dsl_dataset_phys(ds2)->ds_prev_snap_txg);
 		VERIFY3U(0, ==, zap_remove_int(dp->dp_meta_objset,
@@ -2054,26 +1132,31 @@ dsl_scan_ds_clone_swapped(dsl_dataset_t *ds1, dsl_dataset_t *ds2, dmu_tx_t *tx)
 		    (u_longlong_t)ds1->ds_object);
 	}
 
-	dsl_scan_sync_state(scn, tx, SYNC_CACHED);
+	dsl_scan_sync_state(scn, tx);
 }
+
+struct enqueue_clones_arg {
+	dmu_tx_t *tx;
+	uint64_t originobj;
+};
 
 /* ARGSUSED */
 static int
 enqueue_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 {
-	uint64_t originobj = *(uint64_t *)arg;
+	struct enqueue_clones_arg *eca = arg;
 	dsl_dataset_t *ds;
 	int err;
 	dsl_scan_t *scn = dp->dp_scan;
 
-	if (dsl_dir_phys(hds->ds_dir)->dd_origin_obj != originobj)
+	if (dsl_dir_phys(hds->ds_dir)->dd_origin_obj != eca->originobj)
 		return (0);
 
 	err = dsl_dataset_hold_obj(dp, hds->ds_object, FTAG, &ds);
 	if (err)
 		return (err);
 
-	while (dsl_dataset_phys(ds)->ds_prev_snap_obj != originobj) {
+	while (dsl_dataset_phys(ds)->ds_prev_snap_obj != eca->originobj) {
 		dsl_dataset_t *prev;
 		err = dsl_dataset_hold_obj(dp,
 		    dsl_dataset_phys(ds)->ds_prev_snap_obj, FTAG, &prev);
@@ -2083,8 +1166,9 @@ enqueue_clones_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 			return (err);
 		ds = prev;
 	}
-	scan_ds_queue_insert(scn, ds->ds_object,
-	    dsl_dataset_phys(ds)->ds_prev_snap_txg);
+	VERIFY(zap_add_int_key(dp->dp_meta_objset,
+	    scn->scn_phys.scn_queue_obj, ds->ds_object,
+	    dsl_dataset_phys(ds)->ds_prev_snap_txg, eca->tx) == 0);
 	dsl_dataset_rele(ds, FTAG);
 	return (0);
 }
@@ -2130,9 +1214,9 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 		dsl_dataset_name(ds, dsname);
 		zfs_dbgmsg("scanning dataset %llu (%s) is unnecessary because "
 		    "cur_min_txg (%llu) >= max_txg (%llu)",
-		    (longlong_t)dsobj, dsname,
-		    (longlong_t)scn->scn_phys.scn_cur_min_txg,
-		    (longlong_t)scn->scn_phys.scn_max_txg);
+		    dsobj, dsname,
+		    scn->scn_phys.scn_cur_min_txg,
+		    scn->scn_phys.scn_max_txg);
 		kmem_free(dsname, MAXNAMELEN);
 
 		goto out;
@@ -2148,7 +1232,7 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 	 * ZIL here, rather than in scan_recurse(), because the regular
 	 * snapshot block-sharing rules don't apply to it.
 	 */
-	if (!ds->ds_is_snapshot)
+	if (DSL_SCAN_IS_SCRUB_RESILVER(scn) && !ds->ds_is_snapshot)
 		dsl_scan_zil(dp, &os->os_zil_header);
 
 	/*
@@ -2182,8 +1266,9 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 	if (scn->scn_phys.scn_flags & DSF_VISIT_DS_AGAIN) {
 		zfs_dbgmsg("incomplete pass; visiting again");
 		scn->scn_phys.scn_flags &= ~DSF_VISIT_DS_AGAIN;
-		scan_ds_queue_insert(scn, ds->ds_object,
-		    scn->scn_phys.scn_cur_max_txg);
+		VERIFY(zap_add_int_key(dp->dp_meta_objset,
+		    scn->scn_phys.scn_queue_obj, ds->ds_object,
+		    scn->scn_phys.scn_cur_max_txg, tx) == 0);
 		goto out;
 	}
 
@@ -2191,9 +1276,10 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 	 * Add descendent datasets to work queue.
 	 */
 	if (dsl_dataset_phys(ds)->ds_next_snap_obj != 0) {
-		scan_ds_queue_insert(scn,
+		VERIFY(zap_add_int_key(dp->dp_meta_objset,
+		    scn->scn_phys.scn_queue_obj,
 		    dsl_dataset_phys(ds)->ds_next_snap_obj,
-		    dsl_dataset_phys(ds)->ds_creation_txg);
+		    dsl_dataset_phys(ds)->ds_creation_txg, tx) == 0);
 	}
 	if (dsl_dataset_phys(ds)->ds_num_children > 1) {
 		boolean_t usenext = B_FALSE;
@@ -2214,21 +1300,17 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 		}
 
 		if (usenext) {
-			zap_cursor_t zc;
-			zap_attribute_t za;
-			for (zap_cursor_init(&zc, dp->dp_meta_objset,
-			    dsl_dataset_phys(ds)->ds_next_clones_obj);
-			    zap_cursor_retrieve(&zc, &za) == 0;
-			    (void) zap_cursor_advance(&zc)) {
-				scan_ds_queue_insert(scn,
-				    zfs_strtonum(za.za_name, NULL),
-				    dsl_dataset_phys(ds)->ds_creation_txg);
-			}
-			zap_cursor_fini(&zc);
+			VERIFY0(zap_join_key(dp->dp_meta_objset,
+			    dsl_dataset_phys(ds)->ds_next_clones_obj,
+			    scn->scn_phys.scn_queue_obj,
+			    dsl_dataset_phys(ds)->ds_creation_txg, tx));
 		} else {
+			struct enqueue_clones_arg eca;
+			eca.tx = tx;
+			eca.originobj = ds->ds_object;
+
 			VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
-			    enqueue_clones_cb, &ds->ds_object,
-			    DS_FIND_CHILDREN));
+			    enqueue_clones_cb, &eca, DS_FIND_CHILDREN));
 		}
 	}
 
@@ -2240,6 +1322,7 @@ out:
 static int
 enqueue_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 {
+	dmu_tx_t *tx = arg;
 	dsl_dataset_t *ds;
 	int err;
 	dsl_scan_t *scn = dp->dp_scan;
@@ -2269,35 +1352,10 @@ enqueue_cb(dsl_pool_t *dp, dsl_dataset_t *hds, void *arg)
 		ds = prev;
 	}
 
-	scan_ds_queue_insert(scn, ds->ds_object,
-	    dsl_dataset_phys(ds)->ds_prev_snap_txg);
+	VERIFY(zap_add_int_key(dp->dp_meta_objset, scn->scn_phys.scn_queue_obj,
+	    ds->ds_object, dsl_dataset_phys(ds)->ds_prev_snap_txg, tx) == 0);
 	dsl_dataset_rele(ds, FTAG);
 	return (0);
-}
-
-/* ARGSUSED */
-void
-dsl_scan_ddt_entry(dsl_scan_t *scn, enum zio_checksum checksum,
-    ddt_entry_t *dde, dmu_tx_t *tx)
-{
-	const ddt_key_t *ddk = &dde->dde_key;
-	ddt_phys_t *ddp = dde->dde_phys;
-	blkptr_t bp;
-	zbookmark_phys_t zb = { 0 };
-	int p;
-
-	if (scn->scn_phys.scn_state != DSS_SCANNING)
-		return;
-
-	for (p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
-		if (ddp->ddp_phys_birth == 0 ||
-		    ddp->ddp_phys_birth > scn->scn_phys.scn_max_txg)
-			continue;
-		ddt_bp_create(checksum, ddk, ddp, &bp);
-
-		scn->scn_visited_this_txg++;
-		scan_funcs[scn->scn_phys.scn_func](scn->scn_dp, &bp, &zb);
-	}
 }
 
 /*
@@ -2374,20 +1432,36 @@ dsl_scan_ddt(dsl_scan_t *scn, dmu_tx_t *tx)
 	    ddb->ddb_class > scn->scn_phys.scn_ddt_class_max);
 }
 
-static uint64_t
-dsl_scan_ds_maxtxg(dsl_dataset_t *ds)
+/* ARGSUSED */
+void
+dsl_scan_ddt_entry(dsl_scan_t *scn, enum zio_checksum checksum,
+    ddt_entry_t *dde, dmu_tx_t *tx)
 {
-	uint64_t smt = ds->ds_dir->dd_pool->dp_scan->scn_phys.scn_max_txg;
-	if (ds->ds_is_snapshot)
-		return (MIN(smt, dsl_dataset_phys(ds)->ds_creation_txg));
-	return (smt);
+	const ddt_key_t *ddk = &dde->dde_key;
+	ddt_phys_t *ddp = dde->dde_phys;
+	blkptr_t bp;
+	zbookmark_phys_t zb = { 0 };
+
+	if (scn->scn_phys.scn_state != DSS_SCANNING)
+		return;
+
+	for (int p = 0; p < DDT_PHYS_TYPES; p++, ddp++) {
+		if (ddp->ddp_phys_birth == 0 ||
+		    ddp->ddp_phys_birth > scn->scn_phys.scn_max_txg)
+			continue;
+		ddt_bp_create(checksum, ddk, ddp, &bp);
+
+		scn->scn_visited_this_txg++;
+		scan_funcs[scn->scn_phys.scn_func](scn->scn_dp, &bp, &zb);
+	}
 }
 
 static void
 dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 {
-	scan_ds_t *sds;
 	dsl_pool_t *dp = scn->scn_dp;
+	zap_cursor_t *zc;
+	zap_attribute_t *za;
 
 	if (scn->scn_phys.scn_ddt_bookmark.ddb_class <=
 	    scn->scn_phys.scn_ddt_class_max) {
@@ -2411,7 +1485,7 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 
 		if (spa_version(dp->dp_spa) < SPA_VERSION_DSL_SCRUB) {
 			VERIFY0(dmu_objset_find_dp(dp, dp->dp_root_dir_obj,
-			    enqueue_cb, NULL, DS_FIND_CHILDREN));
+			    enqueue_cb, tx, DS_FIND_CHILDREN));
 		} else {
 			dsl_scan_visitds(scn,
 			    dp->dp_origin_snap->ds_object, tx);
@@ -2419,42 +1493,42 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 		ASSERT(!scn->scn_suspending);
 	} else if (scn->scn_phys.scn_bookmark.zb_objset !=
 	    ZB_DESTROYED_OBJSET) {
-		uint64_t dsobj = scn->scn_phys.scn_bookmark.zb_objset;
 		/*
-		 * If we were suspended, continue from here. Note if the
+		 * If we were suspended, continue from here.  Note if the
 		 * ds we were suspended on was deleted, the zb_objset may
 		 * be -1, so we will skip this and find a new objset
 		 * below.
 		 */
-		dsl_scan_visitds(scn, dsobj, tx);
+		dsl_scan_visitds(scn, scn->scn_phys.scn_bookmark.zb_objset, tx);
 		if (scn->scn_suspending)
 			return;
 	}
 
 	/*
-	 * In case we suspended right at the end of the ds, zero the
+	 * In case we were suspended right at the end of the ds, zero the
 	 * bookmark so we don't think that we're still trying to resume.
 	 */
 	bzero(&scn->scn_phys.scn_bookmark, sizeof (zbookmark_phys_t));
+	zc = kmem_alloc(sizeof (zap_cursor_t), KM_SLEEP);
+	za = kmem_alloc(sizeof (zap_attribute_t), KM_SLEEP);
 
-	/*
-	 * Keep pulling things out of the dataset avl queue. Updates to the
-	 * persistent zap-object-as-queue happen only at checkpoints.
-	 */
-	while ((sds = avl_first(&scn->scn_queue)) != NULL) {
+	/* keep pulling things out of the zap-object-as-queue */
+	while (zap_cursor_init(zc, dp->dp_meta_objset,
+	    scn->scn_phys.scn_queue_obj),
+	    zap_cursor_retrieve(zc, za) == 0) {
 		dsl_dataset_t *ds;
-		uint64_t dsobj = sds->sds_dsobj;
-		uint64_t txg = sds->sds_txg;
+		uint64_t dsobj;
 
-		/* dequeue and free the ds from the queue */
-		scan_ds_queue_remove(scn, dsobj);
-		sds = NULL;
+		dsobj = zfs_strtonum(za->za_name, NULL);
+		VERIFY3U(0, ==, zap_remove_int(dp->dp_meta_objset,
+		    scn->scn_phys.scn_queue_obj, dsobj, tx));
 
-		/* set up min / max txg */
+		/* Set up min/max txg */
 		VERIFY3U(0, ==, dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
-		if (txg != 0) {
+		if (za->za_first_integer != 0) {
 			scn->scn_phys.scn_cur_min_txg =
-			    MAX(scn->scn_phys.scn_min_txg, txg);
+			    MAX(scn->scn_phys.scn_min_txg,
+			    za->za_first_integer);
 		} else {
 			scn->scn_phys.scn_cur_min_txg =
 			    MAX(scn->scn_phys.scn_min_txg,
@@ -2464,360 +1538,14 @@ dsl_scan_visit(dsl_scan_t *scn, dmu_tx_t *tx)
 		dsl_dataset_rele(ds, FTAG);
 
 		dsl_scan_visitds(scn, dsobj, tx);
+		zap_cursor_fini(zc);
 		if (scn->scn_suspending)
-			return;
+			goto out;
 	}
-
-	/* No more objsets to fetch, we're done */
-	scn->scn_phys.scn_bookmark.zb_objset = ZB_DESTROYED_OBJSET;
-	ASSERT0(scn->scn_suspending);
-}
-
-static uint64_t
-dsl_scan_count_leaves(vdev_t *vd)
-{
-	uint64_t i, leaves = 0;
-
-	/* we only count leaves that belong to the main pool and are readable */
-	if (vd->vdev_islog || vd->vdev_isspare ||
-	    vd->vdev_isl2cache || !vdev_readable(vd))
-		return (0);
-
-	if (vd->vdev_ops->vdev_op_leaf)
-		return (1);
-
-	for (i = 0; i < vd->vdev_children; i++) {
-		leaves += dsl_scan_count_leaves(vd->vdev_child[i]);
-	}
-
-	return (leaves);
-}
-
-static void
-scan_io_queues_update_zio_stats(dsl_scan_io_queue_t *q, const blkptr_t *bp)
-{
-	int i;
-	uint64_t cur_size = 0;
-
-	for (i = 0; i < BP_GET_NDVAS(bp); i++) {
-		cur_size += DVA_GET_ASIZE(&bp->blk_dva[i]);
-	}
-
-	q->q_total_zio_size_this_txg += cur_size;
-	q->q_zios_this_txg++;
-}
-
-static void
-scan_io_queues_update_seg_stats(dsl_scan_io_queue_t *q, uint64_t start,
-    uint64_t end)
-{
-	q->q_total_seg_size_this_txg += end - start;
-	q->q_segs_this_txg++;
-}
-
-static boolean_t
-scan_io_queue_check_suspend(dsl_scan_t *scn)
-{
-	/* See comment in dsl_scan_check_suspend() */
-	uint64_t curr_time_ns = gethrtime();
-	uint64_t scan_time_ns = curr_time_ns - scn->scn_sync_start_time;
-	uint64_t sync_time_ns = curr_time_ns -
-	    scn->scn_dp->dp_spa->spa_sync_starttime;
-	int dirty_pct = scn->scn_dp->dp_dirty_total * 100 / zfs_dirty_data_max;
-	int mintime = (scn->scn_phys.scn_func == POOL_SCAN_RESILVER) ?
-	    zfs_resilver_min_time_ms : zfs_scrub_min_time_ms;
-
-	return ((NSEC2MSEC(scan_time_ns) > mintime &&
-	    (dirty_pct >= zfs_vdev_async_write_active_min_dirty_percent ||
-	    txg_sync_waiting(scn->scn_dp) ||
-	    NSEC2SEC(sync_time_ns) >= zfs_txg_timeout)) ||
-	    spa_shutting_down(scn->scn_dp->dp_spa));
-}
-
-/*
- * Given a list of scan_io_t's in io_list, this issues the io's out to
- * disk. This consumes the io_list and frees the scan_io_t's. This is
- * called when emptying queues, either when we're up against the memory
- * limit or when we have finished scanning. Returns B_TRUE if we stopped
- * processing the list before we finished. Any zios that were not issued
- * will remain in the io_list.
- */
-static boolean_t
-scan_io_queue_issue(dsl_scan_io_queue_t *queue, list_t *io_list)
-{
-	dsl_scan_t *scn = queue->q_scn;
-	scan_io_t *sio;
-	int64_t bytes_issued = 0;
-	boolean_t suspended = B_FALSE;
-
-	while ((sio = list_head(io_list)) != NULL) {
-		blkptr_t bp;
-
-		if (scan_io_queue_check_suspend(scn)) {
-			suspended = B_TRUE;
-			break;
-		}
-
-		sio2bp(sio, &bp, queue->q_vd->vdev_id);
-		bytes_issued += sio->sio_asize;
-		scan_exec_io(scn->scn_dp, &bp, sio->sio_flags,
-		    &sio->sio_zb, queue);
-		(void) list_remove_head(io_list);
-		scan_io_queues_update_zio_stats(queue, &bp);
-		kmem_cache_free(sio_cache, sio);
-	}
-
-	atomic_add_64(&scn->scn_bytes_pending, -bytes_issued);
-
-	return (suspended);
-}
-
-/*
- * This function removes sios from an IO queue which reside within a given
- * range_seg_t and inserts them (in offset order) into a list. Note that
- * we only ever return a maximum of 32 sios at once. If there are more sios
- * to process within this segment that did not make it onto the list we
- * return B_TRUE and otherwise B_FALSE.
- */
-static boolean_t
-scan_io_queue_gather(dsl_scan_io_queue_t *queue, range_seg_t *rs, list_t *list)
-{
-	scan_io_t srch_sio, *sio, *next_sio;
-	avl_index_t idx;
-	uint_t num_sios = 0;
-	int64_t bytes_issued = 0;
-
-	ASSERT(rs != NULL);
-	ASSERT(MUTEX_HELD(&queue->q_vd->vdev_scan_io_queue_lock));
-
-	srch_sio.sio_offset = rs->rs_start;
-
-	/*
-	 * The exact start of the extent might not contain any matching zios,
-	 * so if that's the case, examine the next one in the tree.
-	 */
-	sio = avl_find(&queue->q_sios_by_addr, &srch_sio, &idx);
-	if (sio == NULL)
-		sio = avl_nearest(&queue->q_sios_by_addr, idx, AVL_AFTER);
-
-	while (sio != NULL && sio->sio_offset < rs->rs_end && num_sios <= 32) {
-		ASSERT3U(sio->sio_offset, >=, rs->rs_start);
-		ASSERT3U(sio->sio_offset + sio->sio_asize, <=, rs->rs_end);
-
-		next_sio = AVL_NEXT(&queue->q_sios_by_addr, sio);
-		avl_remove(&queue->q_sios_by_addr, sio);
-
-		bytes_issued += sio->sio_asize;
-		num_sios++;
-		list_insert_tail(list, sio);
-		sio = next_sio;
-	}
-
-	/*
-	 * We limit the number of sios we process at once to 32 to avoid
-	 * biting off more than we can chew. If we didn't take everything
-	 * in the segment we update it to reflect the work we were able to
-	 * complete. Otherwise, we remove it from the range tree entirely.
-	 */
-	if (sio != NULL && sio->sio_offset < rs->rs_end) {
-		range_tree_adjust_fill(queue->q_exts_by_addr, rs,
-		    -bytes_issued);
-		range_tree_resize_segment(queue->q_exts_by_addr, rs,
-		    sio->sio_offset, rs->rs_end - sio->sio_offset);
-
-		return (B_TRUE);
-	} else {
-		range_tree_remove(queue->q_exts_by_addr, rs->rs_start,
-		    rs->rs_end - rs->rs_start);
-		return (B_FALSE);
-	}
-}
-
-/*
- * This is called from the queue emptying thread and selects the next
- * extent from which we are to issue io's. The behavior of this function
- * depends on the state of the scan, the current memory consumption and
- * whether or not we are performing a scan shutdown.
- * 1) We select extents in an elevator algorithm (LBA-order) if the scan
- * 	needs to perform a checkpoint
- * 2) We select the largest available extent if we are up against the
- * 	memory limit.
- * 3) Otherwise we don't select any extents.
- */
-static range_seg_t *
-scan_io_queue_fetch_ext(dsl_scan_io_queue_t *queue)
-{
-	dsl_scan_t *scn = queue->q_scn;
-
-	ASSERT(MUTEX_HELD(&queue->q_vd->vdev_scan_io_queue_lock));
-	ASSERT(scn->scn_is_sorted);
-
-	/* handle tunable overrides */
-	if (scn->scn_checkpointing || scn->scn_clearing) {
-		if (zfs_scan_issue_strategy == 1) {
-			return (range_tree_first(queue->q_exts_by_addr));
-		} else if (zfs_scan_issue_strategy == 2) {
-			return (avl_first(&queue->q_exts_by_size));
-		}
-	}
-
-	/*
-	 * During normal clearing, we want to issue our largest segments
-	 * first, keeping IO as sequential as possible, and leaving the
-	 * smaller extents for later with the hope that they might eventually
-	 * grow to larger sequential segments. However, when the scan is
-	 * checkpointing, no new extents will be added to the sorting queue,
-	 * so the way we are sorted now is as good as it will ever get.
-	 * In this case, we instead switch to issuing extents in LBA order.
-	 */
-	if (scn->scn_checkpointing) {
-		return (range_tree_first(queue->q_exts_by_addr));
-	} else if (scn->scn_clearing) {
-		return (avl_first(&queue->q_exts_by_size));
-	} else {
-		return (NULL);
-	}
-}
-
-static void
-scan_io_queues_run_one(void *arg)
-{
-	dsl_scan_io_queue_t *queue = arg;
-	kmutex_t *q_lock = &queue->q_vd->vdev_scan_io_queue_lock;
-	boolean_t suspended = B_FALSE;
-	range_seg_t *rs = NULL;
-	scan_io_t *sio = NULL;
-	list_t sio_list;
-	uint64_t bytes_per_leaf = zfs_scan_vdev_limit;
-	uint64_t nr_leaves = dsl_scan_count_leaves(queue->q_vd);
-
-	ASSERT(queue->q_scn->scn_is_sorted);
-
-	list_create(&sio_list, sizeof (scan_io_t),
-	    offsetof(scan_io_t, sio_nodes.sio_list_node));
-	mutex_enter(q_lock);
-
-	/* calculate maximum in-flight bytes for this txg (min 1MB) */
-	queue->q_maxinflight_bytes =
-	    MAX(nr_leaves * bytes_per_leaf, 1ULL << 20);
-
-	/* reset per-queue scan statistics for this txg */
-	queue->q_total_seg_size_this_txg = 0;
-	queue->q_segs_this_txg = 0;
-	queue->q_total_zio_size_this_txg = 0;
-	queue->q_zios_this_txg = 0;
-
-	/* loop until we run out of time or sios */
-	while ((rs = scan_io_queue_fetch_ext(queue)) != NULL) {
-		uint64_t seg_start = 0, seg_end = 0;
-		boolean_t more_left = B_TRUE;
-
-		ASSERT(list_is_empty(&sio_list));
-
-		/* loop while we still have sios left to process in this rs */
-		while (more_left) {
-			scan_io_t *first_sio, *last_sio;
-
-			/*
-			 * We have selected which extent needs to be
-			 * processed next. Gather up the corresponding sios.
-			 */
-			more_left = scan_io_queue_gather(queue, rs, &sio_list);
-			ASSERT(!list_is_empty(&sio_list));
-			first_sio = list_head(&sio_list);
-			last_sio = list_tail(&sio_list);
-
-			seg_end = last_sio->sio_offset + last_sio->sio_asize;
-			if (seg_start == 0)
-				seg_start = first_sio->sio_offset;
-
-			/*
-			 * Issuing sios can take a long time so drop the
-			 * queue lock. The sio queue won't be updated by
-			 * other threads since we're in syncing context so
-			 * we can be sure that our trees will remain exactly
-			 * as we left them.
-			 */
-			mutex_exit(q_lock);
-			suspended = scan_io_queue_issue(queue, &sio_list);
-			mutex_enter(q_lock);
-
-			if (suspended)
-				break;
-		}
-
-		/* update statistics for debugging purposes */
-		scan_io_queues_update_seg_stats(queue, seg_start, seg_end);
-
-		if (suspended)
-			break;
-	}
-
-	/*
-	 * If we were suspended in the middle of processing,
-	 * requeue any unfinished sios and exit.
-	 */
-	while ((sio = list_head(&sio_list)) != NULL) {
-		list_remove(&sio_list, sio);
-		scan_io_queue_insert_impl(queue, sio);
-	}
-
-	mutex_exit(q_lock);
-	list_destroy(&sio_list);
-}
-
-/*
- * Performs an emptying run on all scan queues in the pool. This just
- * punches out one thread per top-level vdev, each of which processes
- * only that vdev's scan queue. We can parallelize the I/O here because
- * we know that each queue's io's only affect its own top-level vdev.
- *
- * This function waits for the queue runs to complete, and must be
- * called from dsl_scan_sync (or in general, syncing context).
- */
-static void
-scan_io_queues_run(dsl_scan_t *scn)
-{
-	spa_t *spa = scn->scn_dp->dp_spa;
-
-	ASSERT(scn->scn_is_sorted);
-	ASSERT(spa_config_held(spa, SCL_CONFIG, RW_READER));
-
-	if (scn->scn_bytes_pending == 0)
-		return;
-
-	if (scn->scn_taskq == NULL) {
-		int nthreads = spa->spa_root_vdev->vdev_children;
-
-		/*
-		 * We need to make this taskq *always* execute as many
-		 * threads in parallel as we have top-level vdevs and no
-		 * less, otherwise strange serialization of the calls to
-		 * scan_io_queues_run_one can occur during spa_sync runs
-		 * and that significantly impacts performance.
-		 */
-		scn->scn_taskq = taskq_create("dsl_scan_iss", nthreads,
-		    minclsyspri, nthreads, nthreads, TASKQ_PREPOPULATE);
-	}
-
-	for (uint64_t i = 0; i < spa->spa_root_vdev->vdev_children; i++) {
-		vdev_t *vd = spa->spa_root_vdev->vdev_child[i];
-
-		mutex_enter(&vd->vdev_scan_io_queue_lock);
-		if (vd->vdev_scan_io_queue != NULL) {
-			VERIFY(taskq_dispatch(scn->scn_taskq,
-			    scan_io_queues_run_one, vd->vdev_scan_io_queue,
-			    TQ_SLEEP) != TASKQID_INVALID);
-		}
-		mutex_exit(&vd->vdev_scan_io_queue_lock);
-	}
-
-	/*
-	 * Wait for the queues to finish issuing thir IOs for this run
-	 * before we return. There may still be IOs in flight at this
-	 * point.
-	 */
-	taskq_wait(scn->scn_taskq);
+	zap_cursor_fini(zc);
+out:
+	kmem_free(za, sizeof (zap_attribute_t));
+	kmem_free(zc, sizeof (zap_cursor_t));
 }
 
 static boolean_t
@@ -2858,41 +1586,6 @@ dsl_scan_free_block_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 	return (0);
 }
 
-static void
-dsl_scan_update_stats(dsl_scan_t *scn)
-{
-	spa_t *spa = scn->scn_dp->dp_spa;
-	uint64_t i;
-	uint64_t seg_size_total = 0, zio_size_total = 0;
-	uint64_t seg_count_total = 0, zio_count_total = 0;
-
-	for (i = 0; i < spa->spa_root_vdev->vdev_children; i++) {
-		vdev_t *vd = spa->spa_root_vdev->vdev_child[i];
-		dsl_scan_io_queue_t *queue = vd->vdev_scan_io_queue;
-
-		if (queue == NULL)
-			continue;
-
-		seg_size_total += queue->q_total_seg_size_this_txg;
-		zio_size_total += queue->q_total_zio_size_this_txg;
-		seg_count_total += queue->q_segs_this_txg;
-		zio_count_total += queue->q_zios_this_txg;
-	}
-
-	if (seg_count_total == 0 || zio_count_total == 0) {
-		scn->scn_avg_seg_size_this_txg = 0;
-		scn->scn_avg_zio_size_this_txg = 0;
-		scn->scn_segs_this_txg = 0;
-		scn->scn_zios_this_txg = 0;
-		return;
-	}
-
-	scn->scn_avg_seg_size_this_txg = seg_size_total / seg_count_total;
-	scn->scn_avg_zio_size_this_txg = zio_size_total / zio_count_total;
-	scn->scn_segs_this_txg = seg_count_total;
-	scn->scn_zios_this_txg = zio_count_total;
-}
-
 boolean_t
 dsl_scan_active(dsl_scan_t *scn)
 {
@@ -2903,7 +1596,8 @@ dsl_scan_active(dsl_scan_t *scn)
 		return (B_FALSE);
 	if (spa_shutting_down(spa))
 		return (B_FALSE);
-	if ((dsl_scan_is_running(scn) && !dsl_scan_is_paused_scrub(scn)) ||
+	if ((scn->scn_phys.scn_state == DSS_SCANNING &&
+	    !dsl_scan_is_paused_scrub(scn)) ||
 	    (scn->scn_async_destroying && !scn->scn_async_stalled))
 		return (B_TRUE);
 
@@ -2914,60 +1608,13 @@ dsl_scan_active(dsl_scan_t *scn)
 	return (used != 0);
 }
 
-static boolean_t
-dsl_scan_need_resilver(spa_t *spa, const dva_t *dva, size_t psize,
-    uint64_t phys_birth)
-{
-	vdev_t *vd;
-
-	if (DVA_GET_GANG(dva)) {
-		/*
-		 * Gang members may be spread across multiple
-		 * vdevs, so the best estimate we have is the
-		 * scrub range, which has already been checked.
-		 * XXX -- it would be better to change our
-		 * allocation policy to ensure that all
-		 * gang members reside on the same vdev.
-		 */
-		return (B_TRUE);
-	}
-
-	vd = vdev_lookup_top(spa, DVA_GET_VDEV(dva));
-
-	/*
-	 * Check if the txg falls within the range which must be
-	 * resilvered.  DVAs outside this range can always be skipped.
-	 */
-	if (!vdev_dtl_contains(vd, DTL_PARTIAL, phys_birth, 1))
-		return (B_FALSE);
-
-	/*
-	 * Check if the top-level vdev must resilver this offset.
-	 * When the offset does not intersect with a dirty leaf DTL
-	 * then it may be possible to skip the resilver IO.  The psize
-	 * is provided instead of asize to simplify the check for RAIDZ.
-	 */
-	if (!vdev_dtl_need_resilver(vd, DVA_GET_OFFSET(dva), psize))
-		return (B_FALSE);
-
-	return (B_TRUE);
-}
-
-/*
- * This is the primary entry point for scans that is called from syncing
- * context. Scans must happen entirely during syncing context so that we
- * cna guarantee that blocks we are currently scanning will not change out
- * from under us. While a scan is active, this funciton controls how quickly
- * transaction groups proceed, instead of the normal handling provided by
- * txg_sync_thread().
- */
+/* Called whenever a txg syncs. */
 void
 dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 {
-	int err = 0;
 	dsl_scan_t *scn = dp->dp_scan;
 	spa_t *spa = dp->dp_spa;
-	state_sync_type_t sync_type = SYNC_OPTIONAL;
+	int err = 0;
 
 	/*
 	 * Check for scn_restart_txg before checking spa_load_state, so
@@ -2980,14 +1627,14 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 		if (vdev_resilver_needed(spa->spa_root_vdev, NULL, NULL))
 			func = POOL_SCAN_RESILVER;
 		zfs_dbgmsg("restarting scan func=%u txg=%llu",
-		    func, (longlong_t)tx->tx_txg);
+		    func, tx->tx_txg);
 		dsl_scan_setup_sync(&func, tx);
 	}
 
 	/*
 	 * Only process scans in sync pass 1.
 	 */
-	if (spa_sync_pass(spa) > 1)
+	if (spa_sync_pass(dp->dp_spa) > 1)
 		return;
 
 	/*
@@ -3004,17 +1651,7 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 	if (!scn->scn_async_stalled && !dsl_scan_active(scn))
 		return;
 
-	/* reset scan statistics */
 	scn->scn_visited_this_txg = 0;
-	scn->scn_holes_this_txg = 0;
-	scn->scn_lt_min_this_txg = 0;
-	scn->scn_gt_max_this_txg = 0;
-	scn->scn_ddt_contained_this_txg = 0;
-	scn->scn_objsets_visited_this_txg = 0;
-	scn->scn_avg_seg_size_this_txg = 0;
-	scn->scn_segs_this_txg = 0;
-	scn->scn_avg_zio_size_this_txg = 0;
-	scn->scn_zios_this_txg = 0;
 	scn->scn_suspending = B_FALSE;
 	scn->scn_sync_start_time = gethrtime();
 	spa->spa_scrub_active = B_TRUE;
@@ -3027,14 +1664,13 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 	 * blocks than to scrub them.
 	 */
 	if (zfs_free_bpobj_enabled &&
-	    spa_version(spa) >= SPA_VERSION_DEADLISTS) {
+	    spa_version(dp->dp_spa) >= SPA_VERSION_DEADLISTS) {
 		scn->scn_is_bptree = B_FALSE;
-		scn->scn_zio_root = zio_root(spa, NULL,
+		scn->scn_zio_root = zio_root(dp->dp_spa, NULL,
 		    NULL, ZIO_FLAG_MUSTSUCCEED);
 		err = bpobj_iterate(&dp->dp_free_bpobj,
 		    dsl_scan_free_block_cb, scn, tx);
-		VERIFY0(zio_wait(scn->scn_zio_root));
-		scn->scn_zio_root = NULL;
+		VERIFY3U(0, ==, zio_wait(scn->scn_zio_root));
 
 		if (err != 0 && err != ERESTART)
 			zfs_panic_recover("error %u from bpobj_iterate()", err);
@@ -3043,12 +1679,11 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 	if (err == 0 && spa_feature_is_active(spa, SPA_FEATURE_ASYNC_DESTROY)) {
 		ASSERT(scn->scn_async_destroying);
 		scn->scn_is_bptree = B_TRUE;
-		scn->scn_zio_root = zio_root(spa, NULL,
+		scn->scn_zio_root = zio_root(dp->dp_spa, NULL,
 		    NULL, ZIO_FLAG_MUSTSUCCEED);
 		err = bptree_iterate(dp->dp_meta_objset,
 		    dp->dp_bptree_obj, B_TRUE, dsl_scan_free_block_cb, scn, tx);
 		VERIFY0(zio_wait(scn->scn_zio_root));
-		scn->scn_zio_root = NULL;
 
 		if (err == EIO || err == ECKSUM) {
 			err = 0;
@@ -3135,188 +1770,109 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 		ASSERT0(dsl_dir_phys(dp->dp_free_dir)->dd_uncompressed_bytes);
 	}
 
-	if (!dsl_scan_is_running(scn) || dsl_scan_is_paused_scrub(scn))
+	if (scn->scn_phys.scn_state != DSS_SCANNING)
 		return;
 
-	/*
-	 * Wait a few txgs after importing to begin scanning so that
-	 * we can get the pool imported quickly.
-	 */
-	if (spa->spa_syncing_txg < spa->spa_first_txg + SCAN_IMPORT_WAIT_TXGS)
-		return;
-
-	/*
-	 * It is possible to switch from unsorted to sorted at any time,
-	 * but afterwards the scan will remain sorted unless reloaded from
-	 * a checkpoint after a reboot.
-	 */
-	if (!zfs_scan_legacy) {
-		scn->scn_is_sorted = B_TRUE;
-		if (scn->scn_last_checkpoint == 0)
-			scn->scn_last_checkpoint = ddi_get_lbolt();
-	}
-
-	/*
-	 * For sorted scans, determine what kind of work we will be doing
-	 * this txg based on our memory limitations and whether or not we
-	 * need to perform a checkpoint.
-	 */
-	if (scn->scn_is_sorted) {
-		/*
-		 * If we are over our checkpoint interval, set scn_clearing
-		 * so that we can begin checkpointing immediately. The
-		 * checkpoint allows us to save a consisent bookmark
-		 * representing how much data we have scrubbed so far.
-		 * Otherwise, use the memory limit to determine if we should
-		 * scan for metadata or start issue scrub IOs. We accumulate
-		 * metadata until we hit our hard memory limit at which point
-		 * we issue scrub IOs until we are at our soft memory limit.
-		 */
-		if (scn->scn_checkpointing ||
-		    ddi_get_lbolt() - scn->scn_last_checkpoint >
-		    SEC_TO_TICK(zfs_scan_checkpoint_intval)) {
-			if (!scn->scn_checkpointing)
-				zfs_dbgmsg("begin scan checkpoint");
-
-			scn->scn_checkpointing = B_TRUE;
-			scn->scn_clearing = B_TRUE;
-		} else {
-			boolean_t should_clear = dsl_scan_should_clear(scn);
-			if (should_clear && !scn->scn_clearing) {
-				zfs_dbgmsg("begin scan clearing");
-				scn->scn_clearing = B_TRUE;
-			} else if (!should_clear && scn->scn_clearing) {
-				zfs_dbgmsg("finish scan clearing");
-				scn->scn_clearing = B_FALSE;
-			}
-		}
-	} else {
-		ASSERT0(scn->scn_checkpointing);
-		ASSERT0(scn->scn_clearing);
-	}
-
-	if (!scn->scn_clearing && scn->scn_done_txg == 0) {
-		/* Need to scan metadata for more blocks to scrub */
-		dsl_scan_phys_t *scnp = &scn->scn_phys;
-		taskqid_t prefetch_tqid;
-		uint64_t bytes_per_leaf = zfs_scan_vdev_limit;
-		uint64_t nr_leaves = dsl_scan_count_leaves(spa->spa_root_vdev);
-
-		/*
-		 * Calculate the max number of in-flight bytes for pool-wide
-		 * scanning operations (minimum 1MB). Limits for the issuing
-		 * phase are done per top-level vdev and are handled separately.
-		 */
-		scn->scn_maxinflight_bytes =
-		    MAX(nr_leaves * bytes_per_leaf, 1ULL << 20);
-
-		if (scnp->scn_ddt_bookmark.ddb_class <=
-		    scnp->scn_ddt_class_max) {
-			ASSERT(ZB_IS_ZERO(&scnp->scn_bookmark));
-			zfs_dbgmsg("doing scan sync txg %llu; "
-			    "ddt bm=%llu/%llu/%llu/%llx",
-			    (longlong_t)tx->tx_txg,
-			    (longlong_t)scnp->scn_ddt_bookmark.ddb_class,
-			    (longlong_t)scnp->scn_ddt_bookmark.ddb_type,
-			    (longlong_t)scnp->scn_ddt_bookmark.ddb_checksum,
-			    (longlong_t)scnp->scn_ddt_bookmark.ddb_cursor);
-		} else {
-			zfs_dbgmsg("doing scan sync txg %llu; "
-			    "bm=%llu/%llu/%llu/%llu",
-			    (longlong_t)tx->tx_txg,
-			    (longlong_t)scnp->scn_bookmark.zb_objset,
-			    (longlong_t)scnp->scn_bookmark.zb_object,
-			    (longlong_t)scnp->scn_bookmark.zb_level,
-			    (longlong_t)scnp->scn_bookmark.zb_blkid);
-		}
-
-		scn->scn_zio_root = zio_root(dp->dp_spa, NULL,
-		    NULL, ZIO_FLAG_CANFAIL);
-
-		scn->scn_prefetch_stop = B_FALSE;
-		prefetch_tqid = taskq_dispatch(dp->dp_sync_taskq,
-		    dsl_scan_prefetch_thread, scn, TQ_SLEEP);
-		ASSERT(prefetch_tqid != TASKQID_INVALID);
-
-		dsl_pool_config_enter(dp, FTAG);
-		dsl_scan_visit(scn, tx);
-		dsl_pool_config_exit(dp, FTAG);
-
-		mutex_enter(&dp->dp_spa->spa_scrub_lock);
-		scn->scn_prefetch_stop = B_TRUE;
-		cv_broadcast(&spa->spa_scrub_io_cv);
-		mutex_exit(&dp->dp_spa->spa_scrub_lock);
-
-		taskq_wait_id(dp->dp_sync_taskq, prefetch_tqid);
-		(void) zio_wait(scn->scn_zio_root);
-		scn->scn_zio_root = NULL;
-
-		zfs_dbgmsg("scan visited %llu blocks in %llums "
-		    "(%llu os's, %llu holes, %llu < mintxg, "
-		    "%llu in ddt, %llu > maxtxg)",
-		    (longlong_t)scn->scn_visited_this_txg,
-		    (longlong_t)NSEC2MSEC(gethrtime() -
-		    scn->scn_sync_start_time),
-		    (longlong_t)scn->scn_objsets_visited_this_txg,
-		    (longlong_t)scn->scn_holes_this_txg,
-		    (longlong_t)scn->scn_lt_min_this_txg,
-		    (longlong_t)scn->scn_ddt_contained_this_txg,
-		    (longlong_t)scn->scn_gt_max_this_txg);
-
-		if (!scn->scn_suspending) {
-			ASSERT0(avl_numnodes(&scn->scn_queue));
-			scn->scn_done_txg = tx->tx_txg + 1;
-			if (scn->scn_is_sorted) {
-				scn->scn_checkpointing = B_TRUE;
-				scn->scn_clearing = B_TRUE;
-			}
-			zfs_dbgmsg("scan complete txg %llu",
-			    (longlong_t)tx->tx_txg);
-		}
-	} else if (scn->scn_is_sorted && scn->scn_bytes_pending != 0) {
-		/* need to issue scrubbing IOs from per-vdev queues */
-		scn->scn_zio_root = zio_root(dp->dp_spa, NULL,
-		    NULL, ZIO_FLAG_CANFAIL);
-		scan_io_queues_run(scn);
-		(void) zio_wait(scn->scn_zio_root);
-		scn->scn_zio_root = NULL;
-
-		/* calculate and dprintf the current memory usage */
-		(void) dsl_scan_should_clear(scn);
-		dsl_scan_update_stats(scn);
-
-		zfs_dbgmsg("scan issued %llu blocks (%llu segs) in %llums "
-		    "(avg_block_size = %llu, avg_seg_size = %llu)",
-		    (longlong_t)scn->scn_zios_this_txg,
-		    (longlong_t)scn->scn_segs_this_txg,
-		    (longlong_t)NSEC2MSEC(gethrtime() -
-		    scn->scn_sync_start_time),
-		    (longlong_t)scn->scn_avg_zio_size_this_txg,
-		    (longlong_t)scn->scn_avg_seg_size_this_txg);
-	} else if (scn->scn_done_txg != 0 && scn->scn_done_txg <= tx->tx_txg) {
-		/* Finished with everything. Mark the scrub as complete */
-		zfs_dbgmsg("scan issuing complete txg %llu",
-		    (longlong_t)tx->tx_txg);
-		ASSERT3U(scn->scn_done_txg, !=, 0);
-		ASSERT0(spa->spa_scrub_inflight);
-		ASSERT0(scn->scn_bytes_pending);
+	if (scn->scn_done_txg == tx->tx_txg) {
+		ASSERT(!scn->scn_suspending);
+		/* finished with scan. */
+		zfs_dbgmsg("txg %llu scan complete", tx->tx_txg);
 		dsl_scan_done(scn, B_TRUE, tx);
-		sync_type = SYNC_MANDATORY;
+		ASSERT3U(spa->spa_scrub_inflight, ==, 0);
+		dsl_scan_sync_state(scn, tx);
+		return;
 	}
 
-	dsl_scan_sync_state(scn, tx, sync_type);
+	if (dsl_scan_is_paused_scrub(scn))
+		return;
+
+	if (scn->scn_phys.scn_ddt_bookmark.ddb_class <=
+	    scn->scn_phys.scn_ddt_class_max) {
+		zfs_dbgmsg("doing scan sync txg %llu; "
+		    "ddt bm=%llu/%llu/%llu/%llx",
+		    (longlong_t)tx->tx_txg,
+		    (longlong_t)scn->scn_phys.scn_ddt_bookmark.ddb_class,
+		    (longlong_t)scn->scn_phys.scn_ddt_bookmark.ddb_type,
+		    (longlong_t)scn->scn_phys.scn_ddt_bookmark.ddb_checksum,
+		    (longlong_t)scn->scn_phys.scn_ddt_bookmark.ddb_cursor);
+		ASSERT(scn->scn_phys.scn_bookmark.zb_objset == 0);
+		ASSERT(scn->scn_phys.scn_bookmark.zb_object == 0);
+		ASSERT(scn->scn_phys.scn_bookmark.zb_level == 0);
+		ASSERT(scn->scn_phys.scn_bookmark.zb_blkid == 0);
+	} else {
+		zfs_dbgmsg("doing scan sync txg %llu; bm=%llu/%llu/%llu/%llu",
+		    (longlong_t)tx->tx_txg,
+		    (longlong_t)scn->scn_phys.scn_bookmark.zb_objset,
+		    (longlong_t)scn->scn_phys.scn_bookmark.zb_object,
+		    (longlong_t)scn->scn_phys.scn_bookmark.zb_level,
+		    (longlong_t)scn->scn_phys.scn_bookmark.zb_blkid);
+	}
+
+	scn->scn_zio_root = zio_root(dp->dp_spa, NULL,
+	    NULL, ZIO_FLAG_CANFAIL);
+	dsl_pool_config_enter(dp, FTAG);
+	dsl_scan_visit(scn, tx);
+	dsl_pool_config_exit(dp, FTAG);
+	(void) zio_wait(scn->scn_zio_root);
+	scn->scn_zio_root = NULL;
+
+	zfs_dbgmsg("visited %llu blocks in %llums",
+	    (longlong_t)scn->scn_visited_this_txg,
+	    (longlong_t)NSEC2MSEC(gethrtime() - scn->scn_sync_start_time));
+
+	if (!scn->scn_suspending) {
+		scn->scn_done_txg = tx->tx_txg + 1;
+		zfs_dbgmsg("txg %llu traversal complete, waiting till txg %llu",
+		    tx->tx_txg, scn->scn_done_txg);
+	}
+
+	if (DSL_SCAN_IS_SCRUB_RESILVER(scn)) {
+		mutex_enter(&spa->spa_scrub_lock);
+		while (spa->spa_scrub_inflight > 0) {
+			cv_wait(&spa->spa_scrub_io_cv,
+			    &spa->spa_scrub_lock);
+		}
+		mutex_exit(&spa->spa_scrub_lock);
+	}
+
+	dsl_scan_sync_state(scn, tx);
 }
 
+/*
+ * This will start a new scan, or restart an existing one.
+ */
+void
+dsl_resilver_restart(dsl_pool_t *dp, uint64_t txg)
+{
+	if (txg == 0) {
+		dmu_tx_t *tx;
+		tx = dmu_tx_create_dd(dp->dp_mos_dir);
+		VERIFY(0 == dmu_tx_assign(tx, TXG_WAIT));
+
+		txg = dmu_tx_get_txg(tx);
+		dp->dp_scan->scn_restart_txg = txg;
+		dmu_tx_commit(tx);
+	} else {
+		dp->dp_scan->scn_restart_txg = txg;
+	}
+	zfs_dbgmsg("restarting resilver txg=%llu", txg);
+}
+
+boolean_t
+dsl_scan_resilvering(dsl_pool_t *dp)
+{
+	return (dp->dp_scan->scn_phys.scn_state == DSS_SCANNING &&
+	    dp->dp_scan->scn_phys.scn_func == POOL_SCAN_RESILVER);
+}
+
+/*
+ * scrub consumers
+ */
+
 static void
-count_block(dsl_scan_t *scn, zfs_all_blkstats_t *zab, const blkptr_t *bp)
+count_block(zfs_all_blkstats_t *zab, const blkptr_t *bp)
 {
 	int i;
-
-	/* update the spa's stats on how many bytes we have issued */
-	for (i = 0; i < BP_GET_NDVAS(bp); i++) {
-		atomic_add_64(&scn->scn_dp->dp_spa->spa_scan_pass_issued,
-		    DVA_GET_ASIZE(&bp->blk_dva[i]));
-	}
 
 	/*
 	 * If we resume after a reboot, zab will be NULL; don't record
@@ -3324,8 +1880,6 @@ count_block(dsl_scan_t *scn, zfs_all_blkstats_t *zab, const blkptr_t *bp)
 	 */
 	if (zab == NULL)
 		return;
-
-	mutex_enter(&zab->zab_lock);
 
 	for (i = 0; i < 4; i++) {
 		int l = (i < 2) ? BP_GET_LEVEL(bp) : DN_MAX_LEVELS;
@@ -3362,97 +1916,63 @@ count_block(dsl_scan_t *scn, zfs_all_blkstats_t *zab, const blkptr_t *bp)
 			break;
 		}
 	}
-
-	mutex_exit(&zab->zab_lock);
 }
 
 static void
-scan_io_queue_insert_impl(dsl_scan_io_queue_t *queue, scan_io_t *sio)
+dsl_scan_scrub_done(zio_t *zio)
 {
-	avl_index_t idx;
-	int64_t asize = sio->sio_asize;
-	dsl_scan_t *scn = queue->q_scn;
+	spa_t *spa = zio->io_spa;
 
-	ASSERT(MUTEX_HELD(&queue->q_vd->vdev_scan_io_queue_lock));
+	abd_free(zio->io_abd);
 
-	if (avl_find(&queue->q_sios_by_addr, sio, &idx) != NULL) {
-		/* block is already scheduled for reading */
-		atomic_add_64(&scn->scn_bytes_pending, -asize);
-		kmem_cache_free(sio_cache, sio);
-		return;
+	mutex_enter(&spa->spa_scrub_lock);
+	spa->spa_scrub_inflight--;
+	cv_broadcast(&spa->spa_scrub_io_cv);
+
+	if (zio->io_error && (zio->io_error != ECKSUM ||
+	    !(zio->io_flags & ZIO_FLAG_SPECULATIVE))) {
+		spa->spa_dsl_pool->dp_scan->scn_phys.scn_errors++;
 	}
-	avl_insert(&queue->q_sios_by_addr, sio, idx);
-	range_tree_add(queue->q_exts_by_addr, sio->sio_offset, asize);
+	mutex_exit(&spa->spa_scrub_lock);
 }
 
-/*
- * Given all the info we got from our metadata scanning process, we
- * construct a scan_io_t and insert it into the scan sorting queue. The
- * I/O must already be suitable for us to process. This is controlled
- * by dsl_scan_enqueue().
- */
-static void
-scan_io_queue_insert(dsl_scan_io_queue_t *queue, const blkptr_t *bp, int dva_i,
-    int zio_flags, const zbookmark_phys_t *zb)
+static boolean_t
+dsl_scan_need_resilver(spa_t *spa, const dva_t *dva, size_t psize,
+    uint64_t phys_birth)
 {
-	dsl_scan_t *scn = queue->q_scn;
-	scan_io_t *sio = kmem_cache_alloc(sio_cache, KM_SLEEP);
+	vdev_t *vd;
 
-	ASSERT0(BP_IS_GANG(bp));
-	ASSERT(MUTEX_HELD(&queue->q_vd->vdev_scan_io_queue_lock));
+	if (DVA_GET_GANG(dva)) {
+		/*
+		 * Gang members may be spread across multiple
+		 * vdevs, so the best estimate we have is the
+		 * scrub range, which has already been checked.
+		 * XXX -- it would be better to change our
+		 * allocation policy to ensure that all
+		 * gang members reside on the same vdev.
+		 */
+		return (B_TRUE);
+	}
 
-	bp2sio(bp, sio, dva_i);
-	sio->sio_flags = zio_flags;
-	sio->sio_zb = *zb;
+	vd = vdev_lookup_top(spa, DVA_GET_VDEV(dva));
 
 	/*
-	 * Increment the bytes pending counter now so that we can't
-	 * get an integer underflow in case the worker processes the
-	 * zio before we get to incrementing this counter.
+	 * Check if the txg falls within the range which must be
+	 * resilvered.  DVAs outside this range can always be skipped.
 	 */
-	atomic_add_64(&scn->scn_bytes_pending, sio->sio_asize);
-
-	scan_io_queue_insert_impl(queue, sio);
-}
-
-/*
- * Given a set of I/O parameters as discovered by the metadata traversal
- * process, attempts to place the I/O into the sorted queues (if allowed),
- * or immediately executes the I/O.
- */
-static void
-dsl_scan_enqueue(dsl_pool_t *dp, const blkptr_t *bp, int zio_flags,
-    const zbookmark_phys_t *zb)
-{
-	spa_t *spa = dp->dp_spa;
-
-	ASSERT(!BP_IS_EMBEDDED(bp));
+	if (!vdev_dtl_contains(vd, DTL_PARTIAL, phys_birth, 1))
+		return (B_FALSE);
 
 	/*
-	 * Gang blocks are hard to issue sequentially, so we just issue them
-	 * here immediately instead of queuing them.
+	 * Check if the top-level vdev must resilver this offset.
+	 * When the offset does not intersect with a dirty leaf DTL
+	 * then it may be possible to skip the resilver IO.  The psize
+	 * is provided instead of asize to simplify the check for RAIDZ.
 	 */
-	if (!dp->dp_scan->scn_is_sorted || BP_IS_GANG(bp)) {
-		scan_exec_io(dp, bp, zio_flags, zb, NULL);
-		return;
-	}
+	if (!vdev_dtl_need_resilver(vd, DVA_GET_OFFSET(dva), psize))
+		return (B_FALSE);
 
-	for (int i = 0; i < BP_GET_NDVAS(bp); i++) {
-		dva_t dva;
-		vdev_t *vdev;
-
-		dva = bp->blk_dva[i];
-		vdev = vdev_lookup_top(spa, DVA_GET_VDEV(&dva));
-		ASSERT(vdev != NULL);
-
-		mutex_enter(&vdev->vdev_scan_io_queue_lock);
-		if (vdev->vdev_scan_io_queue == NULL)
-			vdev->vdev_scan_io_queue = scan_io_queue_create(vdev);
-		ASSERT(dp->dp_scan != NULL);
-		scan_io_queue_insert(vdev->vdev_scan_io_queue, bp,
-		    i, zio_flags, zb);
-		mutex_exit(&vdev->vdev_scan_io_queue_lock);
-	}
+	return (B_TRUE);
 }
 
 static int
@@ -3460,29 +1980,32 @@ dsl_scan_scrub_cb(dsl_pool_t *dp,
     const blkptr_t *bp, const zbookmark_phys_t *zb)
 {
 	dsl_scan_t *scn = dp->dp_scan;
+	size_t psize = BP_GET_PSIZE(bp);
 	spa_t *spa = dp->dp_spa;
 	uint64_t phys_birth = BP_PHYSICAL_BIRTH(bp);
-	size_t psize = BP_GET_PSIZE(bp);
 	boolean_t needs_io = B_FALSE;
 	int zio_flags = ZIO_FLAG_SCAN_THREAD | ZIO_FLAG_RAW | ZIO_FLAG_CANFAIL;
+	int scan_delay = 0;
 
 	if (phys_birth <= scn->scn_phys.scn_min_txg ||
 	    phys_birth >= scn->scn_phys.scn_max_txg)
 		return (0);
 
-	if (BP_IS_EMBEDDED(bp)) {
-		count_block(scn, dp->dp_blkstats, bp);
+	count_block(dp->dp_blkstats, bp);
+
+	if (BP_IS_EMBEDDED(bp))
 		return (0);
-	}
 
 	ASSERT(DSL_SCAN_IS_SCRUB_RESILVER(scn));
 	if (scn->scn_phys.scn_func == POOL_SCAN_SCRUB) {
 		zio_flags |= ZIO_FLAG_SCRUB;
 		needs_io = B_TRUE;
+		scan_delay = zfs_scrub_delay;
 	} else {
 		ASSERT3U(scn->scn_phys.scn_func, ==, POOL_SCAN_RESILVER);
 		zio_flags |= ZIO_FLAG_RESILVER;
 		needs_io = B_FALSE;
+		scan_delay = zfs_resilver_delay;
 	}
 
 	/* If it's an intent log block, failure is expected. */
@@ -3506,348 +2029,91 @@ dsl_scan_scrub_cb(dsl_pool_t *dp,
 	}
 
 	if (needs_io && !zfs_no_scrub_io) {
-		dsl_scan_enqueue(dp, bp, zio_flags, zb);
-	} else {
-		count_block(scn, dp->dp_blkstats, bp);
+		vdev_t *rvd = spa->spa_root_vdev;
+		uint64_t maxinflight = rvd->vdev_children * zfs_top_maxinflight;
+
+		mutex_enter(&spa->spa_scrub_lock);
+		while (spa->spa_scrub_inflight >= maxinflight)
+			cv_wait(&spa->spa_scrub_io_cv, &spa->spa_scrub_lock);
+		spa->spa_scrub_inflight++;
+		mutex_exit(&spa->spa_scrub_lock);
+
+		/*
+		 * If we're seeing recent (zfs_scan_idle) "important" I/Os
+		 * then throttle our workload to limit the impact of a scan.
+		 */
+		if (ddi_get_lbolt64() - spa->spa_last_io <= zfs_scan_idle)
+			delay(scan_delay);
+
+		zio_nowait(zio_read(NULL, spa, bp,
+		    abd_alloc_for_io(psize, B_FALSE),
+		    psize, dsl_scan_scrub_done, NULL,
+		    ZIO_PRIORITY_SCRUB, zio_flags, zb));
 	}
 
 	/* do not relocate this block */
 	return (0);
 }
 
-static void
-dsl_scan_scrub_done(zio_t *zio)
-{
-	spa_t *spa = zio->io_spa;
-	blkptr_t *bp = zio->io_bp;
-	dsl_scan_io_queue_t *queue = zio->io_private;
-
-	abd_free(zio->io_abd);
-
-	if (queue == NULL) {
-		mutex_enter(&spa->spa_scrub_lock);
-		ASSERT3U(spa->spa_scrub_inflight, >=, BP_GET_PSIZE(bp));
-		spa->spa_scrub_inflight -= BP_GET_PSIZE(bp);
-		cv_broadcast(&spa->spa_scrub_io_cv);
-		mutex_exit(&spa->spa_scrub_lock);
-	} else {
-		mutex_enter(&queue->q_vd->vdev_scan_io_queue_lock);
-		ASSERT3U(queue->q_inflight_bytes, >=, BP_GET_PSIZE(bp));
-		queue->q_inflight_bytes -= BP_GET_PSIZE(bp);
-		cv_broadcast(&queue->q_zio_cv);
-		mutex_exit(&queue->q_vd->vdev_scan_io_queue_lock);
-	}
-
-	if (zio->io_error && (zio->io_error != ECKSUM ||
-	    !(zio->io_flags & ZIO_FLAG_SPECULATIVE))) {
-		atomic_inc_64(&spa->spa_dsl_pool->dp_scan->scn_phys.scn_errors);
-	}
-}
-
 /*
- * Given a scanning zio's information, executes the zio. The zio need
- * not necessarily be only sortable, this function simply executes the
- * zio, no matter what it is. The optional queue argument allows the
- * caller to specify that they want per top level vdev IO rate limiting
- * instead of the legacy global limiting.
+ * Called by the ZFS_IOC_POOL_SCAN ioctl to start a scrub or resilver.
+ * Can also be called to resume a paused scrub.
  */
-static void
-scan_exec_io(dsl_pool_t *dp, const blkptr_t *bp, int zio_flags,
-    const zbookmark_phys_t *zb, dsl_scan_io_queue_t *queue)
+int
+dsl_scan(dsl_pool_t *dp, pool_scan_func_t func)
 {
 	spa_t *spa = dp->dp_spa;
 	dsl_scan_t *scn = dp->dp_scan;
-	size_t size = BP_GET_PSIZE(bp);
-	abd_t *data = abd_alloc_for_io(size, B_FALSE);
-
-	if (queue == NULL) {
-		mutex_enter(&spa->spa_scrub_lock);
-		while (spa->spa_scrub_inflight >= scn->scn_maxinflight_bytes)
-			cv_wait(&spa->spa_scrub_io_cv, &spa->spa_scrub_lock);
-		spa->spa_scrub_inflight += BP_GET_PSIZE(bp);
-		mutex_exit(&spa->spa_scrub_lock);
-	} else {
-		kmutex_t *q_lock = &queue->q_vd->vdev_scan_io_queue_lock;
-
-		mutex_enter(q_lock);
-		while (queue->q_inflight_bytes >= queue->q_maxinflight_bytes)
-			cv_wait(&queue->q_zio_cv, q_lock);
-		queue->q_inflight_bytes += BP_GET_PSIZE(bp);
-		mutex_exit(q_lock);
-	}
-
-	count_block(scn, dp->dp_blkstats, bp);
-	zio_nowait(zio_read(scn->scn_zio_root, spa, bp, data, size,
-	    dsl_scan_scrub_done, queue, ZIO_PRIORITY_SCRUB, zio_flags, zb));
-}
-
-/*
- * This is the primary extent sorting algorithm. We balance two parameters:
- * 1) how many bytes of I/O are in an extent
- * 2) how well the extent is filled with I/O (as a fraction of its total size)
- * Since we allow extents to have gaps between their constituent I/Os, it's
- * possible to have a fairly large extent that contains the same amount of
- * I/O bytes than a much smaller extent, which just packs the I/O more tightly.
- * The algorithm sorts based on a score calculated from the extent's size,
- * the relative fill volume (in %) and a "fill weight" parameter that controls
- * the split between whether we prefer larger extents or more well populated
- * extents:
- *
- * SCORE = FILL_IN_BYTES + (FILL_IN_PERCENT * FILL_IN_BYTES * FILL_WEIGHT)
- *
- * Example:
- * 1) assume extsz = 64 MiB
- * 2) assume fill = 32 MiB (extent is half full)
- * 3) assume fill_weight = 3
- * 4)	SCORE = 32M + (((32M * 100) / 64M) * 3 * 32M) / 100
- *	SCORE = 32M + (50 * 3 * 32M) / 100
- *	SCORE = 32M + (4800M / 100)
- *	SCORE = 32M + 48M
- *	         ^     ^
- *	         |     +--- final total relative fill-based score
- *	         +--------- final total fill-based score
- *	SCORE = 80M
- *
- * As can be seen, at fill_ratio=3, the algorithm is slightly biased towards
- * extents that are more completely filled (in a 3:2 ratio) vs just larger.
- * Note that as an optimization, we replace multiplication and division by
- * 100 with bitshifting by 7 (which effecitvely multiplies and divides by 128).
- */
-static int
-ext_size_compare(const void *x, const void *y)
-{
-	const range_seg_t *rsa = x, *rsb = y;
-	uint64_t sa = rsa->rs_end - rsa->rs_start,
-	    sb = rsb->rs_end - rsb->rs_start;
-	uint64_t score_a, score_b;
-
-	score_a = rsa->rs_fill + ((((rsa->rs_fill << 7) / sa) *
-	    fill_weight * rsa->rs_fill) >> 7);
-	score_b = rsb->rs_fill + ((((rsb->rs_fill << 7) / sb) *
-	    fill_weight * rsb->rs_fill) >> 7);
-
-	if (score_a > score_b)
-		return (-1);
-	if (score_a == score_b) {
-		if (rsa->rs_start < rsb->rs_start)
-			return (-1);
-		if (rsa->rs_start == rsb->rs_start)
-			return (0);
-		return (1);
-	}
-	return (1);
-}
-
-/*
- * Comparator for the q_sios_by_addr tree. Sorting is simply performed
- * based on LBA-order (from lowest to highest).
- */
-static int
-sio_addr_compare(const void *x, const void *y)
-{
-	const scan_io_t *a = x, *b = y;
-
-	if (a->sio_offset < b->sio_offset)
-		return (-1);
-	if (a->sio_offset == b->sio_offset)
-		return (0);
-	return (1);
-}
-
-/* IO queues are created on demand when they are needed. */
-static dsl_scan_io_queue_t *
-scan_io_queue_create(vdev_t *vd)
-{
-	dsl_scan_t *scn = vd->vdev_spa->spa_dsl_pool->dp_scan;
-	dsl_scan_io_queue_t *q = kmem_zalloc(sizeof (*q), KM_SLEEP);
-
-	q->q_scn = scn;
-	q->q_vd = vd;
-	cv_init(&q->q_zio_cv, NULL, CV_DEFAULT, NULL);
-	q->q_exts_by_addr = range_tree_create_impl(&rt_avl_ops,
-	    &q->q_exts_by_size, ext_size_compare,
-	    &q->q_vd->vdev_scan_io_queue_lock, zfs_scan_max_ext_gap);
-	avl_create(&q->q_sios_by_addr, sio_addr_compare,
-	    sizeof (scan_io_t), offsetof(scan_io_t, sio_nodes.sio_addr_node));
-
-	return (q);
-}
-
-/*
- * Destroys a scan queue and all segments and scan_io_t's contained in it.
- * No further execution of I/O occurs, anything pending in the queue is
- * simply freed without being executed.
- */
-void
-dsl_scan_io_queue_destroy(dsl_scan_io_queue_t *queue)
-{
-	dsl_scan_t *scn = queue->q_scn;
-	scan_io_t *sio;
-	void *cookie = NULL;
-	int64_t bytes_dequeued = 0;
-
-	ASSERT(MUTEX_HELD(&queue->q_vd->vdev_scan_io_queue_lock));
-
-	while ((sio = avl_destroy_nodes(&queue->q_sios_by_addr, &cookie)) !=
-	    NULL) {
-		ASSERT(range_tree_contains(queue->q_exts_by_addr,
-		    sio->sio_offset, sio->sio_asize));
-		bytes_dequeued += sio->sio_asize;
-		kmem_cache_free(sio_cache, sio);
-	}
-
-	atomic_add_64(&scn->scn_bytes_pending, -bytes_dequeued);
-	range_tree_vacate(queue->q_exts_by_addr, NULL, queue);
-	range_tree_destroy(queue->q_exts_by_addr);
-	avl_destroy(&queue->q_sios_by_addr);
-	cv_destroy(&queue->q_zio_cv);
-
-	kmem_free(queue, sizeof (*queue));
-}
-
-/*
- * Properly transfers a dsl_scan_queue_t from `svd' to `tvd'. This is
- * called on behalf of vdev_top_transfer when creating or destroying
- * a mirror vdev due to zpool attach/detach.
- */
-void
-dsl_scan_io_queue_vdev_xfer(vdev_t *svd, vdev_t *tvd)
-{
-	mutex_enter(&svd->vdev_scan_io_queue_lock);
-	mutex_enter(&tvd->vdev_scan_io_queue_lock);
-
-	VERIFY3P(tvd->vdev_scan_io_queue, ==, NULL);
-	tvd->vdev_scan_io_queue = svd->vdev_scan_io_queue;
-	svd->vdev_scan_io_queue = NULL;
-	if (tvd->vdev_scan_io_queue != NULL) {
-		tvd->vdev_scan_io_queue->q_vd = tvd;
-		range_tree_set_lock(tvd->vdev_scan_io_queue->q_exts_by_addr,
-		    &tvd->vdev_scan_io_queue_lock);
-	}
-
-	mutex_exit(&tvd->vdev_scan_io_queue_lock);
-	mutex_exit(&svd->vdev_scan_io_queue_lock);
-}
-
-static void
-scan_io_queues_destroy(dsl_scan_t *scn)
-{
-	vdev_t *rvd = scn->scn_dp->dp_spa->spa_root_vdev;
-
-	for (uint64_t i = 0; i < rvd->vdev_children; i++) {
-		vdev_t *tvd = rvd->vdev_child[i];
-
-		mutex_enter(&tvd->vdev_scan_io_queue_lock);
-		if (tvd->vdev_scan_io_queue != NULL)
-			dsl_scan_io_queue_destroy(tvd->vdev_scan_io_queue);
-		tvd->vdev_scan_io_queue = NULL;
-		mutex_exit(&tvd->vdev_scan_io_queue_lock);
-	}
-}
-
-static void
-dsl_scan_freed_dva(spa_t *spa, const blkptr_t *bp, int dva_i)
-{
-	dsl_pool_t *dp = spa->spa_dsl_pool;
-	dsl_scan_t *scn = dp->dp_scan;
-	vdev_t *vdev;
-	kmutex_t *q_lock;
-	dsl_scan_io_queue_t *queue;
-	scan_io_t srch, *sio;
-	avl_index_t idx;
-	uint64_t start, size;
-
-	vdev = vdev_lookup_top(spa, DVA_GET_VDEV(&bp->blk_dva[dva_i]));
-	ASSERT(vdev != NULL);
-	q_lock = &vdev->vdev_scan_io_queue_lock;
-	queue = vdev->vdev_scan_io_queue;
-
-	mutex_enter(q_lock);
-	if (queue == NULL) {
-		mutex_exit(q_lock);
-		return;
-	}
-
-	bp2sio(bp, &srch, dva_i);
-	start = srch.sio_offset;
-	size = srch.sio_asize;
 
 	/*
-	 * We can find the zio in two states:
-	 * 1) Cold, just sitting in the queue of zio's to be issued at
-	 *	some point in the future. In this case, all we do is
-	 *	remove the zio from the q_sios_by_addr tree, decrement
-	 *	its data volume from the containing range_seg_t and
-	 *	resort the q_exts_by_size tree to reflect that the
-	 *	range_seg_t has lost some of its 'fill'. We don't shorten
-	 *	the range_seg_t - this is usually rare enough not to be
-	 *	worth the extra hassle of trying keep track of precise
-	 *	extent boundaries.
-	 * 2) Hot, where the zio is currently in-flight in
-	 *	dsl_scan_issue_ios. In this case, we can't simply
-	 *	reach in and stop the in-flight zio's, so we instead
-	 *	block the caller. Eventually, dsl_scan_issue_ios will
-	 *	be done with issuing the zio's it gathered and will
-	 *	signal us.
+	 * Purge all vdev caches and probe all devices.  We do this here
+	 * rather than in sync context because this requires a writer lock
+	 * on the spa_config lock, which we can't do from sync context.  The
+	 * spa_scrub_reopen flag indicates that vdev_open() should not
+	 * attempt to start another scrub.
 	 */
-	sio = avl_find(&queue->q_sios_by_addr, &srch, &idx);
-	if (sio != NULL) {
-		int64_t asize = sio->sio_asize;
-		blkptr_t tmpbp;
+	spa_vdev_state_enter(spa, SCL_NONE);
+	spa->spa_scrub_reopen = B_TRUE;
+	vdev_reopen(spa->spa_root_vdev);
+	spa->spa_scrub_reopen = B_FALSE;
+	(void) spa_vdev_state_exit(spa, NULL, 0);
 
-		/* Got it while it was cold in the queue */
-		ASSERT3U(start, ==, sio->sio_offset);
-		ASSERT3U(size, ==, asize);
-		avl_remove(&queue->q_sios_by_addr, sio);
+	if (func == POOL_SCAN_SCRUB && dsl_scan_is_paused_scrub(scn)) {
+		/* got scrub start cmd, resume paused scrub */
+		int err = dsl_scrub_set_pause_resume(scn->scn_dp,
+		    POOL_SCRUB_NORMAL);
+		if (err == 0)
+			return (SET_ERROR(ECANCELED));
 
-		ASSERT(range_tree_contains(queue->q_exts_by_addr, start, size));
-		range_tree_remove_fill(queue->q_exts_by_addr, start, size);
-
-		/*
-		 * We only update scn_bytes_pending in the cold path,
-		 * otherwise it will already have been accounted for as
-		 * part of the zio's execution.
-		 */
-		atomic_add_64(&scn->scn_bytes_pending, -asize);
-
-		/* count the block as though we issued it */
-		sio2bp(sio, &tmpbp, dva_i);
-		count_block(scn, dp->dp_blkstats, &tmpbp);
-
-		kmem_cache_free(sio_cache, sio);
+		return (SET_ERROR(err));
 	}
-	mutex_exit(q_lock);
+
+	return (dsl_sync_task(spa_name(spa), dsl_scan_setup_check,
+	    dsl_scan_setup_sync, &func, 0, ZFS_SPACE_CHECK_NONE));
 }
 
-/*
- * Callback invoked when a zio_free() zio is executing. This needs to be
- * intercepted to prevent the zio from deallocating a particular portion
- * of disk space and it then getting reallocated and written to, while we
- * still have it queued up for processing.
- */
-void
-dsl_scan_freed(spa_t *spa, const blkptr_t *bp)
+static boolean_t
+dsl_scan_restarting(dsl_scan_t *scn, dmu_tx_t *tx)
 {
-	dsl_pool_t *dp = spa->spa_dsl_pool;
-	dsl_scan_t *scn = dp->dp_scan;
-
-	ASSERT(!BP_IS_EMBEDDED(bp));
-	ASSERT(scn != NULL);
-	if (!dsl_scan_is_running(scn))
-		return;
-
-	for (int i = 0; i < BP_GET_NDVAS(bp); i++)
-		dsl_scan_freed_dva(spa, bp, i);
+	return (scn->scn_restart_txg != 0 &&
+	    scn->scn_restart_txg <= tx->tx_txg);
 }
 
 #if defined(_KERNEL) && defined(HAVE_SPL)
-/* CSTYLED */
-module_param(zfs_scan_vdev_limit, ulong, 0644);
-MODULE_PARM_DESC(zfs_scan_vdev_limit,
-	"Max bytes in flight per leaf vdev for scrubs and resilvers");
+module_param(zfs_top_maxinflight, int, 0644);
+MODULE_PARM_DESC(zfs_top_maxinflight, "Max I/Os per top-level");
 
-module_param(zfs_scrub_min_time_ms, int, 0644);
-MODULE_PARM_DESC(zfs_scrub_min_time_ms, "Min millisecs to scrub per txg");
+module_param(zfs_resilver_delay, int, 0644);
+MODULE_PARM_DESC(zfs_resilver_delay, "Number of ticks to delay resilver");
+
+module_param(zfs_scrub_delay, int, 0644);
+MODULE_PARM_DESC(zfs_scrub_delay, "Number of ticks to delay scrub");
+
+module_param(zfs_scan_idle, int, 0644);
+MODULE_PARM_DESC(zfs_scan_idle, "Idle window in clock ticks");
+
+module_param(zfs_scan_min_time_ms, int, 0644);
+MODULE_PARM_DESC(zfs_scan_min_time_ms, "Min millisecs to scrub per txg");
 
 module_param(zfs_free_min_time_ms, int, 0644);
 MODULE_PARM_DESC(zfs_free_min_time_ms, "Min millisecs to free per txg");
@@ -3867,30 +2133,4 @@ MODULE_PARM_DESC(zfs_free_max_blocks, "Max number of blocks freed in one txg");
 
 module_param(zfs_free_bpobj_enabled, int, 0644);
 MODULE_PARM_DESC(zfs_free_bpobj_enabled, "Enable processing of the free_bpobj");
-
-module_param(zfs_scan_mem_lim_fact, int, 0644);
-MODULE_PARM_DESC(zfs_scan_mem_lim_fact, "Fraction of RAM for scan hard limit");
-
-module_param(zfs_scan_issue_strategy, int, 0644);
-MODULE_PARM_DESC(zfs_scan_issue_strategy,
-	"IO issuing strategy during scrubbing. 0 = default, 1 = LBA, 2 = size");
-
-module_param(zfs_scan_legacy, int, 0644);
-MODULE_PARM_DESC(zfs_scan_legacy, "Scrub using legacy non-sequential method");
-
-module_param(zfs_scan_checkpoint_intval, int, 0644);
-MODULE_PARM_DESC(zfs_scan_checkpoint_intval,
-	"Scan progress on-disk checkpointing interval");
-
-module_param(zfs_scan_mem_lim_soft_fact, int, 0644);
-MODULE_PARM_DESC(zfs_scan_mem_lim_soft_fact,
-	"Fraction of hard limit used as soft limit");
-
-module_param(zfs_scan_strict_mem_lim, int, 0644);
-MODULE_PARM_DESC(zfs_scan_strict_mem_lim,
-	"Tunable to attempt to reduce lock contention");
-
-module_param(zfs_scan_fill_weight, int, 0644);
-MODULE_PARM_DESC(zfs_scan_fill_weight,
-	"Tunable to adjust bias towards more filled segments during scans");
 #endif

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -972,6 +972,85 @@ metaslab_rangesize_compare(const void *x1, const void *x2)
 }
 
 /*
+ * Create any block allocator specific components. The current allocators
+ * rely on using both a size-ordered range_tree_t and an array of uint64_t's.
+ */
+static void
+metaslab_rt_create(range_tree_t *rt, void *arg)
+{
+	metaslab_t *msp = arg;
+
+	ASSERT3P(rt->rt_arg, ==, msp);
+	ASSERT(msp->ms_tree == NULL);
+
+	avl_create(&msp->ms_size_tree, metaslab_rangesize_compare,
+	    sizeof (range_seg_t), offsetof(range_seg_t, rs_pp_node));
+}
+
+/*
+ * Destroy the block allocator specific components.
+ */
+static void
+metaslab_rt_destroy(range_tree_t *rt, void *arg)
+{
+	metaslab_t *msp = arg;
+
+	ASSERT3P(rt->rt_arg, ==, msp);
+	ASSERT3P(msp->ms_tree, ==, rt);
+	ASSERT0(avl_numnodes(&msp->ms_size_tree));
+
+	avl_destroy(&msp->ms_size_tree);
+}
+
+static void
+metaslab_rt_add(range_tree_t *rt, range_seg_t *rs, void *arg)
+{
+	metaslab_t *msp = arg;
+
+	ASSERT3P(rt->rt_arg, ==, msp);
+	ASSERT3P(msp->ms_tree, ==, rt);
+	VERIFY(!msp->ms_condensing);
+	avl_add(&msp->ms_size_tree, rs);
+}
+
+static void
+metaslab_rt_remove(range_tree_t *rt, range_seg_t *rs, void *arg)
+{
+	metaslab_t *msp = arg;
+
+	ASSERT3P(rt->rt_arg, ==, msp);
+	ASSERT3P(msp->ms_tree, ==, rt);
+	VERIFY(!msp->ms_condensing);
+	avl_remove(&msp->ms_size_tree, rs);
+}
+
+static void
+metaslab_rt_vacate(range_tree_t *rt, void *arg)
+{
+	metaslab_t *msp = arg;
+
+	ASSERT3P(rt->rt_arg, ==, msp);
+	ASSERT3P(msp->ms_tree, ==, rt);
+
+	/*
+	 * Normally one would walk the tree freeing nodes along the way.
+	 * Since the nodes are shared with the range trees we can avoid
+	 * walking all nodes and just reinitialize the avl tree. The nodes
+	 * will be freed by the range tree, so we don't want to free them here.
+	 */
+	avl_create(&msp->ms_size_tree, metaslab_rangesize_compare,
+	    sizeof (range_seg_t), offsetof(range_seg_t, rs_pp_node));
+}
+
+static range_tree_ops_t metaslab_rt_ops = {
+	metaslab_rt_create,
+	metaslab_rt_destroy,
+	metaslab_rt_add,
+	metaslab_rt_remove,
+	metaslab_rt_vacate
+};
+
+/*
  * ==========================================================================
  * Common allocator routines
  * ==========================================================================
@@ -1346,8 +1425,7 @@ metaslab_init(metaslab_group_t *mg, uint64_t id, uint64_t object, uint64_t txg,
 	 * addition of new space; and for debugging, it ensures that we'd
 	 * data fault on any attempt to use this metaslab before it's ready.
 	 */
-	ms->ms_tree = range_tree_create_impl(&rt_avl_ops, &ms->ms_size_tree,
-	    metaslab_rangesize_compare, &ms->ms_lock, 0);
+	ms->ms_tree = range_tree_create(&metaslab_rt_ops, ms, &ms->ms_lock);
 	metaslab_group_add(mg, ms);
 
 	metaslab_set_fragmentation(ms);

--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -33,57 +33,7 @@
 #include <sys/zio.h>
 #include <sys/range_tree.h>
 
-/*
- * Range trees are tree-based data structures that can be used to
- * track free space or generally any space allocation information.
- * A range tree keeps track of individual segments and automatically
- * provides facilities such as adjacent extent merging and extent
- * splitting in response to range add/remove requests.
- *
- * A range tree starts out completely empty, with no segments in it.
- * Adding an allocation via range_tree_add to the range tree can either:
- * 1) create a new extent
- * 2) extend an adjacent extent
- * 3) merge two adjacent extents
- * Conversely, removing an allocation via range_tree_remove can:
- * 1) completely remove an extent
- * 2) shorten an extent (if the allocation was near one of its ends)
- * 3) split an extent into two extents, in effect punching a hole
- *
- * A range tree is also capable of 'bridging' gaps when adding
- * allocations. This is useful for cases when close proximity of
- * allocations is an important detail that needs to be represented
- * in the range tree. See range_tree_set_gap(). The default behavior
- * is not to bridge gaps (i.e. the maximum allowed gap size is 0).
- *
- * In order to traverse a range tree, use either the range_tree_walk()
- * or range_tree_vacate() functions.
- *
- * To obtain more accurate information on individual segment
- * operations that the range tree performs "under the hood", you can
- * specify a set of callbacks by passing a range_tree_ops_t structure
- * to the range_tree_create function. Any callbacks that are non-NULL
- * are then called at the appropriate times.
- *
- * The range tree code also supports a special variant of range trees
- * that can bridge small gaps between segments. This kind of tree is used
- * by the dsl scanning code to group I/Os into mostly sequential chunks to
- * optimize disk performance. The code here attempts to do this with as
- * little memory and computational overhead as possible. One limitation of
- * this implementation is that segments of range trees with gaps can only
- * support removing complete segments.
- */
-
 kmem_cache_t *range_seg_cache;
-
-/* Generic ops for managing an AVL tree alongside a range tree */
-struct range_tree_ops rt_avl_ops = {
-	.rtop_create = rt_avl_create,
-	.rtop_destroy = rt_avl_destroy,
-	.rtop_add = rt_avl_add,
-	.rtop_remove = rt_avl_remove,
-	.rtop_vacate = rt_avl_vacate,
-};
 
 void
 range_tree_init(void)
@@ -123,18 +73,6 @@ range_tree_stat_verify(range_tree_t *rt)
 		}
 		VERIFY3U(hist[i], ==, rt->rt_histogram[i]);
 	}
-}
-
-/*
- * Changes out the lock used by the range tree. Useful when you are moving
- * the range tree between containing structures without having to recreate
- * it. Both the old and new locks must be held by the caller.
- */
-void
-range_tree_set_lock(range_tree_t *rt, kmutex_t *lp)
-{
-	ASSERT(MUTEX_HELD(rt->rt_lock) && MUTEX_HELD(lp));
-	rt->rt_lock = lp;
 }
 
 static void
@@ -183,30 +121,23 @@ range_tree_seg_compare(const void *x1, const void *x2)
 }
 
 range_tree_t *
-range_tree_create_impl(range_tree_ops_t *ops, void *arg,
-    int (*avl_compare) (const void *, const void *), kmutex_t *lp, uint64_t gap)
+range_tree_create(range_tree_ops_t *ops, void *arg, kmutex_t *lp)
 {
-	range_tree_t *rt = kmem_zalloc(sizeof (range_tree_t), KM_SLEEP);
+	range_tree_t *rt;
+
+	rt = kmem_zalloc(sizeof (range_tree_t), KM_SLEEP);
 
 	avl_create(&rt->rt_root, range_tree_seg_compare,
 	    sizeof (range_seg_t), offsetof(range_seg_t, rs_node));
 
 	rt->rt_lock = lp;
 	rt->rt_ops = ops;
-	rt->rt_gap = gap;
 	rt->rt_arg = arg;
-	rt->rt_avl_compare = avl_compare;
 
-	if (rt->rt_ops != NULL && rt->rt_ops->rtop_create != NULL)
+	if (rt->rt_ops != NULL)
 		rt->rt_ops->rtop_create(rt, rt->rt_arg);
 
 	return (rt);
-}
-
-range_tree_t *
-range_tree_create(range_tree_ops_t *ops, void *arg, kmutex_t *lp)
-{
-	return (range_tree_create_impl(ops, arg, NULL, lp, 0));
 }
 
 void
@@ -214,7 +145,7 @@ range_tree_destroy(range_tree_t *rt)
 {
 	VERIFY0(rt->rt_space);
 
-	if (rt->rt_ops != NULL && rt->rt_ops->rtop_destroy != NULL)
+	if (rt->rt_ops != NULL)
 		rt->rt_ops->rtop_destroy(rt, rt->rt_arg);
 
 	avl_destroy(&rt->rt_root);
@@ -222,102 +153,40 @@ range_tree_destroy(range_tree_t *rt)
 }
 
 void
-range_tree_adjust_fill(range_tree_t *rt, range_seg_t *rs, int64_t delta)
-{
-	ASSERT(MUTEX_HELD(rt->rt_lock));
-
-	ASSERT3U(rs->rs_fill + delta, !=, 0);
-	ASSERT3U(rs->rs_fill + delta, <=, rs->rs_end - rs->rs_start);
-
-	if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
-		rt->rt_ops->rtop_remove(rt, rs, rt->rt_arg);
-	rs->rs_fill += delta;
-	if (rt->rt_ops != NULL && rt->rt_ops->rtop_add != NULL)
-		rt->rt_ops->rtop_add(rt, rs, rt->rt_arg);
-}
-
-static void
-range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
+range_tree_add(void *arg, uint64_t start, uint64_t size)
 {
 	range_tree_t *rt = arg;
 	avl_index_t where;
 	range_seg_t rsearch, *rs_before, *rs_after, *rs;
-	uint64_t end = start + size, gap = rt->rt_gap;
-	uint64_t bridge_size = 0;
+	uint64_t end = start + size;
 	boolean_t merge_before, merge_after;
 
 	ASSERT(MUTEX_HELD(rt->rt_lock));
-	ASSERT3U(size, !=, 0);
-	ASSERT3U(fill, <=, size);
+	VERIFY(size != 0);
 
 	rsearch.rs_start = start;
 	rsearch.rs_end = end;
 	rs = avl_find(&rt->rt_root, &rsearch, &where);
 
-	if (gap == 0 && rs != NULL &&
-	    rs->rs_start <= start && rs->rs_end >= end) {
+	if (rs != NULL && rs->rs_start <= start && rs->rs_end >= end) {
 		zfs_panic_recover("zfs: allocating allocated segment"
-		    "(offset=%llu size=%llu) of (offset=%llu size=%llu)\n",
-		    (longlong_t)start, (longlong_t)size,
-		    (longlong_t)rs->rs_start,
-		    (longlong_t)rs->rs_end - rs->rs_start);
+		    "(offset=%llu size=%llu)\n",
+		    (longlong_t)start, (longlong_t)size);
 		return;
 	}
 
-	/*
-	 * If this is a gap-supporting range tree, it is possible that we
-	 * are inserting into an existing segment. In this case simply
-	 * bump the fill count and call the remove / add callbacks. If the
-	 * new range will extend an existing segment, we remove the
-	 * existing one, apply the new extent to it and re-insert it using
-	 * the normal code paths.
-	 */
-	if (rs != NULL) {
-		ASSERT3U(gap, !=, 0);
-		if (rs->rs_start <= start && rs->rs_end >= end) {
-			range_tree_adjust_fill(rt, rs, fill);
-			return;
-		}
+	/* Make sure we don't overlap with either of our neighbors */
+	VERIFY(rs == NULL);
 
-		avl_remove(&rt->rt_root, rs);
-		if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
-			rt->rt_ops->rtop_remove(rt, rs, rt->rt_arg);
-
-		range_tree_stat_decr(rt, rs);
-		rt->rt_space -= rs->rs_end - rs->rs_start;
-
-		fill += rs->rs_fill;
-		start = MIN(start, rs->rs_start);
-		end = MAX(end, rs->rs_end);
-		size = end - start;
-
-		range_tree_add_impl(rt, start, size, fill);
-
-		kmem_cache_free(range_seg_cache, rs);
-		return;
-	}
-
-	ASSERT3P(rs, ==, NULL);
-
-	/*
-	 * Determine whether or not we will have to merge with our neighbors.
-	 * If gap != 0, we might need to merge with our neighbors even if we
-	 * aren't directly touching.
-	 */
 	rs_before = avl_nearest(&rt->rt_root, where, AVL_BEFORE);
 	rs_after = avl_nearest(&rt->rt_root, where, AVL_AFTER);
 
-	merge_before = (rs_before != NULL && rs_before->rs_end >= start - gap);
-	merge_after = (rs_after != NULL && rs_after->rs_start <= end + gap);
-
-	if (merge_before && gap != 0)
-		bridge_size += start - rs_before->rs_end;
-	if (merge_after && gap != 0)
-		bridge_size += rs_after->rs_start - end;
+	merge_before = (rs_before != NULL && rs_before->rs_end == start);
+	merge_after = (rs_after != NULL && rs_after->rs_start == end);
 
 	if (merge_before && merge_after) {
 		avl_remove(&rt->rt_root, rs_before);
-		if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL) {
+		if (rt->rt_ops != NULL) {
 			rt->rt_ops->rtop_remove(rt, rs_before, rt->rt_arg);
 			rt->rt_ops->rtop_remove(rt, rs_after, rt->rt_arg);
 		}
@@ -325,59 +194,43 @@ range_tree_add_impl(void *arg, uint64_t start, uint64_t size, uint64_t fill)
 		range_tree_stat_decr(rt, rs_before);
 		range_tree_stat_decr(rt, rs_after);
 
-		rs_after->rs_fill += rs_before->rs_fill + fill;
 		rs_after->rs_start = rs_before->rs_start;
 		kmem_cache_free(range_seg_cache, rs_before);
 		rs = rs_after;
 	} else if (merge_before) {
-		if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
+		if (rt->rt_ops != NULL)
 			rt->rt_ops->rtop_remove(rt, rs_before, rt->rt_arg);
 
 		range_tree_stat_decr(rt, rs_before);
 
-		rs_before->rs_fill += fill;
 		rs_before->rs_end = end;
 		rs = rs_before;
 	} else if (merge_after) {
-		if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
+		if (rt->rt_ops != NULL)
 			rt->rt_ops->rtop_remove(rt, rs_after, rt->rt_arg);
 
 		range_tree_stat_decr(rt, rs_after);
 
-		rs_after->rs_fill += fill;
 		rs_after->rs_start = start;
 		rs = rs_after;
 	} else {
 		rs = kmem_cache_alloc(range_seg_cache, KM_SLEEP);
-
-		rs->rs_fill = fill;
 		rs->rs_start = start;
 		rs->rs_end = end;
 		avl_insert(&rt->rt_root, rs, where);
 	}
 
-	if (gap != 0)
-		ASSERT3U(rs->rs_fill, <=, rs->rs_end - rs->rs_start);
-	else
-		ASSERT3U(rs->rs_fill, ==, rs->rs_end - rs->rs_start);
-
-	if (rt->rt_ops != NULL && rt->rt_ops->rtop_add != NULL)
+	if (rt->rt_ops != NULL)
 		rt->rt_ops->rtop_add(rt, rs, rt->rt_arg);
 
 	range_tree_stat_incr(rt, rs);
-	rt->rt_space += size + bridge_size;
+	rt->rt_space += size;
 }
 
 void
-range_tree_add(void *arg, uint64_t start, uint64_t size)
+range_tree_remove(void *arg, uint64_t start, uint64_t size)
 {
-	range_tree_add_impl(arg, start, size, size);
-}
-
-static void
-range_tree_remove_impl(range_tree_t *rt, uint64_t start, uint64_t size,
-    boolean_t do_fill)
-{
+	range_tree_t *rt = arg;
 	avl_index_t where;
 	range_seg_t rsearch, *rs, *newseg;
 	uint64_t end = start + size;
@@ -398,34 +251,6 @@ range_tree_remove_impl(range_tree_t *rt, uint64_t start, uint64_t size,
 		    (longlong_t)start, (longlong_t)size);
 		return;
 	}
-
-	/*
-	 * Range trees with gap support must only remove complete segments
-	 * from the tree. This allows us to maintain accurate fill accounting
-	 * and to ensure that bridged sections are not leaked. If we need to
-	 * remove less than the full segment, we can only adjust the fill count.
-	 */
-	if (rt->rt_gap != 0) {
-		if (do_fill) {
-			if (rs->rs_fill == size) {
-				start = rs->rs_start;
-				end = rs->rs_end;
-				size = end - start;
-			} else {
-				range_tree_adjust_fill(rt, rs, -size);
-				return;
-			}
-		} else if (rs->rs_start != start || rs->rs_end != end) {
-			zfs_panic_recover("zfs: freeing partial segment of "
-			    "gap tree (offset=%llu size=%llu) of "
-			    "(offset=%llu size=%llu)",
-			    (longlong_t)start, (longlong_t)size,
-			    (longlong_t)rs->rs_start,
-			    (longlong_t)rs->rs_end - rs->rs_start);
-			return;
-		}
-	}
-
 	VERIFY3U(rs->rs_start, <=, start);
 	VERIFY3U(rs->rs_end, >=, end);
 
@@ -434,20 +259,19 @@ range_tree_remove_impl(range_tree_t *rt, uint64_t start, uint64_t size,
 
 	range_tree_stat_decr(rt, rs);
 
-	if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
+	if (rt->rt_ops != NULL)
 		rt->rt_ops->rtop_remove(rt, rs, rt->rt_arg);
 
 	if (left_over && right_over) {
 		newseg = kmem_cache_alloc(range_seg_cache, KM_SLEEP);
 		newseg->rs_start = end;
 		newseg->rs_end = rs->rs_end;
-		newseg->rs_fill = newseg->rs_end - newseg->rs_start;
 		range_tree_stat_incr(rt, newseg);
 
 		rs->rs_end = start;
 
 		avl_insert_here(&rt->rt_root, newseg, rs, AVL_AFTER);
-		if (rt->rt_ops != NULL && rt->rt_ops->rtop_add != NULL)
+		if (rt->rt_ops != NULL)
 			rt->rt_ops->rtop_add(rt, newseg, rt->rt_arg);
 	} else if (left_over) {
 		rs->rs_end = start;
@@ -460,53 +284,13 @@ range_tree_remove_impl(range_tree_t *rt, uint64_t start, uint64_t size,
 	}
 
 	if (rs != NULL) {
-		/*
-		 * The fill of the leftover segment will always be equal to
-		 * the size, since we do not support removing partial segments
-		 * of range trees with gaps.
-		 */
-		rs->rs_fill = rs->rs_end - rs->rs_start;
 		range_tree_stat_incr(rt, rs);
 
-		if (rt->rt_ops != NULL && rt->rt_ops->rtop_add != NULL)
+		if (rt->rt_ops != NULL)
 			rt->rt_ops->rtop_add(rt, rs, rt->rt_arg);
 	}
 
 	rt->rt_space -= size;
-}
-
-void
-range_tree_remove(void *arg, uint64_t start, uint64_t size)
-{
-	range_tree_remove_impl(arg, start, size, B_FALSE);
-}
-
-void
-range_tree_remove_fill(range_tree_t *rt, uint64_t start, uint64_t size)
-{
-	range_tree_remove_impl(rt, start, size, B_TRUE);
-}
-
-void
-range_tree_resize_segment(range_tree_t *rt, range_seg_t *rs,
-    uint64_t newstart, uint64_t newsize)
-{
-	int64_t delta = newsize - (rs->rs_end - rs->rs_start);
-
-	ASSERT(MUTEX_HELD(rt->rt_lock));
-
-	range_tree_stat_decr(rt, rs);
-	if (rt->rt_ops != NULL && rt->rt_ops->rtop_remove != NULL)
-		rt->rt_ops->rtop_remove(rt, rs, rt->rt_arg);
-
-	rs->rs_start = newstart;
-	rs->rs_end = newstart + newsize;
-
-	range_tree_stat_incr(rt, rs);
-	if (rt->rt_ops != NULL && rt->rt_ops->rtop_add != NULL)
-		rt->rt_ops->rtop_add(rt, rs, rt->rt_arg);
-
-	rt->rt_space += delta;
 }
 
 static range_seg_t *
@@ -524,7 +308,7 @@ range_tree_find_impl(range_tree_t *rt, uint64_t start, uint64_t size)
 	return (avl_find(&rt->rt_root, &rsearch, &where));
 }
 
-range_seg_t *
+static range_seg_t *
 range_tree_find(range_tree_t *rt, uint64_t start, uint64_t size)
 {
 	range_seg_t *rs = range_tree_find_impl(rt, start, size);
@@ -589,7 +373,7 @@ range_tree_vacate(range_tree_t *rt, range_tree_func_t *func, void *arg)
 
 	ASSERT(MUTEX_HELD(rt->rt_lock));
 
-	if (rt->rt_ops != NULL && rt->rt_ops->rtop_vacate != NULL)
+	if (rt->rt_ops != NULL)
 		rt->rt_ops->rtop_vacate(rt, rt->rt_arg);
 
 	while ((rs = avl_destroy_nodes(&rt->rt_root, &cookie)) != NULL) {
@@ -613,60 +397,8 @@ range_tree_walk(range_tree_t *rt, range_tree_func_t *func, void *arg)
 		func(arg, rs->rs_start, rs->rs_end - rs->rs_start);
 }
 
-range_seg_t *
-range_tree_first(range_tree_t *rt)
-{
-	ASSERT(MUTEX_HELD(rt->rt_lock));
-	return (avl_first(&rt->rt_root));
-}
-
 uint64_t
 range_tree_space(range_tree_t *rt)
 {
 	return (rt->rt_space);
-}
-
-/* Generic range tree functions for maintaining segments in an AVL tree. */
-void
-rt_avl_create(range_tree_t *rt, void *arg)
-{
-	avl_tree_t *tree = arg;
-
-	avl_create(tree, rt->rt_avl_compare, sizeof (range_seg_t),
-	    offsetof(range_seg_t, rs_pp_node));
-}
-
-void
-rt_avl_destroy(range_tree_t *rt, void *arg)
-{
-	avl_tree_t *tree = arg;
-
-	ASSERT0(avl_numnodes(tree));
-	avl_destroy(tree);
-}
-
-void
-rt_avl_add(range_tree_t *rt, range_seg_t *rs, void *arg)
-{
-	avl_tree_t *tree = arg;
-	avl_add(tree, rs);
-}
-
-void
-rt_avl_remove(range_tree_t *rt, range_seg_t *rs, void *arg)
-{
-	avl_tree_t *tree = arg;
-	avl_remove(tree, rs);
-}
-
-void
-rt_avl_vacate(range_tree_t *rt, void *arg)
-{
-	/*
-	 * Normally one would walk the tree freeing nodes along the way.
-	 * Since the nodes are shared with the range trees we can avoid
-	 * walking all nodes and just reinitialize the avl tree. The nodes
-	 * will be freed by the range tree, so we don't want to free them here.
-	 */
-	rt_avl_create(rt, arg);
 }

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1996,7 +1996,7 @@ spa_load_verify_done(zio_t *zio)
 	}
 
 	mutex_enter(&spa->spa_scrub_lock);
-	spa->spa_load_verify_ios--;
+	spa->spa_scrub_inflight--;
 	cv_broadcast(&spa->spa_scrub_io_cv);
 	mutex_exit(&spa->spa_scrub_lock);
 }
@@ -2030,9 +2030,9 @@ spa_load_verify_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 	size_t size = BP_GET_PSIZE(bp);
 
 	mutex_enter(&spa->spa_scrub_lock);
-	while (spa->spa_load_verify_ios >= spa_load_verify_maxinflight)
+	while (spa->spa_scrub_inflight >= spa_load_verify_maxinflight)
 		cv_wait(&spa->spa_scrub_io_cv, &spa->spa_scrub_lock);
-	spa->spa_load_verify_ios++;
+	spa->spa_scrub_inflight++;
 	mutex_exit(&spa->spa_scrub_lock);
 
 	zio_nowait(zio_read(rio, spa, bp, abd_alloc_for_io(size, B_FALSE), size,

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1892,7 +1892,6 @@ spa_init(int mode)
 	zpool_feature_init();
 	spa_config_load();
 	l2arc_start();
-	scan_init();
 	qat_init();
 }
 
@@ -1916,7 +1915,6 @@ spa_fini(void)
 	unique_fini();
 	refcount_fini();
 	fm_fini();
-	scan_fini();
 	qat_fini();
 
 	avl_destroy(&spa_namespace_avl);
@@ -2018,7 +2016,6 @@ spa_scan_stat_init(spa_t *spa)
 		spa->spa_scan_pass_scrub_pause = 0;
 	spa->spa_scan_pass_scrub_spent_paused = 0;
 	spa->spa_scan_pass_exam = 0;
-	spa->spa_scan_pass_issued = 0;
 	vdev_scan_stat_init(spa->spa_root_vdev);
 }
 
@@ -2036,21 +2033,18 @@ spa_scan_get_stats(spa_t *spa, pool_scan_stat_t *ps)
 
 	/* data stored on disk */
 	ps->pss_func = scn->scn_phys.scn_func;
-	ps->pss_state = scn->scn_phys.scn_state;
 	ps->pss_start_time = scn->scn_phys.scn_start_time;
 	ps->pss_end_time = scn->scn_phys.scn_end_time;
 	ps->pss_to_examine = scn->scn_phys.scn_to_examine;
+	ps->pss_examined = scn->scn_phys.scn_examined;
 	ps->pss_to_process = scn->scn_phys.scn_to_process;
 	ps->pss_processed = scn->scn_phys.scn_processed;
 	ps->pss_errors = scn->scn_phys.scn_errors;
-	ps->pss_examined = scn->scn_phys.scn_examined;
-	ps->pss_issued =
-	    scn->scn_issued_before_pass + spa->spa_scan_pass_issued;
+	ps->pss_state = scn->scn_phys.scn_state;
 
 	/* data not stored on disk */
 	ps->pss_pass_start = spa->spa_scan_pass_start;
 	ps->pss_pass_exam = spa->spa_scan_pass_exam;
-	ps->pss_pass_issued = spa->spa_scan_pass_issued;
 	ps->pss_pass_scrub_pause = spa->spa_scan_pass_scrub_pause;
 	ps->pss_pass_scrub_spent_paused = spa->spa_scan_pass_scrub_spent_paused;
 

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -160,7 +160,7 @@ txg_fini(dsl_pool_t *dp)
 	tx_state_t *tx = &dp->dp_tx;
 	int c;
 
-	ASSERT(tx->tx_threads == 0);
+	ASSERT0(tx->tx_threads);
 
 	mutex_destroy(&tx->tx_sync_lock);
 
@@ -201,7 +201,7 @@ txg_sync_start(dsl_pool_t *dp)
 
 	dprintf("pool %p\n", dp);
 
-	ASSERT(tx->tx_threads == 0);
+	ASSERT0(tx->tx_threads);
 
 	tx->tx_threads = 2;
 
@@ -263,7 +263,7 @@ txg_sync_stop(dsl_pool_t *dp)
 	/*
 	 * Finish off any work in progress.
 	 */
-	ASSERT(tx->tx_threads == 2);
+	ASSERT3U(tx->tx_threads, ==, 2);
 
 	/*
 	 * We need to ensure that we've vacated the deferred space_maps.
@@ -275,7 +275,7 @@ txg_sync_stop(dsl_pool_t *dp)
 	 */
 	mutex_enter(&tx->tx_sync_lock);
 
-	ASSERT(tx->tx_threads == 2);
+	ASSERT3U(tx->tx_threads, ==, 2);
 
 	tx->tx_exiting = 1;
 
@@ -648,7 +648,7 @@ txg_wait_synced(dsl_pool_t *dp, uint64_t txg)
 	ASSERT(!dsl_pool_config_held(dp));
 
 	mutex_enter(&tx->tx_sync_lock);
-	ASSERT(tx->tx_threads == 2);
+	ASSERT3U(tx->tx_threads, ==, 2);
 	if (txg == 0)
 		txg = tx->tx_open_txg + TXG_DEFER_SIZE;
 	if (tx->tx_sync_txg_waiting < txg)
@@ -673,7 +673,7 @@ txg_wait_open(dsl_pool_t *dp, uint64_t txg)
 	ASSERT(!dsl_pool_config_held(dp));
 
 	mutex_enter(&tx->tx_sync_lock);
-	ASSERT(tx->tx_threads == 2);
+	ASSERT3U(tx->tx_threads, ==, 2);
 	if (txg == 0)
 		txg = tx->tx_open_txg + 1;
 	if (tx->tx_quiesce_txg_waiting < txg)

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -360,7 +360,6 @@ vdev_alloc_common(spa_t *spa, uint_t id, uint64_t guid, vdev_ops_t *ops)
 	mutex_init(&vd->vdev_stat_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&vd->vdev_probe_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&vd->vdev_queue_lock, NULL, MUTEX_DEFAULT, NULL);
-	mutex_init(&vd->vdev_scan_io_queue_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	for (int t = 0; t < DTL_TYPES; t++) {
 		vd->vdev_dtl[t] = range_tree_create(NULL, NULL,
@@ -649,18 +648,6 @@ vdev_free(vdev_t *vd)
 	spa_t *spa = vd->vdev_spa;
 
 	/*
-	 * Scan queues are normally destroyed at the end of a scan. If the
-	 * queue exists here, that implies the vdev is being removed while
-	 * the scan is still running.
-	 */
-	if (vd->vdev_scan_io_queue != NULL) {
-		mutex_enter(&vd->vdev_scan_io_queue_lock);
-		dsl_scan_io_queue_destroy(vd->vdev_scan_io_queue);
-		vd->vdev_scan_io_queue = NULL;
-		mutex_exit(&vd->vdev_scan_io_queue_lock);
-	}
-
-	/*
 	 * vdev_free() implies closing the vdev first.  This is simpler than
 	 * trying to ensure complicated semantics for all callers.
 	 */
@@ -736,7 +723,6 @@ vdev_free(vdev_t *vd)
 	mutex_destroy(&vd->vdev_dtl_lock);
 	mutex_destroy(&vd->vdev_stat_lock);
 	mutex_destroy(&vd->vdev_probe_lock);
-	mutex_destroy(&vd->vdev_scan_io_queue_lock);
 
 	zfs_ratelimit_fini(&vd->vdev_delay_rl);
 	zfs_ratelimit_fini(&vd->vdev_checksum_rl);
@@ -814,8 +800,6 @@ vdev_top_transfer(vdev_t *svd, vdev_t *tvd)
 
 	tvd->vdev_islog = svd->vdev_islog;
 	svd->vdev_islog = 0;
-
-	dsl_scan_io_queue_vdev_xfer(svd, tvd);
 }
 
 static void

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -169,7 +169,7 @@ int zfs_vdev_async_write_active_max_dirty_percent = 60;
  * we include spans of optional I/Os to aid aggregation at the disk even when
  * they aren't able to help us aggregate at this level.
  */
-int zfs_vdev_aggregation_limit = 1 << 20;
+int zfs_vdev_aggregation_limit = SPA_OLD_MAXBLOCKSIZE;
 int zfs_vdev_read_gap_limit = 32 << 10;
 int zfs_vdev_write_gap_limit = 4 << 10;
 

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -1070,7 +1070,7 @@ zap_join_key(objset_t *os, uint64_t fromobj, uint64_t intoobj,
 		}
 		err = zap_add(os, intoobj, za.za_name,
 		    8, 1, &value, tx);
-		if (err != 0)
+		if (err)
 			break;
 	}
 	zap_cursor_fini(&zc);

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -2071,8 +2071,6 @@ zil_process_commit_list(zilog_t *zilog)
 				else
 					list_insert_tail(&lwb->lwb_itxs, itx);
 			} else {
-				ASSERT3P(lwb, ==, NULL);
-
 				if (lrc->lrc_txtype == TX_COMMIT) {
 					zil_commit_waiter_link_nolwb(
 					    itx->itx_private, &nolwb_waiters);

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -2079,9 +2079,6 @@ zil_process_commit_list(zilog_t *zilog)
 				list_insert_tail(&nolwb_itxs, itx);
 			}
 		} else {
-			ASSERT3B(synced, ==, B_TRUE);
-			ASSERT3B(frozen, ==, B_FALSE);
-
 			/*
 			 * If this is a commit itx, then there will be a
 			 * thread that is either: already waiting for

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -44,30 +44,51 @@
 #include <sys/abd.h>
 
 /*
- * The zfs intent log (ZIL) saves transaction records of system calls
- * that change the file system in memory with enough information
- * to be able to replay them. These are stored in memory until
- * either the DMU transaction group (txg) commits them to the stable pool
- * and they can be discarded, or they are flushed to the stable log
- * (also in the pool) due to a fsync, O_DSYNC or other synchronous
- * requirement. In the event of a panic or power fail then those log
- * records (transactions) are replayed.
+ * The ZFS Intent Log (ZIL) saves "transaction records" (itxs) of system
+ * calls that change the file system. Each itx has enough information to
+ * be able to replay them after a system crash, power loss, or
+ * equivalent failure mode. These are stored in memory until either:
  *
- * There is one ZIL per file system. Its on-disk (pool) format consists
- * of 3 parts:
+ *   1. they are committed to the pool by the DMU transaction group
+ *      (txg), at which point they can be discarded; or
+ *   2. they are committed to the on-disk ZIL for the dataset being
+ *      modified (e.g. due to an fsync, O_DSYNC, or other synchronous
+ *      requirement).
  *
- * 	- ZIL header
- * 	- ZIL blocks
- * 	- ZIL records
+ * In the event of a crash or power loss, the itxs contained by each
+ * dataset's on-disk ZIL will be replayed when that dataset is first
+ * instantianted (e.g. if the dataset is a normal fileystem, when it is
+ * first mounted).
  *
- * A log record holds a system call transaction. Log blocks can
- * hold many log records and the blocks are chained together.
- * Each ZIL block contains a block pointer (blkptr_t) to the next
- * ZIL block in the chain. The ZIL header points to the first
- * block in the chain. Note there is not a fixed place in the pool
- * to hold blocks. They are dynamically allocated and freed as
- * needed from the blocks available. Figure X shows the ZIL structure:
+ * As hinted at above, there is one ZIL per dataset (both the in-memory
+ * representation, and the on-disk representation). The on-disk format
+ * consists of 3 parts:
+ *
+ * 	- a single, per-dataset, ZIL header; which points to a chain of
+ * 	- zero or more ZIL blocks; each of which contains
+ * 	- zero or more ZIL records
+ *
+ * A ZIL record holds the information necessary to replay a single
+ * system call transaction. A ZIL block can hold many ZIL records, and
+ * the blocks are chained together, similarly to a singly linked list.
+ *
+ * Each ZIL block contains a block pointer (blkptr_t) to the next ZIL
+ * block in the chain, and the ZIL header points to the first block in
+ * the chain.
+ *
+ * Note, there is not a fixed place in the pool to hold these ZIL
+ * blocks; they are dynamically allocated and freed as needed from the
+ * blocks available on the pool, though they can be preferentially
+ * allocated from a dedicated "log" vdev.
  */
+
+/*
+ * This controls the amount of time that a ZIL block (lwb) will remain
+ * "open" when it isn't "full", and it has a thread waiting for it to be
+ * committed to stable storage. Please refer to the zil_commit_waiter()
+ * function (and the comments within it) for more details.
+ */
+int zfs_commit_timeout_pct = 5;
 
 /*
  * See zil.h for more information about these fields.
@@ -110,6 +131,7 @@ int zfs_nocacheflush = 0;
 unsigned long zil_slog_bulk = 768 * 1024;
 
 static kmem_cache_t *zil_lwb_cache;
+static kmem_cache_t *zil_zcw_cache;
 
 static void zil_async_to_sync(zilog_t *zilog, uint64_t foid);
 
@@ -476,6 +498,15 @@ zil_free_log_record(zilog_t *zilog, lr_t *lrc, void *tx, uint64_t claim_txg)
 	return (0);
 }
 
+static int
+zil_lwb_vdev_compare(const void *x1, const void *x2)
+{
+	const uint64_t v1 = ((zil_vdev_node_t *)x1)->zv_vdev;
+	const uint64_t v2 = ((zil_vdev_node_t *)x2)->zv_vdev;
+
+	return (AVL_CMP(v1, v2));
+}
+
 static lwb_t *
 zil_alloc_lwb(zilog_t *zilog, blkptr_t *bp, boolean_t slog, uint64_t txg,
     boolean_t fastwrite)
@@ -487,10 +518,13 @@ zil_alloc_lwb(zilog_t *zilog, blkptr_t *bp, boolean_t slog, uint64_t txg,
 	lwb->lwb_blk = *bp;
 	lwb->lwb_fastwrite = fastwrite;
 	lwb->lwb_slog = slog;
+	lwb->lwb_state = LWB_STATE_CLOSED;
 	lwb->lwb_buf = zio_buf_alloc(BP_GET_LSIZE(bp));
 	lwb->lwb_max_txg = txg;
-	lwb->lwb_zio = NULL;
+	lwb->lwb_write_zio = NULL;
+	lwb->lwb_root_zio = NULL;
 	lwb->lwb_tx = NULL;
+	lwb->lwb_issued_timestamp = 0;
 	if (BP_GET_CHECKSUM(bp) == ZIO_CHECKSUM_ZILOG2) {
 		lwb->lwb_nused = sizeof (zil_chain_t);
 		lwb->lwb_sz = BP_GET_LSIZE(bp);
@@ -503,7 +537,62 @@ zil_alloc_lwb(zilog_t *zilog, blkptr_t *bp, boolean_t slog, uint64_t txg,
 	list_insert_tail(&zilog->zl_lwb_list, lwb);
 	mutex_exit(&zilog->zl_lock);
 
+	ASSERT(!MUTEX_HELD(&lwb->lwb_vdev_lock));
+	ASSERT(avl_is_empty(&lwb->lwb_vdev_tree));
+	ASSERT(list_is_empty(&lwb->lwb_waiters));
+	ASSERT(list_is_empty(&lwb->lwb_itxs));
+
 	return (lwb);
+}
+
+static void
+zil_free_lwb(zilog_t *zilog, lwb_t *lwb)
+{
+	ASSERT(MUTEX_HELD(&zilog->zl_lock));
+	ASSERT(!MUTEX_HELD(&lwb->lwb_vdev_lock));
+	ASSERT(list_is_empty(&lwb->lwb_waiters));
+
+	if (lwb->lwb_state == LWB_STATE_OPENED) {
+		avl_tree_t *t = &lwb->lwb_vdev_tree;
+		void *cookie = NULL;
+		zil_vdev_node_t *zv;
+		itx_t *itx;
+
+		while ((zv = avl_destroy_nodes(t, &cookie)) != NULL)
+			kmem_free(zv, sizeof (*zv));
+
+		while ((itx = list_head(&lwb->lwb_itxs)) != NULL) {
+			if (itx->itx_callback != NULL)
+				itx->itx_callback(itx->itx_callback_data);
+			list_remove(&lwb->lwb_itxs, itx);
+			zil_itx_destroy(itx);
+		}
+
+		ASSERT3P(lwb->lwb_root_zio, !=, NULL);
+		ASSERT3P(lwb->lwb_write_zio, !=, NULL);
+
+		zio_cancel(lwb->lwb_root_zio);
+		zio_cancel(lwb->lwb_write_zio);
+
+		lwb->lwb_root_zio = NULL;
+		lwb->lwb_write_zio = NULL;
+	} else {
+		ASSERT3S(lwb->lwb_state, !=, LWB_STATE_ISSUED);
+	}
+
+	ASSERT(avl_is_empty(&lwb->lwb_vdev_tree));
+	ASSERT(list_is_empty(&lwb->lwb_itxs));
+	ASSERT3P(lwb->lwb_write_zio, ==, NULL);
+	ASSERT3P(lwb->lwb_root_zio, ==, NULL);
+
+	/*
+	 * Clear the zilog's field to indicate this lwb is no longer
+	 * valid, and prevent use-after-free errors.
+	 */
+	if (zilog->zl_last_lwb_opened == lwb)
+		zilog->zl_last_lwb_opened = NULL;
+
+	kmem_cache_free(zil_lwb_cache, lwb);
 }
 
 /*
@@ -516,12 +605,16 @@ zilog_dirty(zilog_t *zilog, uint64_t txg)
 	dsl_pool_t *dp = zilog->zl_dmu_pool;
 	dsl_dataset_t *ds = dmu_objset_ds(zilog->zl_os);
 
+	ASSERT(spa_writeable(zilog->zl_spa));
+
 	if (ds->ds_is_snapshot)
 		panic("dirtying snapshot!");
 
 	if (txg_list_add(&dp->dp_dirty_zilogs, zilog, txg)) {
 		/* up the hold count until we can be written out */
 		dmu_buf_add_ref(ds->ds_dbuf, zilog);
+
+		zilog->zl_dirty_max_txg = MAX(txg, zilog->zl_dirty_max_txg);
 	}
 }
 
@@ -590,7 +683,7 @@ zil_create(zilog_t *zilog)
 	 */
 	if (BP_IS_HOLE(&blk) || BP_SHOULD_BYTESWAP(&blk)) {
 		tx = dmu_tx_create(zilog->zl_os);
-		VERIFY(dmu_tx_assign(tx, TXG_WAIT) == 0);
+		VERIFY0(dmu_tx_assign(tx, TXG_WAIT));
 		dsl_dataset_dirty(dmu_objset_ds(zilog->zl_os), tx);
 		txg = dmu_tx_get_txg(tx);
 
@@ -608,7 +701,7 @@ zil_create(zilog_t *zilog)
 	}
 
 	/*
-	 * Allocate a log write buffer (lwb) for the first log block.
+	 * Allocate a log write block (lwb) for the first log block.
 	 */
 	if (error == 0)
 		lwb = zil_alloc_lwb(zilog, &blk, slog, txg, fastwrite);
@@ -629,13 +722,13 @@ zil_create(zilog_t *zilog)
 }
 
 /*
- * In one tx, free all log blocks and clear the log header.
- * If keep_first is set, then we're replaying a log with no content.
- * We want to keep the first block, however, so that the first
- * synchronous transaction doesn't require a txg_wait_synced()
- * in zil_create().  We don't need to txg_wait_synced() here either
- * when keep_first is set, because both zil_create() and zil_destroy()
- * will wait for any in-progress destroys to complete.
+ * In one tx, free all log blocks and clear the log header. If keep_first
+ * is set, then we're replaying a log with no content. We want to keep the
+ * first block, however, so that the first synchronous transaction doesn't
+ * require a txg_wait_synced() in zil_create(). We don't need to
+ * txg_wait_synced() here either when keep_first is set, because both
+ * zil_create() and zil_destroy() will wait for any in-progress destroys
+ * to complete.
  */
 void
 zil_destroy(zilog_t *zilog, boolean_t keep_first)
@@ -656,7 +749,7 @@ zil_destroy(zilog_t *zilog, boolean_t keep_first)
 		return;
 
 	tx = dmu_tx_create(zilog->zl_os);
-	VERIFY(dmu_tx_assign(tx, TXG_WAIT) == 0);
+	VERIFY0(dmu_tx_assign(tx, TXG_WAIT));
 	dsl_dataset_dirty(dmu_objset_ds(zilog->zl_os), tx);
 	txg = dmu_tx_get_txg(tx);
 
@@ -670,15 +763,15 @@ zil_destroy(zilog_t *zilog, boolean_t keep_first)
 		ASSERT(zh->zh_claim_txg == 0);
 		VERIFY(!keep_first);
 		while ((lwb = list_head(&zilog->zl_lwb_list)) != NULL) {
-			ASSERT(lwb->lwb_zio == NULL);
 			if (lwb->lwb_fastwrite)
 				metaslab_fastwrite_unmark(zilog->zl_spa,
 				    &lwb->lwb_blk);
+
 			list_remove(&zilog->zl_lwb_list, lwb);
 			if (lwb->lwb_buf != NULL)
 				zio_buf_free(lwb->lwb_buf, lwb->lwb_sz);
-			zio_free_zil(zilog->zl_spa, txg, &lwb->lwb_blk);
-			kmem_cache_free(zil_lwb_cache, lwb);
+			zio_free(zilog->zl_spa, txg, &lwb->lwb_blk);
+			zil_free_lwb(zilog, lwb);
 		}
 	} else if (!keep_first) {
 		zil_destroy_sync(zilog, tx);
@@ -820,19 +913,64 @@ zil_check_log_chain(dsl_pool_t *dp, dsl_dataset_t *ds, void *tx)
 	return ((error == ECKSUM || error == ENOENT) ? 0 : error);
 }
 
-static int
-zil_vdev_compare(const void *x1, const void *x2)
+/*
+ * When an itx is "skipped", this function is used to properly mark the
+ * waiter as "done, and signal any thread(s) waiting on it. An itx can
+ * be skipped (and not committed to an lwb) for a variety of reasons,
+ * one of them being that the itx was committed via spa_sync(), prior to
+ * it being committed to an lwb; this can happen if a thread calling
+ * zil_commit() is racing with spa_sync().
+ */
+static void
+zil_commit_waiter_skip(zil_commit_waiter_t *zcw)
 {
-	const uint64_t v1 = ((zil_vdev_node_t *)x1)->zv_vdev;
-	const uint64_t v2 = ((zil_vdev_node_t *)x2)->zv_vdev;
+	mutex_enter(&zcw->zcw_lock);
+	ASSERT3B(zcw->zcw_done, ==, B_FALSE);
+	zcw->zcw_done = B_TRUE;
+	cv_broadcast(&zcw->zcw_cv);
+	mutex_exit(&zcw->zcw_lock);
+}
 
-	return (AVL_CMP(v1, v2));
+/*
+ * This function is used when the given waiter is to be linked into an
+ * lwb's "lwb_waiter" list; i.e. when the itx is committed to the lwb.
+ * At this point, the waiter will no longer be referenced by the itx,
+ * and instead, will be referenced by the lwb.
+ */
+static void
+zil_commit_waiter_link_lwb(zil_commit_waiter_t *zcw, lwb_t *lwb)
+{
+	mutex_enter(&zcw->zcw_lock);
+	ASSERT(!list_link_active(&zcw->zcw_node));
+	ASSERT3P(zcw->zcw_lwb, ==, NULL);
+	ASSERT3P(lwb, !=, NULL);
+	ASSERT(lwb->lwb_state == LWB_STATE_OPENED ||
+	    lwb->lwb_state == LWB_STATE_ISSUED);
+
+	list_insert_tail(&lwb->lwb_waiters, zcw);
+	zcw->zcw_lwb = lwb;
+	mutex_exit(&zcw->zcw_lock);
+}
+
+/*
+ * This function is used when zio_alloc_zil() fails to allocate a ZIL
+ * block, and the given waiter must be linked to the "nolwb waiters"
+ * list inside of zil_process_commit_list().
+ */
+static void
+zil_commit_waiter_link_nolwb(zil_commit_waiter_t *zcw, list_t *nolwb)
+{
+	mutex_enter(&zcw->zcw_lock);
+	ASSERT(!list_link_active(&zcw->zcw_node));
+	ASSERT3P(zcw->zcw_lwb, ==, NULL);
+	list_insert_tail(nolwb, zcw);
+	mutex_exit(&zcw->zcw_lock);
 }
 
 void
-zil_add_block(zilog_t *zilog, const blkptr_t *bp)
+zil_lwb_add_block(lwb_t *lwb, const blkptr_t *bp)
 {
-	avl_tree_t *t = &zilog->zl_vdev_tree;
+	avl_tree_t *t = &lwb->lwb_vdev_tree;
 	avl_index_t where;
 	zil_vdev_node_t *zv, zvsearch;
 	int ndvas = BP_GET_NDVAS(bp);
@@ -841,14 +979,7 @@ zil_add_block(zilog_t *zilog, const blkptr_t *bp)
 	if (zfs_nocacheflush)
 		return;
 
-	ASSERT(zilog->zl_writer);
-
-	/*
-	 * Even though we're zl_writer, we still need a lock because the
-	 * zl_get_data() callbacks may have dmu_sync() done callbacks
-	 * that will run concurrently.
-	 */
-	mutex_enter(&zilog->zl_vdev_lock);
+	mutex_enter(&lwb->lwb_vdev_lock);
 	for (i = 0; i < ndvas; i++) {
 		zvsearch.zv_vdev = DVA_GET_VDEV(&bp->blk_dva[i]);
 		if (avl_find(t, &zvsearch, &where) == NULL) {
@@ -857,80 +988,91 @@ zil_add_block(zilog_t *zilog, const blkptr_t *bp)
 			avl_insert(t, zv, where);
 		}
 	}
-	mutex_exit(&zilog->zl_vdev_lock);
+	mutex_exit(&lwb->lwb_vdev_lock);
 }
 
-static void
-zil_flush_vdevs(zilog_t *zilog)
+void
+zil_lwb_add_txg(lwb_t *lwb, uint64_t txg)
 {
-	spa_t *spa = zilog->zl_spa;
-	avl_tree_t *t = &zilog->zl_vdev_tree;
-	void *cookie = NULL;
-	zil_vdev_node_t *zv;
-	zio_t *zio;
-
-	ASSERT(zilog->zl_writer);
-
-	/*
-	 * We don't need zl_vdev_lock here because we're the zl_writer,
-	 * and all zl_get_data() callbacks are done.
-	 */
-	if (avl_numnodes(t) == 0)
-		return;
-
-	spa_config_enter(spa, SCL_STATE, FTAG, RW_READER);
-
-	zio = zio_root(spa, NULL, NULL, ZIO_FLAG_CANFAIL);
-
-	while ((zv = avl_destroy_nodes(t, &cookie)) != NULL) {
-		vdev_t *vd = vdev_lookup_top(spa, zv->zv_vdev);
-		if (vd != NULL)
-			zio_flush(zio, vd);
-		kmem_free(zv, sizeof (*zv));
-	}
-
-	/*
-	 * Wait for all the flushes to complete.  Not all devices actually
-	 * support the DKIOCFLUSHWRITECACHE ioctl, so it's OK if it fails.
-	 */
-	(void) zio_wait(zio);
-
-	spa_config_exit(spa, SCL_STATE, FTAG);
+	lwb->lwb_max_txg = MAX(lwb->lwb_max_txg, txg);
 }
 
 /*
- * Function called when a log block write completes
+ * This function is a called after all VDEVs associated with a given lwb
+ * write have completed their DKIOCFLUSHWRITECACHE command; or as soon
+ * as the lwb write completes, if "zfs_nocacheflush" is set.
+ *
+ * The intention is for this function to be called as soon as the
+ * contents of an lwb are considered "stable" on disk, and will survive
+ * any sudden loss of power. At this point, any threads waiting for the
+ * lwb to reach this state are signalled, and the "waiter" structures
+ * are marked "done".
  */
 static void
-zil_lwb_write_done(zio_t *zio)
+zil_lwb_flush_vdevs_done(zio_t *zio)
 {
 	lwb_t *lwb = zio->io_private;
 	zilog_t *zilog = lwb->lwb_zilog;
 	dmu_tx_t *tx = lwb->lwb_tx;
+	zil_commit_waiter_t *zcw;
+	itx_t *itx;
 
-	ASSERT(BP_GET_COMPRESS(zio->io_bp) == ZIO_COMPRESS_OFF);
-	ASSERT(BP_GET_TYPE(zio->io_bp) == DMU_OT_INTENT_LOG);
-	ASSERT(BP_GET_LEVEL(zio->io_bp) == 0);
-	ASSERT(BP_GET_BYTEORDER(zio->io_bp) == ZFS_HOST_BYTEORDER);
-	ASSERT(!BP_IS_GANG(zio->io_bp));
-	ASSERT(!BP_IS_HOLE(zio->io_bp));
-	ASSERT(BP_GET_FILL(zio->io_bp) == 0);
+	spa_config_exit(zilog->zl_spa, SCL_STATE, lwb);
+
+	zio_buf_free(lwb->lwb_buf, lwb->lwb_sz);
+
+	mutex_enter(&zilog->zl_lock);
 
 	/*
-	 * Ensure the lwb buffer pointer is cleared before releasing
-	 * the txg. If we have had an allocation failure and
-	 * the txg is waiting to sync then we want want zil_sync()
-	 * to remove the lwb so that it's not picked up as the next new
-	 * one in zil_commit_writer(). zil_sync() will only remove
-	 * the lwb if lwb_buf is null.
+	 * Ensure the lwb buffer pointer is cleared before releasing the
+	 * txg. If we have had an allocation failure and the txg is
+	 * waiting to sync then we want zil_sync() to remove the lwb so
+	 * that it's not picked up as the next new one in
+	 * zil_process_commit_list(). zil_sync() will only remove the
+	 * lwb if lwb_buf is null.
 	 */
-	abd_put(zio->io_abd);
-	zio_buf_free(lwb->lwb_buf, lwb->lwb_sz);
-	mutex_enter(&zilog->zl_lock);
-	lwb->lwb_zio = NULL;
-	lwb->lwb_fastwrite = FALSE;
 	lwb->lwb_buf = NULL;
 	lwb->lwb_tx = NULL;
+
+	ASSERT3U(lwb->lwb_issued_timestamp, >, 0);
+	zilog->zl_last_lwb_latency = gethrtime() - lwb->lwb_issued_timestamp;
+
+	lwb->lwb_root_zio = NULL;
+	lwb->lwb_state = LWB_STATE_DONE;
+
+	if (zilog->zl_last_lwb_opened == lwb) {
+		/*
+		 * Remember the highest committed log sequence number
+		 * for ztest. We only update this value when all the log
+		 * writes succeeded, because ztest wants to ASSERT that
+		 * it got the whole log chain.
+		 */
+		zilog->zl_commit_lr_seq = zilog->zl_lr_seq;
+	}
+
+	while ((itx = list_head(&lwb->lwb_itxs)) != NULL) {
+		list_remove(&lwb->lwb_itxs, itx);
+		zil_itx_destroy(itx);
+	}
+
+	while ((zcw = list_head(&lwb->lwb_waiters)) != NULL) {
+		mutex_enter(&zcw->zcw_lock);
+
+		ASSERT(list_link_active(&zcw->zcw_node));
+		list_remove(&lwb->lwb_waiters, zcw);
+
+		ASSERT3P(zcw->zcw_lwb, ==, lwb);
+		zcw->zcw_lwb = NULL;
+
+		zcw->zcw_zio_error = zio->io_error;
+
+		ASSERT3B(zcw->zcw_done, ==, B_FALSE);
+		zcw->zcw_done = B_TRUE;
+		cv_broadcast(&zcw->zcw_cv);
+
+		mutex_exit(&zcw->zcw_lock);
+	}
+
 	mutex_exit(&zilog->zl_lock);
 
 	/*
@@ -942,43 +1084,150 @@ zil_lwb_write_done(zio_t *zio)
 }
 
 /*
- * Initialize the io for a log block.
+ * This is called when an lwb write completes. This means, this specific
+ * lwb was written to disk, and all dependent lwb have also been
+ * written to disk.
+ *
+ * At this point, a DKIOCFLUSHWRITECACHE command hasn't been issued to
+ * the VDEVs involved in writing out this specific lwb. The lwb will be
+ * "done" once zil_lwb_flush_vdevs_done() is called, which occurs in the
+ * zio completion callback for the lwb's root zio.
  */
 static void
-zil_lwb_write_init(zilog_t *zilog, lwb_t *lwb)
+zil_lwb_write_done(zio_t *zio)
+{
+	lwb_t *lwb = zio->io_private;
+	spa_t *spa = zio->io_spa;
+	zilog_t *zilog = lwb->lwb_zilog;
+	avl_tree_t *t = &lwb->lwb_vdev_tree;
+	void *cookie = NULL;
+	zil_vdev_node_t *zv;
+
+	ASSERT3S(spa_config_held(spa, SCL_STATE, RW_READER), !=, 0);
+
+	ASSERT(BP_GET_COMPRESS(zio->io_bp) == ZIO_COMPRESS_OFF);
+	ASSERT(BP_GET_TYPE(zio->io_bp) == DMU_OT_INTENT_LOG);
+	ASSERT(BP_GET_LEVEL(zio->io_bp) == 0);
+	ASSERT(BP_GET_BYTEORDER(zio->io_bp) == ZFS_HOST_BYTEORDER);
+	ASSERT(!BP_IS_GANG(zio->io_bp));
+	ASSERT(!BP_IS_HOLE(zio->io_bp));
+	ASSERT(BP_GET_FILL(zio->io_bp) == 0);
+
+	abd_put(zio->io_abd);
+
+	ASSERT3S(lwb->lwb_state, ==, LWB_STATE_ISSUED);
+
+	mutex_enter(&zilog->zl_lock);
+	lwb->lwb_write_zio = NULL;
+	lwb->lwb_fastwrite = FALSE;
+	mutex_exit(&zilog->zl_lock);
+
+	if (avl_numnodes(t) == 0)
+		return;
+
+	/*
+	 * If there was an IO error, we're not going to call zio_flush()
+	 * on these vdevs, so we simply empty the tree and free the
+	 * nodes. We avoid calling zio_flush() since there isn't any
+	 * good reason for doing so, after the lwb block failed to be
+	 * written out.
+	 */
+	if (zio->io_error != 0) {
+		while ((zv = avl_destroy_nodes(t, &cookie)) != NULL)
+			kmem_free(zv, sizeof (*zv));
+		return;
+	}
+
+	while ((zv = avl_destroy_nodes(t, &cookie)) != NULL) {
+		vdev_t *vd = vdev_lookup_top(spa, zv->zv_vdev);
+		if (vd != NULL)
+			zio_flush(lwb->lwb_root_zio, vd);
+		kmem_free(zv, sizeof (*zv));
+	}
+}
+
+/*
+ * This function's purpose is to "open" an lwb such that it is ready to
+ * accept new itxs being committed to it. To do this, the lwb's zio
+ * structures are created, and linked to the lwb. This function is
+ * idempotent; if the passed in lwb has already been opened, this
+ * function is essentially a no-op.
+ */
+static void
+zil_lwb_write_open(zilog_t *zilog, lwb_t *lwb)
 {
 	zbookmark_phys_t zb;
 	zio_priority_t prio;
+
+	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT3P(lwb, !=, NULL);
+	EQUIV(lwb->lwb_root_zio == NULL, lwb->lwb_state == LWB_STATE_CLOSED);
+	EQUIV(lwb->lwb_root_zio != NULL, lwb->lwb_state == LWB_STATE_OPENED);
 
 	SET_BOOKMARK(&zb, lwb->lwb_blk.blk_cksum.zc_word[ZIL_ZC_OBJSET],
 	    ZB_ZIL_OBJECT, ZB_ZIL_LEVEL,
 	    lwb->lwb_blk.blk_cksum.zc_word[ZIL_ZC_SEQ]);
 
-	if (zilog->zl_root_zio == NULL) {
-		zilog->zl_root_zio = zio_root(zilog->zl_spa, NULL, NULL,
-		    ZIO_FLAG_CANFAIL);
-	}
-
 	/* Lock so zil_sync() doesn't fastwrite_unmark after zio is created */
 	mutex_enter(&zilog->zl_lock);
-	if (lwb->lwb_zio == NULL) {
+	if (lwb->lwb_root_zio == NULL) {
 		abd_t *lwb_abd = abd_get_from_buf(lwb->lwb_buf,
 		    BP_GET_LSIZE(&lwb->lwb_blk));
+
 		if (!lwb->lwb_fastwrite) {
 			metaslab_fastwrite_mark(zilog->zl_spa, &lwb->lwb_blk);
 			lwb->lwb_fastwrite = 1;
 		}
+
 		if (!lwb->lwb_slog || zilog->zl_cur_used <= zil_slog_bulk)
 			prio = ZIO_PRIORITY_SYNC_WRITE;
 		else
 			prio = ZIO_PRIORITY_ASYNC_WRITE;
-		lwb->lwb_zio = zio_rewrite(zilog->zl_root_zio, zilog->zl_spa,
-		    0, &lwb->lwb_blk, lwb_abd, BP_GET_LSIZE(&lwb->lwb_blk),
-		    zil_lwb_write_done, lwb, prio,
-		    ZIO_FLAG_CANFAIL | ZIO_FLAG_DONT_PROPAGATE |
+
+		lwb->lwb_root_zio = zio_root(zilog->zl_spa,
+		    zil_lwb_flush_vdevs_done, lwb, ZIO_FLAG_CANFAIL);
+		ASSERT3P(lwb->lwb_root_zio, !=, NULL);
+
+		lwb->lwb_write_zio = zio_rewrite(lwb->lwb_root_zio,
+		    zilog->zl_spa, 0, &lwb->lwb_blk, lwb_abd,
+		    BP_GET_LSIZE(&lwb->lwb_blk), zil_lwb_write_done, lwb,
+		    prio, ZIO_FLAG_CANFAIL | ZIO_FLAG_DONT_PROPAGATE |
 		    ZIO_FLAG_FASTWRITE, &zb);
+		ASSERT3P(lwb->lwb_write_zio, !=, NULL);
+
+		lwb->lwb_state = LWB_STATE_OPENED;
+
+		/*
+		 * The zilog's "zl_last_lwb_opened" field is used to
+		 * build the lwb/zio dependency chain, which is used to
+		 * preserve the ordering of lwb completions that is
+		 * required by the semantics of the ZIL. Each new lwb
+		 * zio becomes a parent of the "previous" lwb zio, such
+		 * that the new lwb's zio cannot complete until the
+		 * "previous" lwb's zio completes.
+		 *
+		 * This is required by the semantics of zil_commit();
+		 * the commit waiters attached to the lwbs will be woken
+		 * in the lwb zio's completion callback, so this zio
+		 * dependency graph ensures the waiters are woken in the
+		 * correct order (the same order the lwbs were created).
+		 */
+		lwb_t *last_lwb_opened = zilog->zl_last_lwb_opened;
+		if (last_lwb_opened != NULL &&
+		    last_lwb_opened->lwb_state != LWB_STATE_DONE) {
+			ASSERT(last_lwb_opened->lwb_state == LWB_STATE_OPENED ||
+			    last_lwb_opened->lwb_state == LWB_STATE_ISSUED);
+			ASSERT3P(last_lwb_opened->lwb_root_zio, !=, NULL);
+			zio_add_child(lwb->lwb_root_zio,
+			    last_lwb_opened->lwb_root_zio);
+		}
+		zilog->zl_last_lwb_opened = lwb;
 	}
 	mutex_exit(&zilog->zl_lock);
+
+	ASSERT3P(lwb->lwb_root_zio, !=, NULL);
+	ASSERT3P(lwb->lwb_write_zio, !=, NULL);
+	ASSERT3S(lwb->lwb_state, ==, LWB_STATE_OPENED);
 }
 
 /*
@@ -1000,7 +1249,7 @@ uint64_t zil_block_buckets[] = {
  * Calls are serialized.
  */
 static lwb_t *
-zil_lwb_write_start(zilog_t *zilog, lwb_t *lwb)
+zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 {
 	lwb_t *nlwb = NULL;
 	zil_chain_t *zilc;
@@ -1011,6 +1260,11 @@ zil_lwb_write_start(zilog_t *zilog, lwb_t *lwb)
 	uint64_t zil_blksz, wsz;
 	int i, error;
 	boolean_t slog;
+
+	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT3P(lwb->lwb_root_zio, !=, NULL);
+	ASSERT3P(lwb->lwb_write_zio, !=, NULL);
+	ASSERT3S(lwb->lwb_state, ==, LWB_STATE_OPENED);
 
 	if (BP_GET_CHECKSUM(&lwb->lwb_blk) == ZIO_CHECKSUM_ZILOG2) {
 		zilc = (zil_chain_t *)lwb->lwb_buf;
@@ -1031,6 +1285,7 @@ zil_lwb_write_start(zilog_t *zilog, lwb_t *lwb)
 	 * We dirty the dataset to ensure that zil_sync() will be called
 	 * to clean up in the event of allocation failure or I/O failure.
 	 */
+
 	tx = dmu_tx_create(zilog->zl_os);
 
 	/*
@@ -1097,19 +1352,16 @@ zil_lwb_write_start(zilog_t *zilog, lwb_t *lwb)
 		bp->blk_cksum.zc_word[ZIL_ZC_SEQ]++;
 
 		/*
-		 * Allocate a new log write buffer (lwb).
+		 * Allocate a new log write block (lwb).
 		 */
 		nlwb = zil_alloc_lwb(zilog, bp, slog, txg, TRUE);
-
-		/* Record the block for later vdev flushing */
-		zil_add_block(zilog, &lwb->lwb_blk);
 	}
 
 	if (BP_GET_CHECKSUM(&lwb->lwb_blk) == ZIO_CHECKSUM_ZILOG2) {
 		/* For Slim ZIL only write what is used. */
 		wsz = P2ROUNDUP_TYPED(lwb->lwb_nused, ZIL_MIN_BLKSZ, uint64_t);
 		ASSERT3U(wsz, <=, lwb->lwb_sz);
-		zio_shrink(lwb->lwb_zio, wsz);
+		zio_shrink(lwb->lwb_write_zio, wsz);
 
 	} else {
 		wsz = lwb->lwb_sz;
@@ -1124,7 +1376,14 @@ zil_lwb_write_start(zilog_t *zilog, lwb_t *lwb)
 	 */
 	bzero(lwb->lwb_buf + lwb->lwb_nused, wsz - lwb->lwb_nused);
 
-	zio_nowait(lwb->lwb_zio); /* Kick off the write for the old log block */
+	spa_config_enter(zilog->zl_spa, SCL_STATE, lwb, RW_READER);
+
+	zil_lwb_add_block(lwb, &lwb->lwb_blk);
+	lwb->lwb_issued_timestamp = gethrtime();
+	lwb->lwb_state = LWB_STATE_ISSUED;
+
+	zio_nowait(lwb->lwb_root_zio);
+	zio_nowait(lwb->lwb_write_zio);
 
 	/*
 	 * If there was an allocation failure then nlwb will be null which
@@ -1141,13 +1400,43 @@ zil_lwb_commit(zilog_t *zilog, itx_t *itx, lwb_t *lwb)
 	char *lr_buf;
 	uint64_t dlen, dnow, lwb_sp, reclen, txg;
 
-	if (lwb == NULL)
-		return (NULL);
+	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT3P(lwb, !=, NULL);
+	ASSERT3P(lwb->lwb_buf, !=, NULL);
 
-	ASSERT(lwb->lwb_buf != NULL);
+	zil_lwb_write_open(zilog, lwb);
 
-	lrc = &itx->itx_lr;		/* Common log record inside itx. */
-	lrw = (lr_write_t *)lrc;	/* Write log record inside itx. */
+	lrc = &itx->itx_lr;
+	lrw = (lr_write_t *)lrc;
+
+	/*
+	 * TODO: What happens when the data for this itx is later (via
+	 * the logic further down in this function) gets split between
+	 * multiple lwb's? We want to add the itx and the waiter to that
+	 * "last" lwb for this itx, not the "first" like we're currently
+	 * doing, right? This seems bad.
+	 */
+
+	list_insert_tail(&lwb->lwb_itxs, itx);
+
+	/*
+	 * A commit itx doesn't represent any on-disk state; instead
+	 * it's simply used as a place holder on the commit list, and
+	 * provides a mechanism for attaching a "commit waiter" onto the
+	 * correct lwb (such that the waiter can be signalled upon
+	 * completion of that lwb). Thus, we don't process this itx's
+	 * log record if it's a commit itx (these itx's don't have log
+	 * records), and instead link the itx's waiter onto the lwb's
+	 * list of waiters.
+	 *
+	 * For more details, see the comment above zil_commit().
+	 */
+	if (lrc->lrc_txtype == TX_COMMIT) {
+		zil_commit_waiter_link_lwb(itx->itx_private, lwb);
+		itx->itx_private = NULL;
+		return (lwb);
+	}
+
 	if (lrc->lrc_txtype == TX_WRITE && itx->itx_wr_state == WR_NEED_COPY) {
 		dlen = P2ROUNDUP_TYPED(
 		    lrw->lr_length, sizeof (uint64_t), uint64_t);
@@ -1158,7 +1447,7 @@ zil_lwb_commit(zilog_t *zilog, itx_t *itx, lwb_t *lwb)
 	zilog->zl_cur_used += (reclen + dlen);
 	txg = lrc->lrc_txg;
 
-	zil_lwb_write_init(zilog, lwb);
+	ASSERT3U(zilog->zl_cur_used, <, UINT64_MAX - (reclen + dlen));
 
 cont:
 	/*
@@ -1169,10 +1458,10 @@ cont:
 	if (reclen > lwb_sp || (reclen + dlen > lwb_sp &&
 	    lwb_sp < ZIL_MAX_WASTE_SPACE && (dlen % ZIL_MAX_LOG_DATA == 0 ||
 	    lwb_sp < reclen + dlen % ZIL_MAX_LOG_DATA))) {
-		lwb = zil_lwb_write_start(zilog, lwb);
+		lwb = zil_lwb_write_issue(zilog, lwb);
 		if (lwb == NULL)
 			return (NULL);
-		zil_lwb_write_init(zilog, lwb);
+		zil_lwb_write_open(zilog, lwb);
 		ASSERT(LWB_EMPTY(lwb));
 		lwb_sp = lwb->lwb_sz - lwb->lwb_nused;
 		ASSERT3U(reclen + MIN(dlen, sizeof (uint64_t)), <=, lwb_sp);
@@ -1210,14 +1499,31 @@ cont:
 				ZIL_STAT_INCR(zil_itx_needcopy_bytes,
 				    lrw->lr_length);
 			} else {
-				ASSERT(itx->itx_wr_state == WR_INDIRECT);
+				ASSERT3S(itx->itx_wr_state, ==, WR_INDIRECT);
 				dbuf = NULL;
 				ZIL_STAT_BUMP(zil_itx_indirect_count);
 				ZIL_STAT_INCR(zil_itx_indirect_bytes,
 				    lrw->lr_length);
 			}
-			error = zilog->zl_get_data(
-			    itx->itx_private, lrwb, dbuf, lwb->lwb_zio);
+
+			/*
+			 * We pass in the "lwb_write_zio" rather than
+			 * "lwb_root_zio" so that the "lwb_write_zio"
+			 * becomes the parent of any zio's created by
+			 * the "zl_get_data" callback. The vdevs are
+			 * flushed after the "lwb_write_zio" completes,
+			 * so we want to make sure that completion
+			 * callback waits for these additional zio's,
+			 * such that the vdevs used by those zio's will
+			 * be included in the lwb's vdev tree, and those
+			 * vdevs will be properly flushed. If we passed
+			 * in "lwb_root_zio" here, then these additional
+			 * vdevs may not be flushed; e.g. if these zio's
+			 * completed after "lwb_write_zio" completed.
+			 */
+			error = zilog->zl_get_data(itx->itx_private,
+			    lrwb, dbuf, lwb, lwb->lwb_write_zio);
+
 			if (error == EIO) {
 				txg_wait_synced(zilog->zl_dmu_pool, txg);
 				return (lwb);
@@ -1236,9 +1542,11 @@ cont:
 	 * equal to the itx sequence number because not all transactions
 	 * are synchronous, and sometimes spa_sync() gets there first.
 	 */
-	lrcb->lrc_seq = ++zilog->zl_lr_seq; /* we are single threaded */
+	lrcb->lrc_seq = ++zilog->zl_lr_seq;
 	lwb->lwb_nused += reclen + dnow;
-	lwb->lwb_max_txg = MAX(lwb->lwb_max_txg, txg);
+
+	zil_lwb_add_txg(lwb, txg);
+
 	ASSERT3U(lwb->lwb_nused, <=, lwb->lwb_sz);
 	ASSERT0(P2PHASE(lwb->lwb_nused, sizeof (uint64_t)));
 
@@ -1272,6 +1580,12 @@ zil_itx_create(uint64_t txtype, size_t lrsize)
 void
 zil_itx_destroy(itx_t *itx)
 {
+	IMPLY(itx->itx_lr.lrc_txtype == TX_COMMIT, itx->itx_callback == NULL);
+	IMPLY(itx->itx_callback != NULL, itx->itx_lr.lrc_txtype != TX_COMMIT);
+
+	if (itx->itx_callback != NULL)
+		itx->itx_callback(itx->itx_callback_data);
+
 	zio_data_buf_free(itx, offsetof(itx_t, itx_lr)+itx->itx_lr.lrc_reclen);
 }
 
@@ -1290,8 +1604,28 @@ zil_itxg_clean(itxs_t *itxs)
 
 	list = &itxs->i_sync_list;
 	while ((itx = list_head(list)) != NULL) {
-		if (itx->itx_callback != NULL)
-			itx->itx_callback(itx->itx_callback_data);
+		/*
+		 * In the general case, commit itxs will not be found
+		 * here, as they'll be committed to an lwb via
+		 * zil_lwb_commit(), and free'd in that function. Having
+		 * said that, it is still possible for commit itxs to be
+		 * found here, due to the following race:
+		 *
+		 *	- a thread calls zil_commit() which assigns the
+		 *	  commit itx to a per-txg i_sync_list
+		 *	- zil_itxg_clean() is called (e.g. via spa_sync())
+		 *	  while the waiter is still on the i_sync_list
+		 *
+		 * There's nothing to prevent syncing the txg while the
+		 * waiter is on the i_sync_list. This normally doesn't
+		 * happen because spa_sync() is slower than zil_commit(),
+		 * but if zil_commit() calls txg_wait_synced() (e.g.
+		 * because zil_create() or zil_commit_writer_stall() is
+		 * called) we will hit this case.
+		 */
+		if (itx->itx_lr.lrc_txtype == TX_COMMIT)
+			zil_commit_waiter_skip(itx->itx_private);
+
 		list_remove(list, itx);
 		zil_itx_destroy(itx);
 	}
@@ -1301,9 +1635,9 @@ zil_itxg_clean(itxs_t *itxs)
 	while ((ian = avl_destroy_nodes(t, &cookie)) != NULL) {
 		list = &ian->ia_list;
 		while ((itx = list_head(list)) != NULL) {
-			if (itx->itx_callback != NULL)
-				itx->itx_callback(itx->itx_callback_data);
 			list_remove(list, itx);
+			/* commit itxs should never be on the async lists. */
+			ASSERT3U(itx->itx_lr.lrc_txtype, !=, TX_COMMIT);
 			zil_itx_destroy(itx);
 		}
 		list_destroy(list);
@@ -1363,9 +1697,9 @@ zil_remove_async(zilog_t *zilog, uint64_t oid)
 		mutex_exit(&itxg->itxg_lock);
 	}
 	while ((itx = list_head(&clean_list)) != NULL) {
-		if (itx->itx_callback != NULL)
-			itx->itx_callback(itx->itx_callback_data);
 		list_remove(&clean_list, itx);
+		/* commit itxs should never be on the async lists. */
+		ASSERT3U(itx->itx_lr.lrc_txtype, !=, TX_COMMIT);
 		zil_itx_destroy(itx);
 	}
 	list_destroy(&clean_list);
@@ -1445,7 +1779,14 @@ zil_itx_assign(zilog_t *zilog, itx_t *itx, dmu_tx_t *tx)
 	}
 
 	itx->itx_lr.lrc_txg = dmu_tx_get_txg(tx);
-	zilog_dirty(zilog, txg);
+
+	/*
+	 * We don't want to dirty the ZIL using ZILTEST_TXG, because
+	 * zil_clean() will never be called using ZILTEST_TXG. Thus, we
+	 * need to be careful to always dirty the ZIL using the "real"
+	 * TXG (not itxg_txg) even when the SPA is frozen.
+	 */
+	zilog_dirty(zilog, dmu_tx_get_txg(tx));
 	mutex_exit(&itxg->itxg_lock);
 
 	/* Release the old itxs now we've dropped the lock */
@@ -1465,6 +1806,8 @@ zil_clean(zilog_t *zilog, uint64_t synced_txg)
 {
 	itxg_t *itxg = &zilog->zl_itxg[synced_txg & TXG_MASK];
 	itxs_t *clean_me;
+
+	ASSERT3U(synced_txg, <, ZILTEST_TXG);
 
 	mutex_enter(&itxg->itxg_lock);
 	if (itxg->itxg_itxs == NULL || itxg->itxg_txg == ZILTEST_TXG) {
@@ -1492,13 +1835,16 @@ zil_clean(zilog_t *zilog, uint64_t synced_txg)
 }
 
 /*
- * Get the list of itxs to commit into zl_itx_commit_list.
+ * This function will traverse the queue of itxs that need to be
+ * committed, and move them onto the ZIL's zl_itx_commit_list.
  */
 static void
 zil_get_commit_list(zilog_t *zilog)
 {
 	uint64_t otxg, txg;
 	list_t *commit_list = &zilog->zl_itx_commit_list;
+
+	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
 
 	if (spa_freeze_txg(zilog->zl_spa) != UINT64_MAX) /* ziltest support */
 		otxg = ZILTEST_TXG;
@@ -1591,154 +1937,809 @@ zil_async_to_sync(zilog_t *zilog, uint64_t foid)
 	}
 }
 
+/*
+ * This function will prune commit itxs that are at the head of the
+ * commit list (it won't prune past the first non-commit itx), and
+ * either: a) attach them to the last lwb that's still pending
+ * completion, or b) skip them altogether.
+ *
+ * This is used as a performance optimization to prevent commit itxs
+ * from generating new lwbs when it's unnecessary to do so.
+ */
 static void
-zil_commit_writer(zilog_t *zilog)
+zil_prune_commit_list(zilog_t *zilog)
 {
-	uint64_t txg;
 	itx_t *itx;
-	lwb_t *lwb;
+
+	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+
+	while ((itx = list_head(&zilog->zl_itx_commit_list)) != NULL) {
+		lr_t *lrc = &itx->itx_lr;
+		if (lrc->lrc_txtype != TX_COMMIT)
+			break;
+
+		mutex_enter(&zilog->zl_lock);
+
+		lwb_t *last_lwb = zilog->zl_last_lwb_opened;
+		if (last_lwb == NULL || last_lwb->lwb_state == LWB_STATE_DONE) {
+			/*
+			 * All of the itxs this waiter was waiting on
+			 * must have already completed (or there were
+			 * never any itx's for it to wait on), so it's
+			 * safe to skip this waiter and mark it done.
+			 */
+			zil_commit_waiter_skip(itx->itx_private);
+		} else {
+			zil_commit_waiter_link_lwb(itx->itx_private, last_lwb);
+			itx->itx_private = NULL;
+		}
+
+		mutex_exit(&zilog->zl_lock);
+
+		list_remove(&zilog->zl_itx_commit_list, itx);
+		zil_itx_destroy(itx);
+	}
+
+	IMPLY(itx != NULL, itx->itx_lr.lrc_txtype != TX_COMMIT);
+}
+
+static void
+zil_commit_writer_stall(zilog_t *zilog)
+{
+	/*
+	 * When zio_alloc_zil() fails to allocate the next lwb block on
+	 * disk, we must call txg_wait_synced() to ensure all of the
+	 * lwbs in the zilog's zl_lwb_list are synced and then freed (in
+	 * zil_sync()), such that any subsequent ZIL writer (i.e. a call
+	 * to zil_process_commit_list()) will have to call zil_create(),
+	 * and start a new ZIL chain.
+	 *
+	 * Since zil_alloc_zil() failed, the lwb that was previously
+	 * issued does not have a pointer to the "next" lwb on disk.
+	 * Thus, if another ZIL writer thread was to allocate the "next"
+	 * on-disk lwb, that block could be leaked in the event of a
+	 * crash (because the previous lwb on-disk would not point to
+	 * it).
+	 *
+	 * We must hold the zilog's zl_writer_lock while we do this, to
+	 * ensure no new threads enter zil_process_commit_list() until
+	 * all lwb's in the zl_lwb_list have been synced and freed
+	 * (which is achieved via the txg_wait_synced() call).
+	 */
+	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	txg_wait_synced(zilog->zl_dmu_pool, 0);
+	ASSERT3P(list_tail(&zilog->zl_lwb_list), ==, NULL);
+}
+
+/*
+ * This function will traverse the commit list, creating new lwbs as
+ * needed, and committing the itxs from the commit list to these newly
+ * created lwbs. Additionally, as a new lwb is created, the previous
+ * lwb will be issued to the zio layer to be written to disk.
+ */
+static void
+zil_process_commit_list(zilog_t *zilog)
+{
 	spa_t *spa = zilog->zl_spa;
-	int error = 0;
+	list_t nolwb_itxs;
+	list_t nolwb_waiters;
+	lwb_t *lwb;
+	itx_t *itx;
 
-	ASSERT(zilog->zl_root_zio == NULL);
-
-	mutex_exit(&zilog->zl_lock);
-
-	zil_get_commit_list(zilog);
+	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
 
 	/*
 	 * Return if there's nothing to commit before we dirty the fs by
 	 * calling zil_create().
 	 */
-	if (list_head(&zilog->zl_itx_commit_list) == NULL) {
-		mutex_enter(&zilog->zl_lock);
+	if (list_head(&zilog->zl_itx_commit_list) == NULL)
 		return;
-	}
 
-	if (zilog->zl_suspend) {
-		lwb = NULL;
+	list_create(&nolwb_itxs, sizeof (itx_t), offsetof(itx_t, itx_node));
+	list_create(&nolwb_waiters, sizeof (zil_commit_waiter_t),
+	    offsetof(zil_commit_waiter_t, zcw_node));
+
+	lwb = list_tail(&zilog->zl_lwb_list);
+	if (lwb == NULL) {
+		lwb = zil_create(zilog);
 	} else {
-		lwb = list_tail(&zilog->zl_lwb_list);
-		if (lwb == NULL)
-			lwb = zil_create(zilog);
+		ASSERT3S(lwb->lwb_state, !=, LWB_STATE_ISSUED);
+		ASSERT3S(lwb->lwb_state, !=, LWB_STATE_DONE);
 	}
 
-	DTRACE_PROBE1(zil__cw1, zilog_t *, zilog);
-	for (itx = list_head(&zilog->zl_itx_commit_list); itx != NULL;
-	    itx = list_next(&zilog->zl_itx_commit_list, itx)) {
-		txg = itx->itx_lr.lrc_txg;
+	while ((itx = list_head(&zilog->zl_itx_commit_list)) != NULL) {
+		lr_t *lrc = &itx->itx_lr;
+		uint64_t txg = lrc->lrc_txg;
+
 		ASSERT3U(txg, !=, 0);
+
+		if (lrc->lrc_txtype == TX_COMMIT) {
+			DTRACE_PROBE2(zil__process__commit__itx,
+			    zilog_t *, zilog, itx_t *, itx);
+		} else {
+			DTRACE_PROBE2(zil__process__normal__itx,
+			    zilog_t *, zilog, itx_t *, itx);
+		}
+
+		list_remove(&zilog->zl_itx_commit_list, itx);
 
 		/*
 		 * This is inherently racy and may result in us writing
-		 * out a log block for a txg that was just synced. This is
-		 * ok since we'll end cleaning up that log block the next
-		 * time we call zil_sync().
+		 * out a log block for a txg that was just synced. This
+		 * is ok since we'll end cleaning up that log block the
+		 * next time we call zil_sync().
 		 */
-		if (txg > spa_last_synced_txg(spa) || txg > spa_freeze_txg(spa))
-			lwb = zil_lwb_commit(zilog, itx, lwb);
+		boolean_t synced = txg <= spa_last_synced_txg(spa);
+		boolean_t frozen = txg > spa_freeze_txg(spa);
+
+		if (!synced || frozen) {
+			if (lwb != NULL) {
+				lwb = zil_lwb_commit(zilog, itx, lwb);
+			} else {
+				ASSERT3P(lwb, ==, NULL);
+
+				if (lrc->lrc_txtype == TX_COMMIT) {
+					zil_commit_waiter_link_nolwb(
+					    itx->itx_private, &nolwb_waiters);
+				}
+
+				list_insert_tail(&nolwb_itxs, itx);
+			}
+		} else {
+			ASSERT3B(synced, ==, B_TRUE);
+			ASSERT3B(frozen, ==, B_FALSE);
+
+			/*
+			 * If this is a commit itx, then there will be a
+			 * thread that is either: already waiting for
+			 * it, or soon will be waiting.
+			 *
+			 * This itx has already been committed to disk
+			 * via spa_sync() so we don't bother committing
+			 * it to an lwb. As a result, we cannot use the
+			 * lwb zio callback to signal the waiter and
+			 * mark it as done, so we must do that here.
+			 */
+			if (lrc->lrc_txtype == TX_COMMIT)
+				zil_commit_waiter_skip(itx->itx_private);
+
+			zil_itx_destroy(itx);
+		}
 	}
-	DTRACE_PROBE1(zil__cw2, zilog_t *, zilog);
 
-	/* write the last block out */
-	if (lwb != NULL && lwb->lwb_zio != NULL)
-		lwb = zil_lwb_write_start(zilog, lwb);
+	if (lwb == NULL) {
+		/*
+		 * This indicates zio_alloc_zil() failed to allocate the
+		 * "next" lwb on-disk. When this happens, we must stall
+		 * the ZIL write pipeline; see the comment within
+		 * zil_commit_writer_stall() for more details.
+		 */
+		zil_commit_writer_stall(zilog);
 
-	zilog->zl_cur_used = 0;
+		/*
+		 * Additionally, we have to signal and mark the "nolwb"
+		 * waiters as "done" here, since without an lwb, we
+		 * can't do this via zil_lwb_flush_vdevs_done() like
+		 * normal.
+		 */
+		zil_commit_waiter_t *zcw;
+		while ((zcw = list_head(&nolwb_waiters)) != NULL) {
+			zil_commit_waiter_skip(zcw);
+			list_remove(&nolwb_waiters, zcw);
+		}
 
-	/*
-	 * Wait if necessary for the log blocks to be on stable storage.
-	 */
-	if (zilog->zl_root_zio) {
-		error = zio_wait(zilog->zl_root_zio);
-		zilog->zl_root_zio = NULL;
-		zil_flush_vdevs(zilog);
+		/*
+		 * And finally, we have to destroy the itx's that
+		 * couldn't be committed to an lwb; this will also call
+		 * the itx's callback if one exists for the itx.
+		 */
+		while ((itx = list_head(&nolwb_itxs)) != NULL) {
+			list_remove(&nolwb_itxs, itx);
+			zil_itx_destroy(itx);
+		}
+	} else {
+		ASSERT(list_is_empty(&nolwb_waiters));
+		ASSERT3P(lwb, !=, NULL);
+		ASSERT3S(lwb->lwb_state, !=, LWB_STATE_ISSUED);
+		ASSERT3S(lwb->lwb_state, !=, LWB_STATE_DONE);
+
+		/*
+		 * At this point, the ZIL block pointed at by the "lwb"
+		 * variable is in one of the following states: "closed"
+		 * or "open".
+		 *
+		 * If its "closed", then no itxs have been committed to
+		 * it, so there's no point in issueing its zio (i.e.
+		 * it's "empty").
+		 *
+		 * If its "open" state, then it contains one or more
+		 * itxs that eventually need to be committed to stable
+		 * storage. In this case we intentionally do not issue
+		 * the lwb's zio to disk yet, and instead rely on one of
+		 * the following two mechanisms for issuing the zio:
+		 *
+		 * 1. Ideally, there will be more ZIL activity occuring
+		 * on the system, such that this function will be
+		 * immeidately called again (not necessarily by the same
+		 * thread) and this lwb's zio will be issued via
+		 * zil_lwb_commit(). This way, the lwb is guaranteed to
+		 * be "full" when it is issued to disk, and we'll make
+		 * use of the lwb's size the best we can.
+		 *
+		 * 2. If there isn't sufficient ZIL activity occuring on
+		 * the system, such that this lwb's zio isn't issued via
+		 * zil_lwb_commit(), zil_commit_waiter() will issue the
+		 * lwb's zio. If this occurs, the lwb is not guaranteed
+		 * to be "full" by the time its zio is issued, and means
+		 * the size of the lwb was "too large" given the amount
+		 * of ZIL activity occuring on the system at that time.
+		 *
+		 * We do this for a couple of reasons:
+		 *
+		 * 1. To try and reduce the number of IOPs needed to
+		 * write the same number of itxs. If an lwb has space
+		 * available in it's buffer for more itxs, and more itxs
+		 * will be committed relatively soon (relative to the
+		 * latency of performing a write), then it's beneficial
+		 * to wait for these "next" itxs. This way, more itxs
+		 * can be committed to stable storage with fewer writes.
+		 *
+		 * 2. To try and use the largest lwb block size that the
+		 * incoming rate of itxs can support. Again, this is to
+		 * try and pack as many itxs into as few lwbs as
+		 * possible, without significantly impacting the latency
+		 * of each individual itx.
+		 */
 	}
-
-	if (error || lwb == NULL)
-		txg_wait_synced(zilog->zl_dmu_pool, 0);
-
-	while ((itx = list_head(&zilog->zl_itx_commit_list))) {
-		txg = itx->itx_lr.lrc_txg;
-		ASSERT(txg);
-
-		if (itx->itx_callback != NULL)
-			itx->itx_callback(itx->itx_callback_data);
-		list_remove(&zilog->zl_itx_commit_list, itx);
-		zil_itx_destroy(itx);
-	}
-
-	mutex_enter(&zilog->zl_lock);
-
-	/*
-	 * Remember the highest committed log sequence number for ztest.
-	 * We only update this value when all the log writes succeeded,
-	 * because ztest wants to ASSERT that it got the whole log chain.
-	 */
-	if (error == 0 && lwb != NULL)
-		zilog->zl_commit_lr_seq = zilog->zl_lr_seq;
 }
 
 /*
- * Commit zfs transactions to stable storage.
- * If foid is 0 push out all transactions, otherwise push only those
- * for that object or might reference that object.
+ * This function is responsible for ensuring the passed in commit waiter
+ * (and associated commit itx) is committed to an lwb. If the waiter is
+ * not already committed to an lwb, all itxs in the zilog's queue of
+ * itxs will be processed. The assumption is the passed in waiter's
+ * commit itx will found in the queue just like the other non-commit
+ * itxs, such that when the entire queue is processed, the waiter will
+ * have been commited to an lwb.
  *
- * itxs are committed in batches. In a heavily stressed zil there will be
- * a commit writer thread who is writing out a bunch of itxs to the log
- * for a set of committing threads (cthreads) in the same batch as the writer.
- * Those cthreads are all waiting on the same cv for that batch.
+ * The lwb associated with the passed in waiter is not guaranteed to
+ * have been issued by the time this function completes. If the lwb is
+ * not issued, we rely on future calls to zil_commit_writer() to issue
+ * the lwb, or the timeout mechanism found in zil_commit_waiter().
+ */
+static void
+zil_commit_writer(zilog_t *zilog, zil_commit_waiter_t *zcw)
+{
+	ASSERT(!MUTEX_HELD(&zilog->zl_lock));
+	ASSERT(spa_writeable(zilog->zl_spa));
+	ASSERT0(zilog->zl_suspend);
+
+	mutex_enter(&zilog->zl_writer_lock);
+
+	if (zcw->zcw_lwb != NULL || zcw->zcw_done) {
+		/*
+		 * It's possible that, while we were waiting to acquire
+		 * the "zl_writer_lock", another thread committed this
+		 * waiter to an lwb. If that occurs, we bail out early,
+		 * without processing any of the zilog's queue of itxs.
+		 *
+		 * On certain workloads and system configurations, the
+		 * "zl_writer_lock" can become highly contended. In an
+		 * attempt to reduce this contention, we immediately drop
+		 * the lock if the waiter has already been processed.
+		 *
+		 * We've measured this optimization to reduce CPU spent
+		 * contending on this lock by up to 5%, using a system
+		 * with 32 CPUs, low latency storage (~50 usec writes),
+		 * and 1024 threads performing sync writes.
+		 */
+		goto out;
+	}
+
+	ZIL_STAT_BUMP(zil_commit_writer_count);
+
+	zil_get_commit_list(zilog);
+	zil_prune_commit_list(zilog);
+	zil_process_commit_list(zilog);
+
+out:
+	mutex_exit(&zilog->zl_writer_lock);
+}
+
+static void
+zil_commit_waiter_timeout(zilog_t *zilog, zil_commit_waiter_t *zcw)
+{
+	ASSERT(!MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(MUTEX_HELD(&zcw->zcw_lock));
+	ASSERT3B(zcw->zcw_done, ==, B_FALSE);
+
+	lwb_t *lwb = zcw->zcw_lwb;
+	ASSERT3P(lwb, !=, NULL);
+	ASSERT3S(lwb->lwb_state, !=, LWB_STATE_CLOSED);
+
+	/*
+	 * If the lwb has already been issued by another thread, we can
+	 * immediately return since there's no work to be done (the
+	 * point of this function is to issue the lwb). Additionally, we
+	 * do this prior to acquiring the zl_writer_lock, to avoid
+	 * acquiring it when it's not necessary to do so.
+	 */
+	if (lwb->lwb_state == LWB_STATE_ISSUED ||
+	    lwb->lwb_state == LWB_STATE_DONE)
+		return;
+
+	/*
+	 * In order to call zil_lwb_write_issue() we must hold the
+	 * zilog's "zl_writer_lock". We can't simply acquire that lock,
+	 * since we're already holding the commit waiter's "zcw_lock",
+	 * and those two locks are aquired in the opposite order
+	 * elsewhere.
+	 */
+	mutex_exit(&zcw->zcw_lock);
+	mutex_enter(&zilog->zl_writer_lock);
+	mutex_enter(&zcw->zcw_lock);
+
+	/*
+	 * Since we just dropped and re-acquired the commit waiter's
+	 * lock, we have to re-check to see if the waiter was marked
+	 * "done" during that process. If the waiter was marked "done",
+	 * the "lwb" pointer is no longer valid (it can be free'd after
+	 * the waiter is marked "done"), so without this check we could
+	 * wind up with a use-after-free error below.
+	 */
+	if (zcw->zcw_done)
+		goto out;
+
+	ASSERT3P(lwb, ==, zcw->zcw_lwb);
+
+	/*
+	 * We've already checked this above, but since we hadn't
+	 * acquired the zilog's zl_writer_lock, we have to perform this
+	 * check a second time while holding the lock. We can't call
+	 * zil_lwb_write_issue() if the lwb had already been issued.
+	 */
+	if (lwb->lwb_state == LWB_STATE_ISSUED ||
+	    lwb->lwb_state == LWB_STATE_DONE)
+		goto out;
+
+	ASSERT3S(lwb->lwb_state, ==, LWB_STATE_OPENED);
+
+	/*
+	 * As described in the comments above zil_commit_waiter() and
+	 * zil_process_commit_list(), we need to issue this lwb's zio
+	 * since we've reached the commit waiter's timeout and it still
+	 * hasn't been issued.
+	 */
+	lwb_t *nlwb = zil_lwb_write_issue(zilog, lwb);
+
+	ASSERT3S(lwb->lwb_state, !=, LWB_STATE_OPENED);
+
+	/*
+	 * Since the lwb's zio hadn't been issued by the time this thread
+	 * reached its timeout, we reset the zilog's "zl_cur_used" field
+	 * to influence the zil block size selection algorithm.
+	 *
+	 * By having to issue the lwb's zio here, it means the size of the
+	 * lwb was too large, given the incoming throughput of itxs.  By
+	 * setting "zl_cur_used" to zero, we communicate this fact to the
+	 * block size selection algorithm, so it can take this informaiton
+	 * into account, and potentially select a smaller size for the
+	 * next lwb block that is allocated.
+	 */
+	zilog->zl_cur_used = 0;
+
+	if (nlwb == NULL) {
+		/*
+		 * When zil_lwb_write_issue() returns NULL, this
+		 * indicates zio_alloc_zil() failed to allocate the
+		 * "next" lwb on-disk. When this occurs, the ZIL write
+		 * pipeline must be stalled; see the comment within the
+		 * zil_commit_writer_stall() function for more details.
+		 *
+		 * We must drop the commit waiter's lock prior to
+		 * calling zil_commit_writer_stall() or else we can wind
+		 * up with the following deadlock:
+		 *
+		 * - This thread is waiting for the txg to sync while
+		 *   holding the waiter's lock; txg_wait_synced() is
+		 *   used within txg_commit_writer_stall().
+		 *
+		 * - The txg can't sync because it is waiting for this
+		 *   lwb's zio callback to call dmu_tx_commit().
+		 *
+		 * - The lwb's zio callback can't call dmu_tx_commit()
+		 *   because it's blocked trying to acquire the waiter's
+		 *   lock, which occurs prior to calling dmu_tx_commit()
+		 */
+		mutex_exit(&zcw->zcw_lock);
+		zil_commit_writer_stall(zilog);
+		mutex_enter(&zcw->zcw_lock);
+	}
+
+out:
+	mutex_exit(&zilog->zl_writer_lock);
+	ASSERT(MUTEX_HELD(&zcw->zcw_lock));
+}
+
+/*
+ * This function is responsible for performing the following two tasks:
  *
- * There will also be a different and growing batch of threads that are
- * waiting to commit (qthreads). When the committing batch completes
- * a transition occurs such that the cthreads exit and the qthreads become
- * cthreads. One of the new cthreads becomes the writer thread for the
- * batch. Any new threads arriving become new qthreads.
+ * 1. its primary responsibility is to block until the given "commit
+ *    waiter" is considered "done".
  *
- * Only 2 condition variables are needed and there's no transition
- * between the two cvs needed. They just flip-flop between qthreads
- * and cthreads.
+ * 2. its secondary responsibility is to issue the zio for the lwb that
+ *    the given "commit waiter" is waiting on, if this function has
+ *    waited "long enough" and the lwb is still in the "open" state.
  *
- * Using this scheme we can efficiently wakeup up only those threads
- * that have been committed.
+ * Given a sufficient amount of itxs being generated and written using
+ * the ZIL, the lwb's zio will be issued via the zil_lwb_commit()
+ * function. If this does not occur, this secondary responsibility will
+ * ensure the lwb is issued even if there is not other synchronous
+ * activity on the system.
+ *
+ * For more details, see zil_process_commit_list(); more specifically,
+ * the comment at the bottom of that function.
+ */
+static void
+zil_commit_waiter(zilog_t *zilog, zil_commit_waiter_t *zcw)
+{
+	ASSERT(!MUTEX_HELD(&zilog->zl_lock));
+	ASSERT(!MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(spa_writeable(zilog->zl_spa));
+	ASSERT0(zilog->zl_suspend);
+
+	mutex_enter(&zcw->zcw_lock);
+
+	/*
+	 * The timeout is scaled based on the lwb latency to avoid
+	 * significantly impacting the latency of each individual itx.
+	 * For more details, see the comment at the bottom of the
+	 * zil_process_commit_list() function.
+	 */
+	int pct = MAX(zfs_commit_timeout_pct, 1);
+	hrtime_t sleep = (zilog->zl_last_lwb_latency * pct) / 100;
+	hrtime_t wakeup = gethrtime() + sleep;
+	boolean_t timedout = B_FALSE;
+
+	while (!zcw->zcw_done) {
+		ASSERT(MUTEX_HELD(&zcw->zcw_lock));
+
+		lwb_t *lwb = zcw->zcw_lwb;
+
+		/*
+		 * Usually, the waiter will have a non-NULL lwb field here,
+		 * but it's possible for it to be NULL as a result of
+		 * zil_commit() racing with spa_sync().
+		 *
+		 * When zil_clean() is called, it's possible for the itxg
+		 * list (which may be cleaned via a taskq) to contain
+		 * commit itxs. When this occurs, the commit waiters linked
+		 * off of these commit itxs will not be committed to an
+		 * lwb.  Additionally, these commit waiters will not be
+		 * marked done until zil_commit_waiter_skip() is called via
+		 * zil_itxg_clean().
+		 *
+		 * Thus, it's possible for this commit waiter (i.e. the
+		 * "zcw" variable) to be found in this "in between" state;
+		 * where it's "zcw_lwb" field is NULL, and it hasn't yet
+		 * been skipped, so it's "zcw_done" field is still B_FALSE.
+		 */
+		IMPLY(lwb != NULL, lwb->lwb_state != LWB_STATE_CLOSED);
+
+		if (lwb != NULL && lwb->lwb_state == LWB_STATE_OPENED) {
+			ASSERT3B(timedout, ==, B_FALSE);
+
+			/*
+			 * If the lwb hasn't been issued yet, then we
+			 * need to wait with a timeout, in case this
+			 * function needs to issue the lwb after the
+			 * timeout is reached; responsibility (2) from
+			 * the comment above this function.
+			 */
+			clock_t timeleft = cv_timedwait_hires(&zcw->zcw_cv,
+			    &zcw->zcw_lock, wakeup, USEC2NSEC(1),
+			    CALLOUT_FLAG_ABSOLUTE);
+
+			if (timeleft >= 0 || zcw->zcw_done)
+				continue;
+
+			timedout = B_TRUE;
+			zil_commit_waiter_timeout(zilog, zcw);
+
+			if (!zcw->zcw_done) {
+				/*
+				 * If the commit waiter has already been
+				 * marked "done", it's possible for the
+				 * waiter's lwb structure to have already
+				 * been freed.  Thus, we can only reliably
+				 * make these assertions if the waiter
+				 * isn't done.
+				 */
+				ASSERT3P(lwb, ==, zcw->zcw_lwb);
+				ASSERT3S(lwb->lwb_state, !=, LWB_STATE_OPENED);
+			}
+		} else {
+			/*
+			 * If the lwb isn't open, then it must have already
+			 * been issued. In that case, there's no need to
+			 * use a timeout when waiting for the lwb to
+			 * complete.
+			 *
+			 * Additionally, if the lwb is NULL, the waiter
+			 * will soon be signalled and marked done via
+			 * zil_clean() and zil_itxg_clean(), so no timeout
+			 * is required.
+			 */
+
+			IMPLY(lwb != NULL,
+			    lwb->lwb_state == LWB_STATE_ISSUED ||
+			    lwb->lwb_state == LWB_STATE_DONE);
+			cv_wait(&zcw->zcw_cv, &zcw->zcw_lock);
+		}
+	}
+
+	mutex_exit(&zcw->zcw_lock);
+}
+
+static zil_commit_waiter_t *
+zil_alloc_commit_waiter(void)
+{
+	zil_commit_waiter_t *zcw = kmem_cache_alloc(zil_zcw_cache, KM_SLEEP);
+
+	cv_init(&zcw->zcw_cv, NULL, CV_DEFAULT, NULL);
+	mutex_init(&zcw->zcw_lock, NULL, MUTEX_DEFAULT, NULL);
+	list_link_init(&zcw->zcw_node);
+	zcw->zcw_lwb = NULL;
+	zcw->zcw_done = B_FALSE;
+	zcw->zcw_zio_error = 0;
+
+	return (zcw);
+}
+
+static void
+zil_free_commit_waiter(zil_commit_waiter_t *zcw)
+{
+	ASSERT(!list_link_active(&zcw->zcw_node));
+	ASSERT3P(zcw->zcw_lwb, ==, NULL);
+	ASSERT3B(zcw->zcw_done, ==, B_TRUE);
+	mutex_destroy(&zcw->zcw_lock);
+	cv_destroy(&zcw->zcw_cv);
+	kmem_cache_free(zil_zcw_cache, zcw);
+}
+
+/*
+ * This function is used to create a TX_COMMIT itx and assign it. This
+ * way, it will be linked into the ZIL's list of synchronous itxs, and
+ * then later committed to an lwb (or skipped) when
+ * zil_process_commit_list() is called.
+ */
+static void
+zil_commit_itx_assign(zilog_t *zilog, zil_commit_waiter_t *zcw)
+{
+	dmu_tx_t *tx = dmu_tx_create(zilog->zl_os);
+	VERIFY0(dmu_tx_assign(tx, TXG_WAIT));
+
+	itx_t *itx = zil_itx_create(TX_COMMIT, sizeof (lr_t));
+	itx->itx_sync = B_TRUE;
+	itx->itx_private = zcw;
+
+	zil_itx_assign(zilog, itx, tx);
+
+	dmu_tx_commit(tx);
+}
+
+/*
+ * Commit ZFS Intent Log transactions (itxs) to stable storage.
+ *
+ * When writing ZIL transactions to the on-disk representation of the
+ * ZIL, the itxs are committed to a Log Write Block (lwb). Multiple
+ * itxs can be committed to a single lwb. Once a lwb is written and
+ * committed to stable storage (i.e. the lwb is written, and vdevs have
+ * been flushed), each itx that was committed to that lwb is also
+ * considered to be committed to stable storage.
+ *
+ * When an itx is committed to an lwb, the log record (lr_t) contained
+ * by the itx is copied into the lwb's zio buffer, and once this buffer
+ * is written to disk, it becomes an on-disk ZIL block.
+ *
+ * As itxs are generated, they're inserted into the ZIL's queue of
+ * uncommitted itxs. The semantics of zil_commit() are such that it will
+ * block until all itxs that were in the queue when it was called, are
+ * committed to stable storage.
+ *
+ * If "foid" is zero, this means all "synchronous" and "asynchronous"
+ * itxs, for all objects in the dataset, will be committed to stable
+ * storage prior to zil_commit() returning. If "foid" is non-zero, all
+ * "synchronous" itxs for all objects, but only "asynchronous" itxs
+ * that correspond to the foid passed in, will be committed to stable
+ * storage prior to zil_commit() returning.
+ *
+ * Generally speaking, when zil_commit() is called, the consumer doesn't
+ * actually care about _all_ of the uncommitted itxs. Instead, they're
+ * simply trying to waiting for a specific itx to be committed to disk,
+ * but the interface(s) for interacting with the ZIL don't allow such
+ * fine-grained communication. A better interface would allow a consumer
+ * to create and assign an itx, and then pass a reference to this itx to
+ * zil_commit(); such that zil_commit() would return as soon as that
+ * specific itx was committed to disk (instead of waiting for _all_
+ * itxs to be committed).
+ *
+ * When a thread calls zil_commit() a special "commit itx" will be
+ * generated, along with a corresponding "waiter" for this commit itx.
+ * zil_commit() will wait on this waiter's CV, such that when the waiter
+ * is marked done, and signalled, zil_commit() will return.
+ *
+ * This commit itx is inserted into the queue of uncommitted itxs. This
+ * provides an easy mechanism for determining which itxs were in the
+ * queue prior to zil_commit() having been called, and which itxs were
+ * added after zil_commit() was called.
+ *
+ * The commit it is special; it doesn't have any on-disk representation.
+ * When a commit itx is "committed" to an lwb, the waiter associated
+ * with it is linked onto the lwb's list of waiters. Then, when that lwb
+ * completes, each waiter on the lwb's list is marked done and signalled
+ * -- allowing the thread waiting on the waiter to return from zil_commit().
+ *
+ * It's important to point out a few critical factors that allow us
+ * to make use of the commit itxs, commit waiters, per-lwb lists of
+ * commit waiters, and zio completion callbacks like we're doing:
+ *
+ *   1. The list of waiters for each lwb is traversed, and each commit
+ *      waiter is marked "done" and signalled, in the zio completion
+ *      callback of the lwb's zio[*].
+ *
+ *      * Actually, the waiters are signalled in the zio completion
+ *        callback of the root zio for the DKIOCFLUSHWRITECACHE commands
+ *        that are sent to the vdevs upon completion of the lwb zio.
+ *
+ *   2. When the itxs are inserted into the ZIL's queue of uncommitted
+ *      itxs, the order in which they are inserted is preserved[*]; as
+ *      itxs are added to the queue, they are added to the tail of
+ *      in-memory linked lists.
+ *
+ *      When committing the itxs to lwbs (to be written to disk), they
+ *      are committed in the same order in which the itxs were added to
+ *      the uncommitted queue's linked list(s); i.e. the linked list of
+ *      itxs to commit is traversed from head to tail, and each itx is
+ *      committed to an lwb in that order.
+ *
+ *      * To clarify:
+ *
+ *        - the order of "sync" itxs is preserved w.r.t. other
+ *          "sync" itxs, regardless of the corresponding objects.
+ *        - the order of "async" itxs is preserved w.r.t. other
+ *          "async" itxs corresponding to the same object.
+ *        - the order of "async" itxs is *not* preserved w.r.t. other
+ *          "async" itxs corresponding to different objects.
+ *        - the order of "sync" itxs w.r.t. "async" itxs (or vice
+ *          versa) is *not* preserved, even for itxs that correspond
+ *          to the same object.
+ *
+ *      For more details, see: zil_itx_assign(), zil_async_to_sync(),
+ *      zil_get_commit_list(), and zil_process_commit_list().
+ *
+ *   3. The lwbs represent a linked list of blocks on disk. Thus, any
+ *      lwb cannot be considered committed to stable storage, until its
+ *      "previous" lwb is also committed to stable storage. This fact,
+ *      coupled with the fact described above, means that itxs are
+ *      committed in (roughly) the order in which they were generated.
+ *      This is essential because itxs are dependent on prior itxs.
+ *      Thus, we *must not* deem an itx as being committed to stable
+ *      storage, until *all* prior itxs have also been committed to
+ *      stable storage.
+ *
+ *      To enforce this ordering of lwb zio's, while still leveraging as
+ *      much of the underlying storage performance as possible, we rely
+ *      on two fundamental concepts:
+ *
+ *          1. The creation and issuance of lwb zio's is protected by
+ *             the zilog's "zl_writer_lock", which ensures only a single
+ *             thread is creating and/or issuing lwb's at a time
+ *          2. The "previous" lwb is a child of the "current" lwb
+ *             (leveraging the zio parent-child depenency graph)
+ *
+ *      By relying on this parent-child zio relationship, we can have
+ *      many lwb zio's concurrently issued to the underlying storage,
+ *      but the order in which they complete will be the same order in
+ *      which they were created.
  */
 void
 zil_commit(zilog_t *zilog, uint64_t foid)
 {
-	uint64_t mybatch;
+	/*
+	 * We should never attempt to call zil_commit on a snapshot for
+	 * a couple of reasons:
+	 *
+	 * 1. A snapshot may never be modified, thus it cannot have any
+	 *    in-flight itxs that would have modified the dataset.
+	 *
+	 * 2. By design, when zil_commit() is called, a commit itx will
+	 *    be assigned to this zilog; as a result, the zilog will be
+	 *    dirtied. We must not dirty the zilog of a snapshot; there's
+	 *    checks in the code that enforce this invariant, and will
+	 *    cause a panic if it's not upheld.
+	 */
+	ASSERT3B(dmu_objset_is_snapshot(zilog->zl_os), ==, B_FALSE);
 
 	if (zilog->zl_sync == ZFS_SYNC_DISABLED)
 		return;
 
-	ZIL_STAT_BUMP(zil_commit_count);
-
-	/* move the async itxs for the foid to the sync queues */
-	zil_async_to_sync(zilog, foid);
-
-	mutex_enter(&zilog->zl_lock);
-	mybatch = zilog->zl_next_batch;
-	while (zilog->zl_writer) {
-		cv_wait(&zilog->zl_cv_batch[mybatch & 1], &zilog->zl_lock);
-		if (mybatch <= zilog->zl_com_batch) {
-			mutex_exit(&zilog->zl_lock);
-			return;
-		}
+	if (!spa_writeable(zilog->zl_spa)) {
+		/*
+		 * If the SPA is not writable, there should never be any
+		 * pending itxs waiting to be committed to disk. If that
+		 * weren't true, we'd skip writing those itxs out, and
+		 * would break the sematics of zil_commit(); thus, we're
+		 * verifying that truth before we return to the caller.
+		 */
+		ASSERT(list_is_empty(&zilog->zl_lwb_list));
+		ASSERT3P(zilog->zl_last_lwb_opened, ==, NULL);
+		for (int i = 0; i < TXG_SIZE; i++)
+			ASSERT3P(zilog->zl_itxg[i].itxg_itxs, ==, NULL);
+		return;
 	}
 
-	zilog->zl_next_batch++;
-	zilog->zl_writer = B_TRUE;
-	ZIL_STAT_BUMP(zil_commit_writer_count);
-	zil_commit_writer(zilog);
-	zilog->zl_com_batch = mybatch;
-	zilog->zl_writer = B_FALSE;
+	/*
+	 * If the ZIL is suspended, we don't want to dirty it by calling
+	 * zil_commit_itx_assign() below, nor can we write out
+	 * lwbs like would be done in zil_commit_write(). Thus, we
+	 * simply rely on txg_wait_synced() to maintain the necessary
+	 * semantics, and avoid calling those functions altogether.
+	 */
+	if (zilog->zl_suspend > 0) {
+		txg_wait_synced(zilog->zl_dmu_pool, 0);
+		return;
+	}
 
-	/* wake up one thread to become the next writer */
-	cv_signal(&zilog->zl_cv_batch[(mybatch+1) & 1]);
+	ZIL_STAT_BUMP(zil_commit_count);
 
-	/* wake up all threads waiting for this batch to be committed */
-	cv_broadcast(&zilog->zl_cv_batch[mybatch & 1]);
+	/*
+	 * Move the "async" itxs for the specified foid to the "sync"
+	 * queues, such that they will be later committed (or skipped)
+	 * to an lwb when zil_process_commit_list() is called.
+	 *
+	 * Since these "async" itxs must be committed prior to this
+	 * call to zil_commit returning, we must perform this operation
+	 * before we call zil_commit_itx_assign().
+	 */
+	zil_async_to_sync(zilog, foid);
 
-	mutex_exit(&zilog->zl_lock);
+	/*
+	 * We allocate a new "waiter" structure which will initially be
+	 * linked to the commit itx using the itx's "itx_private" field.
+	 * Since the commit itx doesn't represent any on-disk state,
+	 * when it's committed to an lwb, rather than copying the its
+	 * lr_t into the lwb's buffer, the commit itx's "waiter" will be
+	 * added to the lwb's list of waiters. Then, when the lwb is
+	 * committed to stable storage, each waiter in the lwb's list of
+	 * waiters will be marked "done", and signalled.
+	 *
+	 * We must create the waiter and assign the commit itx prior to
+	 * calling zil_commit_writer(), or else our specific commit itx
+	 * is not guaranteed to be committed to an lwb prior to calling
+	 * zil_commit_waiter().
+	 */
+	zil_commit_waiter_t *zcw = zil_alloc_commit_waiter();
+	zil_commit_itx_assign(zilog, zcw);
+
+	zil_commit_writer(zilog, zcw);
+	zil_commit_waiter(zilog, zcw);
+
+	if (zcw->zcw_zio_error != 0) {
+		/*
+		 * If there was an error writing out the ZIL blocks that
+		 * this thread is waiting on, then we fallback to
+		 * relying on spa_sync() to write out the data this
+		 * thread is waiting on. Obviously this has performance
+		 * implications, but the expectation is for this to be
+		 * an exceptional case, and shouldn't occur often.
+		 */
+		DTRACE_PROBE2(zil__commit__io__error,
+		    zilog_t *, zilog, zil_commit_waiter_t *, zcw);
+		txg_wait_synced(zilog->zl_dmu_pool, 0);
+	}
+
+	zil_free_commit_waiter(zcw);
 }
 
 /*
@@ -1796,12 +2797,9 @@ zil_sync(zilog_t *zilog, dmu_tx_t *tx)
 		zh->zh_log = lwb->lwb_blk;
 		if (lwb->lwb_buf != NULL || lwb->lwb_max_txg > txg)
 			break;
-
-		ASSERT(lwb->lwb_zio == NULL);
-
 		list_remove(&zilog->zl_lwb_list, lwb);
-		zio_free_zil(spa, txg, &lwb->lwb_blk);
-		kmem_cache_free(zil_lwb_cache, lwb);
+		zio_free(spa, txg, &lwb->lwb_blk);
+		zil_free_lwb(zilog, lwb);
 
 		/*
 		 * If we don't have anything left in the lwb list then
@@ -1819,7 +2817,7 @@ zil_sync(zilog_t *zilog, dmu_tx_t *tx)
 	 * unused, long-lived LWBs.
 	 */
 	for (; lwb != NULL; lwb = list_next(&zilog->zl_lwb_list, lwb)) {
-		if (lwb->lwb_fastwrite && !lwb->lwb_zio) {
+		if (lwb->lwb_fastwrite && !lwb->lwb_write_zio) {
 			metaslab_fastwrite_unmark(zilog->zl_spa, &lwb->lwb_blk);
 			lwb->lwb_fastwrite = 0;
 		}
@@ -1828,11 +2826,39 @@ zil_sync(zilog_t *zilog, dmu_tx_t *tx)
 	mutex_exit(&zilog->zl_lock);
 }
 
+/* ARGSUSED */
+static int
+zil_lwb_cons(void *vbuf, void *unused, int kmflag)
+{
+	lwb_t *lwb = vbuf;
+	list_create(&lwb->lwb_itxs, sizeof (itx_t), offsetof(itx_t, itx_node));
+	list_create(&lwb->lwb_waiters, sizeof (zil_commit_waiter_t),
+	    offsetof(zil_commit_waiter_t, zcw_node));
+	avl_create(&lwb->lwb_vdev_tree, zil_lwb_vdev_compare,
+	    sizeof (zil_vdev_node_t), offsetof(zil_vdev_node_t, zv_node));
+	mutex_init(&lwb->lwb_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
+	return (0);
+}
+
+/* ARGSUSED */
+static void
+zil_lwb_dest(void *vbuf, void *unused)
+{
+	lwb_t *lwb = vbuf;
+	mutex_destroy(&lwb->lwb_vdev_lock);
+	avl_destroy(&lwb->lwb_vdev_tree);
+	list_destroy(&lwb->lwb_waiters);
+	list_destroy(&lwb->lwb_itxs);
+}
+
 void
 zil_init(void)
 {
 	zil_lwb_cache = kmem_cache_create("zil_lwb_cache",
-	    sizeof (struct lwb), 0, NULL, NULL, NULL, NULL, NULL, 0);
+	    sizeof (lwb_t), 0, zil_lwb_cons, zil_lwb_dest, NULL, NULL, NULL, 0);
+
+	zil_zcw_cache = kmem_cache_create("zil_zcw_cache",
+	    sizeof (zil_commit_waiter_t), 0, NULL, NULL, NULL, NULL, NULL, 0);
 
 	zil_ksp = kstat_create("zfs", 0, "zil", "misc",
 	    KSTAT_TYPE_NAMED, sizeof (zil_stats) / sizeof (kstat_named_t),
@@ -1847,6 +2873,7 @@ zil_init(void)
 void
 zil_fini(void)
 {
+	kmem_cache_destroy(zil_zcw_cache);
 	kmem_cache_destroy(zil_lwb_cache);
 
 	if (zil_ksp != NULL) {
@@ -1881,9 +2908,12 @@ zil_alloc(objset_t *os, zil_header_t *zh_phys)
 	zilog->zl_destroy_txg = TXG_INITIAL - 1;
 	zilog->zl_logbias = dmu_objset_logbias(os);
 	zilog->zl_sync = dmu_objset_syncprop(os);
-	zilog->zl_next_batch = 1;
+	zilog->zl_dirty_max_txg = 0;
+	zilog->zl_last_lwb_opened = NULL;
+	zilog->zl_last_lwb_latency = 0;
 
 	mutex_init(&zilog->zl_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&zilog->zl_writer_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	for (int i = 0; i < TXG_SIZE; i++) {
 		mutex_init(&zilog->zl_itxg[i].itxg_lock, NULL,
@@ -1896,15 +2926,7 @@ zil_alloc(objset_t *os, zil_header_t *zh_phys)
 	list_create(&zilog->zl_itx_commit_list, sizeof (itx_t),
 	    offsetof(itx_t, itx_node));
 
-	mutex_init(&zilog->zl_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
-
-	avl_create(&zilog->zl_vdev_tree, zil_vdev_compare,
-	    sizeof (zil_vdev_node_t), offsetof(zil_vdev_node_t, zv_node));
-
-	cv_init(&zilog->zl_cv_writer, NULL, CV_DEFAULT, NULL);
 	cv_init(&zilog->zl_cv_suspend, NULL, CV_DEFAULT, NULL);
-	cv_init(&zilog->zl_cv_batch[0], NULL, CV_DEFAULT, NULL);
-	cv_init(&zilog->zl_cv_batch[1], NULL, CV_DEFAULT, NULL);
 
 	return (zilog);
 }
@@ -1922,9 +2944,6 @@ zil_free(zilog_t *zilog)
 	ASSERT(list_is_empty(&zilog->zl_lwb_list));
 	list_destroy(&zilog->zl_lwb_list);
 
-	avl_destroy(&zilog->zl_vdev_tree);
-	mutex_destroy(&zilog->zl_vdev_lock);
-
 	ASSERT(list_is_empty(&zilog->zl_itx_commit_list));
 	list_destroy(&zilog->zl_itx_commit_list);
 
@@ -1941,12 +2960,10 @@ zil_free(zilog_t *zilog)
 		mutex_destroy(&zilog->zl_itxg[i].itxg_lock);
 	}
 
+	mutex_destroy(&zilog->zl_writer_lock);
 	mutex_destroy(&zilog->zl_lock);
 
-	cv_destroy(&zilog->zl_cv_writer);
 	cv_destroy(&zilog->zl_cv_suspend);
-	cv_destroy(&zilog->zl_cv_batch[0]);
-	cv_destroy(&zilog->zl_cv_batch[1]);
 
 	kmem_free(zilog, sizeof (zilog_t));
 }
@@ -1959,7 +2976,8 @@ zil_open(objset_t *os, zil_get_data_t *get_data)
 {
 	zilog_t *zilog = dmu_objset_zil(os);
 
-	ASSERT(zilog->zl_get_data == NULL);
+	ASSERT3P(zilog->zl_get_data, ==, NULL);
+	ASSERT3P(zilog->zl_last_lwb_opened, ==, NULL);
 	ASSERT(list_is_empty(&zilog->zl_lwb_list));
 
 	zilog->zl_get_data = get_data;
@@ -1974,22 +2992,30 @@ void
 zil_close(zilog_t *zilog)
 {
 	lwb_t *lwb;
-	uint64_t txg = 0;
+	uint64_t txg;
 
-	zil_commit(zilog, 0); /* commit all itx */
+	if (!dmu_objset_is_snapshot(zilog->zl_os)) {
+		zil_commit(zilog, 0);
+	} else {
+		ASSERT3P(list_tail(&zilog->zl_lwb_list), ==, NULL);
+		ASSERT0(zilog->zl_dirty_max_txg);
+		ASSERT3B(zilog_is_dirty(zilog), ==, B_FALSE);
+	}
 
-	/*
-	 * The lwb_max_txg for the stubby lwb will reflect the last activity
-	 * for the zil.  After a txg_wait_synced() on the txg we know all the
-	 * callbacks have occurred that may clean the zil.  Only then can we
-	 * destroy the zl_clean_taskq.
-	 */
 	mutex_enter(&zilog->zl_lock);
 	lwb = list_tail(&zilog->zl_lwb_list);
-	if (lwb != NULL)
-		txg = lwb->lwb_max_txg;
+	if (lwb == NULL)
+		txg = zilog->zl_dirty_max_txg;
+	else
+		txg = MAX(zilog->zl_dirty_max_txg, lwb->lwb_max_txg);
 	mutex_exit(&zilog->zl_lock);
-	if (txg)
+
+	/*
+	 * We need to use txg_wait_synced() to wait long enough for the
+	 * ZIL to be clean, and to wait for all pending lwbs to be
+	 * written out.
+	 */
+	if (txg != 0)
 		txg_wait_synced(zilog->zl_dmu_pool, txg);
 
 	if (zilog_is_dirty(zilog))
@@ -2000,18 +3026,20 @@ zil_close(zilog_t *zilog)
 	zilog->zl_get_data = NULL;
 
 	/*
-	 * We should have only one LWB left on the list; remove it now.
+	 * We should have only one lwb left on the list; remove it now.
 	 */
 	mutex_enter(&zilog->zl_lock);
 	lwb = list_head(&zilog->zl_lwb_list);
 	if (lwb != NULL) {
-		ASSERT(lwb == list_tail(&zilog->zl_lwb_list));
-		ASSERT(lwb->lwb_zio == NULL);
+		ASSERT3P(lwb, ==, list_tail(&zilog->zl_lwb_list));
+		ASSERT3S(lwb->lwb_state, !=, LWB_STATE_ISSUED);
+
 		if (lwb->lwb_fastwrite)
 			metaslab_fastwrite_unmark(zilog->zl_spa, &lwb->lwb_blk);
+
 		list_remove(&zilog->zl_lwb_list, lwb);
 		zio_buf_free(lwb->lwb_buf, lwb->lwb_sz);
-		kmem_cache_free(zil_lwb_cache, lwb);
+		zil_free_lwb(zilog, lwb);
 	}
 	mutex_exit(&zilog->zl_lock);
 }
@@ -2373,7 +3401,7 @@ EXPORT_SYMBOL(zil_sync);
 EXPORT_SYMBOL(zil_clean);
 EXPORT_SYMBOL(zil_suspend);
 EXPORT_SYMBOL(zil_resume);
-EXPORT_SYMBOL(zil_add_block);
+EXPORT_SYMBOL(zil_lwb_add_block);
 EXPORT_SYMBOL(zil_bp_tree_add);
 EXPORT_SYMBOL(zil_set_sync);
 EXPORT_SYMBOL(zil_set_logbias);

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1301,7 +1301,7 @@ zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 	 */
 	error = dmu_tx_assign(tx, TXG_WAITED);
 	if (error != 0) {
-		ASSERT3S(error, ==, EIO);
+		ASSERT(error == EIO || error == ERESTART);
 		dmu_tx_abort(tx);
 		return (NULL);
 	}

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -568,7 +568,7 @@ zio_add_child(zio_t *pio, zio_t *cio)
 	 * Vdev I/Os can only have vdev children.
 	 * The following ASSERT captures all of these constraints.
 	 */
-	ASSERT(cio->io_child_type <= pio->io_child_type);
+	ASSERT3S(cio->io_child_type, <=, pio->io_child_type);
 
 	zl->zl_parent = pio;
 	zl->zl_child = cio;
@@ -1281,9 +1281,9 @@ zio_flush(zio_t *zio, vdev_t *vd)
 void
 zio_shrink(zio_t *zio, uint64_t size)
 {
-	ASSERT(zio->io_executor == NULL);
-	ASSERT(zio->io_orig_size == zio->io_size);
-	ASSERT(size <= zio->io_size);
+	ASSERT3P(zio->io_executor, ==, NULL);
+	ASSERT3U(zio->io_orig_size, ==, zio->io_size);
+	ASSERT3U(size, <=, zio->io_size);
 
 	/*
 	 * We don't shrink for raidz because of problems with the
@@ -1877,8 +1877,8 @@ zio_wait(zio_t *zio)
 {
 	int error;
 
-	ASSERT(zio->io_stage == ZIO_STAGE_OPEN);
-	ASSERT(zio->io_executor == NULL);
+	ASSERT3S(zio->io_stage, ==, ZIO_STAGE_OPEN);
+	ASSERT3P(zio->io_executor, ==, NULL);
 
 	zio->io_waiter = curthread;
 	ASSERT0(zio->io_queued_timestamp);
@@ -1900,7 +1900,7 @@ zio_wait(zio_t *zio)
 void
 zio_nowait(zio_t *zio)
 {
-	ASSERT(zio->io_executor == NULL);
+	ASSERT3P(zio->io_executor, ==, NULL);
 
 	if (zio->io_child_type == ZIO_CHILD_LOGICAL &&
 	    zio_unique_parent(zio) == NULL) {
@@ -1926,7 +1926,7 @@ zio_nowait(zio_t *zio)
 
 /*
  * ==========================================================================
- * Reexecute or suspend/resume failed I/O
+ * Reexecute, cancel, or suspend/resume failed I/O
  * ==========================================================================
  */
 
@@ -1981,6 +1981,20 @@ zio_reexecute(zio_t *pio)
 		pio->io_queued_timestamp = gethrtime();
 		__zio_execute(pio);
 	}
+}
+
+void
+zio_cancel(zio_t *zio)
+{
+	/*
+	 * Disallow cancellation of a zio that's already been issued.
+	 */
+	VERIFY3P(zio->io_executor, ==, NULL);
+
+	zio->io_pipeline = ZIO_INTERLOCK_PIPELINE;
+	zio->io_done = NULL;
+
+	zio_nowait(zio);
 }
 
 void
@@ -3276,6 +3290,9 @@ zio_alloc_zil(spa_t *spa, objset_t *os, uint64_t txg, blkptr_t *new_bp,
 
 			zio_crypt_encode_params_bp(new_bp, salt, iv);
 		}
+	} else {
+		zfs_dbgmsg("%s: zil block allocation failure: "
+		    "size %llu, error %d", spa_name(spa), size, error);
 	}
 
 	return (error);

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -39,7 +39,6 @@
 #include <sys/ddt.h>
 #include <sys/blkptr.h>
 #include <sys/zfeature.h>
-#include <sys/dsl_scan.h>
 #include <sys/metaslab_impl.h>
 #include <sys/time.h>
 #include <sys/trace_zio.h>
@@ -1051,7 +1050,6 @@ zio_free_sync(zio_t *pio, spa_t *spa, uint64_t txg, const blkptr_t *bp,
 
 	metaslab_check_free(spa, bp);
 	arc_freed(spa, bp);
-	dsl_scan_freed(spa, bp);
 
 	/*
 	 * GANG and DEDUP blocks can induce a read (for the gang block header,
@@ -3351,6 +3349,26 @@ zio_vdev_io_start(zio_t *zio)
 	}
 
 	ASSERT3P(zio->io_logical, !=, zio);
+
+	/*
+	 * We keep track of time-sensitive I/Os so that the scan thread
+	 * can quickly react to certain workloads.  In particular, we care
+	 * about non-scrubbing, top-level reads and writes with the following
+	 * characteristics:
+	 *	- synchronous writes of user data to non-slog devices
+	 *	- any reads of user data
+	 * When these conditions are met, adjust the timestamp of spa_last_io
+	 * which allows the scan thread to adjust its workload accordingly.
+	 */
+	if (!(zio->io_flags & ZIO_FLAG_SCAN_THREAD) && zio->io_bp != NULL &&
+	    vd == vd->vdev_top && !vd->vdev_islog &&
+	    zio->io_bookmark.zb_objset != DMU_META_OBJSET &&
+	    zio->io_txg != spa_syncing_txg(spa)) {
+		uint64_t old = spa->spa_last_io;
+		uint64_t new = ddi_get_lbolt64();
+		if (old != new)
+			(void) atomic_cas_64(&spa->spa_last_io, old, new);
+	}
 
 	align = 1ULL << vd->vdev_top->vdev_ashift;
 

--- a/scripts/zloop.sh
+++ b/scripts/zloop.sh
@@ -254,7 +254,7 @@ while [[ $timeout -eq 0 ]] || [[ $curtime -le $((starttime + timeout)) ]]; do
 	$cmd >>ztest.out 2>&1
 	ztrc=$?
 	egrep '===|WARNING' ztest.out >>ztest.history
-	$ZDB -U "$workdir/zpool.cache" -DD ztest >>ztest.ddt
+	$ZDB -U "$workdir/zpool.cache" -DD ztest >>ztest.ddt 2>&1
 
 	store_core
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_003_pos.ksh
@@ -33,7 +33,7 @@
 # 8. Put another device offline and check if the test file checksum is correct.
 #
 # NOTES:
-#	A 250ms delay is added to make sure that the scrub is running while
+#	A 25ms delay is added to make sure that the scrub is running while
 #	the reopen kicks the resilver.
 #
 
@@ -70,7 +70,7 @@ log_must md5sum $TESTFILE > $TESTFILE_MD5
 
 # 4. Execute scrub.
 # add delay to I/O requests for remaining disk in pool
-log_must zinject -d $DISK2 -D250:1 $TESTPOOL
+log_must zinject -d $DISK2 -D25:1 $TESTPOOL
 log_must zpool scrub $TESTPOOL
 
 # 5. "Plug back" disk.
@@ -81,12 +81,12 @@ log_must check_state $TESTPOOL "$REMOVED_DISK_ID" "online"
 # 7. Check if scrub scan is replaced by resilver.
 # the scrub operation has to be running while reopen is executed
 log_must is_pool_scrubbing $TESTPOOL true
-# remove delay from disk
-log_must zinject -c all
 # the scrub will be replaced by resilver, wait until it ends
 log_must wait_for_resilver_end $TESTPOOL $MAXTIMEOUT
 # check if the scrub scan has been interrupted by resilver
 log_must is_scan_restarted $TESTPOOL
+# remove delay from disk
+log_must zinject -c all
 
 # 8. Put another device offline and check if the test file checksum is correct.
 log_must zpool offline $TESTPOOL $DISK2

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen_004_pos.ksh
@@ -34,7 +34,7 @@
 #    replicas.
 #
 # NOTES:
-#	A 125ms delay is added to make sure that the scrub is running while
+#	A 25ms delay is added to make sure that the scrub is running while
 #	the reopen is invoked.
 #
 
@@ -64,18 +64,19 @@ log_must check_state $TESTPOOL "$REMOVED_DISK_ID" "unavail"
 log_must generate_random_file /$TESTPOOL/data $LARGE_FILE_SIZE
 # 4. Execute scrub.
 # add delay to I/O requests for remaining disk in pool
-log_must zinject -d $DISK2 -D125:1 $TESTPOOL
+log_must zinject -d $DISK2 -D25:1 $TESTPOOL
 log_must zpool scrub $TESTPOOL
 # 5. "Plug back" disk.
 insert_disk $REMOVED_DISK $scsi_host
 # 6. Reopen a pool with an -n flag.
 log_must zpool reopen -n $TESTPOOL
 log_must check_state $TESTPOOL "$REMOVED_DISK_ID" "online"
-# remove delay from disk
-log_must zinject -c all
 # 7. Check if scrub scan is NOT replaced by resilver.
 log_must wait_for_scrub_end $TESTPOOL $MAXTIMEOUT
 log_mustnot is_scan_restarted $TESTPOOL
+
+# remove delay from disk
+log_must zinject -c all
 
 # 8. Check if trying to put device to offline fails because of no valid
 #    replicas.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/cleanup.ksh
@@ -26,9 +26,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
-. $STF_SUITE/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
 
 verify_runnable "global"
 
-log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_DEFAULT
 destroy_mirrors

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/setup.ksh
@@ -37,8 +37,8 @@ verify_disk_count "$DISKS" 2
 
 default_mirror_setup_noexit $DISK1 $DISK2
 
-mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+mntpnt=$(get_prop mountpoint $TESTPOOL)
 
-# Create 256M of data
-log_must file_write -b 1048576 -c 256 -o create -d 0 -f $mntpnt/bigfile
+# Create 100MB of data
+log_must file_write -b 1048576 -c 100 -o create -d 0 -f $mntpnt/bigfile
 log_pass

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub.cfg
@@ -30,6 +30,3 @@
 
 export DISK1=${DISKS%% *}
 export DISK2=$(echo $DISKS | awk '{print $2}')
-
-export ZFS_SCAN_VDEV_LIMIT_SLOW=$((128*1024))
-export ZFS_SCAN_VDEV_LIMIT_DEFAULT=$((4*1024*1024))

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_002_pos.ksh
@@ -46,9 +46,9 @@
 #	6. Verify zpool scrub -s succeed when the system is scrubbing.
 #
 # NOTES:
-#	Artificially limit the scrub speed by setting the zfs_scan_vdev_limit
-#	low and adding a 50ms zio delay in order to ensure that the scrub does
-#	not complete early.
+#	A 10ms delay is added to the ZIOs in order to ensure that the
+#	scrub does not complete before it has a chance to be cancelled.
+#	This can occur when testing with small pools or very fast hardware.
 #
 
 verify_runnable "global"
@@ -56,21 +56,13 @@ verify_runnable "global"
 function cleanup
 {
 	log_must zinject -c all
-	log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_DEFAULT
-	log_must rm -f $mntpnt/biggerfile
 }
 
 log_onexit cleanup
 
 log_assert "Verify scrub, scrub -p, and scrub -s show the right status."
 
-# Create 1G of additional data
-mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
-log_must file_write -b 1048576 -c 1024 -o create -d 0 -f $mntpnt/biggerfile
-log_must sync
-
-log_must zinject -d $DISK1 -D50:1 $TESTPOOL
-log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_SLOW
+log_must zinject -d $DISK1 -D20:1 $TESTPOOL
 log_must zpool scrub $TESTPOOL
 log_must is_pool_scrubbing $TESTPOOL true
 log_must zpool scrub -p $TESTPOOL

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_003_pos.ksh
@@ -43,22 +43,23 @@
 #	2. Kick off a second scrub and verify it fails
 #
 # NOTES:
-#	Artificially limit the scrub speed by setting the zfs_scan_vdev_limit
-#	low in order to ensure that the scrub does not complete early.
+#	A 10ms delay is added to the ZIOs in order to ensure that the
+#	scrub does not complete before it has a chance to be restarted.
+#	This can occur when testing with small pools or very fast hardware.
 #
 
 verify_runnable "global"
 
 function cleanup
 {
-	log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_DEFAULT
+	        log_must zinject -c all
 }
 
 log_onexit cleanup
 
 log_assert "Scrub command fails when there is already a scrub in progress"
 
-log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_SLOW
+log_must zinject -d $DISK1 -D10:1 $TESTPOOL
 log_must zpool scrub $TESTPOOL
 log_must is_pool_scrubbing $TESTPOOL true
 log_mustnot zpool scrub $TESTPOOL

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
@@ -42,13 +42,13 @@
 #	3. Verify scrub failed until the resilver completed
 #
 # NOTES:
-#	Artificially limit the scrub speed by setting the zfs_scan_vdev_limit
-#	low in order to ensure that the scrub does not complete early.
-#
+#	A 10ms delay is added to 10% of zio's in order to ensure that the
+#	resilver does not complete before the scrub can be issued.  This
+#	can occur when testing with small pools or very fast hardware.
 
 function cleanup
 {
-	log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_DEFAULT
+	log_must zinject -c all
 }
 
 verify_runnable "global"
@@ -62,12 +62,13 @@ log_onexit cleanup
 
 log_assert "Resilver prevent scrub from starting until the resilver completes"
 
-log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_SLOW
 log_must zpool detach $TESTPOOL $DISK2
+log_must zinject -d $DISK1 -D10:1 $TESTPOOL
 log_must zpool attach $TESTPOOL $DISK1 $DISK2
 log_must is_pool_resilvering $TESTPOOL
 log_mustnot zpool scrub $TESTPOOL
 
+# Allow the resilver to finish, or it will interfere with the next test.
 while ! is_pool_resilvered $TESTPOOL; do
 	sleep 1
 done

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_005_pos.ksh
@@ -63,8 +63,4 @@ log_must zpool scrub $TESTPOOL
 log_must zpool detach $TESTPOOL $DISK1
 log_must zpool attach $TESTPOOL $DISK2 $DISK1
 
-while ! is_pool_resilvered $TESTPOOL; do
-	sleep 1
-done
-
 log_pass "When scrubbing, detach device should not break system."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_offline_device.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_offline_device.ksh
@@ -49,7 +49,7 @@ verify_runnable "global"
 function cleanup
 {
 	poolexists $TESTPOOL && destroy_pool $TESTPOOL
-	log_must rm -f $DISK1 $DISK2 $DISK3 $DISK4
+	log_must rm -f $DISK1 $DISK2 $DISK3
 }
 
 #
@@ -94,16 +94,14 @@ TESTDIR="$TEST_BASE_DIR/zpool_scrub_offline_device"
 DISK1="$TEST_BASE_DIR/zpool_disk1.dat"
 DISK2="$TEST_BASE_DIR/zpool_disk2.dat"
 DISK3="$TEST_BASE_DIR/zpool_disk3.dat"
-DISK4="$TEST_BASE_DIR/zpool_disk4.dat"
 
 # 1. Create the pool
 log_must truncate -s $DEVSIZE $DISK1
 log_must truncate -s $DEVSIZE $DISK2
 log_must truncate -s $DEVSIZE $DISK3
-log_must truncate -s $DEVSIZE $DISK4
 poolexists $TESTPOOL && destroy_pool $TESTPOOL
 log_must zpool create -O mountpoint=$TESTDIR $TESTPOOL \
-    raidz2 $DISK1 $DISK2 $DISK3 $DISK4
+    raidz1 $DISK1 $DISK2 $DISK3
 
 # 2. Offline the first device
 zpool_do_sync 'offline' $TESTPOOL $DISK1

--- a/tests/zfs-tests/tests/functional/events/events_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/events/events_002_pos.ksh
@@ -81,10 +81,6 @@ log_must truncate -s 0 $ZED_DEBUG_LOG
 # 4. Generate additional events.
 log_must zpool offline $MPOOL $VDEV1
 log_must zpool online $MPOOL $VDEV1
-while ! is_pool_resilvered $MPOOL; do
-	sleep 1
-done
-
 log_must zpool scrub $MPOOL
 
 # Wait for the scrub to wrap, or is_healthy will be wrong.

--- a/tests/zfs-tests/tests/functional/events/events_common.kshlib
+++ b/tests/zfs-tests/tests/functional/events/events_common.kshlib
@@ -78,6 +78,7 @@ function run_and_verify
 	zedlog=${zedlog:-$ZED_DEBUG_LOG}
 	fullcmd="$1"
 	cmd=$(echo $fullcmd | awk '{print $1}')
+	subcmd=$(echo $fullcmd | awk '{print $2}')
 
 	# If we aren't running zpool or zfs, something is wrong
 	[[ $cmd == "zpool" || $cmd == "zfs" ]] || \


### PR DESCRIPTION
testing latest "working" (non-conflicting branch with the zfetch / prefetch performance improvements and the new ARC hitrate fix https://github.com/zfsonlinux/zfs/pull/6989 ) for testing / bleeding-edge

via build-bots

sequential scrub and resilvers are left out

Fixed the 'Fix ARC hit rate' commit to leave out the bits that were left out with the revert of  the 'sequential scrub and resilvers' commit.

This is a temporary branch (if it passes the buildbots) for those who focus on performance enhancements and don't want to miss out the benefits of the zfetch and zil enhancement patches and can work with the "old" scrub prefetch behavior
  