### PR TITLE
Add omitted set for os->os_next_write_raw

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -847,8 +847,11 @@ dmu_free_long_range_impl(objset_t *os, dnode_t *dn, uint64_t offset,
 
 			while (dr != NULL && dr->dr_txg > tx->tx_txg)
 				dr = dr->dr_next;
-			if (dr != NULL && dr->dr_txg == tx->tx_txg)
+			if (dr != NULL && dr->dr_txg == tx->tx_txg) {
 				dr->dt.dl.dr_raw = B_TRUE;
+				dn->dn_objset->os_next_write_raw
+				    [tx->tx_txg & TXG_MASK] = B_TRUE;
+			}
 		}
 
 		dmu_tx_commit(tx);


### PR DESCRIPTION
This one line patch adds adds a set to os->os_next_write_raw
that was omitted when the code was updated in 1b66810. Without
it, the code (in some instances) could attempt to write raw
encrypted data as regular unencrypted data without the keys
being loaded, triggering an ASSERT in zio_encrypt().

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
