### PR TITLE
Document that pool names begin with mirror,raidz,spare are not allowed

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -27,7 +27,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd January 10, 2018
+.Dd February 23, 2018
 .Dt ZPOOL 8 SMM
 .Os Linux
 .Sh NAME
@@ -888,7 +888,12 @@ The pool names
 .Sy spare
 and
 .Sy log
-are reserved, as are names beginning with the pattern
+are reserved, as are names beginning with
+.Sy mirror ,
+.Sy raidz ,
+.Sy spare
+.\" names begin with "log" are ok for some reason.
+and the pattern
 .Sy c[0-9] .
 The
 .Ar vdev


### PR DESCRIPTION
PR #7208 was a patch to allow non-reserved pool names which begin with
mirror,raidz,spare (but do not equal), however we rather document it
in the man page for compatibility with other OpenZFS implementations,
i.e. avoid pool names that may not work on non-Linux platforms.

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
This is a follow-up PR for https://github.com/zfsonlinux/zfs/pull/7208.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Document the existing behavior rather than fix/change it (allow non-reserved pool names), for compatibility with OpenZFS on other platforms.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Checked the modified man page section after installation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
