### PR TITLE
enable zfs_dbgmsg() by default, without dprintf()

### DIFF
--- a/include/sys/zfs_debug.h
+++ b/include/sys/zfs_debug.h
@@ -41,6 +41,7 @@ extern "C" {
 extern int zfs_flags;
 extern int zfs_recover;
 extern int zfs_free_leak_on_eio;
+extern int zfs_dbgmsg_enable;
 
 #define	ZFS_DEBUG_DPRINTF		(1 << 0)
 #define	ZFS_DEBUG_DBUF_VERIFY		(1 << 1)
@@ -55,10 +56,22 @@ extern int zfs_free_leak_on_eio;
 
 extern void __dprintf(const char *file, const char *func,
     int line, const char *fmt, ...);
-#define	dprintf(...) \
-	__dprintf(__FILE__, __func__, __LINE__, __VA_ARGS__)
 #define	zfs_dbgmsg(...) \
-	__dprintf(__FILE__, __func__, __LINE__, __VA_ARGS__)
+	if (zfs_dbgmsg_enable) \
+		__dprintf(__FILE__, __func__, __LINE__, __VA_ARGS__)
+
+#ifdef ZFS_DEBUG
+/*
+ * To enable this:
+ *
+ * $ echo 1 >/sys/module/zfs/parameters/zfs_flags
+ */
+#define	dprintf(...) \
+	if (zfs_flags & ZFS_DEBUG_DPRINTF) \
+		__dprintf(__FILE__, __func__, __LINE__, __VA_ARGS__)
+#else
+#define	dprintf(...) ((void)0)
+#endif /* ZFS_DEBUG */
 
 extern void zfs_panic_recover(const char *fmt, ...);
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7138,6 +7138,7 @@ arc_tempreserve_space(uint64_t reserve, uint64_t txg)
 
 	if (reserve + arc_tempreserve + anon_size > arc_c / 2 &&
 	    anon_size > arc_c / 4) {
+#ifdef ZFS_DEBUG
 		uint64_t meta_esize =
 		    refcount_count(&arc_anon->arcs_esize[ARC_BUFC_METADATA]);
 		uint64_t data_esize =
@@ -7146,6 +7147,7 @@ arc_tempreserve_space(uint64_t reserve, uint64_t txg)
 		    "anon_data=%lluK tempreserve=%lluK arc_c=%lluK\n",
 		    arc_tempreserve >> 10, meta_esize >> 10,
 		    data_esize >> 10, reserve >> 10, arc_c >> 10);
+#endif
 		DMU_TX_STAT_BUMP(dmu_tx_dirty_throttle);
 		return (SET_ERROR(ERESTART));
 	}

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -3440,6 +3440,7 @@ receive_read_record(struct receive_arg *ra)
 static void
 dprintf_drr(struct receive_record_arg *rrd, int err)
 {
+#ifdef ZFS_DEBUG
 	switch (rrd->header.drr_type) {
 	case DRR_OBJECT:
 	{
@@ -3520,6 +3521,7 @@ dprintf_drr(struct receive_record_arg *rrd, int err)
 	default:
 		return;
 	}
+#endif
 }
 
 /*

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -243,8 +243,7 @@ kmem_cache_t *spa_buffer_pool;
 int spa_mode_global;
 
 #ifdef ZFS_DEBUG
-/* Everything except dprintf and spa is on by default in debug builds */
-int zfs_flags = ~(ZFS_DEBUG_DPRINTF | ZFS_DEBUG_SPA);
+int zfs_flags = ~(ZFS_DEBUG_DPRINTF | ZFS_DEBUG_SET_ERROR | ZFS_DEBUG_SPA);
 #else
 int zfs_flags = 0;
 #endif


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
zfs_dbgmsg() should record a message by default.  As a general
principal, these messages shouldn't be too verbose.  Furthermore, the
amount of memory used is limited to 4MB (by default).

dprintf() should only record a message if this is a debug build, and
ZFS_DEBUG_DPRINTF is set in zfs_flags.  This flag is not set by default
(even on debug builds).  These messages are extremely verbose, and
sometimes nontrivial to compute.

SET_ERROR() should only record a message if ZFS_DEBUG_SET_ERROR is set
in zfs_flags.  This flag is not set by default (even on debug builds).

This brings our behavior in line with illumos.  Note that the message
format is unchanged (including file, line, and function, even though
these are not recorded on illumos).


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
Manual testing:
```
# cat /proc/spl/kstat/zfs/dbgmsg
8 0 0x01 -1 0 5832644642763 5916360941213
timestamp    message
1521501685   spa.c:6241:spa_async_request(): spa=test async request task=1
1521501685   spa_history.c:322:spa_history_log_sync(): txg 1109 open pool version 5000; software version 5000/5; uts ubuntu 4.13.0-16-generic #19-Ubuntu SMP Wed Oct 11 18:35:14 UTC 2017 x86_64
1521501685   spa.c:6241:spa_async_request(): spa=test async request task=32
1521501685   spa_history.c:322:spa_history_log_sync(): txg 1111 import pool version 5000; software version 5000/5; uts ubuntu 4.13.0-16-generic #19-Ubuntu SMP Wed Oct 11 18:35:14 UTC 2017 x86_64
1521501690   spa_history.c:309:spa_history_log_sync(): command: zpool import test
1521501710   spa_history.c:317:spa_history_log_sync(): txg 1117 create test/a (id 151)
1521501715   spa_history.c:342:spa_history_log_sync(): ioctl create
1521501715   spa_history.c:309:spa_history_log_sync(): command: zfs create test/a

# echo 512 >/sys/module/zfs/parameters/zfs_flags
# cat /proc/spl/kstat/zfs/dbgmsg
8 0 0x01 -1 0 5832644642763 6546442484870
timestamp    message
...
1521502314   zap.c:765:fzap_checksize(): error 22
1521502319   zap.c:765:fzap_checksize(): error 22
1521502324   zap.c:765:fzap_checksize(): error 22
1521502329   zap.c:765:fzap_checksize(): error 22
1521502330   zfeature.c:239:feature_get_refcount(): error 95
1521502334   zap.c:765:fzap_checksize(): error 22
1521502339   zap.c:765:fzap_checksize(): error 22
1521502345   zap.c:765:fzap_checksize(): error 22
1521502350   zap.c:765:fzap_checksize(): error 22

# echo 1 >/sys/module/zfs/parameters/zfs_flags
# cat /proc/spl/kstat/zfs/dbgmsg
8 0 0x01 -1 0 5832644642763 6568626837325
timestamp    message
...
1521502373   txg.c:594:txg_quiesce_thread(): txg=1252 quiesce_txg=1253 sync_txg=1254
1521502373   txg.c:602:txg_quiesce_thread(): quiesce done, handing off txg 1252
1521502373   txg.c:543:txg_sync_thread(): txg=1252 quiesce_txg=1253 sync_txg=1254
1521502373   txg.c:594:txg_quiesce_thread(): txg=1253 quiesce_txg=1254 sync_txg=1254
1521502373   txg.c:602:txg_quiesce_thread(): quiesce done, handing off txg 1253
1521502373   txg.c:543:txg_sync_thread(): txg=1253 quiesce_txg=1254 sync_txg=1254
1521502373   txg.c:594:txg_quiesce_thread(): txg=1254 quiesce_txg=1255 sync_txg=1254
1521502373   txg.c:602:txg_quiesce_thread(): quiesce done, handing off txg 1254
1521502373   txg.c:543:txg_sync_thread(): txg=1254 quiesce_txg=1255 sync_txg=1254
1521502373   txg.c:510:txg_sync_thread(): waiting; tx_synced=1254 waiting=1254 dp=ffffa0bdaa0d8000
```


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
