### PR TITLE
Fix zfs_allow_004_pos

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -380,7 +380,7 @@ function create_recv_clone
 	log_must zfs snapshot $incr
 	log_must eval "zfs send -i $snap $incr | dd bs=10K count=1 > $sendfile"
 	log_mustnot eval "zfs recv -su $recvfs < $sendfile"
-	log_must zfs destroy -r $sendfs
+	destroy_dataset "$sendfs" "-r"
 	log_must rm -f "$sendfile"
 
 	if [[ $(get_prop 'inconsistent' "$recvfs/%recv") -ne 1 ]]; then
@@ -546,8 +546,7 @@ function default_cleanup_noexit
 		typeset fs=""
 		for fs in $(zfs list -H -o name \
 		    | grep "^$ZONE_POOL/$ZONE_CTR[01234]/"); do
-			datasetexists $fs && \
-				log_must zfs destroy -Rf $fs
+			destroy_dataset "$fs" "-Rf"
 		done
 
 		# Need cleanup here to avoid garbage dir left.
@@ -608,11 +607,8 @@ function default_container_cleanup
 	[[ $? -eq 0 ]] && \
 	    log_must zfs unmount $TESTPOOL/$TESTCTR/$TESTFS1
 
-	datasetexists $TESTPOOL/$TESTCTR/$TESTFS1 && \
-	    log_must zfs destroy -R $TESTPOOL/$TESTCTR/$TESTFS1
-
-	datasetexists $TESTPOOL/$TESTCTR && \
-	    log_must zfs destroy -Rf $TESTPOOL/$TESTCTR
+	destroy_dataset "$TESTPOOL/$TESTCTR/$TESTFS1" "-R"
+	destroy_dataset "$TESTPOOL/$TESTCTR" "-Rf"
 
 	[[ -e $TESTDIR1 ]] && \
 	    log_must rm -rf $TESTDIR1 > /dev/null 2>&1
@@ -646,7 +642,7 @@ function destroy_snapshot
 			log_fail "get_prop mountpoint $snap failed."
 	fi
 
-	log_must zfs destroy $snap
+	destroy_dataset "$snap"
 	[[ $mtpt != "" && -d $mtpt ]] && \
 		log_must rm -rf $mtpt
 }
@@ -672,7 +668,7 @@ function destroy_clone
 			log_fail "get_prop mountpoint $clone failed."
 	fi
 
-	log_must zfs destroy $clone
+	destroy_dataset "$clone"
 	[[ $mtpt != "" && -d $mtpt ]] && \
 		log_must rm -rf $mtpt
 }
@@ -691,7 +687,7 @@ function destroy_bookmark
 		log_fail "'$bkmarkp' does not existed."
 	fi
 
-	log_must zfs destroy $bkmark
+	destroy_dataset "$bkmark"
 }
 
 # Return 0 if a snapshot exists; $? otherwise
@@ -1595,6 +1591,40 @@ function destroy_pool #pool
 	return 0
 }
 
+# Return 0 if destroy successfully or the dataset exists; $? otherwise
+# Note: In local zones, this function should return 0 silently.
+#
+# $1 - dataset name
+# $2 - custom arguments for zfs destroy
+# Destroy dataset with the given parameters.
+
+function destroy_dataset #dataset #args
+{
+	typeset dataset=$1
+	typeset mtpt
+	typeset args=${2:-""}
+
+	if [[ -z $dataset ]]; then
+		log_note "No dataset name given."
+		return 1
+	fi
+
+	if is_global_zone ; then
+		if datasetexists "$dataset" ; then
+			mtpt=$(get_prop mountpoint "$dataset")
+			log_must_busy zfs destroy $args $dataset
+
+			[[ -d $mtpt ]] && \
+				log_must rm -rf $mtpt
+		else
+			log_note "Dataset does not exist. ($dataset)"
+			return 1
+		fi
+	fi
+
+	return 0
+}
+
 #
 # Firstly, create a pool with 5 datasets. Then, create a single zone and
 # export the 5 datasets to it. In addition, we also add a ZFS filesystem
@@ -2463,9 +2493,7 @@ function verify_opt_p_ops
 	esac
 
 	# make sure the upper level filesystem does not exist
-	if datasetexists ${newdataset%/*} ; then
-		log_must zfs destroy -rRf ${newdataset%/*}
-	fi
+	destroy_dataset "${newdataset%/*}" "-rRf"
 
 	# without -p option, operation will fail
 	log_mustnot zfs $ops $dataset $newdataset

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_002_pos.ksh
@@ -49,8 +49,7 @@ function cleanup
 {
 	typeset -i i=0
 	while (( $i < ${#data_objs[*]} )); do
-		datasetexists "${data_objs[i]}" && \
-			zfs destroy -rf ${data_objs[i]}
+		destroy_dataset "${data_objs[i]}" "-rf"
 		((i = i + 1))
 	done
 }
@@ -87,7 +86,7 @@ done
 
 i=0
 while (( $i < ${#data_objs[*]} )); do
-	log_must zfs destroy ${data_objs[i]}
+	destroy_dataset "${data_objs[i]}"
 	datasetexists ${data_objs[i]} && \
 		log_fail "'zfs destroy <filesystem>|<volume>|<snapshot>' fail."
 	((i = i + 1))

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_008_pos.ksh
@@ -49,7 +49,7 @@ function cleanup
 		log_must zfs promote $vol
 	fi
 
-	log_must zfs destroy -rR $snap
+	destroy_dataset "$snap" "-rR"
 }
 
 log_assert "'zfs promote' can promote a volume clone."

--- a/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
+++ b/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
@@ -53,15 +53,11 @@ function cleanup_user_group
 #
 function restore_root_datasets
 {
-	if datasetexists $ROOT_TESTFS ; then
-		log_must zfs destroy -Rf $ROOT_TESTFS
-	fi
+	destroy_dataset "$ROOT_TESTFS" "-Rf"
 	log_must zfs create $ROOT_TESTFS
 
 	if is_global_zone ; then
-		if datasetexists $ROOT_TESTVOL ; then
-			log_must zfs destroy -Rf $ROOT_TESTVOL
-		fi
+		destroy_dataset "$ROOT_TESTVOL" "-Rf"
 		log_must zfs create -V $VOLSIZE $ROOT_TESTVOL
 		block_device_wait
 	fi


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Datasets can be busy when calling zfs destroy. Introduce
a helper function to destroy datasets and use it to destroy
datasets in zfs_allow_004_pos.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix failing tests.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Locally on a CentOS 7 VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
