### PR TITLE
Correct count_uberblocks in mmp.kshlib

### DIFF
--- a/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -198,6 +198,6 @@ function count_uberblocks # pool duration
 	typeset -i duration=$2
 	typeset hist_path="/proc/spl/kstat/zfs/$pool/multihost"
 
-	log_must sleep $duration
+	sleep $duration
 	echo $(cat "$hist_path" | sed '1,2d' | wc -l)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
In mmp test cases that use `count_uberblocks`, the following error is logged:
```
18:53:55.95 /usr/share/zfs/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh[65]: [: sleep: unknown operator
18:53:55.95 /usr/share/zfs/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh[69]: [: sleep: unknown operator
```
The issue is a `log_must sleep` in `count_uberblocks` in `mmp.kshlib`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolve the test case error to ensure it functions correctly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Reproduced in a CentOS 7 VM and locally tested that my fix resolves the problem.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
