### PR TITLE
[WIP] load modules automatically on boot / package installation

### DIFF
--- a/etc/modules-load.d/zfs.conf.in
+++ b/etc/modules-load.d/zfs.conf.in
@@ -1,3 +1,2 @@
-# Always load kernel modules at boot.  The default behavior is to load the
-# kernel modules in the zfs-import-*.service or when blkid(8) detects a pool.
-#zfs
+# Always load kernel modules at boot.
+zfs

--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -12,7 +12,6 @@ ConditionPathExists=@sysconfdir@/zfs/zpool.cache
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=-/sbin/modprobe zfs
 ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
 ExecStartPost=/bin/bash -c "/bin/systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | /bin/awk '$1 != \"-\" {print; exit}')"
 

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -11,7 +11,6 @@ ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=-/sbin/modprobe zfs
 ExecStart=@sbindir@/zpool import -aN -o cachefile=none
 ExecStartPost=/bin/bash -c "/bin/systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | /bin/awk '$1 != \"-\" {print; exit}')"
 

--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -58,7 +58,9 @@ fi
 for POSTINST in /usr/lib/dkms/common.postinst; do
     if [ -f $POSTINST ]; then
         $POSTINST %{module} %{version}
-        exit $?
+        DKMS_RET=$?
+        modprobe %{module}
+        exit ${DKMS_RET}
     fi
     echo "WARNING: $POSTINST does not exist."
 done

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -184,6 +184,7 @@ for kernel_version in %{?kernel_versions}; do
 done
 # find-debuginfo.sh only considers executables
 chmod u+x ${RPM_BUILD_ROOT}%{kmodinstdir_prefix}/*/extra/*/*/*
+modprobe %{module}
 %{?akmod_install}
 
 

--- a/rpm/redhat/zfs-kmod.spec.in
+++ b/rpm/redhat/zfs-kmod.spec.in
@@ -85,6 +85,7 @@ make install \
 
 # find-debuginfo.sh only considers executables
 %{__chmod} u+x  %{buildroot}/lib/modules/%{kverrel}/extra/*/*/*
+modprobe %{module}
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
the current situation in ZoL (with `/` not on ZFS) is the following:
- a `modules-load.d` snippet for loading at boot time is included, but not active
- a `zfs-import-scan` systemd service which would load the ZFS module before being started is shipped, but not enabled/started by default
- a `zfs-import-cache` systemd service which loads the ZFS module before being start is shipped and started/enabled by default, but it has a condition on a zpool.cache file existing in the default location.

this means that in the absence of manual intervention, a default install will leave the module not loaded, and all zfs services (`zfs-mount`, `zfs-share`, `zfs-zed`) implicitly depending on the modules failing with error messages indicating the lack of loaded module(s).

this PR changes this in the following manner:
- the `modules-load.d` snipped is switched to be active by default
- the RPM packaging for DKMS and kmod packages is adapted to do a manual `modprobe` (after the DKMS postinstall script has run in the former, after the module installation in the latter case)
- removal of modprobe `ExecStartPre` directives from `zfs-import-*`, as those are no longer needed

the first takes care of the general loading at boot, the second takes care of initial loading on the first installation. the third one is optional cleanup which might be postponed to keep potential for breakage to a minimum.

this should fix issue #6083 , although not in the original way that has been proposed (and implemented in #7259)

### How Has This Been Tested?

just build and diff-tested so far - I neither use the RPM packages, nor the alienized deb packages. 

hence the WIP, feedback and actual test results for the second commit highly appreciated ;)

I do use the `modules-load.d` snippet in our own packages, so I can confirm that works as expected and loads the modules early on in the boot process, and thus allows starting `zfs-mount` et al. without starting any of the `zfs-import-*` services.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux code style requirements.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.