### PR TITLE
OpenZFS 8899 - zpool list property documentation doesn't match actual

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -27,7 +27,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd August 23, 2017
+.Dd January 10, 2018
 .Dt ZPOOL 8 SMM
 .Os Linux
 .Sh NAME
@@ -472,10 +472,8 @@ change the behavior of the pool.
 .Pp
 The following are read-only properties:
 .Bl -tag -width Ds
-.It Sy available
-Amount of storage available within the pool.
-This property can also be referred to by its shortened column name,
-.Sy avail .
+.It Cm allocated
+Amount of storage used within the pool.
 .It Sy capacity
 Percentage of pool space used.
 This property can also be referred to by its shortened column name,
@@ -516,8 +514,6 @@ Information about unsupported features that are enabled on the pool.
 See
 .Xr zpool-features 5
 for details.
-.It Sy used
-Amount of storage space used within the pool.
 .El
 .Pp
 The space usage properties report actual physical space available to the
@@ -1661,8 +1657,8 @@ See the
 .Sx Properties
 section for a list of valid properties.
 The default list is
-.Sy name, size, alloc, free, fragmentation, expandsize, capacity,
-.Sy dedupratio, health, altroot .
+.Cm name , size , allocated , free , expandsize , fragmentation , capacity ,
+.Cm dedupratio , health , altroot .
 .It Fl L
 Display real paths for vdevs resolving all symbolic links. This can
 be used to look up the current block device name regardless of the


### PR DESCRIPTION
### Description

The `zpool list` section of the zpool(8) manpage says that the default list of displayed properties is as below:

```
The default list is name, size, used, available, fragmentation, expandsize, capacity, health, altroot.
```

This does not seem to be the case. In fact:

```
    # zpool list
    NAME   SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
    tank  10.9T  6.05T  4.83T         -    29%    55%  1.00x  ONLINE  -
```

The Properties section of the same manpage includes the `used` property, but this seems not to be recognized:

```
    # zpool list -o used
    bad property list: invalid property 'used'
    usage:
    [...]
    #
```

The usage message produced here indeed doesn't include `used`.

### Motivation and Context

OpenZFS-issue: https://www.illumos.org/issues/8899
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/b0e142e57d

### How Has This Been Tested?

Merged to OpenZFS, locally builds, pending buildbot results.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
