### PR TITLE
Fix systemd_ RPM macros usage on Debian-based distributions

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -266,7 +266,14 @@ find %{?buildroot}%{_libdir} -name '*.la' -exec rm -f {} \;
 
 %post
 %if 0%{?_systemd}
+%if 0%{?systemd_post:1}
 %systemd_post %{systemd_svcs}
+%else
+if [ "$1" = "1" -o "$1" = "install" ] ; then
+    # Initial installation
+    systemctl preset %{systemd_svcs} >/dev/null || true
+fi
+%endif
 %else
 if [ -x /sbin/chkconfig ]; then
     /sbin/chkconfig --add zfs-import
@@ -279,9 +286,17 @@ exit 0
 
 %preun
 %if 0%{?_systemd}
+%if 0%{?systemd_preun:1}
 %systemd_preun %{systemd_svcs}
 %else
-if [ "$1" = "0" ] && [ -x /sbin/chkconfig ]; then
+if [ "$1" = "0" -o "$1" = "remove" ] ; then
+    # Package removal, not upgrade
+    systemctl --no-reload disable %{systemd_svcs} >/dev/null || true
+    systemctl stop %{systemd_svcs} >/dev/null || true
+fi
+%endif
+%else
+if [ "$1" = "0" -o "$1" = "remove" ] && [ -x /sbin/chkconfig ]; then
     /sbin/chkconfig --del zfs-import
     /sbin/chkconfig --del zfs-mount
     /sbin/chkconfig --del zfs-share
@@ -292,7 +307,11 @@ exit 0
 
 %postun
 %if 0%{?_systemd}
+%if 0%{?systemd_postun:1}
 %systemd_postun %{systemd_svcs}
+%else
+systemctl --system daemon-reload >/dev/null || true
+%endif
 %endif
 
 %files


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

Debian-based distributions do not seem to provide RPM macros for dealing with systemd pre- and post- (un)install actions: this results in errors when installing or upgrading .deb packages because the
resulting control scripts contain the following unresolved macros:

 * %systemd_post
 * %systemd_preun
 * %systemd_postun

Fix this by providing default values for postinstall, preuninstall and postuninstall scripts when these macros are not defined.

I think this was accidentally introduced by fixing systemd packaging (https://github.com/zfsonlinux/zfs/commit/ee410eefc2a9c0f0e77bd765894ee7767af647ea).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7074 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on Debian8 (both with `--enable-systemd` and `--disable-systemd`):

without systemd:
```
root@linux:/usr/src/zfs# strace -tf -e trace=execve dpkg -i zfs_0.7.0-266_amd64.deb |& grep chkconfig
[pid 19453] 23:45:15 execve("/sbin/chkconfig", ["/sbin/chkconfig", "--add", "zfs-import"], [/* 19 vars */]) = 0
[pid 19455] 23:45:15 execve("/sbin/chkconfig", ["/sbin/chkconfig", "--add", "zfs-mount"], [/* 19 vars */]) = 0
[pid 19457] 23:45:15 execve("/sbin/chkconfig", ["/sbin/chkconfig", "--add", "zfs-share"], [/* 19 vars */]) = 0
[pid 19459] 23:45:15 execve("/sbin/chkconfig", ["/sbin/chkconfig", "--add", "zfs-zed"], [/* 19 vars */]) = 0
root@linux:/usr/src/zfs# strace -tf -e trace=execve dpkg -r zfs |& grep chkconfig
[pid 19916] 23:45:21 execve("/sbin/chkconfig", ["/sbin/chkconfig", "--del", "zfs-import"], [/* 19 vars */]) = 0
[pid 19918] 23:45:22 execve("/sbin/chkconfig", ["/sbin/chkconfig", "--del", "zfs-mount"], [/* 19 vars */]) = 0
[pid 19920] 23:45:22 execve("/sbin/chkconfig", ["/sbin/chkconfig", "--del", "zfs-share"], [/* 19 vars */]) = 0
[pid 19922] 23:45:22 execve("/sbin/chkconfig", ["/sbin/chkconfig", "--del", "zfs-zed"], [/* 19 vars */]) = 0
```

with systemd:
```
root@linux:/usr/src/zfs# strace -tf -e trace=execve dpkg -i zfs_0.7.0-266_amd64.deb |& grep systemctl
[pid 21845] 00:11:54 execve("/bin/systemctl", ["systemctl", "--system", "daemon-reload"], [/* 21 vars */]) = 0
root@linux:/usr/src/zfs# strace -tf -e trace=execve dpkg -r zfs |& grep systemctl
[pid 22413] 00:12:04 execve("/bin/systemctl", ["systemctl", "--no-reload", "disable", "zfs-import-cache.service", "zfs-import-scan.service", "zfs-mount.service", "zfs-share.service", "zfs-zed.service", "zfs.target", "zfs-import.target"], [/* 21 vars */]) = 0
[pid 22414] 00:12:04 execve("/bin/systemctl", ["systemctl", "stop", "zfs-import-cache.service", "zfs-import-scan.service", "zfs-mount.service", "zfs-share.service", "zfs-zed.service", "zfs.target", "zfs-import.target"], [/* 21 vars */]) = 0
[pid 22417] 00:12:04 execve("/bin/systemctl", ["systemctl", "--system", "daemon-reload"], [/* 21 vars */]) = 0
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.