### PR TITLE
SHA256 QAT acceleration

### DIFF
--- a/module/zfs/qat.c
+++ b/module/zfs/qat.c
@@ -38,10 +38,12 @@ qat_stats_t qat_stats = {
 	{ "decrypt_total_in_bytes",		KSTAT_DATA_UINT64 },
 	{ "decrypt_total_out_bytes",		KSTAT_DATA_UINT64 },
 	{ "crypt_fails",			KSTAT_DATA_UINT64 },
+	{ "cksum_requests",			KSTAT_DATA_UINT64 },
+	{ "cksum_total_in_bytes",		KSTAT_DATA_UINT64 },
+	{ "cksum_fails",			KSTAT_DATA_UINT64 },
 };
 
 static kstat_t *qat_ksp = NULL;
-int zfs_qat_disable = 0;
 
 CpaStatus
 qat_mem_alloc_contig(void **pp_mem_addr, Cpa32U size_bytes)

--- a/module/zfs/qat_compress.c
+++ b/module/zfs/qat_compress.c
@@ -47,11 +47,12 @@ static CpaBufferList **buffer_array[QAT_DC_MAX_INSTANCES];
 static Cpa16U num_inst = 0;
 static Cpa32U inst_num = 0;
 static boolean_t qat_dc_init_done = B_FALSE;
+int zfs_qat_compress_disable = 0;
 
 boolean_t
 qat_dc_use_accel(size_t s_len)
 {
-	return (!zfs_qat_disable &&
+	return (!zfs_qat_compress_disable &&
 	    qat_dc_init_done &&
 	    s_len >= QAT_MIN_BUF_SIZE &&
 	    s_len <= QAT_MAX_BUF_SIZE);
@@ -470,5 +471,8 @@ fail:
 
 	return (ret);
 }
+
+module_param(zfs_qat_compress_disable, int, 0644);
+MODULE_PARM_DESC(zfs_qat_compress_disable, "Disable QAT compression");
 
 #endif


### PR DESCRIPTION
This patch enables acceleration of SHA256 and SHA512
checksums using Intel Quick Assist Technology.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### How Has This Been Tested?
Tested on an Ubuntu 16.04 machine with a DH895XCC QAT add-in card. I will have performance numbers soon.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
