### PR TITLE
OpenZFS 9004 - Some ZFS tests used files removed with 32 bit kernel

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -10,6 +10,7 @@
 export SYSTEM_FILES='arp
     awk
     attr
+    base64
     basename
     bc
     blkid

--- a/tests/zfs-tests/tests/functional/rsend/send-cD.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-cD.ksh
@@ -12,7 +12,7 @@
 #
 
 #
-# Copyright (c) 2015 by Delphix. All rights reserved.
+# Copyright (c) 2015, 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
@@ -46,7 +46,7 @@ log_must zfs create -o compress=lz4 $sendfs
 log_must zfs create -o compress=lz4 $recvfs
 typeset dir=$(get_prop mountpoint $sendfs)
 # Don't use write_compressible: we want compressible but undedupable data here.
-log_must file_write -o overwrite -f $dir/file -d R -b 4096 -c 1000
+log_must eval "dd if=/dev/urandom bs=1024k count=4 | base64 >$dir/file"
 log_must zfs snapshot $sendfs@snap0
 log_must eval "zfs send -D -c $sendfs@snap0 >$stream0"
 


### PR DESCRIPTION
Authored by: John Wren Kennedy <john.kennedy@delphix.com>
Reviewed by: Igor Kozhukhov <igor@dilos.org>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Approved by: Dan McDonald <danmcd@joyent.com>
Ported-by: Giuseppe Di Natale <dinatale2@llnl.gov>

OpenZFS-issue: https://www.illumos.org/issues/9004
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/fafe9b241f

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
