### PR TITLE
Fix incompatibility with Reiser4 patched kernels

### DIFF
--- a/config/kernel-vfs-rw-iterate.m4
+++ b/config/kernel-vfs-rw-iterate.m4
@@ -32,15 +32,23 @@ dnl #
 dnl # Linux 4.1 API
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_NEW_SYNC_READ],
-	[AC_MSG_CHECKING([whether new_sync_read() is available])
+	[AC_MSG_CHECKING([whether new_sync_read/write() are available])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/fs.h>
 	],[
-		new_sync_read(NULL, NULL, 0, NULL);
+		        ssize_t ret __attribute__ ((unused));
+			struct file *filp = NULL;
+			char __user *rbuf = NULL;
+			const char __user *wbuf = NULL;
+			size_t len = 0;
+			loff_t ppos;
+
+			ret = new_sync_read(filp, rbuf, len, &ppos);
+			ret = new_sync_write(filp, wbuf, len, &ppos);
 	],[
 		AC_MSG_RESULT(yes)
 		AC_DEFINE(HAVE_NEW_SYNC_READ, 1,
-			[new_sync_read() is available])
+			[new_sync_read()/new_sync_write() are available])
 	],[
 		AC_MSG_RESULT(no)
 	])


### PR DESCRIPTION
### Description
In ZFSOnLinux, our sources and build system are self contained such that
we do not need to make changes to the Linux kernel sources. Reiser4 on
the other hand exists solely as a kernel tree patch and opts to make
changes to the kernel rather than adapt to it. After Linux 4.1 made a
VFS change that replaced new_sync_read with do_sync_read, Reiser4's
maintainer decided to modify the kernel VFS to export the old function.
This caused our autotools check to misidentify the kernel API as
predating Linux 4.1 on kernels that have been patched with Reiser4
support, which breaks our build.
### Motivation and Context
The few people running systems that support both filesystems are affected by Reiser4's modification of the kernel. I had wanted to make a simple fix as part of getting started again after a long hiatus on contribution activity. This was a simple fix, so I figured that it could be it.

Also, I notice that `new_sync_read()` and `new_sync_read()` both return a value, but `new_sync_read()` was checked as if it were a void function without a `(void)` typecast. I added a typecast to correct that too.

### How Has This Been Tested?
This change is trivial. No testing was done. I am leaning on the build bot.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
