### PR TITLE
Do not initiate MMP writes while pool is suspended

### DIFF
--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -438,7 +438,7 @@ mmp_thread(void *arg)
 			zio_suspend(spa, NULL);
 		}
 
-		if (multihost)
+		if (multihost && !suspended)
 			mmp_write_uberblock(spa);
 
 		CALLB_CPR_SAFE_BEGIN(&cpr);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
If the pool is suspended, skip the MMP write.  At the next cycle of the mmp thread's main loop (which is after a timed wait) check again.  In this case the thread will be sleeping most of the time, even though it's polling rather than waiting on the spa_suspend_cv.

I chose to do this rather than waiting on spa_suspend_cv so that the MMP thread does not need to start taking the spa_suspend_lock on every cycle.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While the pool is suspended on host A, it may be imported on host B.
If host A continued to write MMP blocks, it would be blindly
overwriting MMP blocks written by host B, and the blocks written by
host A would have outdated txg information.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Ran `ztest` many times.  Imported test pools by hand and triggered suspension via `zinject`; monitored writes via `multihost_history` and via `zdb -lu -VVV`.

I did not add a new test to verify this behavior change because the test methods I came up with were not clean.

The best test would be to set `failmode` to `WAIT`, import a pool, trigger suspension using zinject, verify that MMP writes stopped via zdb or via multihost_history, and then resume the pool with `zpool clear` or simply export it.  However currently `zpool clear` and `zpool export` fail for different reasons.  I also attempted modifying ztest to trigger a suspension internally, but it was not clear it would be reliable as ztest does not always tolerate suspension well and a test might pass because ztest crashed, which would not validate mmp.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
