### PR TITLE
Fix default lib for x86_64 Debian/Ubuntu

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -192,6 +192,19 @@ AC_DEFUN([ZFS_AC_RPM], [
 	RPM_DEFINE_UTIL+=' $(DEFINE_INITRAMFS)'
 	RPM_DEFINE_UTIL+=' $(DEFINE_SYSTEMD)'
 
+	dnl # Override default lib directory on Debian/Ubuntu systems.  The provided
+	dnl # /usr/lib/rpm/platform/<arch>/macros files do not specify the correct
+	dnl # path for multiarch systems as described by the packaging guidelines.
+	dnl #
+	dnl # https://wiki.ubuntu.com/MultiarchSpec
+	dnl # https://wiki.debian.org/Multiarch/Implementation
+	dnl #
+	AS_IF([test "$DEFAULT_PACKAGE" = "deb"], [
+		MULTIARCH_LIBDIR="lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+		RPM_DEFINE_UTIL+=' --define "_lib $(MULTIARCH_LIBDIR)"'
+		AC_SUBST(MULTIARCH_LIBDIR)
+	])
+
 	RPM_DEFINE_KMOD='--define "kernels $(LINUX_VERSION)"'
 	RPM_DEFINE_KMOD+=' --define "require_spldir $(SPL)"'
 	RPM_DEFINE_KMOD+=' --define "require_splobj $(SPL_OBJ)"'


### PR DESCRIPTION
### Description

The distribution provided architecture specific RPM macro files for x86_64 on Debian/Ubuntu specify the wrong default install location.  When building x86_64 deb packages override _lib with the correct location.

### Motivation and Context

Potential alternative to @albundy83's fix in #7094 for comment and review.  Resolves #7083.

### How Has This Been Tested?

Locally built packages, pending buildbot results.  We may want to extend this override to additional architectures but initially this has been restricted to x86_64.  We should also inquire with the upstream Debian `rpm` package maintainer and determine if this is a bug or for some reason intentional.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
