### PR TITLE
Incorrect maximum DVA value in DDE_GET_NDVAS()

### DIFF
--- a/include/sys/ddt.h
+++ b/include/sys/ddt.h
@@ -95,7 +95,7 @@ typedef struct ddt_key {
 #define	DDT_KEY_WORDS	(sizeof (ddt_key_t) / sizeof (uint64_t))
 
 #define	DDE_GET_NDVAS(dde) (DDK_GET_CRYPT(&dde->dde_key) \
-	? SPA_DVAS_PER_BP : SPA_DVAS_PER_BP - 1)
+	? SPA_DVAS_PER_BP - 1 : SPA_DVAS_PER_BP)
 
 typedef struct ddt_phys {
 	dva_t		ddp_dva[SPA_DVAS_PER_BP];


### PR DESCRIPTION
The conditional was reversed which caused garbage values to be used when
calculating dds_ref_dsize.

### Description
Fixed the conditional.

### Motivation and Context
Discovered while porting the vdev evacuation code.  This problem caused bogus values to be stored both in-core and on-disk for dds_ref_dsize which should show up in, for example, ```zpool status -D <pool>``` as wild values for ```DSIZE```.  It has the effect of, among other things, causing ```dsl_pool_adjustedsize()``` to return bogus values.

### How Has This Been Tested?
I used the following reproducer script and observed the value of DSIZE:
```
#!/bin/sh

truncate -s 1g tank.img
zpool create tank $(pwd)/tank.img
[ -f tank.key ] || dd if=/dev/urandom of=tank.key bs=32 count=1 > /dev/null 2>&1
zfs create -o dedup=on -o encryption=on -o keyformat=raw -o keylocation=file://`pwd`/tank.key tank/fs
yes | dd bs=1M count=100 iflag=fullblock of=/tank/fs/yes
zpool status -D tank
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.