### PR TITLE
Fix shellcheck v0.4.6 warnings

### DIFF
--- a/cmd/zed/zed.d/zed-functions.sh
+++ b/cmd/zed/zed.d/zed-functions.sh
@@ -397,7 +397,7 @@ zed_rate_limit()
 
     zed_lock "${lockfile}" "${lockfile_fd}"
     time_now="$(date +%s)"
-    time_prev="$(egrep "^[0-9]+;${tag}\$" "${statefile}" 2>/dev/null \
+    time_prev="$(grep -E "^[0-9]+;${tag}\$" "${statefile}" 2>/dev/null \
         | tail -1 | cut -d\; -f1)"
 
     if [ -n "${time_prev}" ] \
@@ -406,7 +406,7 @@ zed_rate_limit()
     else
         umask_bak="$(umask)"
         umask 077
-        egrep -v "^[0-9]+;${tag}\$" "${statefile}" 2>/dev/null \
+        grep -E -v "^[0-9]+;${tag}\$" "${statefile}" 2>/dev/null \
             > "${statefile}.$$"
         echo "${time_now};${tag}" >> "${statefile}.$$"
         mv -f "${statefile}.$$" "${statefile}"

--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -19,7 +19,7 @@ function test_url()
 function test_commit_bodylength()
 {
     length="72"
-    body=$(git log -n 1 --pretty=%b "$REF" | egrep -m 1 ".{$((length + 1))}")
+    body=$(git log -n 1 --pretty=%b "$REF" | grep -E -m 1 ".{$((length + 1))}")
     if [ -n "$body" ]; then
         echo "error: commit message body contains line over ${length} characters"
         return 1
@@ -32,7 +32,7 @@ function test_commit_bodylength()
 function check_tagged_line()
 {
     regex='^\s*'"$1"':\s[[:print:]]+\s<[[:graph:]]+>$'
-    foundline=$(git log -n 1 "$REF" | egrep -m 1 "$regex")
+    foundline=$(git log -n 1 "$REF" | grep -E -m 1 "$regex")
     if [ -z "$foundline" ]; then
         echo "error: missing \"$1\""
         return 1
@@ -69,7 +69,7 @@ function new_change_commit()
     error=0
 
     # subject is not longer than 50 characters
-    long_subject=$(git log -n 1 --pretty=%s "$REF" | egrep -m 1 '.{51}')
+    long_subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '.{51}')
     if [ -n "$long_subject" ]; then
         echo "error: commit subject over 50 characters"
         error=1
@@ -91,7 +91,7 @@ function new_change_commit()
 function is_openzfs_port()
 {
     # subject starts with OpenZFS means it's an openzfs port
-    subject=$(git log -n 1 --pretty=%s "$REF" | egrep -m 1 '^OpenZFS')
+    subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '^OpenZFS')
     if [ -n "$subject" ]; then
         return 0
     fi
@@ -104,7 +104,7 @@ function openzfs_port_commit()
     error=0
 
     # subject starts with OpenZFS dddd
-    subject=$(git log -n 1 --pretty=%s "$REF" | egrep -m 1 '^OpenZFS [[:digit:]]+(, [[:digit:]]+)* - ')
+    subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '^OpenZFS [[:digit:]]+(, [[:digit:]]+)* - ')
     if [ -z "$subject" ]; then
         echo "error: OpenZFS patch ports must have a subject line that starts with \"OpenZFS dddd - \""
         error=1
@@ -146,7 +146,7 @@ function openzfs_port_commit()
 function is_coverity_fix()
 {
     # subject starts with Fix coverity defects means it's a coverity fix
-    subject=$(git log -n 1 --pretty=%s "$REF" | egrep -m 1 '^Fix coverity defects')
+    subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '^Fix coverity defects')
     if [ -n "$subject" ]; then
         return 0
     fi
@@ -160,7 +160,7 @@ function coverity_fix_commit()
 
     # subject starts with Fix coverity defects: CID dddd, dddd...
     subject=$(git log -n 1 --pretty=%s "$REF" |
-        egrep -m 1 'Fix coverity defects: CID [[:digit:]]+(, [[:digit:]]+)*')
+        grep -E -m 1 'Fix coverity defects: CID [[:digit:]]+(, [[:digit:]]+)*')
     if [ -z "$subject" ]; then
         echo "error: Coverity defect fixes must have a subject line that starts with \"Fix coverity defects: CID dddd\""
         error=1
@@ -174,8 +174,9 @@ function coverity_fix_commit()
     # test each summary line for the proper format
     OLDIFS=$IFS
     IFS=$'\n'
