### PR TITLE
Add support for nvme disk detection

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -300,6 +300,20 @@ efi_get_info(int fd, struct dk_cinfo *dki_info)
 		rval = sscanf(dev_path, "/dev/loop%[0-9]p%hu",
 		    dki_info->dki_dname + 4,
 		    &dki_info->dki_partition);
+	} else if ((strncmp(dev_path, "/dev/nvme", 9) == 0)) {
+		strcpy(dki_info->dki_cname, "nvme");
+		dki_info->dki_ctype = DKC_SCSI_CCS;
+		strcpy(dki_info->dki_dname, "nvme");
+		(void) sscanf(dev_path, "/dev/nvme%[0-9]",
+		    dki_info->dki_dname + 4);
+		size_t controller_length = strlen(
+		    dki_info->dki_dname);
+		strcpy(dki_info->dki_dname + controller_length,
+		    "n");
+		rval = sscanf(dev_path,
+		    "/dev/nvme%*[0-9]n%[0-9]p%hu",
+		    dki_info->dki_dname + controller_length + 1,
+		    &dki_info->dki_partition);
 	} else {
 		strcpy(dki_info->dki_dname, "unknown");
 		strcpy(dki_info->dki_cname, "unknown");


### PR DESCRIPTION
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
This treats /dev/nvme.. devices the same way as /dev/sd... devices.
Perhaps there should be a separate DKC_ type for this, but I don't know enough
about the code to know the implications of that.


### Motivation and Context
The motivation behind this is that whole disk detection did not work on nvme SSDs
without that, because it DKC_UNKNOWN was returned for such devices.

### How Has This Been Tested?
Tested by creating a new zfs pool on a /dev/nvme... device (e.g. /dev/nvme0n1), observing that a GPT is created and zdb reports the whole_disk flag set for the data partition.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
