### PR TITLE
Misc fixes and cleanup for project quota

### DIFF
--- a/cmd/zfs/zfs_project.c
+++ b/cmd/zfs/zfs_project.c
@@ -43,7 +43,7 @@
 
 typedef struct zfs_project_item {
 	list_node_t	zpi_list;
-	char		zpi_name[PATH_MAX];
+	char		zpi_name[0];
 } zfs_project_item_t;
 
 static void
@@ -51,7 +51,7 @@ zfs_project_item_alloc(list_t *head, const char *name)
 {
 	zfs_project_item_t *zpi;
 
-	zpi = safe_malloc(sizeof (zfs_project_item_t));
+	zpi = safe_malloc(sizeof (zfs_project_item_t) + strlen(name) + 1);
 	strcpy(zpi->zpi_name, name);
 	list_insert_tail(head, zpi);
 }

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -3179,7 +3179,8 @@ zfs_prop_get_userquota(zfs_handle_t *zhp, const char *propname,
 	} else if (propvalue == 0 &&
 	    (type == ZFS_PROP_USERQUOTA || type == ZFS_PROP_GROUPQUOTA ||
 	    type == ZFS_PROP_USEROBJQUOTA || type == ZFS_PROP_GROUPOBJQUOTA ||
-	    type == ZFS_PROP_PROJECTQUOTA || ZFS_PROP_PROJECTOBJQUOTA)) {
+	    type == ZFS_PROP_PROJECTQUOTA ||
+	    type == ZFS_PROP_PROJECTOBJQUOTA)) {
 		(void) strlcpy(propbuf, "none", proplen);
 	} else if (type == ZFS_PROP_USERQUOTA || type == ZFS_PROP_GROUPQUOTA ||
 	    type == ZFS_PROP_USERUSED || type == ZFS_PROP_GROUPUSED ||

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -2077,7 +2077,7 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 		if (flags & DN_ID_OLD_EXIST) {
 			dn->dn_newuid = dn->dn_olduid;
 			dn->dn_newgid = dn->dn_oldgid;
-			dn->dn_newgid = dn->dn_oldprojid;
+			dn->dn_newprojid = dn->dn_oldprojid;
 		} else {
 			dn->dn_newuid = 0;
 			dn->dn_newgid = 0;

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2891,10 +2891,12 @@ zfs_setattr(struct inode *ip, vattr_t *vap, int flags, cred_t *cr)
 		}
 
 		if (XVA_ISSET_REQ(xvap, XAT_PROJINHERIT) &&
+		    (xoap->xoa_projinherit !=
+		    ((zp->z_pflags & ZFS_PROJINHERIT) != 0)) &&
 		    (!dmu_objset_projectquota_enabled(os) ||
 		    (!S_ISREG(ip->i_mode) && !S_ISDIR(ip->i_mode)))) {
-				ZFS_EXIT(zfsvfs);
-				return (SET_ERROR(ENOTSUP));
+			ZFS_EXIT(zfsvfs);
+			return (SET_ERROR(ENOTSUP));
 		}
 	}
 


### PR DESCRIPTION
1) The Coverity Scan reports some issues for the project
   quota patch, including:

1.1) zfs_prop_get_userquota() directly uses the const quota
   type value as the condition check by wrong.

1.2) dmu_objset_userquota_get_ids() may cause dnode::dn_newgid
   to be overwritten by dnode::dn->dn_oldprojid.

2) This patch fixes related issues. It also enhances the logic
   for zfs_project_item_alloc() to avoid buffer overflow.

3) Skip project quota ability check if does not change project
   quota related things (id or flag). Otherwise, it will cause
   chattr (for other non project quota flags) operation failed
   if project quota disabled.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Description
Fix the issues that were introduced by the project quota patch

### Motivation and Context
The Coverity Scan reported some issues for the project quota patch, including:

