### PR TITLE
Add support for nvme based devids

### DIFF
--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  * Copyright 2015 RackTop Systems.
  * Copyright (c) 2016, Intel Corporation.
  */
@@ -144,7 +144,18 @@ zfs_device_get_devid(struct udev_device *dev, char *bufptr, size_t buflen)
 			(void) snprintf(bufptr, buflen, "dm-uuid-%s", dm_uuid);
 			return (0);
 		}
-		return (ENODATA);
+
+		/*
+		 * NVME 'by-id' symlinks are similar to bus case
+		 */
+		struct udev_device *parent;
+
+		parent = udev_device_get_parent_with_subsystem_devtype(dev,
+		    "nvme", NULL);
+		if (parent != NULL)
+			bus = "nvme";	/* continue with bus symlink search */
+		else
+			return (ENODATA);
 	}
 
 	/*


### PR DESCRIPTION
### Description
Adds a `devid` for nvme devices.  This is very similar to how the other 'bus' (scsi|sata|usb) devids are generated. The devid resides in a name/value pair in the leaf vdevs in a zpool config.

### Motivation and Context
The ZED logic uses the devid for matching devices for operations like auto-online. The device ID is also useful for matching a zfs device with devices seen by libudev.

### How Has This Been Tested?
ztest
zfs test suite:  functional/fault tests
manual testing, as in:
```
$ lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
sda           8:0    0 111.8G  0 disk 
├─sda1        8:1    0   511M  0 part /boot/efi
├─sda2        8:2    0    16G  0 part [SWAP]
└─sda3        8:3    0  84.1G  0 part /
nvme0n1     259:0    0 238.5G  0 disk 

$ sudo zpool create expresso nvme0n1
$ sudo zdb -C expresso | grep -E "path|devid"
                path: '/dev/nvme0n1p1'
                devid: 'nvme-INTEL_SSDPEKKW256G7_BTPY722506V2256D-part1'
                phys_path: 'pci-0000:3c:00.0-nvme-1'
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
