### PR TITLE
zfs-functions: skip lines where mntpnt is 'none'

### DIFF
--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -393,7 +393,8 @@ read_fstab()
 	i=0
 	while read -r fs mntpnt fstype opts; do
 		echo "$fs" | egrep -qE '^#|^$' && continue
-		echo "$mntpnt" | egrep -qE '^none' && continue
+		echo "$mntpnt" | egrep -qE '^none|^swap' && continue
+		echo "$fstype" | egrep -qE '^swap' && continue
 
 		if echo "$fs $mntpnt $fstype $opts" | grep -qE "$match"; then
 			eval export FSTAB_dev_$i="$fs"

--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -393,6 +393,7 @@ read_fstab()
 	i=0
 	while read -r fs mntpnt fstype opts; do
 		echo "$fs" | egrep -qE '^#|^$' && continue
+		echo "$mntpnt" | egrep -qE '^none' && continue
 
 		if echo "$fs $mntpnt $fstype $opts" | grep -qE "$match"; then
 			eval export FSTAB_dev_$i="$fs"


### PR DESCRIPTION
This fixes zfs-mount initscript trying to mount
swap volumes as filesystems or anything that
has 'none' as a mountpoint in /etc/fstab

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
added a single line that skips processing any fstab entry where mountpoint is `none`
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7346
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
I edited the initscript and tried to run it with different zvols and swaps in /etc/fstab
re-generated dracut initramfs.
zvols with filesystem on it still work.
zvols without mountpoint no longer attempted to be mounted.
System booted without trying to mount swap.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [x] Change has been approved by a ZFS on Linux member.
