### PR TITLE
Propose fix some typos

### DIFF
--- a/cmd/arcstat/arcstat.py
+++ b/cmd/arcstat/arcstat.py
@@ -280,7 +280,7 @@ def init():
                 "outfile",
                 "help",
                 "verbose",
-                "seperator",
+                "separator",
                 "columns"
             ]
         )
@@ -299,7 +299,7 @@ def init():
             hflag = True
         if opt in ('-v', '--verbose'):
             vflag = True
-        if opt in ('-s', '--seperator'):
+        if opt in ('-s', '--separator'):
             sep = arg
             i += 1
         if opt in ('-f', '--columns'):

--- a/cmd/dbufstat/dbufstat.py
+++ b/cmd/dbufstat/dbufstat.py
@@ -529,7 +529,7 @@ def main():
                 "help",
                 "infile",
                 "outfile",
-                "seperator",
+                "separator",
                 "types",
                 "verbose",
                 "extended",
@@ -555,7 +555,7 @@ def main():
             ofile = arg
         if opt in ('-r', '--raw'):
             raw += 1
-        if opt in ('-s', '--seperator'):
+        if opt in ('-s', '--separator'):
             sep = arg
         if opt in ('-t', '--types'):
             tflag = True

--- a/contrib/initramfs/scripts/zfs.in
+++ b/contrib/initramfs/scripts/zfs.in
@@ -478,7 +478,7 @@ destroy_fs()
 		echo "Message: $ZFS_STDERR"
 		echo "Error: $ZFS_ERROR"
 		echo ""
-		echo "Failed to destroy '$fs'. Please make sure that '$fs' is not availible."
+		echo "Failed to destroy '$fs'. Please make sure that '$fs' is not available."
 		echo "Hint: Try:  zfs destroy -Rfn $fs"
 		echo "If this dryrun looks good, then remove the 'n' from '-Rfn' and try again."
 		/bin/sh

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -729,7 +729,7 @@ man page.  In order to enable this property each host must set a unique hostid.
 See
 .Xr genhostid 1
 .Xr zgenhostid 8
-.Xr spl-module-paramters 5
+.Xr spl-module-parameters 5
 for additional details.  The default value is
 .Sy off .
 .It Sy version Ns = Ns Ar version

--- a/tests/zfs-tests/tests/functional/migration/migration_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_001_pos.ksh
@@ -60,7 +60,7 @@ prepare $DNAME "tar cf $TESTDIR/tar$$.tar $BNAME"
 (( $? != 0 )) && log_fail "Unable to create src archive"
 
 migrate $TESTDIR $SUMA $SUMB "tar xf $TESTDIR/tar$$.tar"
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to ZFS fs"
 
-log_pass "Successully migrated test file from ZFS fs to ZFS fs".
+log_pass "Successfully migrated test file from ZFS fs to ZFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_002_pos.ksh
@@ -60,7 +60,7 @@ prepare $DNAME "tar cf $TESTDIR/tar$$.tar $BNAME"
 (( $? != 0 )) && log_fail "Unable to create src archive"
 
 migrate $NONZFS_TESTDIR $SUMA $SUMB "tar xf $TESTDIR/tar$$.tar"
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to UFS fs"
 
-log_pass "Successully migrated test file from ZFS fs to UFS fs".
+log_pass "Successfully migrated test file from ZFS fs to UFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_003_pos.ksh
@@ -60,7 +60,7 @@ prepare $DNAME "tar cf $NONZFS_TESTDIR/tar$$.tar $BNAME"
 (( $? != 0 )) && log_fail "Unable to create src archive"
 
 migrate $TESTDIR $SUMA $SUMB "tar xvf $NONZFS_TESTDIR/tar$$.tar"
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "UFS fs to ZFS fs"
 
-log_pass "Successully migrated test file from UFS fs to ZFS fs".
+log_pass "Successfully migrated test file from UFS fs to ZFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_004_pos.ksh
@@ -67,7 +67,7 @@ cd $cwd
 (( $? != 0 )) && log_untested "Could not change directory to $cwd"
 
 migrate_cpio $TESTDIR "$TESTDIR/cpio$$.cpio" $SUMA $SUMB
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to ZFS fs"
 
-log_pass "Successully migrated test file from ZFS fs to ZFS fs".
+log_pass "Successfully migrated test file from ZFS fs to ZFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_005_pos.ksh
@@ -67,7 +67,7 @@ cd $cwd
 (( $? != 0 )) && log_untested "Could not change directory to $cwd"
 
 migrate_cpio $NONZFS_TESTDIR "$TESTDIR/cpio$$.cpio" $SUMA $SUMB
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to UFS fs"
 
