### PR TITLE
Remove l2arc_nocompress from zfs-module-parameters(5)

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -100,17 +100,6 @@ Default value: \fB200\fR%.
 .sp
 .ne 2
 .na
-\fBl2arc_nocompress\fR (int)
-.ad
-.RS 12n
-Skip compressing L2ARC buffers
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
 \fBl2arc_noprefetch\fR (int)
 .ad
 .RS 12n


### PR DESCRIPTION
Parameter was removed in d3c2ae1c0806
(OpenZFS 6950 - ARC should cache compressed data)

### Description
Fixes man page

### Motivation and Context
Man page is now wrong

### How Has This Been Tested?
N/A

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux code style requirements.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
