### PR TITLE
Resolve QAT issues with incompressible data

### DIFF
--- a/module/zfs/qat.h
+++ b/module/zfs/qat.h
@@ -172,6 +172,9 @@ extern void qat_crypt_fini(void);
 extern int qat_init(void);
 extern void qat_fini(void);
 
+/* fake CpaStatus used to indicate data was not compressible */
+#define	CPA_STATUS_INCOMPRESSIBLE				(-127)
+
 extern boolean_t qat_dc_use_accel(size_t s_len);
 extern boolean_t qat_crypt_use_accel(size_t s_len);
 extern boolean_t qat_checksum_use_accel(size_t s_len);
@@ -184,6 +187,7 @@ extern int qat_checksum(uint64_t cksum, uint8_t *buf, uint64_t size,
     zio_cksum_t *zcp);
 #else
 #define	CPA_STATUS_SUCCESS					0
+#define	CPA_STATUS_INCOMPRESSIBLE				(-127)
 #define	qat_init()
 #define	qat_fini()
 #define	qat_dc_use_accel(s_len)					0

--- a/module/zfs/qat_compress.c
+++ b/module/zfs/qat_compress.c
@@ -25,6 +25,7 @@
 #include <linux/pagemap.h>
 #include <linux/completion.h>
 #include <sys/zfs_context.h>
+#include <sys/zio.h>
 #include "qat.h"
 
 /*
@@ -224,9 +225,16 @@ qat_dc_fini(void)
 	qat_dc_clean();
 }
 
-int
-qat_compress(qat_compress_dir_t dir, char *src, int src_len,
-    char *dst, int dst_len, size_t *c_len)
+/*
+ * The "add" parameter is an additional buffer which is passed
+ * to QAT as a scratch buffer alongside the destination buffer
+ * in case the "compressed" data ends up being larger than the
+ * original source data. This is necessary to prevent QAT from
+ * generating buffer overflow warnings for incompressible data.
+ */
+static int
+qat_compress_impl(qat_compress_dir_t dir, char *src, int src_len,
+    char *dst, int dst_len, char *add, int add_len, size_t *c_len)
 {
 	CpaInstanceHandle dc_inst_handle;
 	CpaDcSessionHandle session_handle;
@@ -243,14 +251,16 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 	Cpa32U compressed_sz;
 	Cpa32U num_src_buf = (src_len >> PAGE_SHIFT) + 2;
 	Cpa32U num_dst_buf = (dst_len >> PAGE_SHIFT) + 2;
+	Cpa32U num_add_buf = (add_len >> PAGE_SHIFT) + 2;
 	Cpa32U bytes_left;
+	Cpa32U dst_pages = 0;
 	char *data;
-	struct page *in_page, *out_page;
+	struct page *page;
 	struct page **in_pages = NULL;
 	struct page **out_pages = NULL;
+	struct page **add_pages = NULL;
 	Cpa32U page_off = 0;
 	struct completion complete;
-	size_t ret = -1;
 	Cpa32U page_num = 0;
 	Cpa16U i;
 
@@ -262,7 +272,7 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 	Cpa32U src_buffer_list_mem_size = sizeof (CpaBufferList) +
 	    (num_src_buf * sizeof (CpaFlatBuffer));
 	Cpa32U dst_buffer_list_mem_size = sizeof (CpaBufferList) +
-	    (num_dst_buf * sizeof (CpaFlatBuffer));
+	    ((num_dst_buf + num_add_buf) * sizeof (CpaFlatBuffer));
 
 	if (QAT_PHYS_CONTIG_ALLOC(&in_pages,
 	    num_src_buf * sizeof (struct page *)) != CPA_STATUS_SUCCESS)
@@ -270,6 +280,10 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 
 	if (QAT_PHYS_CONTIG_ALLOC(&out_pages,
 	    num_dst_buf * sizeof (struct page *)) != CPA_STATUS_SUCCESS)
+		goto fail;
+
+	if (QAT_PHYS_CONTIG_ALLOC(&add_pages,
+	    num_add_buf * sizeof (struct page *)) != CPA_STATUS_SUCCESS)
 		goto fail;
 
 	i = atomic_inc_32_nv(&inst_num) % num_inst;
@@ -282,7 +296,7 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 	    CPA_STATUS_SUCCESS)
 		goto fail;
 
