### PR TITLE
Fix hung z_zvol tasks during 'zfs receive'

### DIFF
--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -280,6 +280,7 @@ struct spa {
 	spa_keystore_t	spa_keystore;		/* loaded crypto keys */
 	hrtime_t	spa_ccw_fail_time;	/* Conf cache write fail time */
 	taskq_t		*spa_zvol_taskq;	/* Taskq for minor management */
+	taskq_t		*spa_prefetch_taskq;	/* Taskq for prefetch threads */
 	uint64_t	spa_multihost;		/* multihost aware (mmp) */
 	mmp_thread_t	spa_mmp;		/* multihost mmp thread */
 

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -31,6 +31,7 @@
 #include <sys/dsl_pool.h>
 #include <sys/dnode.h>
 #include <sys/spa.h>
+#include <sys/spa_impl.h>
 #include <sys/zio.h>
 #include <sys/dmu_impl.h>
 #include <sys/sa.h>
@@ -661,7 +662,7 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 	}
 
 	if (!(flags & TRAVERSE_PREFETCH_DATA) ||
-	    taskq_dispatch(system_taskq, traverse_prefetch_thread,
+	    taskq_dispatch(spa->spa_prefetch_taskq, traverse_prefetch_thread,
 	    td, TQ_NOQUEUE) == TASKQID_INVALID)
 		pd->pd_exited = B_TRUE;
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1187,6 +1187,14 @@ spa_activate(spa_t *spa, int mode)
 	    1, INT_MAX, 0);
 
 	/*
+	 * Taskq dedicated to prefetcher threads: this is used to prevent the
+	 * pool traverse code from monopolizing the global (and limited)
+	 * system_taskq by inappropriately scheduling long running tasks on it.
+	 */
+	spa->spa_prefetch_taskq = taskq_create("z_prefetch", boot_ncpus,
+	    defclsyspri, 1, INT_MAX, TASKQ_DYNAMIC);
+
+	/*
 	 * The taskq to upgrade datasets in this pool. Currently used by
 	 * feature SPA_FEATURE_USEROBJ_ACCOUNTING/SPA_FEATURE_PROJECT_QUOTA.
 	 */
@@ -1211,6 +1219,11 @@ spa_deactivate(spa_t *spa)
 	if (spa->spa_zvol_taskq) {
 		taskq_destroy(spa->spa_zvol_taskq);
 		spa->spa_zvol_taskq = NULL;
+	}
+
+	if (spa->spa_prefetch_taskq) {
+		taskq_destroy(spa->spa_prefetch_taskq);
+		spa->spa_prefetch_taskq = NULL;
 	}
 
 	if (spa->spa_upgrade_taskq) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

During a receive operation `zvol_create_minors_impl()` can wait needlessly for the prefetch thread because both share the same tasks queue.  This results in hung tasks:

```
<3>INFO: task z_zvol:5541 blocked for more than 120 seconds.
<3>      Tainted: P           O  3.16.0-4-amd64 #1
<3>"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
```

The first z_zvol:5541 (zvol_task_cb) is waiting for the long running traverse_prefetch_thread:260. We should not need to wait for anything since both "testpool" and "testpool/media" are not ZVOLs and have "snapdev=hidden".

```
(gdb) !cat /proc/spl/taskq
taskq                       act  nthr  spwn  maxt   pri  mina         maxa  cura      flags
spl_system_taskq/0            1     2     0    64   100     1   2147483647     1   80000005
	active: [260]traverse_prefetch_thread [zfs](0xffff88003347ae40)
	wait: 5541
spl_delay_taskq/0             0     1     0     4   100     1   2147483647     1   80000005
	delay: spa_deadman [zfs](0xffff880039924000)
z_zvol/1                      1     1     0     1   120     1   2147483647     2   80000000
	active: [5541]zvol_task_cb [zfs](0xffff88001fde6400)
	pend: zvol_task_cb [zfs](0xffff88001fde6800)
(gdb)  
(gdb) p *((zvol_task_t *) 0xffff88001fde6400)
$4 = {
  op = ZVOL_ASYNC_CREATE_MINORS, 
  pool = "testpool", '\000' <repeats 247 times>, 
  name1 = "testpool", '\000' <repeats 247 times>, 
  name2 = '\000' <repeats 255 times>, 
  source = (unknown: 0), 
  value = 18446744073709551615
}
(gdb)  
(gdb) p *((zvol_task_t *) 0xffff88001fde6800)
$5 = {
  op = ZVOL_ASYNC_CREATE_MINORS, 
  pool = "testpool", '\000' <repeats 247 times>, 
  name1 = "testpool/media", '\000' <repeats 241 times>, 
  name2 = '\000' <repeats 255 times>, 
  source = (unknown: 0), 
  value = 18446744073709551615
}
(gdb) !zfs get type,snapdev testpool/media
NAME            PROPERTY  VALUE       SOURCE
testpool/media  type      filesystem  -
testpool/media  snapdev   hidden      default
(gdb) !zfs get type,snapdev testpool
NAME      PROPERTY  VALUE       SOURCE
testpool  type      filesystem  -
testpool  snapdev   hidden      default
(gdb) 
```

Fix this by waiting for tasks on the system queue only if needed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #6330 
Fix #6890 (this seems to be a duplicate)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
EDIT: tested on current master on Debian8 builder receiving ~100GB of snapshot data.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
