### PR TITLE
Fix multiple zdb bugs

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -4235,8 +4235,10 @@ zdb_embedded_block(char *thing)
 {
 	blkptr_t bp;
 	unsigned long long *words = (void *)&bp;
-	char buf[SPA_MAXBLOCKSIZE];
+	char *buf;
 	int err;
+
+	buf = umem_alloc(SPA_MAXBLOCKSIZE, UMEM_NOFAIL);
 
 	bzero(&bp, sizeof (bp));
 	err = sscanf(thing, "%llx:%llx:%llx:%llx:%llx:%llx:%llx:%llx:"
@@ -4256,6 +4258,7 @@ zdb_embedded_block(char *thing)
 		exit(1);
 	}
 	zdb_dump_block_raw(buf, BPE_GET_LSIZE(&bp), 0);
+	umem_free(buf, SPA_MAXBLOCKSIZE);
 }
 
 int

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -3984,13 +3984,6 @@ name:
 	return (NULL);
 }
 
-/* ARGSUSED */
-static int
-random_get_pseudo_bytes_cb(void *buf, size_t len, void *unused)
-{
-	return (random_get_pseudo_bytes(buf, len));
-}
-
 /*
  * Read a block from a pool and print it out.  The syntax of the
  * block descriptor is:
@@ -4160,16 +4153,7 @@ zdb_read_block(char *thing, spa_t *spa)
 		 * every decompress function at every inflated blocksize.
 		 */
 		enum zio_compress c;
-		void *pbuf2 = umem_alloc(SPA_MAXBLOCKSIZE, UMEM_NOFAIL);
 		void *lbuf2 = umem_alloc(SPA_MAXBLOCKSIZE, UMEM_NOFAIL);
-
-		abd_copy_to_buf(pbuf2, pabd, psize);
-
-		VERIFY0(abd_iterate_func(pabd, psize, SPA_MAXBLOCKSIZE - psize,
-		    random_get_pseudo_bytes_cb, NULL));
-
-		VERIFY0(random_get_pseudo_bytes((uint8_t *)pbuf2 + psize,
-		    SPA_MAXBLOCKSIZE - psize));
 
 		/*
 		 * XXX - On the one hand, with SPA_MAXBLOCKSIZE at 16MB,
@@ -4180,13 +4164,29 @@ zdb_read_block(char *thing, spa_t *spa)
 		for (lsize = psize + SPA_MINBLOCKSIZE;
 		    lsize <= SPA_MAXBLOCKSIZE; lsize += SPA_MINBLOCKSIZE) {
 			for (c = 0; c < ZIO_COMPRESS_FUNCTIONS; c++) {
+				/*
+				 * ZLE can easily decompress non zle stream.
+				 * So have an option to disable it.
+				 */
+				if (c == ZIO_COMPRESS_ZLE &&
+				    getenv("ZDB_NO_ZLE"))
+					continue;
+
 				(void) fprintf(stderr,
 				    "Trying %05llx -> %05llx (%s)\n",
 				    (u_longlong_t)psize, (u_longlong_t)lsize,
 				    zio_compress_table[c].ci_name);
+
+				/*
+				 * We randomize lbuf2, and decompress to both
+				 * lbuf and lbuf2. This way, we will know if
+				 * decompression fill exactly to lsize.
+				 */
+				VERIFY0(random_get_pseudo_bytes(lbuf2, lsize));
+
 				if (zio_decompress_data(c, pabd,
 				    lbuf, psize, lsize) == 0 &&
-				    zio_decompress_data_buf(c, pbuf2,
+				    zio_decompress_data(c, pabd,
 				    lbuf2, psize, lsize) == 0 &&
 				    bcmp(lbuf, lbuf2, lsize) == 0)
 					break;
@@ -4194,11 +4194,9 @@ zdb_read_block(char *thing, spa_t *spa)
 			if (c != ZIO_COMPRESS_FUNCTIONS)
 				break;
 		}
-
-		umem_free(pbuf2, SPA_MAXBLOCKSIZE);
 		umem_free(lbuf2, SPA_MAXBLOCKSIZE);
 
