### PR TITLE
can't boot from encrypted nested dataset using openrc

### DIFF
--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -61,10 +61,11 @@ if import_pool "${ZFS_POOL}" ; then
 		# if the root dataset has encryption enabled
 		if $(zfs list -H -o encryption "${ZFS_DATASET}" | grep -q -v off); then
 			# figure out where the root dataset has its key, the keylocation should not be none
+			ZFS_CRYPTPARENT="$ZFS_DATASET"
 			while true; do
-				if [[ $(zfs list -H -o keylocation "${ZFS_DATASET}") == 'none' ]]; then
-					ZFS_DATASET=$(echo -n "${ZFS_DATASET}" | awk 'BEGIN{FS=OFS="/"}{NF--; print}')
-					if [[ "${ZFS_DATASET}" == '' ]]; then
+				if [[ $(zfs list -H -o keylocation "${ZFS_CRYPTPARENT}") == 'none' ]]; then
+					ZFS_CRYPTPARENT=$(echo -n "${ZFS_CRYPTPARENT}" | awk 'BEGIN{FS=OFS="/"}{NF--; print}')
+					if [[ "${ZFS_CRYPTPARENT}" == '' ]]; then
 						rootok=0
 						break
 					fi
@@ -77,7 +78,7 @@ if import_pool "${ZFS_POOL}" ; then
 			# decrypt them
 			TRY_COUNT=5
 			while [ $TRY_COUNT != 0 ]; do
-				zfs load-key "${ZFS_DATASET}"
+				zfs load-key "${ZFS_CRYPTPARENT}"
 				[ $? == 0 ] && break
 				((TRY_COUNT-=1))
 			done


### PR DESCRIPTION
variable was being wrongly overwritten

Signed-off-by: Kash Pande <kash@tripleback.net>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
