### PR TITLE
ZTS: Fix add_nested_replacing_spare test case

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/add_nested_replacing_spare.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/add_nested_replacing_spare.ksh
@@ -79,7 +79,7 @@ do
 
 	# 2.1 Fault a device, verify the spare is kicked in
 	log_must zinject -d $FAULT_DEV -e nxio -T all -f 100 $TESTPOOL
-	log_must zpool scrub $TESTPOOL
+	log_must zpool reopen $TESTPOOL
 	log_must wait_vdev_state $TESTPOOL $FAULT_DEV "UNAVAIL" 60
 	log_must wait_vdev_state $TESTPOOL $SPARE_DEV1 "ONLINE" 60
 	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV1 "INUSE"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
It seems `zpool scrub` is not a good candidate to kick in a hot spare, use `zpool reopen` instead.

Spurious failures are caused by a race condition: ZED replaces a faulted device with a spare after `zfs_ioc_pool_scan() -> dsl_scan()` has reopened the root vdev (which finds the leaf "faulted" by `zinject`) but before the scrub is actually started: `dsl_scan_setup_check()` returns EBUSY which results in the following failure:

```
21:52:46.94 NOTE: Starting ZED
21:52:46.95 SUCCESS: truncate -s 0 /var/tmp/zed/zed.debug.log
21:52:46.95 SUCCESS: eval zed -vF -d /var/tmp/zed -p /var/tmp/zed/zed.pid -P /var/tmp/constrained_path.T0sJ -s /var/tmp/zed/state 2>/var/tmp/zed/zed.log &
21:52:47.12 SUCCESS: zpool create testpool mirror /mnt/fault-dev /mnt/safe-dev1 /mnt/safe-dev2 /mnt/safe-dev3
21:52:47.20 SUCCESS: zpool add testpool spare /mnt/spare-dev1
21:52:47.21 Added handler 273 with the following properties:
21:52:47.21   pool: testpool
21:52:47.21   vdev: 3e41072b2fd21d1a
21:52:47.21 SUCCESS: zinject -d /mnt/fault-dev -e nxio -T all -f 100 testpool
21:52:47.32 cannot scrub testpool: currently resilvering
21:52:47.32 ERROR: zpool scrub testpool exited 1
```


Output of Systemtap tracing:
```
[execname  :pid   ] caller <-> probefunc
------------------------------------------------------------------
[vdev_open :20176 ] vdev_open -> vdev_set_state 7
[vdev_open :20177 ] vdev_open -> vdev_set_state 7
[vdev_open :20178 ] vdev_open -> vdev_set_state 7
[vdev_open :20179 ] vdev_open -> vdev_set_state 7
[vdev_open :20175 ] vdev_open -> vdev_set_state 7
[zpool     :20135 ] vdev_open -> vdev_set_state 7
[zpool     :20135 ] vdev_open -> vdev_set_state 7
[zpool     :20135 ] vdev_open -> vdev_set_state 7
[zpool     :20386 ] zfs_ioc_pool_scan -> dsl_scan
[zpool     :20386 ] dsl_scan -> vdev_reopen
[vdev_open :20388 ] vdev_open -> vdev_set_state 4 (VDEV_STATE_CANT_OPEN)
[vdev_open :20389 ] vdev_open -> vdev_set_state 7
[vdev_open :20390 ] vdev_open -> vdev_set_state 7
[vdev_open :20388 ] vdev_open -> vdev_set_state 7
[vdev_open :20387 ] vdev_open -> vdev_set_state 7
[vdev_open :20387 ] vdev_open -> vdev_set_state 6
[zpool     :20386 ] vdev_open -> vdev_set_state 7
[zpool     :20386 ] vdev_open -> vdev_set_state 6
[zpool     :20386 ] vdev_propagate_state -> vdev_set_state 6
[zpool     :20386 ] 0xffffffff8104f605 <- vdev_reopen 
[zed       :17565 ] zfs_ioc_vdev_attach -> spa_vdev_attach * ZED kicks in the spare *
[vdev_open :20397 ] vdev_open -> vdev_set_state 7
[zed       :17565 ] vdev_open -> vdev_set_state 7
[zed       :17565 ] vdev_propagate_state -> vdev_set_state 6
[zed       :17565 ] vdev_propagate_state -> vdev_set_state 6
[zed       :17565 ] vdev_propagate_state -> vdev_set_state 6
[zed       :17565 ] vdev_propagate_state -> vdev_set_state 6
[zed       :17565 ] vdev_propagate_state -> vdev_set_state 6
[zed       :17565 ] spa_vdev_attach -> dsl_resilver_restart * resilver starts after the spare is attached *
[txg_sync  :20195 ] dsl_scan_sync -> dsl_scan_setup_sync
[txg_sync  :20195 ] spa_sync <- dsl_scan_setup_sync 
[zpool     :20386 ] dsl_sync_task -> dsl_scan_setup_check
[zpool     :20386 ] dsl_scan <- dsl_scan_setup_check return=16 (EBUSY)
[zpool     :20386 ] zfsdev_ioctl <- dsl_scan return=16
[txg_sync  :20195 ] dsl_scan_done ->spa_async_request 8
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7247 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested locally on Debian builder, traced code with Systemtap to find the race condition.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
