### PR TITLE
Revert raidz_map and _col structure types

### DIFF
--- a/include/sys/vdev_raidz_impl.h
+++ b/include/sys/vdev_raidz_impl.h
@@ -102,30 +102,30 @@ typedef struct raidz_impl_ops {
 } raidz_impl_ops_t;
 
 typedef struct raidz_col {
-	size_t rc_devidx;		/* child device index for I/O */
-	size_t rc_offset;		/* device offset */
-	size_t rc_size;			/* I/O size */
+	uint64_t rc_devidx;		/* child device index for I/O */
+	uint64_t rc_offset;		/* device offset */
+	uint64_t rc_size;		/* I/O size */
 	abd_t *rc_abd;			/* I/O data */
 	void *rc_gdata;			/* used to store the "good" version */
 	int rc_error;			/* I/O error for this device */
-	unsigned int rc_tried;		/* Did we attempt this I/O column? */
-	unsigned int rc_skipped;	/* Did we skip this I/O column? */
+	uint8_t rc_tried;		/* Did we attempt this I/O column? */
+	uint8_t rc_skipped;		/* Did we skip this I/O column? */
 } raidz_col_t;
 
 typedef struct raidz_map {
-	size_t rm_cols;			/* Regular column count */
-	size_t rm_scols;		/* Count including skipped columns */
-	size_t rm_bigcols;		/* Number of oversized columns */
-	size_t rm_asize;		/* Actual total I/O size */
-	size_t rm_missingdata;		/* Count of missing data devices */
-	size_t rm_missingparity;	/* Count of missing parity devices */
-	size_t rm_firstdatacol;		/* First data column/parity count */
-	size_t rm_nskip;		/* Skipped sectors for padding */
-	size_t rm_skipstart;		/* Column index of padding start */
+	uint64_t rm_cols;		/* Regular column count */
+	uint64_t rm_scols;		/* Count including skipped columns */
+	uint64_t rm_bigcols;		/* Number of oversized columns */
+	uint64_t rm_asize;		/* Actual total I/O size */
+	uint64_t rm_missingdata;	/* Count of missing data devices */
+	uint64_t rm_missingparity;	/* Count of missing parity devices */
+	uint64_t rm_firstdatacol;	/* First data column/parity count */
+	uint64_t rm_nskip;		/* Skipped sectors for padding */
+	uint64_t rm_skipstart;		/* Column index of padding start */
 	abd_t *rm_abd_copy;		/* rm_asize-buffer of copied data */
-	size_t rm_reports;		/* # of referencing checksum reports */
-	unsigned int rm_freed;		/* map no longer has referencing ZIO */
-	unsigned int rm_ecksuminjected;	/* checksum error was injected */
+	uintptr_t rm_reports;		/* # of referencing checksum reports */
+	uint8_t	rm_freed;		/* map no longer has referencing ZIO */
+	uint8_t	rm_ecksuminjected;	/* checksum error was injected */
 	raidz_impl_ops_t *rm_ops;	/* RAIDZ math operations */
 	raidz_col_t rm_col[1];		/* Flexible array of I/O columns */
 } raidz_map_t;


### PR DESCRIPTION
As part of the refactoring of ab9f4b0b824ab4cc64a4fa382c037f4154de12d6,
several uint64_t-s and uint8_t-s were changed to other types.  This
caused ZoL github issue #6981, an overflow of a size_t on a 32-bit ARM
machine.  In absense of any strong motivation for the type changes, this
simply puts them back, modulo the changes accumulated for ABD.

Compile-tested on amd64 and run-tested on armhf.

Signed-off-by: Nathaniel Wesley Filardo <nwf@cs.jhu.edu>

Fixes: #6981

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
