### PR TITLE
OpenZFS 8965 - zfs_acl_ls_001_pos fails due to no longer supported gr…

### DIFF
--- a/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
+++ b/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/acl/acl.cfg
@@ -185,7 +185,7 @@ function plus_sign_check_l #<obj>
 		return 1
 	fi
 
-	ls -ld $obj | awk '{print $1}' | grep "+\>" > /dev/null
+	ls -ld $obj | awk '{print $1}' | grep "+$" > /dev/null
 
         return $?
 }
@@ -202,7 +202,7 @@ function plus_sign_check_v #<obj>
 		return 1
 	fi
 
-	ls -vd $obj | nawk '(NR == 1) {print $1}' | grep "+\>" > /dev/null
+	ls -vd $obj | awk '(NR == 1) {print $1}' | grep "+$" > /dev/null
 
         return $?
 }


### PR DESCRIPTION
…ep regex

The test used \> to detect the end of a string, but this no longer works,
so use $ which works as well since the string ends the line anyway.

Authored by: John Wren Kennedy <john.kennedy@delphix.com>
Reviewed by: Akash Ayare <aayare@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: Yuri Pankov <yuripv@icloud.com>
Reviewed by: Igor Kozhukhov <igor@dilos.org>
Approved by: Dan McDonald <danmcd@joyent.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/8965
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/cb1204e444

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