-		if (lsize <= psize) {
+		if (lsize > SPA_MAXBLOCKSIZE) {
 			(void) printf("Decompress of %s failed\n", thing);
 			goto out;
 		}

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -248,7 +248,9 @@ and, optionally,
 .It Sy b Ar offset
 Print block pointer
 .It Sy d
-Decompress the block
+Decompress the block. Set environment variable
+.Nm ZBD_NO_ZLE
+to skip zle when guessing.
 .It Sy e
 Byte swap the block
 .It Sy g

--- a/module/zfs/zle.c
+++ b/module/zfs/zle.c
@@ -74,10 +74,14 @@ zle_decompress(void *s_start, void *d_start, size_t s_len, size_t d_len, int n)
 	while (src < s_end && dst < d_end) {
 		int len = 1 + *src++;
 		if (len <= n) {
+			if (src + len > s_end || dst + len > d_end)
+				return (-1);
 			while (len-- != 0)
 				*dst++ = *src++;
 		} else {
 			len -= n;
+			if (dst + len > d_end)
+				return (-1);
 			while (len-- != 0)
 				*dst++ = 0;
 		}

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -77,7 +77,7 @@ tags = ['functional', 'clean_mirror']
 
 [tests/functional/cli_root/zdb]
 tests = ['zdb_001_neg', 'zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos',
-    'zdb_005_pos']
+    'zdb_005_pos', 'zdb_006_pos']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zdb']

--- a/tests/zfs-tests/tests/functional/clean_mirror/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/clean_mirror/cleanup.ksh
@@ -38,10 +38,10 @@ df -F zfs -h | grep "$TESTFS " >/dev/null
 [[ $? == 0 ]] && log_must zfs umount -f $TESTDIR
 destroy_pool $TESTPOOL
 
-if is_mpath_device $MIRROR_PRIMARY; then
+if ( is_mpath_device $MIRROR_PRIMARY || is_loop_device $MIRROR_SECONDARY); then
 	parted $DEV_DSKDIR/$MIRROR_PRIMARY -s rm 1
 fi
-if is_mpath_device $MIRROR_SECONDARY; then
+if ( is_mpath_device $MIRROR_SECONDARY || is_loop_device $MIRROR_SECONDARY); then
 	parted $DEV_DSKDIR/$MIRROR_SECONDARY -s rm 1
 fi
 # recreate and destroy a zpool over the disks to restore the partitions to

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
@@ -4,4 +4,5 @@ dist_pkgdata_SCRIPTS = \
 	zdb_002_pos.ksh \
 	zdb_003_pos.ksh \
 	zdb_004_pos.ksh \
-	zdb_005_pos.ksh
+	zdb_005_pos.ksh \
+	zdb_006_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_006_pos.ksh
@@ -1,0 +1,64 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018 by Nutanix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb -d will work on imported/exported pool with pool/dataset argument
+#
+# Strategy:
+# 1. Create a pool
+# 2. Run zdb -d with pool and dataset arguments.
+# 3. Export the pool
+# 4. Run zdb -ed with pool and dataset arguments.
+#
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	for DISK in $DISKS; do
+		zpool labelclear -f $DEV_RDSKDIR/$DISK
+	done
+}
+
+log_assert "Verify zdb -d works on imported/exported pool with pool/dataset argument"
+log_onexit cleanup
+
+verify_runnable "global"
+verify_disk_count "$DISKS" 2
+
+default_mirror_setup_noexit $DISKS
+log_must zfs snap $TESTPOOL/$TESTFS@snap
+
+log_must zdb -d $TESTPOOL
+log_must zdb -d $TESTPOOL/
+log_must zdb -d $TESTPOOL/$TESTFS
+log_must zdb -d $TESTPOOL/$TESTFS@snap
+
+log_must zpool export $TESTPOOL
+
+log_must zdb -ed $TESTPOOL
+log_must zdb -ed $TESTPOOL/
+log_must zdb -ed $TESTPOOL/$TESTFS
+log_must zdb -ed $TESTPOOL/$TESTFS@snap
+
+log_must zpool import $TESTPOOL
+
+cleanup
+
+log_pass "zdb -d works on imported/exported pool with pool/dataset argument"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
This series fix some bugs in zdb I found recently when I tried to debug a corrupted pool (The corruption is likely not a ZFS issue)

1. Fix zdb -c traverse stop on damaged objset root
If a corruption happens to be on a root block of an objset, zdb -c will
not correctly report the error, and it will not traverse the datasets
that come after

2. Fix zle_decompress out of bound access

3. Fix racy assignment of zcb.zcb_haderrors

4. Fix zdb -R decompression 
Add ZDB_NO_ZLE env to make zdb skip ZLE.
The random bytes appended to pabd, pbuf2 stuff serves no purpose. Instead, we randomize lbuf2 to make sure we fill exactly to lsize.
Fix wrong compression fail condition.

5. Fix zdb -E segfault

6. Fix zdb -ed on objset for exported pool
zdb pass objset name to spa_import, when dmu_objset_own tries to lookup the spa using real pool name, it can't find one.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
