### PR TITLE
Fix `zpool status` overflow on fast scrubs

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -5989,7 +5989,7 @@ print_scan_status(pool_scan_stat_t *ps)
 	uint64_t total_secs_left;
 	uint64_t elapsed, secs_left, mins_left, hours_left, days_left;
 	uint64_t pass_scanned, scanned, pass_issued, issued, total;
-	uint_t scan_rate, issue_rate;
+	uint64_t scan_rate, issue_rate;
 	double fraction_done;
 	char processed_buf[7], scanned_buf[7], issued_buf[7], total_buf[7];
 	char srate_buf[7], irate_buf[7];


### PR DESCRIPTION
Signed-off-by: DHE <git@dehacked.net>

### Description
`uint_t` used for the scan rate on a pool easily overflows if the rate exceeds 4 gigabytes per second.

### Motivation and Context
I first noticed this on my pool with metadata allocation classes (#5182) when rebuilding the metadata vdev. Since the resilver didn't need to touch any data, I was "resilvering" at what I assume to be in excess of 40 gigabytes per second. I watched the speed counter overflow multiple times.

### How Has This Been Tested?
`echo 1 > /sys/module/zfs/paramters/zfs_no_scrub_io` and start a scrub. Don't even need SSDs most of the time.

(Just remember to set it back when you're done)

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
