### PR TITLE
Accommodate 0735ecb33 in trace_dmu.h

### DIFF
--- a/include/sys/trace_dmu.h
+++ b/include/sys/trace_dmu.h
@@ -50,7 +50,7 @@ DECLARE_EVENT_CLASS(zfs_delay_mintime_class,
 	    __field(uint64_t,			tx_lastsnap_txg)
 	    __field(uint64_t,			tx_lasttried_txg)
 	    __field(boolean_t,			tx_anyobj)
-	    __field(boolean_t,			tx_waited)
+	    __field(boolean_t,			tx_dirty_delayed)
 	    __field(hrtime_t,			tx_start)
 	    __field(boolean_t,			tx_wait_dirty)
 	    __field(int,			tx_err)
@@ -62,7 +62,7 @@ DECLARE_EVENT_CLASS(zfs_delay_mintime_class,
 	    __entry->tx_lastsnap_txg		= tx->tx_lastsnap_txg;
 	    __entry->tx_lasttried_txg		= tx->tx_lasttried_txg;
 	    __entry->tx_anyobj			= tx->tx_anyobj;
-	    __entry->tx_waited			= tx->tx_waited;
+	    __entry->tx_dirty_delayed		= tx->tx_dirty_delayed;
 	    __entry->tx_start			= tx->tx_start;
 	    __entry->tx_wait_dirty		= tx->tx_wait_dirty;
 	    __entry->tx_err			= tx->tx_err;
@@ -70,10 +70,10 @@ DECLARE_EVENT_CLASS(zfs_delay_mintime_class,
 	    __entry->min_tx_time		= min_tx_time;
 	),
 	TP_printk("tx { txg %llu lastsnap_txg %llu tx_lasttried_txg %llu "
-	    "anyobj %d waited %d start %llu wait_dirty %d err %i "
+	    "anyobj %d dirty_delayed %d start %llu wait_dirty %d err %i "
 	    "} dirty %llu min_tx_time %llu",
 	    __entry->tx_txg, __entry->tx_lastsnap_txg,
-	    __entry->tx_lasttried_txg, __entry->tx_anyobj, __entry->tx_waited,
+	    __entry->tx_lasttried_txg, __entry->tx_anyobj, __entry->tx_dirty_delayed,
 	    __entry->tx_start, __entry->tx_wait_dirty, __entry->tx_err,
 	    __entry->dirty, __entry->min_tx_time)
 );


### PR DESCRIPTION
0735ecb33485e91a78357a274e47c2782858d8b9 renamed tx_waited to tx_dirty_delayed, but trace_dmu.h wasn't updated.

This is a minimal fix needed to enable the code to build, avoiding the error

include/sys/trace_dmu.h:65:31: error: ‘dmu_tx_t {aka struct dmu_tx}’ has
  no member named ‘tx_waited’
      __entry->tx_waited   = tx->tx_waited;
                               ^

Signed-off-by: András Korn <korn-github@elan.rulez.org>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?

It builds successfully on latest Debian sid, with the stock Debian kernel. It didn't build before.

I don't know how I could test the functionality of the impacted code.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
