### PR TITLE
ZTS: fix spurious failures in mv_files

### DIFF
--- a/tests/zfs-tests/tests/functional/mv_files/mv_files_common.kshlib
+++ b/tests/zfs-tests/tests/functional/mv_files/mv_files_common.kshlib
@@ -108,16 +108,6 @@ function init_setup
 
 }
 
-function wait_pid
-{
-	for pid in $1
-	do
-		ps -e | grep $pid >/dev/null 2>&1
-		(( $? == 0 )) && wait $pid
-        done
-}
-
-
 #
 # Generate given number files in a
 # directory of zfs file system
@@ -141,18 +131,17 @@ function generate_files
                 cp /etc/passwd $1/file_$count \
                          > /dev/null 2>&1 &
 
-                PIDS="$PIDS $!"
+                (( proc_num = proc_num + 1 ))
 
-                proc_num=`echo $PIDS | wc -w`
                 if (( proc_num >= GANGPIDS )); then
-                        wait_pid "$PIDS"
+                        wait
                         proc_num=0
-                        PIDS=""
                 fi
 
                (( count = count + 1 ))
         done
 
+        wait
 }
 
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix spurious failures in mv_files.

### Description
<!--- Describe your changes in detail -->
The test could fail because of a race condition between the files being generated in the background and attempting to move the files. Wait for all file generation to complete before trying to move the files around.

Also, clean up the waiting: the 'wait' command without arguments waits for all child pids. There's no need to imperfectly look to see if each pid exists and then wait for that pid explicitly. (Imperfectly: no need to look at all pids on the system with `-e`, just our own pids would have been fine, and looking for pid 123 with `grep` would find 1234 thus negating the purpose of the check).

Note: the leading whitespace in this file is atrocious, but fixing it all hides what's being fixed.

### Motivation and Context

Spurious failures are annoying and time wasting.

### How Has This Been Tested?
Run zfs-tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
