### PR TITLE
mmp should use a fixed tag for spa_config locks

### DIFF
--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -124,6 +124,7 @@ uint_t zfs_multihost_import_intervals = MMP_DEFAULT_IMPORT_INTERVALS;
  */
 uint_t zfs_multihost_fail_intervals = MMP_DEFAULT_FAIL_INTERVALS;
 
+char *mmp_tag = "mmp_write_uberblock";
 static void mmp_thread(void *arg);
 
 void
@@ -278,7 +279,7 @@ mmp_write_done(zio_t *zio)
 
 unlock:
 	mutex_exit(&mts->mmp_io_lock);
-	spa_config_exit(spa, SCL_STATE, FTAG);
+	spa_config_exit(spa, SCL_STATE, mmp_tag);
 
 	abd_free(zio->io_abd);
 }
@@ -314,7 +315,7 @@ mmp_write_uberblock(spa_t *spa)
 	int label;
 	uint64_t offset;
 
-	spa_config_enter(spa, SCL_STATE, FTAG, RW_READER);
+	spa_config_enter(spa, SCL_STATE, mmp_tag, RW_READER);
 	vd = mmp_random_leaf(spa->spa_root_vdev);
 	if (vd == NULL) {
 		spa_config_exit(spa, SCL_STATE, FTAG);


### PR DESCRIPTION
mmp_write_uberblock() and mmp_write_done() should the same tag
for spa_config_locks.

Signed-off-by: Sanjeev Bagewadi sanjeev.bagewadi@gmail.com

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
mmp_write_uberblock() takes the spa_config lock before issuing the uberblock update.
And once the operation is complete the spa_config lock is dropped by mmp_write_done().
Both these routines would need to use the same TAG during spa_config_enter() and spa_config_exit(). Using FTAG is incorrect as it records the caller's function name and they
would be different (mmp_write_uberblock vs mmp_write_done) and ends up confusing the
refcount framework and triggering an ASSERT.

The fix is to define a string specific to mmp and use that instead.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Without this changes the mmp setup test of zfs-testsuite fail when run with
debug-enabled ZFS modules.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/zfsonlinux/zfs/issues/6530
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Run the mmp setup test of zfs-testsuite.
"Test: /usr/share/zfs/zfs-tests/tests/functional/mmp/mmp_on_thread"

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.