### PR TITLE
contrib/initramfs: add missing conf.d/zfs

### DIFF
--- a/contrib/initramfs/Makefile.am
+++ b/contrib/initramfs/Makefile.am
@@ -1,15 +1,17 @@
 initrddir = $(datarootdir)/initramfs-tools
 
-initrd_SCRIPTS = conf-hooks.d/zfs hooks/zfs scripts/zfs scripts/local-top/zfs
+initrd_SCRIPTS = \
+	conf.d/zfs conf-hooks.d/zfs hooks/zfs scripts/zfs scripts/local-top/zfs
 
 SUBDIRS = hooks scripts
 
 EXTRA_DIST = \
+	$(top_srcdir)/contrib/initramfs/conf.d/zfs \
 	$(top_srcdir)/contrib/initramfs/conf-hooks.d/zfs \
 	$(top_srcdir)/contrib/initramfs/README.initramfs.markdown
 
 install-initrdSCRIPTS: $(EXTRA_DIST)
-	for d in conf-hooks.d hooks scripts scripts/local-top; do \
+	for d in conf.d conf-hooks.d hooks scripts scripts/local-top; do \
 	  $(MKDIR_P) $(DESTDIR)$(initrddir)/$$d; \
 	  cp $(top_srcdir)/contrib/initramfs/$$d/zfs \
 	    $(DESTDIR)$(initrddir)/$$d/; \

--- a/contrib/initramfs/conf.d/zfs
+++ b/contrib/initramfs/conf.d/zfs
@@ -1,0 +1,8 @@
+for x in $(cat /proc/cmdline)
+do
+	case $x in
+		root=ZFS=*|root=zfs:*)
+			BOOT=zfs
+			;;
+	esac
+done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

When upgrading from the distribution-provided zfs-initramfs package on root-on-zfs Ubuntu and Debian the system may fail to boot: this change adds the missing initramfs configuration file.

* Debian issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=848157 (_zfs-initramfs: The boot=zfs kernel parameter is still neccessary to boot an zfs root system._)
* Ubuntu Xenial zfs-initramfs package files: https://packages.ubuntu.com/xenial-updates/all/zfs-initramfs/filelist

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #6606 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on local Ubuntu16 builder (root-on-zfs), upgrading from "0.6.5.6-0ubuntu18" to current master:

Without this change (modified `/init` with `set -x`):

