### PR TITLE
ZTS: Fix zfs_share_* test case failures

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1420,7 +1420,13 @@ function setup_nfs_server
 	fi
 
 	if is_linux; then
-		log_note "NFS server must started prior to running test framework."
+		#
+		# Re-synchronize /var/lib/nfs/etab with /etc/exports and
+		# /etc/exports.d./* to provide a clean test environment.
+		#
+		log_must share -r
+
+		log_note "NFS server must be started prior to running ZTS."
 		return
 	fi
 


### PR DESCRIPTION
### Description

Prevent false positives when running the zfs_share_* test cases due to leftover stale /var/lib/nfs/etab entries.  When starting the test group re-synchronize the /var/lib/nfs/etab file with /etc/exports.  At this point in the testing there will be no additional `zfs share` entries to add.

### Motivation and Context

Occasion test failures are reported by the buildbot when the zfs_share test group is run on an instance which failed to completely cleanup its shares.

http://build.zfsonlinux.org/builders/Fedora%2027%20x86_64%20%28TEST%29/builds/967/steps/shell_8/logs/summary

### How Has This Been Tested?

Locally by manually creating stale entired in the `/var/lib/nfs/etab` file.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
