### PR TITLE
Remove unnecessary txg syncs from receive_object()

### DIFF
--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -2546,6 +2546,8 @@ receive_object(struct receive_writer_arg *rwa, struct drr_object *drro,
 	 * these objects before we attempt to allocate the new dnode.
 	 */
 	if (drro->drr_dn_slots > 1) {
+		boolean_t need_sync = B_FALSE;
+
 		for (uint64_t slot = drro->drr_object + 1;
 		    slot < drro->drr_object + drro->drr_dn_slots;
 		    slot++) {
@@ -2564,9 +2566,12 @@ receive_object(struct receive_writer_arg *rwa, struct drr_object *drro,
 
 			if (err != 0)
 				return (err);
+
+			need_sync = B_TRUE;
 		}
 
-		txg_wait_synced(dmu_objset_pool(rwa->os), 0);
+		if (need_sync)
+			txg_wait_synced(dmu_objset_pool(rwa->os), 0);
 	}
 
 	tx = dmu_tx_create(rwa->os);


### PR DESCRIPTION
1b66810b introduced serveral changes which improved the reliability
of zfs sends when large dnodes were involved. However, these fixes
required adding a few calls to txg_wait_synced() in the DRR_OBJECT
handling code. Although most of them are currently necessary, this
patch allows the code to continue without waiting in some cases
where it doesn't have to.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
