### PR TITLE
Fix zdb and inuse tests that don't pass with real disks

### DIFF
--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -423,3 +423,19 @@ function get_debug_device
 {
 	lsscsi | nawk '/scsi_debug/ {print $6; exit}' | cut -d / -f3
 }
+
+#
+# Get actual devices used by the pool (i.e. linux sdb1 not sdb).
+#
+function get_pool_devices #testpool #devdir
+{
+	typeset testpool=$1
+	typeset devdir=$2
+	typeset out=""
+
+	if is_linux; then
+		out=$(zpool status -P $testpool |grep ${devdir} | awk '{print $1}')
+		out=$(echo $out | sed -e "s|${devdir}/||g" | tr '\n' ' ')
+	fi
+	echo $out
+}

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -810,7 +810,11 @@ function zero_partitions #<whole_disk_name>
 	typeset i
 
 	if is_linux; then
-		log_must parted $DEV_DSKDIR/$diskname -s -- mklabel gpt
+		DSK=$DEV_DSKDIR/$diskname
+		DSK=$(echo $DSK | sed -e "s|//|/|g")
+		log_must parted $DSK -s -- mklabel gpt
+		blockdev --rereadpt $DSK 2>/dev/null
+		block_device_wait
 	else
 		for i in 0 1 3 4 5 6 7
 		do
@@ -838,10 +842,11 @@ function set_partition #<slice_num> <slice_start> <size_plus_units>  <whole_disk
 	typeset start=$2
 	typeset size=$3
 	typeset disk=$4
-	[[ -z $slicenum || -z $size || -z $disk ]] && \
-	    log_fail "The slice, size or disk name is unspecified."
 
 	if is_linux; then
+		if [[ -z $size || -z $disk ]]; then
+			log_fail "The size or disk name is unspecified."
+		fi
 		typeset size_mb=${size%%[mMgG]}
 
 		size_mb=${size_mb%%[mMgG][bB]}
@@ -884,6 +889,10 @@ function set_partition #<slice_num> <slice_start> <size_plus_units>  <whole_disk
 		blockdev --rereadpt $DEV_DSKDIR/$disk 2>/dev/null
 		block_device_wait
 	else
+		if [[ -z $slicenum || -z $size || -z $disk ]]; then
+			log_fail "The slice, size or disk name is unspecified."
+		fi
+
 		typeset format_file=/var/tmp/format_in.$$
 
 		echo "partition" >$format_file

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_003_pos.ksh
@@ -43,6 +43,11 @@ config_count=(1 2)
 set -A DISK $DISKS
 
 default_mirror_setup_noexit $DISKS
+
+DEVS=$(get_pool_devices ${TESTPOOL} ${DEV_RDSKDIR})
+log_note "$DEVS"
+[[ -n $DEVS ]] && set -A DISK $DEVS
+
 log_must dd if=/dev/${DISK[0]} of=/dev/${DISK[1]} bs=1K count=256 conv=notrunc
 
 for x in 0 1 ; do

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_005_pos.ksh
@@ -45,6 +45,10 @@ verify_disk_count "$DISKS" 2
 set -A DISK $DISKS
 
 default_mirror_setup_noexit $DISKS
+DEVS=$(get_pool_devices ${TESTPOOL} ${DEV_RDSKDIR})
+log_note "$DEVS"
+[[ -n $DEVS ]] && set -A DISK $DEVS
+
 log_must dd if=/dev/zero of=$DEV_RDSKDIR/${DISK[1]} bs=1K count=256 conv=notrunc
 log_must truncate -s 0 $TEMPFILE
 

--- a/tests/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
@@ -82,19 +82,18 @@ typeset -i i=0
 
 unset NOINUSE_CHECK
 while (( i < ${#vdevs[*]} )); do
-
 	for num in 0 1 2 3 ; do
 		eval typeset disk=\${FS_DISK$num}
 		zero_partitions $disk
 	done
-
 	typeset cyl=""
 	for num in 0 1 2 3 ; do
 		eval typeset slice=\${FS_SIDE$num}
 		disk=${slice%${SLICE_PREFIX}*}
-		slice=${slice##*${SLICE_PREFIX}}
+		[[ -z $SLICE_PREFIX ]] && eval typeset disk=\${FS_DISK$num}
+		slice=$(echo $slice | awk '{ print substr($1,length($1),1) }')
 		log_must set_partition $slice "$cyl" $FS_SIZE $disk
-	        cyl=$(get_endslice $disk $slice)
+		[[ $num < 3 ]] && cyl=$(get_endslice $disk $slice)
 	done
 
 	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then
@@ -115,7 +114,6 @@ while (( i < ${#vdevs[*]} )); do
 		(( i = i + 1 ))
 		continue
 	fi
-
 	create_pool $TESTPOOL1 ${vdevs[i]} $vdisks spare $sdisks
 	verify_assertion "$rawtargets"
 	destroy_pool $TESTPOOL1

--- a/tests/zfs-tests/tests/functional/inuse/inuse_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_008_pos.ksh
@@ -92,9 +92,10 @@ done
 for num in 0 1 2 3 ; do
 	eval typeset slice=\${FS_SIDE$num}
 	disk=${slice%${SLICE_PREFIX}*}
-	slice=${slice##*${SLICE_PREFIX}}
+	[[ -z $SLICE_PREFIX ]] && eval typeset disk=\${FS_DISK$num}
+	slice=$(echo $slice | awk '{ print substr($1,length($1),1) }')
 	log_must set_partition $slice "$cyl" $FS_SIZE $disk
-	cyl=$(get_endslice $disk $slice)
+	[[ $num < 3 ]] && cyl=$(get_endslice $disk $slice)
 done
 
 while (( i < ${#vdevs[*]} )); do

--- a/tests/zfs-tests/tests/functional/inuse/inuse_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_009_pos.ksh
@@ -82,13 +82,19 @@ typeset -i i=0
 
 while (( i < ${#vdevs[*]} )); do
 
+	for num in 0 1 2 3 ; do
+		eval typeset disk=\${FS_DISK$num}
+		zero_partitions $disk
+	done
+
 	typeset cyl=""
 	for num in 0 1 2 3 ; do
 		eval typeset slice=\${FS_SIDE$num}
 		disk=${slice%${SLICE_PREFIX}*}
-		slice=${slice##*${SLICE_PREFIX}}
+		[[ -z $SLICE_PREFIX ]] && eval typeset disk=\${FS_DISK$num}
+		slice=$(echo $slice | awk '{ print substr($1,length($1),1) }')
 		log_must set_partition $slice "$cyl" $FS_SIZE $disk
-		cyl=$(get_endslice $disk $slice)
+		[[ $num < 3 ]] && cyl=$(get_endslice $disk $slice)
 	done
 
 	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then


### PR DESCRIPTION
Due to zpool create auto-partioning in Linux (i.e. sdb1),
certain utilities need to use the parition (sdb1) while
others use the whole disk name (sdb).
Fixes #6939

Authored-by: Paul Zuchowski <pzuchowski@datto.com>
Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>

### Description
For Linux, we need to carefully choose between partition 1 of a disk (i.e. sdb1) and the whole disk when passing disk names to utilities such as zdb, parted, and dd.  Also we must clear disks using parted to create a whole disk gpt label before getting into the body of some tests.

### Motivation and Context
Linux zfstest zdb and inuse tests will only pass in the default DISKS setup using loop devices.  Setting DISKS="sdb sdc sdd" will result in failure.  These fixes enable the tests to pass using actual disks.

### How Has This Been Tested?
Tested with loop devices and real disks.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
