### PR TITLE
'zfs receive' fails with "dataset is busy"

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6123,7 +6123,7 @@ share_mount_one(zfs_handle_t *zhp, int op, int flags, char *protocol,
 
 		(void) fprintf(stderr, gettext("cannot %s '%s': "
 		    "Contains partially-completed state from "
-		    "\"zfs receive -r\", which can be resumed with "
+		    "\"zfs receive -s\", which can be resumed with "
 		    "\"zfs send -t\"\n"),
 		    cmdname, zfs_get_name(zhp));
 		return (1);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3605,6 +3605,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 	zfs_type_t type;
 	boolean_t toplevel = B_FALSE;
 	boolean_t zoned = B_FALSE;
+	boolean_t hastoken = B_FALSE;
 
 	begin_time = time(NULL);
 	bzero(origin, MAXNAMELEN);
@@ -3928,6 +3929,11 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		/* we want to know if we're zoned when validating -o|-x props */
 		zoned = zfs_prop_get_int(zhp, ZFS_PROP_ZONED);
 
+		/* may need this info later, get it now we have zhp around */
+		if (zfs_prop_get(zhp, ZFS_PROP_RECEIVE_RESUME_TOKEN, NULL, 0,
+		    NULL, NULL, 0, B_TRUE) == 0)
+			hastoken = B_TRUE;
+
 		/* gather existing properties on destination */
 		origprops = fnvlist_alloc();
 		fnvlist_merge(origprops, zhp->zfs_props);
@@ -4186,9 +4192,19 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 			break;
 		case EDQUOT:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "destination %s space quota exceeded"), name);
+			    "destination %s space quota exceeded."), name);
 			(void) zfs_error(hdl, EZFS_NOSPC, errbuf);
 			break;
+		case EBUSY:
+			if (hastoken) {
+				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+				    "destination %s contains "
+				    "partially-complete state from "
+				    "\"zfs receive -s\"."), name);
+				(void) zfs_error(hdl, EZFS_BUSY, errbuf);
+				break;
+			}
+			/* fallthru */
 		default:
 			(void) zfs_standard_error(hdl, ioctl_errno, errbuf);
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Receiving an incremental stream after an interrupted "zfs receive -s" fails with the message "dataset is busy": this is because we still have the hidden clone ../%recv from the resumable receive.

Improve the error message suggesting the existence of a partially complete resumable stream from "zfs receive -s" which can be either aborted ("zfs receive -A") or resumed ("zfs send -t").

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7129

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Local Debian8 worker:

```
root@linux:/usr/src/zfs# POOLNAME='testpool'
root@linux:/usr/src/zfs# TMPDIR='/var/tmp'
root@linux:/usr/src/zfs# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:/usr/src/zfs# zpool destroy -f $POOLNAME
root@linux:/usr/src/zfs# rm -f $TMPDIR/zpool_$POOLNAME.dat
root@linux:/usr/src/zfs# truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
root@linux:/usr/src/zfs# zpool create -f $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
root@linux:/usr/src/zfs# #
root@linux:/usr/src/zfs# zfs create $POOLNAME/sendfs
root@linux:/usr/src/zfs# zfs snap $POOLNAME/sendfs@snap1
root@linux:/usr/src/zfs# dd if=/dev/urandom of=/$POOLNAME/sendfs/file bs=1M count=10 status=none
root@linux:/usr/src/zfs# zfs snap $POOLNAME/sendfs@snap2
root@linux:/usr/src/zfs# #
root@linux:/usr/src/zfs# zfs send $POOLNAME/sendfs@snap1 | zfs recv $POOLNAME/recvfs
root@linux:/usr/src/zfs# zfs send -i $POOLNAME/sendfs@snap1 $POOLNAME/sendfs@snap2 | dd bs=1M count=8 iflag=fullblock status=none | zfs recv -s $POOLNAME/recvfs
cannot receive incremental stream: checksum mismatch or incomplete stream.
Partially received snapshot is saved.
A resuming stream can be generated on the sending system by running:
    zfs send -t 1-113894673d-e8-789c636064000310a501c49c50360710a715e5e7a69766a6304081e28e29fb8e4bcebfa60064b323a9cb4fca4a4d2e61606082aac3904f4b2b4e2d01c9d4c0e5d990e4932a4b528b81f48fd03aacfa4bf221ae085535f7ff657740d600499e132c9f97989b0aa4538b4b0af2f373f48b53f352d28a1d8af3120b8ca06e02004a9122fd
root@linux:/usr/src/zfs# zfs send -i $POOLNAME/sendfs@snap1 $POOLNAME/sendfs@snap2 | zfs recv $POOLNAME/recvfs
cannot receive incremental stream: destination testpool/recvfs contains partially-complete state from "zfs receive -s".
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