-log_pass "Successully migrated test file from ZFS fs to UFS fs".
+log_pass "Successfully migrated test file from ZFS fs to UFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_006_pos.ksh
@@ -67,7 +67,7 @@ cd $cwd
 (( $? != 0 )) && log_untested "Could not change directory to $cwd"
 
 migrate_cpio $TESTDIR "$NONZFS_TESTDIR/cpio$$.cpio" $SUMA $SUMB
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to ZFS fs"
 
-log_pass "Successully migrated test file from UFS fs to ZFS fs".
+log_pass "Successfully migrated test file from UFS fs to ZFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_007_pos.ksh
@@ -60,7 +60,7 @@ prepare $DNAME "dd if=$BNAME obs=128k of=$TESTDIR/dd$$.dd"
 (( $? != 0 )) && log_fail "Unable to create src archive"
 
 migrate $TESTDIR $SUMA $SUMB "dd if=$TESTDIR/dd$$.dd obs=128k of=$BNAME"
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to ZFS fs"
 
-log_pass "Successully migrated test file from ZFS fs to ZFS fs".
+log_pass "Successfully migrated test file from ZFS fs to ZFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_008_pos.ksh
@@ -60,7 +60,7 @@ prepare $DNAME "dd if=$BNAME obs=128k of=$TESTDIR/dd$$.dd"
 (( $? != 0 )) && log_fail "Unable to create src archive"
 
 migrate $NONZFS_TESTDIR $SUMA $SUMB "dd if=$TESTDIR/dd$$.dd obs=128k of=$BNAME"
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to ZFS fs"
 
-log_pass "Successully migrated test file from ZFS fs to UFS fs".
+log_pass "Successfully migrated test file from ZFS fs to UFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_009_pos.ksh
@@ -60,7 +60,7 @@ prepare $DNAME "dd if=$BNAME obs=128k of=$NONZFS_TESTDIR/dd$$.dd"
 (( $? != 0 )) && log_fail "Unable to create src archive"
 
 migrate $TESTDIR $SUMA $SUMB "dd if=$NONZFS_TESTDIR/dd$$.dd obs=128k of=$BNAME"
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to ZFS fs"
 
-log_pass "Successully migrated test file from UFS fs to ZFS fs".
+log_pass "Successfully migrated test file from UFS fs to ZFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_010_pos.ksh
@@ -60,7 +60,7 @@ prepare $DNAME "cp $BNAME $TESTDIR/cp$$.cp"
 (( $? != 0 )) && log_fail "Unable to create src archive"
 
 migrate $TESTDIR $SUMA $SUMB "cp $TESTDIR/cp$$.cp $BNAME"
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to ZFS fs"
 
-log_pass "Successully migrated test file from ZFS fs to ZFS fs".
+log_pass "Successfully migrated test file from ZFS fs to ZFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_011_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_011_pos.ksh
@@ -60,7 +60,7 @@ prepare $DNAME "cp $BNAME $TESTDIR/cp$$.cp"
 (( $? != 0 )) && log_fail "Unable to create src archive"
 
 migrate $NONZFS_TESTDIR $SUMA $SUMB "cp $TESTDIR/cp$$.cp $BNAME"
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "ZFS fs to UFS fs"
 
-log_pass "Successully migrated test file from ZFS fs to UFS fs".
+log_pass "Successfully migrated test file from ZFS fs to UFS fs".

--- a/tests/zfs-tests/tests/functional/migration/migration_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/migration/migration_012_pos.ksh
@@ -60,7 +60,7 @@ prepare $DNAME "cp $BNAME $NONZFS_TESTDIR/cp$$.cp"
 (( $? != 0 )) && log_fail "Unable to create src archive"
 
 migrate $TESTDIR $SUMA $SUMB "cp $NONZFS_TESTDIR/cp$$.cp $BNAME"
-(( $? != 0 )) && log_fail "Uable to successfully migrate test file from" \
+(( $? != 0 )) && log_fail "Unable to successfully migrate test file from" \
     "UFS fs to ZFS fs"
 
-log_pass "Successully migrated test file from UFS fs to ZFS fs".
+log_pass "Successfully migrated test file from UFS fs to ZFS fs".


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

Just a doc update to fix typos

In one script I don't understand the operator for the integer test

```sh
-	if [ "$ZFS_INITRD_PRE_MOUNTROOT_SLEEP" > 0 ]
+	if [ "$ZFS_INITRD_PRE_MOUNTROOT_SLEEP" -gt 0 ]
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
