### PR TITLE
ZFS ARC dirty data limit not changed after bumping up the memory.

### DIFF
--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -392,6 +392,7 @@ struct spa {
 	uint64_t	spa_multihost;		/* multihost aware (mmp) */
 	mmp_thread_t	spa_mmp;		/* multihost mmp thread */
 
+	kmutex_t	spa_config_update_lock;	/* To serialize config update */
 	/*
 	 * spa_refcount & spa_config_lock must be the last elements
 	 * because zfs_refcount_t changes size based on compilation options.

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -662,6 +662,7 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	spa_set_deadman_failmode(spa, zfs_deadman_failmode);
 
 	zfs_refcount_create(&spa->spa_refcount);
+	mutex_init(&spa->spa_config_update_lock, NULL, MUTEX_DEFAULT, NULL);
 	spa_config_lock_init(spa);
 	spa_stats_init(spa);
 
@@ -805,6 +806,7 @@ spa_remove(spa_t *spa)
 	mutex_destroy(&spa->spa_suspend_lock);
 	mutex_destroy(&spa->spa_vdev_top_lock);
 	mutex_destroy(&spa->spa_feat_stats_lock);
+	mutex_destroy(&spa->spa_config_update_lock);
 
 	kmem_free(spa, sizeof (spa_t));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
During a hot memory plug, we update arc_c_max which triggers setting other relevant zfs parameters via the arc_tuning_update. This however doesn't change the amount of dirty data that can be accumulated before we start delaying/blocking the clients. So, even with a larger RAM, we will ending up delaying the clients at a very early stage leading to lower throughput. 
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
