### PR TITLE
Show block IO errors in zpool status -c

### DIFF
--- a/cmd/zpool/Makefile.am
+++ b/cmd/zpool/Makefile.am
@@ -67,7 +67,8 @@ dist_zpoolexec_SCRIPTS = \
 	zpool.d/test_type \
 	zpool.d/test_status \
 	zpool.d/test_progress \
-	zpool.d/test_ended
+	zpool.d/test_ended \
+	zpool.d/ioerr_cnt
 
 zpoolconfdefaults = \
 	enc \
@@ -111,7 +112,8 @@ zpoolconfdefaults = \
 	test_type \
 	test_status \
 	test_progress \
-	test_ended
+	test_ended \
+	ioerr_cnt
 
 install-data-hook:
 	$(MKDIR_P) "$(DESTDIR)$(zpoolconfdir)"

--- a/cmd/zpool/zpool.d/ioerr_cnt
+++ b/cmd/zpool/zpool.d/ioerr_cnt
@@ -1,0 +1,11 @@
+#!/bin/sh
+if [ "$1" = "-h" ] ; then
+	echo "Show block IO error count (/sys/block/<dev>/device/ioerr_cnt in decimal)"
+	exit
+fi
+dev=$(basename "$VDEV_UPATH")
+if [ -e /sys/block/"$dev"/device/ioerr_cnt ] ; then
+	# Get value and convert it from hex
+	ioerr=$(printf %d "$(cat /sys/block/"$dev"/device/ioerr_cnt)")
+	echo ioerr_cnt="$ioerr"
+fi


### PR DESCRIPTION
### Description
Show the (decimal) value of `/sys/block/<dev>/device/ioerr_cnt` in `zpool status|iostat -c ioerr_cnt`.

```
$ zpool status -c ioerr_cnt
  pool: mypool
 state: ONLINE
  scan: none requested
config:

	NAME        STATE     READ WRITE CKSUM  ioerr_cnt
	mypool      ONLINE       0     0     0
	  sdb       ONLINE       0     0     0         13
	  sdc       ONLINE       0     0     0          9
```

### Motivation and Context
We've seen drives with tons of block errors only show a handful of ZFS errors due to multipath handling the errors.  We still want to know about the block errors though.

### How Has This Been Tested?
Tested on a VM with virtual block devices.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
