### PR TITLE
Allow pool names that are not reserved but only start with reserved

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -946,10 +946,10 @@ zpool_name_valid(libzfs_handle_t *hdl, boolean_t isopen, const char *pool)
 	 * create (or import), and only in userland.
 	 */
 	if (ret == 0 && !isopen &&
-	    (strncmp(pool, "mirror", 6) == 0 ||
-	    strncmp(pool, "raidz", 5) == 0 ||
-	    strncmp(pool, "spare", 5) == 0 ||
-	    strcmp(pool, "log") == 0)) {
+	    (strncmp(pool, "mirror", 7) == 0 ||
+	    strncmp(pool, "raidz", 6) == 0 ||
+	    strncmp(pool, "spare", 6) == 0 ||
+	    strncmp(pool, "log", 4) == 0)) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl,
 			    dgettext(TEXT_DOMAIN, "name is reserved"));


### PR DESCRIPTION
zpool(8) says "The pool names mirror, raidz, spare and log are
reserved,", but the command actually avoids entire patterns which
start with "mirror"/"raidz"/"spare" by using strncmp(3) without
terminating null considered. It does right for "log" by not using
strncmp(3) with size of 3 (should be 4 or strcmp(3)).
(or fix zpool(8) man page if this is really intended behavior.)

e.g. zpool(8) avoids "spare\<something\>".
 \# zpool create spareribs /dev/sdb
 cannot create 'spareribs': name is reserved
 pool name may have been omitted

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Fixes zpool_name_valid() used for sanity checks of zpool name.
strncmp(3) size should contain termination null string.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow pool names that are not reserved but *only start with* reserved names.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
By running for e.g. zpool create command.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
