### PR TITLE
Clarify zpool actions for an intent log device

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -435,8 +435,9 @@ See the
 .Sx EXAMPLES
 section for an example of mirroring multiple log devices.
 .Pp
-Log devices can be added, replaced, attached, detached, and imported and
-exported as part of the larger pool.
+Log devices can be added, replaced, attached, detached and removed.  In
+addition, log devices are imported and exported as part of the pool
+that contains them.
 Mirrored log devices can be removed by specifying the top-level mirror for the
 log.
 .Ss Cache Devices


### PR DESCRIPTION
Signed-off-by: Peter Ashford <ashford@accs.com>

<!--- Provide a general summary of your changes in the Title above -->
Minor fix for documentation.
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Updated the "Intent Log" section of the "zpool" manual page to properly reflect the actions that may be performed.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#6938 
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Checked man page on local VM after change.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