-	cpaDcBufferListGetMetaSize(dc_inst_handle, num_dst_buf,
+	cpaDcBufferListGetMetaSize(dc_inst_handle, num_dst_buf + num_add_buf,
 	    &buffer_meta_size);
 	if (QAT_PHYS_CONTIG_ALLOC(&buffer_meta_dst, buffer_meta_size) !=
 	    CPA_STATUS_SUCCESS)
@@ -313,9 +327,9 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 	page_num = 0;
 	while (bytes_left > 0) {
 		page_off = ((long)data & ~PAGE_MASK);
-		in_page = qat_mem_to_page(data);
-		in_pages[page_num] = in_page;
-		flat_buf_src->pData = kmap(in_page) + page_off;
+		page = qat_mem_to_page(data);
+		in_pages[page_num] = page;
+		flat_buf_src->pData = kmap(page) + page_off;
 		flat_buf_src->dataLenInBytes =
 		    min((long)PAGE_SIZE - page_off, (long)bytes_left);
 
@@ -333,9 +347,29 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 	page_num = 0;
 	while (bytes_left > 0) {
 		page_off = ((long)data & ~PAGE_MASK);
-		out_page = qat_mem_to_page(data);
-		flat_buf_dst->pData = kmap(out_page) + page_off;
-		out_pages[page_num] = out_page;
+		page = qat_mem_to_page(data);
+		flat_buf_dst->pData = kmap(page) + page_off;
+		out_pages[page_num] = page;
+		flat_buf_dst->dataLenInBytes =
+		    min((long)PAGE_SIZE - page_off, (long)bytes_left);
+
+		bytes_left -= flat_buf_dst->dataLenInBytes;
+		data += flat_buf_dst->dataLenInBytes;
+		flat_buf_dst++;
+		buf_list_dst->numBuffers++;
+		page_num++;
+		dst_pages++;
+	}
+
+	/* map additional scratch pages into the destination buffer list */
+	bytes_left = add_len;
+	data = add;
+	page_num = 0;
+	while (bytes_left > 0) {
+		page_off = ((long)data & ~PAGE_MASK);
+		page = qat_mem_to_page(data);
+		flat_buf_dst->pData = kmap(page) + page_off;
+		add_pages[page_num] = page;
 		flat_buf_dst->dataLenInBytes =
 		    min((long)PAGE_SIZE - page_off, (long)bytes_left);
 
@@ -379,6 +413,7 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 
 		compressed_sz = dc_results.produced;
 		if (compressed_sz + hdr_sz + ZLIB_FOOT_SZ > dst_len) {
+			status = CPA_STATUS_INCOMPRESSIBLE;
 			goto fail;
 		}
 
@@ -388,8 +423,10 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 
 		/* no space for gzip footer in the last page */
 		if (((compressed_sz + hdr_sz) % PAGE_SIZE)
-		    + ZLIB_FOOT_SZ > PAGE_SIZE)
+		    + ZLIB_FOOT_SZ > PAGE_SIZE) {
+			status = CPA_STATUS_INCOMPRESSIBLE;
 			goto fail;
+		}
 
 		/* jump to the end of the buffer and append footer */
 		flat_buf_dst->pData =
@@ -400,16 +437,11 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 		dc_results.produced = 0;
 		status = cpaDcGenerateFooter(session_handle,
 		    flat_buf_dst, &dc_results);
-		if (status != CPA_STATUS_SUCCESS) {
+		if (status != CPA_STATUS_SUCCESS)
 			goto fail;
-		}
 
 		*c_len = compressed_sz + dc_results.produced + hdr_sz;
-
 		QAT_STAT_INCR(comp_total_out_bytes, *c_len);
-
-		ret = 0;
-
 	} else {
 		ASSERT3U(dir, ==, QAT_DECOMPRESS);
 		QAT_STAT_BUMP(decomp_requests);
@@ -417,12 +449,8 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 
 		buf_list_src->pBuffers->pData += ZLIB_HEAD_SZ;
 		buf_list_src->pBuffers->dataLenInBytes -= ZLIB_HEAD_SZ;
-		status = cpaDcDecompressData(dc_inst_handle,
-		    session_handle,
-		    buf_list_src,
-		    buf_list_dst,
-		    &dc_results,
-		    CPA_DC_FLUSH_FINAL,
+		status = cpaDcDecompressData(dc_inst_handle, session_handle,
+		    buf_list_src, buf_list_dst, &dc_results, CPA_DC_FLUSH_FINAL,
 		    &complete);
 
 		if (CPA_STATUS_SUCCESS != status) {
@@ -443,16 +471,12 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 		}
 
 		*c_len = dc_results.produced;
-
 		QAT_STAT_INCR(decomp_total_out_bytes, *c_len);
-
-		ret = 0;
 	}
 
 fail:
-	if (status != CPA_STATUS_SUCCESS) {
+	if (status != CPA_STATUS_SUCCESS && status != CPA_STATUS_INCOMPRESSIBLE)
 		QAT_STAT_BUMP(dc_fails);
-	}
 
 	if (in_pages) {
 		for (page_num = 0;
@@ -464,18 +488,50 @@ fail:
 	}
 
 	if (out_pages) {
-		for (page_num = 0;
-		    page_num < buf_list_dst->numBuffers;
-		    page_num++) {
+		for (page_num = 0; page_num < dst_pages; page_num++) {
 			kunmap(out_pages[page_num]);
 		}
 		QAT_PHYS_CONTIG_FREE(out_pages);
+	}
+
+	if (add_pages) {
+		for (page_num = 0;
+		    page_num < buf_list_dst->numBuffers - dst_pages;
+		    page_num++) {
+			kunmap(add_pages[page_num]);
+		}
+		QAT_PHYS_CONTIG_FREE(add_pages);
 	}
 
 	QAT_PHYS_CONTIG_FREE(buffer_meta_src);
 	QAT_PHYS_CONTIG_FREE(buffer_meta_dst);
 	QAT_PHYS_CONTIG_FREE(buf_list_src);
 	QAT_PHYS_CONTIG_FREE(buf_list_dst);
+
+	return (status);
+}
+
+/*
+ * Entry point for QAT accelerated compression / decompression.
+ */
+int
+qat_compress(qat_compress_dir_t dir, char *src, int src_len,
+    char *dst, int dst_len, size_t *c_len)
+{
+	int ret;
+	size_t add_len = 0;
+	void *add = NULL;
+
+	if (dir == QAT_COMPRESS) {
+		add_len = dst_len;
+		add = zio_data_buf_alloc(add_len);
+	}
+
+	ret = qat_compress_impl(dir, src, src_len, dst,
+	    dst_len, add, add_len, c_len);
+
+	if (dir == QAT_COMPRESS)
+		zio_data_buf_free(add, add_len);
 
 	return (ret);
 }


### PR DESCRIPTION
Currently, when ZFS wants to accelerate compression with QAT, it
passes a destination buffer of the same size as the source buffer.
Unfortunately, if the data is incompressible, QAT can actually
"compress" the data to be larger than the source buffer. When this
happens, the QAT driver will return a FAILED error code and print
warnings to dmesg. This patch fixes this issue by allocating a
larger temporary buffer for QAT to use before copying the data to
the final destination if it was actually compressed.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### How Has This Been Tested?
There were concerns about how the extra buffer copy would effect performance. I ran 2 tests, one with incompressible data (from /dev/urandom) and one with compressible data (from the yes executable). Each test wrote to a test dataset with `compression=gzip` and all other settings at their defaults:

#### Incompressible data
```
root@qat-test:~# cat /sys/module/zfs/parameters/zfs_qat_compress_disable
0 
root@qat-test:~# cat /root/urand.txt | pv > /pool/crypt/urand.txt 
1000MiB 0:00:05 [ 199MiB/s] [       <=>                                                     ]
root@qat-test:~# cat /root/urand.txt | pv > /pool/crypt/urand.txt 
1000MiB 0:00:05 [ 194MiB/s] [       <=>                                                     ]
root@qat-test:~# cat /root/urand.txt | pv > /pool/crypt/urand.txt 
1000MiB 0:00:04 [ 204MiB/s] [      <=>                                                      ]
root@qat-test:~# cat /root/urand.txt | pv > /pool/crypt/urand.txt 
1000MiB 0:00:04 [ 204MiB/s] [      <=>                                                      ]
root@qat-test:~# 
root@qat-test:~# 
root@qat-test:~# 
root@qat-test:~# echo 1 > /sys/module/zfs/parameters/zfs_qat_compress_disable                
root@qat-test:~# cat /root/urand.txt | pv > /pool/crypt/urand.txt 
1000MiB 0:00:06 [ 160MiB/s] [        <=>                                                    ]
root@qat-test:~# cat /root/urand.txt | pv > /pool/crypt/urand.txt 
1000MiB 0:00:05 [ 167MiB/s] [       <=>                                                     ]
root@qat-test:~# cat /root/urand.txt | pv > /pool/crypt/urand.txt 
1000MiB 0:00:06 [ 161MiB/s] [        <=>                                                    ]
root@qat-test:~# cat /root/urand.txt | pv > /pool/crypt/urand.txt 
1000MiB 0:00:06 [ 158MiB/s] [        <=>                                                    ]
root@qat-test:~# cat /root/urand.txt | pv > /pool/crypt/urand.txt 
1000MiB 0:00:06 [ 160MiB/s] [        <=>                                                    ]
root@qat-test:~# 
```
During this test, CPU usage for EACH of the `z_wr_iss` threads was routinely at about 70% without QAT and <1% with QAT.

#### Compressible data
```
root@qat-test:~# cat /sys/module/zfs/parameters/zfs_qat_compress_disable                     
0
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt                                
1000MiB 0:00:05 [ 199MiB/s] [       <=>                                                     ]
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt 
1000MiB 0:00:04 [ 206MiB/s] [      <=>                                                      ]
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt 
1000MiB 0:00:04 [ 201MiB/s] [      <=>                                                      ]
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt 
1000MiB 0:00:04 [ 207MiB/s] [      <=>                                                      ]
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt 
1000MiB 0:00:04 [ 200MiB/s] [      <=>                                                      ]
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt 
1000MiB 0:00:05 [ 196MiB/s] [       <=>                                                     ]
root@qat-test:~# 
root@qat-test:~# 
root@qat-test:~# 
root@qat-test:~# echo 1 > /sys/module/zfs/parameters/zfs_qat_compress_disable                
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt                                
1000MiB 0:00:05 [ 184MiB/s] [       <=>                                                     ]
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt 
1000MiB 0:00:05 [ 192MiB/s] [       <=>                                                     ]
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt 
1000MiB 0:00:05 [ 189MiB/s] [       <=>                                                     ]
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt 
1000MiB 0:00:05 [ 190MiB/s] [       <=>                                                     ]
root@qat-test:~# cat /root/yes.txt | pv > /pool/crypt/yes.txt 
1000MiB 0:00:05 [ 188MiB/s] [       <=>                                                     ]
```
During this test, CPU usage for each of the `z_wr_iss` threads was routinely at about 20% without QAT and <1% with QAT.

TL:DR: It looks like even with this change the benefits of 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