-    for line in $(git log -n 1 --pretty=%b "$REF" | egrep '^CID'); do
-        echo "$line" | egrep '^CID [[:digit:]]+: ([[:graph:]]+|[[:space:]])+ \(([[:upper:]]|\_)+\)' > /dev/null
+    for line in $(git log -n 1 --pretty=%b "$REF" | grep -E '^CID'); do
+        echo "$line" | grep -E '^CID [[:digit:]]+: ([[:graph:]]+|[[:space:]])+ \(([[:upper:]]|\_)+\)' > /dev/null
+        # shellcheck disable=SC2181
         if [[ $? -ne 0 ]]; then
             echo "error: commit message has an improperly formatted CID defect line"
             error=1

--- a/scripts/zfs.sh
+++ b/scripts/zfs.sh
@@ -79,7 +79,7 @@ check_modules() {
 	    $KMOD_ZUNICODE $KMOD_ZCOMMON $KMOD_ICP $KMOD_ZFS; do
 		NAME=$(basename "$KMOD" .ko)
 
-		if lsmod | egrep -q "^${NAME}"; then
+		if lsmod | grep -E -q "^${NAME}"; then
 			LOADED_MODULES="$LOADED_MODULES\t$NAME\n"
 		fi
 
@@ -114,6 +114,7 @@ load_module() {
 	fi
 
 	$LDMOD "$KMOD" >/dev/null 2>&1
+	# shellcheck disable=SC2181
 	if [ $? -ne 0 ]; then
 		echo "Failed to load $KMOD"
 		return 1
@@ -165,7 +166,7 @@ unload_modules() {
 	for KMOD in $KMOD_ZFS $KMOD_ICP $KMOD_ZCOMMON $KMOD_ZUNICODE \
 	    $KMOD_ZNVPAIR  $KMOD_ZAVL $KMOD_SPLAT $KMOD_SPL; do
 		NAME=$(basename "$KMOD" .ko)
-		USE_COUNT=$(lsmod | egrep "^${NAME} " | awk '{print $3}')
+		USE_COUNT=$(lsmod | grep -E "^${NAME} " | awk '{print $3}')
 
 		if [ "$USE_COUNT" = "0" ] ; then
 			unload_module "$KMOD" || return 1

--- a/scripts/zimport.sh
+++ b/scripts/zimport.sh
@@ -566,6 +566,7 @@ for TAG in $POOL_TAGS; do
 
 		$ZPOOL_CMD import -N -d "$POOL_DIR_COPY" \
 		   "$POOL_NAME" &>/dev/null
+		# shellcheck disable=SC2181
 		if [ $? -ne 0 ]; then
 			fail_nonewline
 			ERROR=1

--- a/scripts/zloop.sh
+++ b/scripts/zloop.sh
@@ -70,12 +70,12 @@ function or_die
 
 # core file helpers
 origcorepattern="$(cat /proc/sys/kernel/core_pattern)"
-coreglob="$(egrep -o '^([^|%[:space:]]*)' /proc/sys/kernel/core_pattern)*"
+coreglob="$(grep -E -o '^([^|%[:space:]]*)' /proc/sys/kernel/core_pattern)*"
 
 if [[ $coreglob = "*" ]]; then
         echo "Setting core file pattern..."
         echo "core" > /proc/sys/kernel/core_pattern
-        coreglob="$(egrep -o '^([^|%[:space:]]*)' \
+        coreglob="$(grep -E -o '^([^|%[:space:]]*)' \
             /proc/sys/kernel/core_pattern)*"
 fi
 
@@ -243,7 +243,7 @@ while [[ $timeout -eq 0 ]] || [[ $curtime -le $((starttime + timeout)) ]]; do
 	echo "$desc" >>ztest.out
 	$cmd >>ztest.out 2>&1
 	ztrc=$?
-	egrep '===|WARNING' ztest.out >>ztest.history
+	grep -E '===|WARNING' ztest.out >>ztest.history
 	$ZDB -U "$workdir/zpool.cache" -DD ztest >>ztest.ddt 2>&1
 
 	store_core

--- a/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
+++ b/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
@@ -410,7 +410,7 @@ function get_xattr #<obj>
 	fi
 
 	for xattr in `runat $obj ls | \
-		/usr/xpg4/bin/egrep -v -e SUNWattr_ro -e SUNWattr_rw` ; do
+		grep -E -v -e SUNWattr_ro -e SUNWattr_rw` ; do
 		runat $obj sum $xattr
 	done
 }


### PR DESCRIPTION
### Description

Resolve new warnings reported after upgrading to shellcheck version 0.4.6.  This patch contains no functional changes.

* egrep is non-standard and deprecated. Use grep -E instead. [SC2196]
* Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.  [SC2181]

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

Keep the build clean with newer versions of shellcheck.

### How Has This Been Tested?

`make checkstyle`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
