### PR TITLE
Fix config issues: frame size and headers

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -2,16 +2,16 @@ deb-local:
 	@(if test "${HAVE_DPKGBUILD}" = "no"; then \
 		echo -e "\n" \
 	"*** Required util ${DPKGBUILD} missing.  Please install the\n" \
-        "*** package for your distribution which provides ${DPKGBUILD},\n" \
+	"*** package for your distribution which provides ${DPKGBUILD},\n" \
 	"*** re-run configure, and try again.\n"; \
-                exit 1; \
+		exit 1; \
 	fi; \
 	if test "${HAVE_ALIEN}" = "no"; then \
 		echo -e "\n" \
 	"*** Required util ${ALIEN} missing.  Please install the\n" \
-        "*** package for your distribution which provides ${ALIEN},\n" \
+	"*** package for your distribution which provides ${ALIEN},\n" \
 	"*** re-run configure, and try again.\n"; \
-                exit 1; \
+		exit 1; \
 	fi)
 
 deb-kmod: deb-local rpm-kmod

--- a/config/kernel-acl.m4
+++ b/config/kernel-acl.m4
@@ -184,6 +184,7 @@ AC_DEFUN([ZFS_AC_KERNEL_INODE_OPERATIONS_PERMISSION_WITH_NAMEIDATA], [
 	AC_MSG_CHECKING([whether iops->permission() wants nameidata])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/fs.h>
+		#include <linux/sched.h>
 
 		int permission_fn(struct inode *inode, int mask,
 		    struct nameidata *nd) { return 0; }

--- a/config/kernel-create-nameidata.m4
+++ b/config/kernel-create-nameidata.m4
@@ -5,6 +5,7 @@ AC_DEFUN([ZFS_AC_KERNEL_CREATE_NAMEIDATA], [
 	AC_MSG_CHECKING([whether iops->create() passes nameidata])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/fs.h>
+		#include <linux/sched.h>
 
 		#ifdef HAVE_MKDIR_UMODE_T
 		int inode_create(struct inode *inode ,struct dentry *dentry,

--- a/config/kernel-dentry-operations.m4
+++ b/config/kernel-dentry-operations.m4
@@ -5,6 +5,7 @@ AC_DEFUN([ZFS_AC_KERNEL_D_REVALIDATE_NAMEIDATA], [
 	AC_MSG_CHECKING([whether dops->d_revalidate() takes struct nameidata])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/dcache.h>
+		#include <linux/sched.h>
 
 		int revalidate (struct dentry *dentry,
 		    struct nameidata *nidata) { return 0; }

--- a/config/kernel-get-link.m4
+++ b/config/kernel-get-link.m4
@@ -41,7 +41,7 @@ AC_DEFUN([ZFS_AC_KERNEL_FOLLOW_LINK], [
 			AC_DEFINE(HAVE_FOLLOW_LINK_NAMEIDATA, 1,
 			          [iops->follow_link() nameidata])
 		],[
-                        AC_MSG_ERROR(no; please file a bug report)
+			AC_MSG_ERROR(no; please file a bug report)
 		])
 	])
 ])

--- a/config/kernel-lookup-nameidata.m4
+++ b/config/kernel-lookup-nameidata.m4
@@ -5,6 +5,7 @@ AC_DEFUN([ZFS_AC_KERNEL_LOOKUP_NAMEIDATA], [
 	AC_MSG_CHECKING([whether iops->lookup() passes nameidata])
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/fs.h>
+		#include <linux/sched.h>
 
 		struct dentry *inode_lookup(struct inode *inode,
 		    struct dentry *dentry, struct nameidata *nidata)

--- a/config/kernel-vm_node_stat.m4
+++ b/config/kernel-vm_node_stat.m4
@@ -7,7 +7,7 @@ AC_DEFUN([ZFS_AC_KERNEL_VM_NODE_STAT], [
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/mm.h>
 		#include <linux/vmstat.h>
-        ],[
+	],[
 			int a __attribute__ ((unused)) = NR_VM_NODE_STAT_ITEMS;
 			long x __attribute__ ((unused)) =
 				atomic_long_read(&vm_node_stat[0]);

--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -711,7 +711,7 @@ AC_DEFUN([ZFS_LINUX_COMPILE_IFELSE], [
 	modpost_flag=''
 	test "x$enable_linux_builtin" = xyes && modpost_flag='modpost=true' # fake modpost stage
 	AS_IF(
-		[AC_TRY_COMMAND(cp conftest.c conftest.h build && make [$2] -C $LINUX_OBJ EXTRA_CFLAGS="-Werror $EXTRA_KCFLAGS" $ARCH_UM M=$PWD/build $modpost_flag) >/dev/null && AC_TRY_COMMAND([$3])],
+		[AC_TRY_COMMAND(cp conftest.c conftest.h build && make [$2] -C $LINUX_OBJ EXTRA_CFLAGS="-Werror $FRAME_LARGER_THAN $EXTRA_KCFLAGS" $ARCH_UM M=$PWD/build $modpost_flag) >/dev/null && AC_TRY_COMMAND([$3])],
 		[$4],
 		[_AC_MSG_LOG_CONFTEST m4_ifvaln([$5],[$5])]
 	)

--- a/config/tgz.am
+++ b/config/tgz.am
@@ -2,9 +2,9 @@ tgz-local:
 	@(if test "${HAVE_ALIEN}" = "no"; then \
 		echo -e "\n" \
 	"*** Required util ${ALIEN} missing.  Please install the\n" \
-        "*** package for your distribution which provides ${ALIEN},\n" \
+	"*** package for your distribution which provides ${ALIEN},\n" \
 	"*** re-run configure, and try again.\n"; \
-                exit 1; \
+		exit 1; \
 	fi)
 
 tgz-kmod: tgz-local rpm-kmod

--- a/config/user-libblkid.m4
+++ b/config/user-libblkid.m4
@@ -6,7 +6,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBBLKID], [
 	LIBBLKID=
 
 	AC_CHECK_HEADER([blkid/blkid.h], [], [AC_MSG_FAILURE([
-        *** blkid.h missing, libblkid-devel package required])])
+	*** blkid.h missing, libblkid-devel package required])])
 
 	AC_SUBST([LIBBLKID], ["-lblkid"])
 	AC_DEFINE([HAVE_LIBBLKID], 1, [Define if you have libblkid])

--- a/config/user-libssl.m4
+++ b/config/user-libssl.m4
@@ -5,7 +5,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBSSL], [
 	LIBSSL=
 
 	AC_CHECK_HEADER([openssl/evp.h], [], [AC_MSG_FAILURE([
-        *** evp.h missing, libssl-devel package required])])
+	*** evp.h missing, libssl-devel package required])])
 
 	AC_SUBST([LIBSSL], ["-lssl -lcrypto"])
 	AC_DEFINE([HAVE_LIBSSL], 1, [Define if you have libssl])


### PR DESCRIPTION
### Description

Fix config issues: frame size and headers

### Motivation and Context

1. With various (debug and/or tracing?) kernel options enabled, it's possible for `struct inode` and `struct super_block` to exceed the default frame size, leaving errors like this in `config.log`:
```
build/conftest.c:116:1: error: the frame size of 1048 bytes is larger than 1024 bytes [-Werror=frame-larger-than=]
```
Fix this by moving the struct declarations off the stack.

2. Without the correct headers included, it's possible for declarations to be missed, leaving errors like this in `config.log`:
```
build/conftest.c:131:14: error: ‘struct nameidata’ declared inside parameter list [-Werror]
```
Fix this by adding appropriate headers.

These issues found by:
```
grep -E 'error: (the frame size|.*declared inside)' config.log
```

**Note:**

Both these issues can result in silent config failures because the compile failure is taken to mean "this option is not supported by this kernel" rather than "there's something wrong with the config test". This can lead to something merely annoying (compile failures) to something potentially serious (miscompiled or misused kernel primitives or functions).

This type of error is likely to reoccur because it only shows up with, perhaps, specific kernel versions and non-standard options, and the failures are "silent" per above.

Is there some way of flagging these sorts of errors via the buildbots? Maybe run the `grep -E 'pattern' config.log`, where `pattern` can be extended to include any further config issues found?


### How Has This Been Tested?

```
$ rm -f config.log
$ ./configure --with-linux=${linux_source_dir} --with-linux-obj=${linux_build_dir} &&
{ grep -E 'error: (the frame size|.*declared inside parameter list)' config.log || echo ' => clear of frame size and declaration issues'; }
```
...fix errors, wash, rinse, repeat until `config.log` is clear. Then:
```
$ make -C module
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.