### PR TITLE
Adjust ARC prefetch tunables to match docs

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -620,7 +620,7 @@ Default value: \fB0\fR.
 .ad
 .RS 12n
 Minimum time prefetched blocks are locked in the ARC, specified in ms.
-A value of \fB0\fR will default to 1 second.
+A value of \fB0\fR will default to 1000 ms.
 .sp
 Default value: \fB0\fR.
 .RE
@@ -633,7 +633,7 @@ Default value: \fB0\fR.
 .RS 12n
 Minimum time "prescient prefetched" blocks are locked in the ARC, specified
 in ms. These blocks are meant to be prefetched fairly aggresively ahead of
-the code that may use them. A value of \fB0\fR will default to 6 seconds.
+the code that may use them. A value of \fB0\fR will default to 6000 ms.
 .sp
 Default value: \fB0\fR.
 .RE

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3845,7 +3845,8 @@ arc_evict_hdr(arc_buf_hdr_t *hdr, kmutex_t *hash_lock)
 	/* prefetch buffers have a minimum lifespan */
 	if (HDR_IO_IN_PROGRESS(hdr) ||
 	    ((hdr->b_flags & (ARC_FLAG_PREFETCH | ARC_FLAG_INDIRECT)) &&
-	    ddi_get_lbolt() - hdr->b_l1hdr.b_arc_access < min_lifetime * hz)) {
+	    ddi_get_lbolt() - hdr->b_l1hdr.b_arc_access <
+	    MSEC_TO_TICK(min_lifetime))) {
 		ARCSTAT_BUMP(arcstat_evict_skip);
 		return (bytes_evicted);
 	}
@@ -7470,9 +7471,8 @@ arc_init(void)
 	cv_init(&arc_reclaim_thread_cv, NULL, CV_DEFAULT, NULL);
 	cv_init(&arc_reclaim_waiters_cv, NULL, CV_DEFAULT, NULL);
 
-	/* Convert seconds to clock ticks */
-	arc_min_prefetch_ms = 1;
-	arc_min_prescient_prefetch_ms = 6;
+	arc_min_prefetch_ms = 1000;
+	arc_min_prescient_prefetch_ms = 6000;
 
 #ifdef _KERNEL
 	/*


### PR DESCRIPTION
Currently, the ARC exposes 2 tunables (zfs_arc_min_prefetch_ms
and zfs_arc_min_prescient_prefetch_ms) which are documented
to be specified in milliseconds. However, the code actually
uses the values as though they were in seconds. This patch
adjusts the code to match the names and documentation of the
tunables.

Signed-off-by: Tom Caputi <tcaputi@datto.com>
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
