### PR TITLE
Fedora 28: Fix "Macro %_dracutdir has empty body"

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -185,10 +185,23 @@ AC_DEFUN([ZFS_AC_RPM], [
 	RPM_DEFINE_COMMON+=' --define "$(DEBUGINFO_ZFS) 1"'
 	RPM_DEFINE_COMMON+=' --define "$(ASAN_ZFS) 1"'
 
-	RPM_DEFINE_UTIL='--define "_dracutdir $(dracutdir)"'
-	RPM_DEFINE_UTIL+=' --define "_udevdir $(udevdir)"'
-	RPM_DEFINE_UTIL+=' --define "_udevruledir $(udevruledir)"'
-	RPM_DEFINE_UTIL+=' --define "_initconfdir $(DEFAULT_INITCONF_DIR)"'
+
+	RPM_DEFINE_UTIL=' --define "_initconfdir $(DEFAULT_INITCONF_DIR)"'
+
+	dnl # Make the next three RPM_DEFINE_UTIL additions conditional, since
+	dnl # their values may not be set when running:
+	dnl #
+	dnl #	./configure --with-config=srpm
+	dnl #
+	AS_IF([test -n "$dracutdir" ], [
+		RPM_DEFINE_UTIL='--define "_dracutdir $(dracutdir)"'
+	])
+	AS_IF([test -n "$udevdir" ], [
+		RPM_DEFINE_UTIL+=' --define "_udevdir $(udevdir)"'
+	])
+	AS_IF([test -n "$udevruledir" ], [
+		RPM_DEFINE_UTIL+=' --define "_udevdir $(udevruledir)"'
+	])
 	RPM_DEFINE_UTIL+=' $(DEFINE_INITRAMFS)'
 	RPM_DEFINE_UTIL+=' $(DEFINE_SYSTEMD)'
 


### PR DESCRIPTION
### Description
If you run ./configure --with-config=srpm, it will not trigger the user m4 scripts to populate the dracut and udev directories. This causes a build error on Fedora 28.  Make the dracut and udev lines conditional to get around this.

### Motivation and Context
Fix one part of Fedora 28 builds.   Closes: #7326 

### How Has This Been Tested?
Tested on Fedora 28 rawhide VM. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
