### PR TITLE
Raw receives must compress metadnode blocks

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -1033,8 +1033,6 @@ int dmu_diff(const char *tosnap_name, const char *fromsnap_name,
 #define	ZFS_CRC64_POLY	0xC96C5795D7870F42ULL	/* ECMA-182, reflected form */
 extern uint64_t zfs_crc64_table[256];
 
-extern int zfs_mdcomp_disable;
-
 #ifdef	__cplusplus
 }
 #endif

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1403,17 +1403,6 @@ Default value: \fB1,048,576\fR.
 .sp
 .ne 2
 .na
-\fBzfs_mdcomp_disable\fR (int)
-.ad
-.RS 12n
-Disable meta data compression
-.sp
-Use \fB1\fR for yes and \fB0\fR for no (default).
-.RE
-
-.sp
-.ne 2
-.na
 \fBzfs_metaslab_fragmentation_threshold\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6776,6 +6776,9 @@ arc_write_ready(zio_t *zio)
 		buf->b_flags &= ~ARC_BUF_FLAG_ENCRYPTED;
 		if (BP_GET_COMPRESS(bp) == ZIO_COMPRESS_OFF)
 			buf->b_flags &= ~ARC_BUF_FLAG_COMPRESSED;
+	} else if (BP_IS_HOLE(bp) && ARC_BUF_ENCRYPTED(buf)) {
+		buf->b_flags &= ~ARC_BUF_FLAG_ENCRYPTED;
+		buf->b_flags &= ~ARC_BUF_FLAG_COMPRESSED;
 	}
 
 	/* this must be done after the buffer flags are adjusted */

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -3465,7 +3465,8 @@ dbuf_check_crypt(dbuf_dirty_record_t *dr)
 		 * Writing raw encrypted data requires the db's arc buffer
 		 * to be converted to raw by the caller.
 		 */
-		ASSERT(arc_is_encrypted(db->db_buf));
+		ASSERT(arc_is_encrypted(db->db_buf) ||
+		    db->db.db_object == DMU_META_DNODE_OBJECT);
 	}
 }
 

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2104,8 +2104,6 @@ dmu_object_dirty_raw(objset_t *os, uint64_t object, dmu_tx_t *tx)
 	return (err);
 }
 
-int zfs_mdcomp_disable = 0;
-
 /*
  * When the "redundant_metadata" property is set to "most", only indirect
  * blocks of this level and higher will have an additional ditto block.
@@ -2135,16 +2133,12 @@ dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp, zio_prop_t *zp)
 	 *	 3. all other level 0 blocks
 	 */
 	if (ismd) {
-		if (zfs_mdcomp_disable) {
-			compress = ZIO_COMPRESS_EMPTY;
-		} else {
-			/*
-			 * XXX -- we should design a compression algorithm
-			 * that specializes in arrays of bps.
-			 */
-			compress = zio_compress_select(os->os_spa,
-			    ZIO_COMPRESS_ON, ZIO_COMPRESS_ON);
-		}
+		/*
+		 * XXX -- we should design a compression algorithm
+		 * that specializes in arrays of bps.
+		 */
+		compress = zio_compress_select(os->os_spa,
+		    ZIO_COMPRESS_ON, ZIO_COMPRESS_ON);
 
 		/*
 		 * Metadata always gets checksummed.  If the data
@@ -2520,9 +2514,6 @@ EXPORT_SYMBOL(dmu_buf_hold);
 EXPORT_SYMBOL(dmu_ot);
 
 /* BEGIN CSTYLED */
-module_param(zfs_mdcomp_disable, int, 0644);
-MODULE_PARM_DESC(zfs_mdcomp_disable, "Disable meta data compression");
-
 module_param(zfs_nopwrite_enabled, int, 0644);
 MODULE_PARM_DESC(zfs_nopwrite_enabled, "Enable NOP writes");
 

--- a/tests/zfs-tests/tests/functional/rsend/send_encrypted_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_encrypted_files.ksh
@@ -39,11 +39,6 @@
 
 verify_runnable "both"
 
-function set_metadata_compression_disabled # <0|1>
-{
-	echo $1 > /sys/module/zfs/parameters/zfs_mdcomp_disable
-}
-
 function cleanup
 {
 	datasetexists $TESTPOOL/$TESTFS2 && \
@@ -72,12 +67,6 @@ log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS2/sparse \
 log_must mkfile 32M /$TESTPOOL/$TESTFS2/truncated
 log_must truncate -s 4M /$TESTPOOL/$TESTFS2/truncated
 sync
-
-log_must set_metadata_compression_disabled 1
-log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS2/no_mdcomp \
-	count=1 bs=512 seek=10G >/dev/null 2>&1
-sync
-log_must set_metadata_compression_disabled 0
 
 log_must mkdir -p /$TESTPOOL/$TESTFS2/dir
 for i in {1..1000}; do


### PR DESCRIPTION
Currently, the DMU relies on ZIO layer compression to free LO
dnode blocks that no longer have objects in them. However,
raw receives disable all compression, meaning that these blocks
can never be freed. In addition to the obvious space concerns,
this could also cause incremental raw receives to fail to mount
since the MAC of a hole is different from that of a completely
zeroed block.

This patch corrects this issue by adding a special case in
zio_write_compress() which will attempt to compress these blocks
to a hole even if ZIO_FLAG_RAW_ENCRYPT is set. This patch also
removes the zfs_mdcomp_disable tunable, since tuning it could
cause these same issues.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
