### PR TITLE
MMP delay logic changes

### DIFF
--- a/include/sys/mmp.h
+++ b/include/sys/mmp.h
@@ -30,7 +30,6 @@ extern "C" {
 #define	MMP_MIN_INTERVAL		100	/* ms */
 #define	MMP_DEFAULT_INTERVAL		1000	/* ms */
 #define	MMP_DEFAULT_IMPORT_INTERVALS	10
-#define	MMP_DEFAULT_FAIL_INTERVALS	5
 
 typedef struct mmp_thread {
 	kmutex_t	mmp_thread_lock; /* protect thread mgmt fields */

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -249,7 +249,7 @@ mmp_write_done(zio_t *zio)
 		goto unlock;
 
 	/*
-	 * Mmp writes are queued on a fixed schedule, but under many
+	 * MMP writes are queued on a fixed schedule, but under many
 	 * circumstances, such as a busy device or faulty hardware,
 	 * the writes will complete at variable, much longer,
 	 * intervals.  In these cases, another node checking for
@@ -269,8 +269,7 @@ mmp_write_done(zio_t *zio)
 		if (delay > mts->mmp_delay)
 			mts->mmp_delay = delay;
 		else
-			mts->mmp_delay = (delay + mts->mmp_delay * 127) /
-			    128;
+			mts->mmp_delay = (delay + mts->mmp_delay * 127) / 128;
 	} else {
 		mts->mmp_delay = 0;
 	}
@@ -381,17 +380,17 @@ mmp_thread(void *arg)
 		uint64_t mmp_fail_intervals = zfs_multihost_fail_intervals;
 		uint64_t mmp_interval = MSEC2NSEC(
 		    MAX(zfs_multihost_interval, MMP_MIN_INTERVAL));
+		uint64_t fail_interval;
+		int vdev_leaves = MAX(vdev_count_leaves(spa), 1);
 		boolean_t suspended = spa_suspended(spa);
 		boolean_t multihost = spa_multihost(spa);
 		hrtime_t start, next_time;
 
 		start = gethrtime();
-		if (multihost) {
-			next_time = start + mmp_interval /
-			    MAX(vdev_count_leaves(spa), 1);
-		} else {
+		if (multihost)
+			next_time = start + mmp_interval / vdev_leaves;
+		else
 			next_time = start + MSEC2NSEC(MMP_DEFAULT_INTERVAL);
-		}
 
 		/*
 		 * When MMP goes off => on, or spa goes suspended =>
@@ -417,16 +416,16 @@ mmp_thread(void *arg)
 		 * immediately suspended before writes can occur at the new
 		 * higher frequency.
 		 */
-		if ((mmp_interval * mmp_fail_intervals) < max_fail_ns) {
-			max_fail_ns = ((31 * max_fail_ns) + (mmp_interval *
-			    mmp_fail_intervals)) / 32;
-		} else {
-			max_fail_ns = mmp_interval * mmp_fail_intervals;
-		}
+		fail_interval = MAX(mmp_interval,
+		    mmp->mmp_delay * vdev_leaves) * mmp_fail_intervals;
+		if (fail_interval < max_fail_ns)
+			max_fail_ns = ((31 * max_fail_ns) + fail_interval) / 32;
+		else
+			max_fail_ns = fail_interval;
 
 		/*
 		 * Suspend the pool if no MMP write has succeeded in over
-		 * mmp_interval * mmp_fail_intervals nanoseconds.
+		 * mmp_delay * vdev_leaves * mmp_fail_intervals nanoseconds.
 		 */
 		if (!suspended && mmp_fail_intervals && multihost &&
 		    (start - mmp->mmp_last_write) > max_fail_ns) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
RFC MMP delay logic changes from @adilger. These are based on the discussion on https://github.com/zfsonlinux/zfs/issues/7045 and https://github.com/zfsonlinux/zfs/pull/7048. (I have not tested these but I plan to.)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
