### PR TITLE
Emit an error message before MMP suspends pool

### DIFF
--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -26,6 +26,7 @@
 #include <sys/mmp.h>
 #include <sys/spa.h>
 #include <sys/spa_impl.h>
+#include <sys/time.h>
 #include <sys/vdev.h>
 #include <sys/vdev_impl.h>
 #include <sys/zfs_context.h>
@@ -429,6 +430,10 @@ mmp_thread(void *arg)
 		 */
 		if (!suspended && mmp_fail_intervals && multihost &&
 		    (start - mmp->mmp_last_write) > max_fail_ns) {
+			cmn_err(CE_WARN, "MMP writes to pool '%s' have not "
+			    "succeeded in over %llus; suspending pool",
+			    spa_name(spa),
+			    NSEC2SEC(start - mmp->mmp_last_write));
 			zio_suspend(spa, NULL);
 		}
 


### PR DESCRIPTION
In mmp_thread(), emit an MMP specific error message before calling
zio_suspend() so that the administrator will understand why the pool
is being suspended.

Signed-off-by: John L. Hammond <john.hammond@intel.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
In mmp_thread(), emit an MMP specific error message before calling zio_suspend(). The error message is of the form
```
[76636.951053] WARNING: MMP writes to pool 'lustre-mdt1' have not succeeded in over 1s.
```
### Motivation and Context
This is done so that administrators will understand why the pool is being suspended.

See issue https://github.com/zfsonlinux/zfs/issues/7045.

### How Has This Been Tested?
I set zfs_multihost_interval to 100ms then ran 'chrt -f 20 dd if=/dev/zero of=/dev/null &' several times to tie up the vCPUs. Then I observed the desired message on the console before the panic:
```
[76629.999018] sched: RT throttling activated
[76636.951053] WARNING: MMP writes to pool 'lustre-mdt1' have not succeeded in over 1s.
[76636.951059] Kernel panic - not syncing: Pool 'lustre-mdt1' has encountered an uncorrectable I/O failure and the failure mode property for this pool is set to panic.
[76636.952007] CPU: 3 PID: 13682 Comm: mmp Tainted: P           OE  ------------   3.10.0-693.11.6.el7.lustre.x86_64 #1
[76636.952007] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS Bochs 01/01/2
...
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