```
+ export PATH=/sbin:/usr/sbin:/bin:/usr/bin
+ [ -d /dev ]
+ [ -d /root ]
+ [ -d /sys ]
+ mkdir /sys
+ [ -d /proc ]
+ mkdir /proc
+ [ -d /tmp ]
+ mkdir /tmp
+ mkdir -p /var/lock
+ mount -t sysfs -o nodev,noexec,nosuid sysfs /sys
+ mount -t proc -o nodev,noexec,nosuid proc /proc
+ ln -sf /proc/mounts /etc/mtab
+ grep -q \<quiet\> /proc/cmdline
+ echo Loading, please wait...
Loading, please wait...
+ mount -t devtmpfs -o nosuid,mode=0755 udev /dev
+ mkdir /dev/pts
+ mount -t devpts -o noexec,nosuid,gid=5,mode=0620 devpts /dev/pts
+ mount -t tmpfs -o noexec,nosuid,size=10%,mode=0755 tmpfs /run
+ mkdir -m 0755 /run/initramfs
+ export DPKG_ARCH=
+ . /conf/arch.conf
+ DPKG_ARCH=amd64
+ export MODPROBE_OPTIONS=-qb
+ export ROOT=
+ export ROOTDELAY=
+ export ROOTFLAGS=
+ export ROOTFSTYPE=
+ export IP=
+ export BOOT=
+ export BOOTIF=
+ export UBIMTD=
+ export break=
+ export init=/sbin/init
+ export quiet=n
+ export readonly=y
+ export rootmnt=/root
+ export debug=
+ export panic=
+ export blacklist=
+ export resume=
+ export resume_offset=
+ export drop_caps=
+ export fastboot=n
+ export forcefsck=n
+ export fsckfix=
+ export recovery=
+ [ -f /etc/hostname ]
+ /bin/hostname -F /etc/hostname
+ . /conf/initramfs.conf
+ MODULES=most
+ BUSYBOX=auto
+ COMPCACHE_SIZE=
+ COMPRESS=gzip
+ DEVICE=
+ NFSROOT=auto
+ [ -f conf/conf.d/* ]
+ . /scripts/functions
+ cat /proc/cmdline
+ ROOT=ZFS=rpool/ROOT/ubuntu
+ [ -z  ]
+ [ ZFS=rpool/ROOT/ubuntu = /dev/nfs ]
+ readonly=y
+ debug=y
+ quiet=n
+ [ -n  ]
+ exec
[    1.281584] systemd-udevd[109]: starting version 229
[    1.282735] random: systemd-udevd: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.283202] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.283217] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.287792] random: systemd-udevd: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.288992] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.289020] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.289112] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.289148] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.289183] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.289220] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.323888] virtio_net virtio0 ens3: renamed from eth0
[    1.335592] FDC 0 is a S82078B
[    2.369106] input: ImExPS/2 Generic Explorer Mouse as /devices/platform/i8042/serio1/input/input3
[   14.951271] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x30e5dd94d34, max_idle_ns: 440795304975 ns
[   31.478888] hidraw: raw HID events driver (C) Jiri Kosina
[   31.482243] usbcore: registered new interface driver usbhid
[   31.483568] usbhid: USB HID core driver


BusyBox v1.22.1 (Ubuntu 1:1.22.0-15ubuntu1) built-in shell (ash)
Enter 'help' for a list of built-in commands.

(initramfs) modprobe zfs
[   38.061921] spl: module verification failed: signature and/or required key missing - tainting kernel
[   38.066081] SPL: Loaded module v0.7.0-26_g48ef8ba
[   38.067550] zavl: module license 'CDDL' taints kernel.
[   38.068960] Disabling lock debugging due to kernel taint
[   39.744181] ZFS: Loaded module v0.7.0-307_gba779f7, ZFS pool version 5000, ZFS filesystem version 5
(initramfs) zpool import 
   pool: rpool
     id: 6578963701138440634
  state: ONLINE
 action: The pool can be imported using its name or numeric identifier.
 config:

	rpool       ONLINE
	  vda1      ONLINE
(initramfs) 
```

With change applied:

