### PR TITLE
Fix Debian packaging on ARMv7/ARM64

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -18,8 +18,9 @@ deb-kmod: deb-local rpm-kmod
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-kmod-$${version}.src.rpm --qf %{arch} | tail -1`; \
+	debarch=`$(DPKG) --print-architecture`; \
 	pkg1=kmod-$${name}*$${version}.$${arch}.rpm; \
-	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch $$pkg1; \
 	$(RM) $$pkg1
 
 
@@ -27,14 +28,16 @@ deb-dkms: deb-local rpm-dkms
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-dkms-$${version}.src.rpm --qf %{arch} | tail -1`; \
+	debarch=`$(DPKG) --print-architecture`; \
 	pkg1=$${name}-dkms-$${version}.$${arch}.rpm; \
-	fakeroot $(ALIEN) --bump=0 --scripts --to-deb $$pkg1; \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch $$pkg1; \
 	$(RM) $$pkg1
 
 deb-utils: deb-local rpm-utils
 	name=${PACKAGE}; \
 	version=${VERSION}-${RELEASE}; \
 	arch=`$(RPM) -qp $${name}-$${version}.src.rpm --qf %{arch} | tail -1`; \
+	debarch=`$(DPKG) --print-architecture`; \
 	pkg1=$${name}-$${version}.$${arch}.rpm; \
 	pkg2=libnvpair1-$${version}.$${arch}.rpm; \
 	pkg3=libuutil1-$${version}.$${arch}.rpm; \
@@ -57,7 +60,7 @@ deb-utils: deb-local rpm-utils
 ## which should NOT be mixed with the alien-generated debs created here
 	chmod +x $${path_prepend}/dh_shlibdeps; \
 	env PATH=$${path_prepend}:$${PATH} \
-	fakeroot $(ALIEN) --bump=0 --scripts --to-deb \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch \
 	    $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
 	    $$pkg8 $$pkg9; \
 	$(RM) $${path_prepend}/dh_shlibdeps; \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

When building packages on Debian-based systems specify the target architecture used by `alien` to convert .rpm packages into .deb: this avoids detecting an incorrect value which results in the following errors:

```
<package>.aarch64.rpm is for architecture aarch64 ; the package cannot be built on this system
<package>.armv7l.rpm is for architecture armel ; the package cannot be built on this system
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/7046

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on a local aarch64 and armhf debootstrapped rootfs

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
