### PR TITLE
OpenZFS 8858, 4580, 8929, 8868, 8860 - Correct use of grep

### DIFF
--- a/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
+++ b/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
@@ -410,7 +410,7 @@ function get_xattr #<obj>
 	fi
 
 	for xattr in `runat $obj ls | \
-		/usr/xpg4/bin/egrep -v -e SUNWattr_ro -e SUNWattr_rw` ; do
+		/usr/bin/egrep -v -e SUNWattr_ro -e SUNWattr_rw` ; do
 		runat $obj sum $xattr
 	done
 }


### PR DESCRIPTION
OpenZFS 8858 - /usr/bin/grep doesn't support -E option
OpenZFS 4580 - /usr/bin/grep can't handle multibyte characters
OpenZFS 8929 - tests are not delivered with system/test/utiltest
OpenZFS 8868 - tests are not delivered with system/test/utiltest
OpenZFS 8860 - Example in grep(1) is incorrect

Authored by: Alexander Pyhalov <apyhalov@gmail.com>
Reviewed by: Peter Tribble <peter.tribble@gmail.com>
Reviewed by: Toomas Soome <tsoome@me.com>
Reviewed by: Yuri Pankov <yuripv@gmx.com>
Approved by: Robert Mustacchi <rm@joyent.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/8858
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/d2d52addd5

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
