### PR TITLE
Force ztest to always use /dev/urandom

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -7064,7 +7064,12 @@ main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	ztest_fd_rand = open("/dev/urandom", O_RDONLY);
+	/*
+	 * Force random_get_bytes() to use /dev/urandom in order to prevent
+	 * ztest from needlessly depleting the system entropy pool.
+	 */
+	random_path = "/dev/urandom";
+	ztest_fd_rand = open(random_path, O_RDONLY);
 	ASSERT3S(ztest_fd_rand, >=, 0);
 
 	if (!fd_data_str) {

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -630,6 +630,8 @@ extern void delay(clock_t ticks);
 #define	NN_NUMBUF_SZ	(6)
 
 extern uint64_t physmem;
+extern char *random_path;
+extern char *urandom_path;
 
 extern int highbit64(uint64_t i);
 extern int lowbit64(uint64_t i);

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -907,13 +907,15 @@ lowbit64(uint64_t i)
 	return (__builtin_ffsll(i));
 }
 
+char *random_path = "/dev/random";
+char *urandom_path = "/dev/urandom";
 static int random_fd = -1, urandom_fd = -1;
 
 void
 random_init(void)
 {
-	VERIFY((random_fd = open("/dev/random", O_RDONLY)) != -1);
-	VERIFY((urandom_fd = open("/dev/urandom", O_RDONLY)) != -1);
+	VERIFY((random_fd = open(random_path, O_RDONLY)) != -1);
+	VERIFY((urandom_fd = open(urandom_path, O_RDONLY)) != -1);
 }
 
 void

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -189,7 +189,6 @@ Requires:       fio
 Requires:       acl
 Requires:       sudo
 Requires:       sysstat
-Requires:       rng-tools
 AutoReqProv:    no
 
 %description test

--- a/scripts/zloop.sh
+++ b/scripts/zloop.sh
@@ -148,15 +148,6 @@ function store_core
 	fi
 }
 
-rngdpid=""
-function on_exit
-{
-	if [ -n "$rngdpid" ]; then
-		kill -9 "$rngdpid"
-	fi
-}
-trap on_exit EXIT
-
 # parse arguments
 # expected format: zloop [-t timeout] [-c coredir] [-- extra ztest args]
 coredir=$DEFAULTCOREDIR
@@ -204,9 +195,6 @@ fi
 or_die rm -f ztest.history
 or_die rm -f ztest.ddt
 or_die rm -f ztest.cores
-
-# start rngd in the background so we don't run out of entropy
-or_die read -r rngdpid < <(rngd -f -r /dev/urandom & echo $!)
 
 ztrc=0		# ztest return value
 foundcrashes=0	# number of crashes found so far


### PR DESCRIPTION
### Description

For ztest, which is solely for testing, using a pseudo random is entirely reasonable.  Using /dev/urandom ensures the system entropy pool doesn't get depleted thus stalling the testing. This is a particular problem when testing in VMs.

### Motivation and Context

Issue #7017 

### How Has This Been Tested?

Locally running ztest with the `rngd` terminated.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
