### PR TITLE
Fix 'zfs receive -o' when used with '-e|-d'

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3603,7 +3603,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 	nvlist_t *oxprops = NULL; /* override (-o) and exclude (-x) props */
 	nvlist_t *origprops = NULL; /* original props (if destination exists) */
 	zfs_type_t type;
-	boolean_t toplevel;
+	boolean_t toplevel = B_FALSE;
 	boolean_t zoned = B_FALSE;
 
 	begin_time = time(NULL);
@@ -4013,7 +4013,8 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		goto out;
 	}
 
-	toplevel = chopprefix[0] != '/';
+	if (top_zfs && *top_zfs == NULL)
+		toplevel = B_TRUE;
 	if (drrb->drr_type == DMU_OST_ZVOL) {
 		type = ZFS_TYPE_VOLUME;
 	} else if (drrb->drr_type == DMU_OST_ZFS) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
When used in conjunction with one of '-e' or '-d' zfs receive options none of the properties requested to be set (-o) o̶r̶ ̶e̶x̶c̶l̶u̶d̶e̶d̶ ̶(̶-̶x̶)̶ (EDIT: excluded properties do actually work fine) are actually applied. The bug is caused by a wrong assumption made about the toplevel dataset in `zfs_receive_one()`: fix it by correctly detecting the toplevel dataset.

NOTE: i'd like to have this change landed in zfs-0.7.6, i will add it to the project if it looks good.
EDIT: added to 0.7.6; apologies for delaying the release.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`zfs recv -o` should work correctly in conjunction with `-e|-d`.

Before this change:
```
root@linux:~# POOLNAME1='testpool1'
root@linux:~# POOLNAME2='testpool2'
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:~# zpool destroy -f $POOLNAME1
cannot open 'testpool1': no such pool
root@linux:~# zpool destroy -f $POOLNAME2
cannot open 'testpool2': no such pool
root@linux:~# rm -f $TMPDIR/zpool_$POOLNAME1.dat $TMPDIR/zpool_$POOLNAME2.dat
root@linux:~# truncate -s 128m $TMPDIR/zpool_$POOLNAME1.dat
root@linux:~# truncate -s 128m $TMPDIR/zpool_$POOLNAME2.dat
root@linux:~# zpool create -f -O mountpoint=none $POOLNAME1 $TMPDIR/zpool_$POOLNAME1.dat
root@linux:~# zpool create -f -O mountpoint=none $POOLNAME2 $TMPDIR/zpool_$POOLNAME2.dat
root@linux:~# #
root@linux:~# zfs create -o mountpoint=none -p $POOLNAME1/1/2/3/4
root@linux:~# zfs snap -r $POOLNAME1@snap1
root@linux:~# zfs send -R $POOLNAME1/1/2/3@snap1 > $TMPDIR/repl
root@linux:~# zfs recv -o exec=off -d $POOLNAME2 < $TMPDIR/repl
root@linux:~# zfs get exec
NAME                     PROPERTY  VALUE  SOURCE
testpool1                exec      on     default
testpool1@snap1          exec      on     default
testpool1/1              exec      on     default
testpool1/1@snap1        exec      on     default
testpool1/1/2            exec      on     default
testpool1/1/2@snap1      exec      on     default
testpool1/1/2/3          exec      on     default
testpool1/1/2/3@snap1    exec      on     default
testpool1/1/2/3/4        exec      on     default
testpool1/1/2/3/4@snap1  exec      on     default
testpool2                exec      on     default
testpool2/1              exec      on     default
testpool2/1/2            exec      on     default
testpool2/1/2/3          exec      on     default
testpool2/1/2/3@snap1    exec      on     default
testpool2/1/2/3/4        exec      on     default
testpool2/1/2/3/4@snap1  exec      on     default
```

With patch applied:
```
root@linux:/usr/src/zfs# POOLNAME1='testpool1'
root@linux:/usr/src/zfs# POOLNAME2='testpool2'
root@linux:/usr/src/zfs# TMPDIR='/var/tmp'
root@linux:/usr/src/zfs# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:/usr/src/zfs# zpool destroy -f $POOLNAME1
root@linux:/usr/src/zfs# zpool destroy -f $POOLNAME2
root@linux:/usr/src/zfs# rm -f $TMPDIR/zpool_$POOLNAME1.dat $TMPDIR/zpool_$POOLNAME2.dat
root@linux:/usr/src/zfs# truncate -s 128m $TMPDIR/zpool_$POOLNAME1.dat
root@linux:/usr/src/zfs# truncate -s 128m $TMPDIR/zpool_$POOLNAME2.dat
root@linux:/usr/src/zfs# zpool create -f -O mountpoint=none $POOLNAME1 $TMPDIR/zpool_$POOLNAME1.dat
root@linux:/usr/src/zfs# zpool create -f -O mountpoint=none $POOLNAME2 $TMPDIR/zpool_$POOLNAME2.dat
root@linux:/usr/src/zfs# #
root@linux:/usr/src/zfs# zfs create -o mountpoint=none -p $POOLNAME1/1/2/3/4
root@linux:/usr/src/zfs# zfs snap -r $POOLNAME1@snap1
root@linux:/usr/src/zfs# zfs send -R $POOLNAME1/1/2/3@snap1 > $TMPDIR/repl
root@linux:/usr/src/zfs# zfs recv -o exec=off -d $POOLNAME2 < $TMPDIR/repl
root@linux:/usr/src/zfs# zfs get exec
NAME                     PROPERTY  VALUE  SOURCE
testpool1                exec      on     default
testpool1@snap1          exec      on     default
testpool1/1              exec      on     default
testpool1/1@snap1        exec      on     default
testpool1/1/2            exec      on     default
testpool1/1/2@snap1      exec      on     default
testpool1/1/2/3          exec      on     default
testpool1/1/2/3@snap1    exec      on     default
testpool1/1/2/3/4        exec      on     default
testpool1/1/2/3/4@snap1  exec      on     default
testpool2                exec      on     default
testpool2/1              exec      on     default
testpool2/1/2            exec      on     default
testpool2/1/2/3          exec      off    local
testpool2/1/2/3@snap1    exec      off    inherited from testpool2/1/2/3
testpool2/1/2/3/4        exec      off    inherited from testpool2/1/2/3
testpool2/1/2/3/4@snap1  exec      off    inherited from testpool2/1/2/3
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
