### PR TITLE
Fix MMP write frequency for large pools

### DIFF
--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -521,9 +521,9 @@ mmp_thread(void *arg)
 			mmp_write_uberblock(spa);
 
 		CALLB_CPR_SAFE_BEGIN(&cpr);
-		(void) cv_timedwait_sig(&mmp->mmp_thread_cv,
-		    &mmp->mmp_thread_lock, ddi_get_lbolt() +
-		    ((next_time - gethrtime()) / (NANOSEC / hz)));
+		(void) cv_timedwait_sig_hires(&mmp->mmp_thread_cv,
+		    &mmp->mmp_thread_lock, next_time, USEC2NSEC(1),
+		    CALLOUT_FLAG_ABSOLUTE);
 		CALLB_CPR_SAFE_END(&cpr, &mmp->mmp_thread_lock);
 	}
 


### PR DESCRIPTION
### Description

When a single pool contains more vdevs than the CONFIG_HZ for for the kernel the mmp thread will not delay properly.  Switch to using cv_timedwait_sig_hires() to handle higher resolution delays.

This issue was reported on Arch Linux where HZ defaults to only 100 and thus could be fairly easily reproduced with a reasonably large pool.  Most distribution kernels set CONFIG_HZ=250 or CONFIG_HZ=1000 thus are unlikely to be impacted.

### Motivation and Context

Issue #7205

### How Has This Been Tested?

Locally created a pool with 2000 vdevs on a system with CONFIG_HZ=1000, enabled `multihost` and observed an IO rate of ~2000 IO/s (one per-vdev per second).  With out the patch the mmp thread would spin.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
