### PR TITLE
Fix dbufstats_001_pos

### DIFF
--- a/tests/zfs-tests/include/math.shlib
+++ b/tests/zfs-tests/include/math.shlib
@@ -43,6 +43,29 @@ function within_percent
 }
 
 #
+# Return 0 if value is within +/-tolerance of target.
+# Return 1 if value exceeds our tolerance.
+# For use like this:
+#
+# Do $action if value is within the tolerance from target passed in:
+#	within_tolerance VAL TAR TOL && $action
+# Do $action if value surpasses the tolerance from target passed in:
+#	within_tolerance VAL TAR TOL || $action
+#
+function within_tolerance #value #target #tolerance
+{
+	typeset val=$1
+	typeset target=$2
+	typeset tol=$3
+
+	typeset diff=$((abs(val - target)))
+	log_note "Checking if $val is within +/-$tol of $target (diff: $diff)"
+	((diff <= tol)) && return 0
+
+	return 1
+}
+
+#
 # Return 0 if the human readable string of the form <value>[suffix] can
 # be converted to bytes.  Allow suffixes are shown in the table below.
 #

--- a/tests/zfs-tests/tests/functional/arc/dbufstats_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/arc/dbufstats_001_pos.ksh
@@ -55,10 +55,11 @@ function testdbufstat # stat_name dbufstat_filter
 
         [[ -n "$2" ]] && filter="-F $2"
 
-        verify_eq \
-	    $(grep -w "$name" "$DBUFSTATS_FILE" | awk '{ print $3 }') \
-	    $(dbufstat.py -bxn -i "$DBUFS_FILE" "$filter" | wc -l) \
-	    "$name"
+	from_dbufstat=$(grep -w "$name" "$DBUFSTATS_FILE" | awk '{ print $3 }')
+	from_dbufs=$(dbufstat.py -bxn -i "$DBUFS_FILE" "$filter" | wc -l)
+
+	within_tolerance $from_dbufstat $from_dbufs 5 \
+	    || log_fail "Stat $name exceeded tolerance"
 }
 
 verify_runnable "both"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Because the dbufstats and dbufs kstat file are being read
at slightly different times, it is possible for stats to be
slightly off. Use within_percent to account for the slight
differences.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolve test cases failures.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Locally on a CentOS 7 VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
