### PR TITLE
destroy makes full snap list before destroying

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -2528,7 +2528,8 @@ If this flag is specified, the
 .Fl d
 flag will have no effect.
 .It Fl d
-Defer snapshot deletion.
+Destroy immediately. If a snapshot cannot be destroyed now, mark it for
+deferred destruction.
 .It Fl n
 Do a dry-run
 .Pq Qq No-op


### PR DESCRIPTION
Change zfs destroy logic so destroying begins before the entire list of snapshots is built.

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>

If a dataset has several thousands of snapshots, it can take quite some time from issuing
the zfs destroy -r command until actual space starts getting reclaimed.   This is because
all the snapshots are put in a list, and when the list is complete, the destroying starts.

### Description
Alter the destroy_callback logic so that for every 10 snapshots accumulated, issue fnvlist_free 
to destroy them, then continue accumulating more snapshots.

### Motivation and Context
For Datto it is common to have thousands of snapshots per dataset.  On a full system, once 
a dataset has been migrated to another pool, we destroy the original.  Since the system is full,
it is important to start reclaiming the space soon rather than waiting many minutes while the 
list of snapshots is built.

### How Has This Been Tested?
Unit tested zfs destroy with 1000 and 10000 snapshots in a dataset.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.