```
+ export PATH=/sbin:/usr/sbin:/bin:/usr/bin
+ [ -d /dev ]
+ [ -d /root ]
+ [ -d /sys ]
+ mkdir /sys
+ [ -d /proc ]
+ mkdir /proc
+ [ -d /tmp ]
+ mkdir /tmp
+ mkdir -p /var/lock
+ mount -t sysfs -o nodev,noexec,nosuid sysfs /sys
+ mount -t proc -o nodev,noexec,nosuid proc /proc
+ ln -sf /proc/mounts /etc/mtab
+ grep -q \<quiet\> /proc/cmdline
+ echo Loading, please wait...
Loading, please wait...
+ mount -t devtmpfs -o nosuid,mode=0755 udev /dev
+ mkdir /dev/pts
+ mount -t devpts -o noexec,nosuid,gid=5,mode=0620 devpts /dev/pts
+ mount -t tmpfs -o noexec,nosuid,size=10%,mode=0755 tmpfs /run
+ mkdir -m 0755 /run/initramfs
+ export DPKG_ARCH=
+ . /conf/arch.conf
+ DPKG_ARCH=amd64
+ export MODPROBE_OPTIONS=-qb
+ export ROOT=
+ export ROOTDELAY=
+ export ROOTFLAGS=
+ export ROOTFSTYPE=
+ export IP=
+ export BOOT=
+ export BOOTIF=
+ export UBIMTD=
+ export break=
+ export init=/sbin/init
+ export quiet=n
+ export readonly=y
+ export rootmnt=/root
+ export debug=
+ export panic=
+ export blacklist=
+ export resume=
+ export resume_offset=
+ export drop_caps=
+ export fastboot=n
+ export forcefsck=n
+ export fsckfix=
+ export recovery=
+ [ -f /etc/hostname ]
+ /bin/hostname -F /etc/hostname
+ . /conf/initramfs.conf
+ MODULES=most
+ BUSYBOX=auto
+ COMPCACHE_SIZE=
+ COMPRESS=gzip
+ DEVICE=
+ NFSROOT=auto
+ [ -f conf/conf.d/zfs ]
+ . conf/conf.d/zfs
+ cat /proc/cmdline
+ BOOT=zfs
+ . /scripts/functions
+ cat /proc/cmdline
+ ROOT=ZFS=rpool/ROOT/ubuntu
+ [ -z zfs ]
+ readonly=y
+ debug=y
+ quiet=n
+ [ -n  ]
+ exec
[    1.260596] systemd-udevd[110]: starting version 229
[    1.261794] random: systemd-udevd: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.262281] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.262301] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.265749] random: systemd-udevd: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.267124] random: systemd-udevd: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.268951] random: systemd-udevd: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.270252] random: systemd-udevd: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.271569] random: systemd-udevd: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.271906] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.271953] random: udevadm: uninitialized urandom read (16 bytes read, 3 bits of entropy available)
[    1.307922] virtio_net virtio0 ens3: renamed from eth0
[    1.350815] FDC 0 is a S82078B
[    1.397165] spl: module verification failed: signature and/or required key missing - tainting kernel
[    1.399976] SPL: Loaded module v0.7.0-26_g48ef8ba
[    1.400748] zavl: module license 'CDDL' taints kernel.
[    1.401499] Disabling lock debugging due to kernel taint
[    2.033948] tsc: Refined TSC clocksource calibration: 3392.218 MHz
[    2.034893] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x30e59788ac7, max_idle_ns: 440795283321 ns
[    2.799444] input: ImExPS/2 Generic Explorer Mouse as /devices/platform/i8042/serio1/input/input3
[    3.060062] ZFS: Loaded module v0.7.0-307_gba779f7, ZFS pool version 5000, ZFS filesystem version 5
[    5.899320] systemd[1]: Mounting cgroup to /sys/fs/cgroup/hugetlb of type cgroup with options hugetlb.
[    5.902681] systemd[1]: Mounting cgroup to /sys/fs/cgroup/memory of type cgroup with options memory.
[    5.906314] systemd[1]: Mounting cgroup to /sys/fs/cgroup/perf_event of type cgroup with options perf_event.
[    5.908941] systemd[1]: Mounting cgroup to /sys/fs/cgroup/cpuset of type cgroup with options cpuset.
[    5.910532] systemd[1]: Mounting cgroup to /sys/fs/cgroup/cpu,cpuacct of type cgroup with options cpu,cpuacct.
[    5.911735] systemd[1]: Mounting cgroup to /sys/fs/cgroup/net_cls,net_prio of type cgroup with options net_cls,net_prio.
[    5.913011] systemd[1]: Mounting cgroup to /sys/fs/cgroup/devices of type cgroup with options devices.
[    5.914945] systemd[1]: Mounting cgroup to /sys/fs/cgroup/pids of type cgroup with options pids.
[    5.916176] systemd[1]: Mounting cgroup to /sys/fs/cgroup/blkio of type cgroup with options blkio.
[    5.917618] systemd[1]: Mounting cgroup to /sys/fs/cgroup/freezer of type cgroup with options freezer.
[    5.918927] systemd[1]: systemd 229 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN)
[    5.921331] systemd[1]: Detected virtualization qemu.
[    5.922069] systemd[1]: Detected architecture x86-64.

Welcome to Ubuntu 16.04 LTS!

```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.