### PR TITLE
Disable history_004_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/history/history_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_004_pos.ksh
@@ -31,6 +31,11 @@
 
 . $STF_SUITE/include/libtest.shlib
 
+# See issue: https://github.com/zfsonlinux/zfs/issues/7026
+if is_linux; then
+	log_unsupported "Test case occasionally fails"
+fi
+
 #
 # DESCRIPTION:
 #	'zpool history' can cope with simultaneous commands.


### PR DESCRIPTION
### Description

Occasionally observed failure of history_004_pos due to the test case not being 100% reliable.  In order to prevent false positives disable this test case until it can be made reliable.

### Motivation and Context

Issue #7026

### How Has This Been Tested?

Locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
