### PR TITLE
[build] Fixed support for --libddir under Ubuntu

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -185,7 +185,8 @@ AC_DEFUN([ZFS_AC_RPM], [
 	RPM_DEFINE_COMMON+=' --define "$(DEBUGINFO_ZFS) 1"'
 	RPM_DEFINE_COMMON+=' --define "$(ASAN_ZFS) 1"'
 
-	RPM_DEFINE_UTIL='--define "_dracutdir $(dracutdir)"'
+	RPM_DEFINE_UTIL='--define "_libdir $(libdir)"'
+	RPM_DEFINE_UTIL+=' --define "_dracutdir $(dracutdir)"'
 	RPM_DEFINE_UTIL+=' --define "_udevdir $(udevdir)"'
 	RPM_DEFINE_UTIL+=' --define "_udevruledir $(udevruledir)"'
 	RPM_DEFINE_UTIL+=' --define "_initconfdir $(DEFAULT_INITCONF_DIR)"'

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -1,5 +1,13 @@
 %global _sbindir    /sbin
-%global _libdir     /%{_lib}
+
+# Set the default libdir directory based on distribution.
+%if %{undefined _libdir}
+%if 0%{?fedora} >= 17 || 0%{?rhel} >= 7 || 0%{?centos} >= 7
+%global _libdir    %{_lib}
+%else
+%global _libdir    /lib
+%endif
+%endif
 
 # Set the default udev directory based on distribution.
 %if %{undefined _udevdir}

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -3,7 +3,7 @@
 # Set the default libdir directory based on distribution.
 %if %{undefined _libdir}
 %if 0%{?fedora} >= 17 || 0%{?rhel} >= 7 || 0%{?centos} >= 7
-%global _libdir    /%{_lib}
+%global _libdir    %{_lib}
 %else
 %global _libdir    /lib
 %endif

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -3,7 +3,7 @@
 # Set the default libdir directory based on distribution.
 %if %{undefined _libdir}
 %if 0%{?fedora} >= 17 || 0%{?rhel} >= 7 || 0%{?centos} >= 7
-%global _libdir    %{_lib}
+%global _libdir    /%{_lib}
 %else
 %global _libdir    /lib
 %endif


### PR DESCRIPTION
Signed-off-by: Gregoire Bellon-Gervais <greggbg@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Under Ubuntu --libdir is not correctly reflected when building rpm file and installation happens in /lib64

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
In file `config/zfs-build.m4`, added support for libdir in RPM_DEFINE_UTIL
In file `rpm/generic/zfs.spec.in`, assign defined value if necessary

### Motivation and Context
If we don't do this, zfs libraries are installed in /lib64 under Ubuntu which is not correct
**https://github.com/zfsonlinux/zfs/issues/7083**

### How Has This Been Tested?
Tested  under Ubuntu 14.04 (kernel 3.13.0-137 and 4.4.0-104) and 17.04 (default kernel)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
