### PR TITLE
Address objtool check failures in lua module

### DIFF
--- a/module/lua/llimits.h
+++ b/module/lua/llimits.h
@@ -97,8 +97,10 @@ typedef LUAI_UACNUMBER l_uacNumber;
 
 /*
 ** non-return type
+**
+** Supress noreturn attribute in kernel builds to avoid objtool check warnings
 */
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(_KERNEL)
 #define l_noret		void __attribute__((noreturn))
 #elif defined(_MSC_VER)
 #define l_noret		void __declspec(noreturn)


### PR DESCRIPTION
Signed-off-by: Don Brady <don.brady@delphix.com>

### Description
The use of `void __attribute__((noreturn))` in kernel builds was causing lots of warnings if `CONFIG_STACK_VALIDATION` is active. For now we just remove this attribute to achieve clean builds for the Lua module.  There was no significant increase in the time to run the full channel_program ZTS tests.

### How Has This Been Tested?
test runs and ZTS `channel_program` suite of tests

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.