### PR TITLE
Add zfs_scan_ignore_errors tunable

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1715,6 +1715,20 @@ Default value: \fB3,000\fR.
 .sp
 .ne 2
 .na
+\fBzfs_scan_ignore_errors\fR (int)
+.ad
+.RS 12n
+If set to a nonzero value, remove the DTL (dirty time list) upon
+completion of a pool scan (scrub) even if there were unrepairable
+errors.  It is intended to be used during pool repair or recovery to
+stop resilvering when the pool is next imported.
+.sp
+Default value: \fB0\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_scrub_min_time_ms\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -67,6 +67,12 @@ unsigned int zfs_delays_per_second = 20;
 unsigned int zfs_checksums_per_second = 20;
 
 /*
+ * Ignore errors during scrub/resilver.  Allows to work around resilver
+ * upon import when there are pool errors.
+ */
+int zfs_scan_ignore_errors = 0;
+
+/*
  * Virtual device management.
  */
 
@@ -1964,6 +1970,12 @@ vdev_dtl_reassess(vdev_t *vd, uint64_t txg, uint64_t scrub_txg, int scrub_done)
 		mutex_enter(&vd->vdev_dtl_lock);
 
 		/*
+		 * If requested, pretend the scan completed cleanly.
+		 */
+		if (zfs_scan_ignore_errors && scn)
+			scn->scn_phys.scn_errors = 0;
+
+		/*
 		 * If we've completed a scan cleanly then determine
 		 * if this vdev should remove any DTLs. We only want to
 		 * excise regions on vdevs that were available during
@@ -3777,5 +3789,9 @@ module_param(zfs_checksums_per_second, uint, 0644);
 	MODULE_PARM_DESC(zfs_checksums_per_second, "Rate limit checksum events "
 	"to this many checksum errors per second (do not set below zed"
 	"threshold).");
+
+module_param(zfs_scan_ignore_errors, int, 0644);
+MODULE_PARM_DESC(zfs_scan_ignore_errors,
+	"Ignore errors during resilver/scrub");
 /* END CSTYLED */
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow to work around some cases of continuous resilvering upon pool import.

### Description
<!--- Describe your changes in detail -->
When it's set, a DTL range will be cleared even if its scan/scrub had
errors.  This allows to work around resilver/scrub upon import when the
pool has errors.

### Motivation and Context
The specific use case for this flag is to deal with permanent errors that occur when a ```zpool replace``` operation has been performed.  Vdev replacement essentially creates a mirror and uses the DTL facility to cause the newly-attached mirror component to be completely resilvered.  If there are permanent errors during the resilvering process, a "full extent" DTL is left in place which will cause a resilver to occur upon the next pool import.  To assist in pool recovery, this flag can be set which will allow the resilver to completely normally, albeit with the resultant pool having some permanent errors.

One of the use cases is described in the issue logs for #5528 and it might also help for issues such as #6613.

### How Has This Been Tested?
Tested using this script:
```
#!/bin/bash

POOL=tank
DS=fs
VDEV_DIR=/run/tank

# Clean existing pool
zpool export $POOL
rm -f $VDEV_DIR/*

# Create vdev file(s)
mkdir -p $VDEV_DIR $VDEV_DIR
truncate -s 1g $VDEV_DIR/{0,1}

# Create pool and dataset
zpool create $POOL $VDEV_DIR/0
zfs create $POOL/$DS

# Create a file of known content
yes | dd bs=128k iflag=fullblock of=/$POOL/$DS/yes count=100
zpool sync
sync

# Get the first L0 DVA on vdev 0 of the second file
dva=$(zdb -ddddd $POOL/$DS $(stat -c %i /$POOL/$DS/yes) | head -40 | grep ' L0 0:' | head -1)

# Export the pool and calculate the offset of the first byte of the file
zpool export $POOL
set -- $dva
dva=$3
offset=${dva#0:}
offset=${offset%%:*}
offset=$(echo $offset | tr '[:lower:]' '[:upper:]')
offset=$(echo "ibase=16; $offset + 400000" | bc)
echo dva=$dva offset=$offset

# Corrupt the first byte of the file
dd bs=1 seek=$offset count=1 conv=notrunc if=/dev/zero of=$VDEV_DIR/0

# Import and replace vdev
zpool import -d $VDEV_DIR $POOL
#zinject -d $VDEV_DIR/0 -f 50 tank
zpool replace $POOL $VDEV_DIR/0 $VDEV_DIR/1

# Export, enable recovery flag and re-import
zpool export $POOL
echo 1 > /sys/module/zfs/parameters/zfs_scan_ignore_errors
zpool import -d $VDEV_DIR $POOL
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