** CID 174157:  Incorrect expression  (UNUSED_VALUE)
/module/zfs/dmu_objset.c: 2064 in dmu_objset_userquota_get_ids()

________________________________________________________________________________________________________
*** CID 174157:  Incorrect expression  (UNUSED_VALUE)
/module/zfs/dmu_objset.c: 2064 in dmu_objset_userquota_get_ids()
2058     	 * If we don't know what the old values are then just assign
2059     	 * them to 0, since that is a new file  being created.
2060     	 */
2061     	if (!before && data == NULL && error == EEXIST) {
2062     		if (flags & DN_ID_OLD_EXIST) {
2063     			dn->dn_newuid = dn->dn_olduid;
>>>     CID 174157:  Incorrect expression  (UNUSED_VALUE)
>>>     Assigning value from "dn->dn_oldgid" to "dn->dn_newgid" here, but that stored value is overwritten before it can be used.
2064     			dn->dn_newgid = dn->dn_oldgid;
2065     			dn->dn_newgid = dn->dn_oldprojid;
2066     		} else {
2067     			dn->dn_newuid = 0;
2068     			dn->dn_newgid = 0;
2069     			dn->dn_newprojid = ZFS_DEFAULT_PROJID;

** CID 174156:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
/lib/libzfs/libzfs_dataset.c: 3180 in zfs_prop_get_userquota()

________________________________________________________________________________________________________
*** CID 174156:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
/lib/libzfs/libzfs_dataset.c: 3180 in zfs_prop_get_userquota()
3174     		return (err);
3175     3176     	if (literal) {
3177     		(void) snprintf(propbuf, proplen, "%llu",
3178     		    (u_longlong_t)propvalue);
3179     	} else if (propvalue == 0 &&
>>>     CID 174156:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
>>>     The expression "type == ZFS_PROP_USERQUOTA || type == ZFS_PROP_GROUPQUOTA || type == ZFS_PROP_USEROBJQUOTA || type == ZFS_PROP_GROUPOBJQUOTA || type == ZFS_PROP_PROJECTQUOTA || ZFS_PROP_PROJECTOBJQUOTA" is suspicious because it performs a Boolean operation on a constant other than 0 or 1.
3180     	    (type == ZFS_PROP_USERQUOTA || type == ZFS_PROP_GROUPQUOTA ||
3181     	    type == ZFS_PROP_USEROBJQUOTA || type ==
ZFS_PROP_GROUPOBJQUOTA ||
3182     	    type == ZFS_PROP_PROJECTQUOTA || ZFS_PROP_PROJECTOBJQUOTA)) {
3183     		(void) strlcpy(propbuf, "none", proplen);
3184     	} else if (type == ZFS_PROP_USERQUOTA || type ==
ZFS_PROP_GROUPQUOTA ||
3185     	    type == ZFS_PROP_USERUSED || type == ZFS_PROP_GROUPUSED ||

** CID 174154:  Security best practices violations  (STRING_OVERFLOW)
/cmd/zfs/zfs_project.c: 55 in zfs_project_item_alloc()

________________________________________________________________________________________________________
*** CID 174154:  Security best practices violations  (STRING_OVERFLOW)
/cmd/zfs/zfs_project.c: 55 in zfs_project_item_alloc()
49     static void
50     zfs_project_item_alloc(list_t *head, const char *name)
51     {
52     	zfs_project_item_t *zpi;
53     54     	zpi = safe_malloc(sizeof (zfs_project_item_t));
>>>     CID 174154:  Security best practices violations  (STRING_OVERFLOW)
>>>     You might overrun the 4096-character fixed-size string "zpi->zpi_name" by copying "name" without checking the length.
55     	strcpy(zpi->zpi_name, name);
56     	list_insert_tail(head, zpi);
57     }
58     59     static int
60     zfs_project_sanity_check(const char *name, zfs_project_control_t
*zpc,


There is another chatter trouble found in #7251 

### How Has This Been Tested?
Using the existing test sets

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.