### PR TITLE
Reduce codecov PR comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -18,4 +18,5 @@ coverage:
 
 comment:
   layout: "reach, diff, flags, footer"
-  behavior: "new"		# delete old, post new
+  behavior: once		# update if exists; post new; skip if deleted
+  require_changes: yes		# only post when coverage changes


### PR DESCRIPTION
### Description

Attempt to reduce the number of comments posted by codecov
to PR requests.  Based on the codecov documenation setting
"require_changes=yes" and "behavior=once" should result in
a single comment under most circumstances.

https://docs.codecov.io/v4.3.6/docs/pull-request-comments

### Motivation and Context

Issue #7022 

### How Has This Been Tested?

It hasn't, but it should work according to the documentation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
