### PR TITLE
cleanup references to deprecated zfs_arc_p_aggressive_disable

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -691,17 +691,6 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
-\fBzfs_arc_p_aggressive_disable\fR (int)
-.ad
-.RS 12n
-Disable aggressive arc_p growth
-.sp
-Use \fB1\fR for yes (default) and \fB0\fR to disable.
-.RE
-
-.sp
-.ne 2
-.na
 \fBzfs_arc_p_dampener_disable\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -410,7 +410,6 @@ unsigned long zfs_arc_dnode_limit_percent = 10;
 unsigned long zfs_arc_sys_free = 0;
 int zfs_arc_min_prefetch_ms = 0;
 int zfs_arc_min_prescient_prefetch_ms = 0;
-int zfs_arc_p_aggressive_disable = 1;
 int zfs_arc_p_dampener_disable = 1;
 int zfs_arc_meta_prune = 10000;
 int zfs_arc_meta_strategy = ARC_STRATEGY_META_BALANCED;
@@ -9087,9 +9086,6 @@ MODULE_PARM_DESC(zfs_arc_meta_strategy, "Meta reclaim strategy");
 
 module_param(zfs_arc_grow_retry, int, 0644);
 MODULE_PARM_DESC(zfs_arc_grow_retry, "Seconds before growing arc size");
-
-module_param(zfs_arc_p_aggressive_disable, int, 0644);
-MODULE_PARM_DESC(zfs_arc_p_aggressive_disable, "disable aggressive arc_p grow");
 
 module_param(zfs_arc_p_dampener_disable, int, 0644);
 MODULE_PARM_DESC(zfs_arc_p_dampener_disable, "disable arc_p adapt dampener");


### PR DESCRIPTION
### Description
zfs_arc_p_aggressive_disable is no more. This PR removes docs and module
parameters for zfs_arc_p_aggressive_disable

### Motivation and Context
Cleanup docs

### How Has This Been Tested?
Tested by compiling, installing and observing that /sys/module/zfs/parmaeters/zfs_arc_p_aggressive_disable  no longer exists

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ x] My code follows the ZFS on Linux code style requirements.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
