### PR TITLE
Fedora 28: Fix misc bounds check compiler warnings

### DIFF
--- a/cmd/zvol_id/zvol_id_main.c
+++ b/cmd/zvol_id/zvol_id_main.c
@@ -55,11 +55,12 @@ main(int argc, char **argv)
 {
 	int fd, error = 0;
 	char zvol_name[ZFS_MAX_DATASET_NAME_LEN];
-	char zvol_name_part[ZFS_MAX_DATASET_NAME_LEN];
+	char *zvol_name_part = NULL;
 	char *dev_name;
 	struct stat64 statbuf;
 	int dev_minor, dev_part;
 	int i;
+	int rc;
 
 	if (argc < 2) {
 		printf("Usage: %s /dev/zvol_device_node\n", argv[0]);
@@ -88,11 +89,13 @@ main(int argc, char **argv)
 		return (errno);
 	}
 	if (dev_part > 0)
-		snprintf(zvol_name_part, ZFS_MAX_DATASET_NAME_LEN,
-		    "%s-part%d", zvol_name, dev_part);
+		rc = asprintf(&zvol_name_part, "%s-part%d", zvol_name,
+		    dev_part);
 	else
-		snprintf(zvol_name_part, ZFS_MAX_DATASET_NAME_LEN,
-		    "%s", zvol_name);
+		rc = asprintf(&zvol_name_part, "%s", zvol_name);
+
+	if (rc == -1 || zvol_name_part == NULL)
+		goto error;
 
 	for (i = 0; i < strlen(zvol_name_part); i++) {
 		if (isblank(zvol_name_part[i]))
@@ -100,6 +103,8 @@ main(int argc, char **argv)
 	}
 
 	printf("%s\n", zvol_name_part);
+	free(zvol_name_part);
+error:
 	close(fd);
 	return (error);
 }

--- a/lib/libspl/include/umem.h
+++ b/lib/libspl/include/umem.h
@@ -146,7 +146,7 @@ umem_cache_create(
 
 	cp = umem_alloc(sizeof (umem_cache_t), UMEM_DEFAULT);
 	if (cp) {
-		strncpy(cp->cache_name, name, UMEM_CACHE_NAMELEN);
+		strlcpy(cp->cache_name, name, UMEM_CACHE_NAMELEN);
 		cp->cache_bufsize = bufsize;
 		cp->cache_align = align;
 		cp->cache_constructor = constructor;

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3758,7 +3758,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 	 * Determine the name of the origin snapshot.
 	 */
 	if (originsnap) {
-		(void) strncpy(origin, originsnap, sizeof (origin));
+		(void) strlcpy(origin, originsnap, sizeof (origin));
 		if (flags->verbose)
 			(void) printf("using provided clone origin %s\n",
 			    origin);

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -1176,14 +1176,15 @@ dsl_scan_check_suspend(dsl_scan_t *scn, const zbookmark_phys_t *zb)
 			    (longlong_t)zb->zb_blkid);
 			scn->scn_phys.scn_bookmark = *zb;
 		} else {
+#ifdef ZFS_DEBUG
 			dsl_scan_phys_t *scnp = &scn->scn_phys;
-
 			dprintf("suspending at at DDT bookmark "
 			    "%llx/%llx/%llx/%llx\n",
 			    (longlong_t)scnp->scn_ddt_bookmark.ddb_class,
 			    (longlong_t)scnp->scn_ddt_bookmark.ddb_type,
 			    (longlong_t)scnp->scn_ddt_bookmark.ddb_checksum,
 			    (longlong_t)scnp->scn_ddt_bookmark.ddb_cursor);
+#endif
 		}
 		scn->scn_suspending = B_TRUE;
 		return (B_TRUE);

--- a/tests/zfs-tests/cmd/devname2devid/devname2devid.c
+++ b/tests/zfs-tests/cmd/devname2devid/devname2devid.c
@@ -83,7 +83,8 @@ udev_device_get_devid(struct udev_device *dev, char *bufptr, size_t buflen)
 		name = udev_list_entry_get_name(entry);
 		if (strncmp(name, devbyid, strlen(devbyid)) == 0) {
 			name += strlen(DEV_BYID_PATH);
-			(void) stpncpy(bufptr, name, buflen);
+			(void) stpncpy(bufptr, name, buflen - 1);
+			bufptr[buflen - 1] = '\0';
 			return (0);
 		}
 		entry = udev_list_entry_get_next(entry);

--- a/tests/zfs-tests/cmd/mkbusy/mkbusy.c
+++ b/tests/zfs-tests/cmd/mkbusy/mkbusy.c
@@ -98,8 +98,9 @@ main(int argc, char *argv[])
 
 	if ((ret = stat(argv[0], &sbuf)) != 0) {
 		char	*arg, *dname, *fname;
-		int	arglen, dlen, flen;
+		int	arglen;
 		char	*slash;
+		int	rc;
 
 		/*
 		 * The argument supplied doesn't exist. Copy the path, and
@@ -126,23 +127,18 @@ main(int argc, char *argv[])
 		free(arg);
 		if (dname == NULL || fname == NULL)
 			fail("strdup", 1);
-		dlen = strlen(dname);
-		flen = strlen(fname);
 
 		/* The directory portion of the path must exist */
 		if ((ret = stat(dname, &sbuf)) != 0 || !(sbuf.st_mode &
 		    S_IFDIR))
 			usage(prog);
 
-		if ((fpath = (char *)malloc(dlen + 1 + flen + 1)) == NULL)
-			fail("malloc", 1);
-		(void) memset(fpath, '\0', dlen + 1 + flen + 1);
-
-		(void) strncpy(fpath, dname, dlen);
-		fpath[dlen] = '/';
-		(void) strncat(fpath, fname, flen);
+		rc = asprintf(&fpath, "%s/%s", dname, fname);
 		free(dname);
 		free(fname);
+		if (rc == -1 || fpath == NULL)
+			fail("asprintf", 1);
+
 	} else if ((sbuf.st_mode & S_IFMT) == S_IFREG ||
 	    (sbuf.st_mode & S_IFMT) == S_IFLNK ||
 	    (sbuf.st_mode & S_IFMT) == S_IFCHR ||

--- a/tests/zfs-tests/cmd/mktree/mktree.c
+++ b/tests/zfs-tests/cmd/mktree/mktree.c
@@ -137,8 +137,12 @@ mktree(char *pdir, int level)
 static char *
 getfdname(char *pdir, char type, int level, int dir, int file)
 {
-	(void) snprintf(fdname, sizeof (fdname),
-	    "%s/%c-l%dd%df%d", pdir, type, level, dir, file);
+	size_t size = sizeof (fdname);
+	if (snprintf(fdname, size, "%s/%c-l%dd%df%d", pdir, type, level, dir,
+	    file) >= size) {
+		(void) fprintf(stderr, "fdname truncated\n");
+		exit(EINVAL);
+	}
 	return (fdname);
 }
 

--- a/tests/zfs-tests/cmd/xattrtest/xattrtest.c
+++ b/tests/zfs-tests/cmd/xattrtest/xattrtest.c
@@ -367,8 +367,10 @@ create_files(void)
 	char *file = NULL;
 	struct timeval start, stop;
 	double seconds;
+	size_t fsize;
 
-	file = malloc(PATH_MAX);
+	fsize = PATH_MAX;
+	file = malloc(fsize);
 	if (file == NULL) {
 		rc = ENOMEM;
 		ERROR("Error %d: malloc(%d) bytes for file name\n", rc,
@@ -379,7 +381,11 @@ create_files(void)
 	(void) gettimeofday(&start, NULL);
 
 	for (i = 1; i <= files; i++) {
-		(void) sprintf(file, "%s/file-%d", path, i);
+		if (snprintf(file, fsize, "%s/file-%d", path, i) >= fsize) {
+			rc = EINVAL;
+			ERROR("Error %d: path too long\n", rc);
+			goto out;
+		}
 
 		if (nth && ((i % nth) == 0))
 			fprintf(stdout, "create: %s\n", file);
@@ -452,6 +458,7 @@ setxattrs(void)
 	char *file = NULL;
 	struct timeval start, stop;
 	double seconds;
+	size_t fsize;
 
 	value = malloc(XATTR_SIZE_MAX);
 	if (value == NULL) {
@@ -461,7 +468,8 @@ setxattrs(void)
 		goto out;
 	}
 
-	file = malloc(PATH_MAX);
+	fsize = PATH_MAX;
+	file = malloc(fsize);
 	if (file == NULL) {
 		rc = ENOMEM;
 		ERROR("Error %d: malloc(%d) bytes for file name\n", rc,
@@ -472,7 +480,11 @@ setxattrs(void)
 	(void) gettimeofday(&start, NULL);
 
 	for (i = 1; i <= files; i++) {
-		(void) sprintf(file, "%s/file-%d", path, i);
+		if (snprintf(file, fsize, "%s/file-%d", path, i) >= fsize) {
+			rc = EINVAL;
+			ERROR("Error %d: path too long\n", rc);
+			goto out;
+		}
 
 		if (nth && ((i % nth) == 0))
 			fprintf(stdout, "setxattr: %s\n", file);
@@ -523,6 +535,7 @@ getxattrs(void)
 	char *file = NULL;
 	struct timeval start, stop;
 	double seconds;
+	size_t fsize;
 
 	verify_value = malloc(XATTR_SIZE_MAX);
 	if (verify_value == NULL) {
@@ -543,7 +556,9 @@ getxattrs(void)
 	verify_string = value_is_random ? "<random>" : verify_value;
 	value_string = value_is_random ? "<random>" : value;
 
-	file = malloc(PATH_MAX);
+	fsize = PATH_MAX;
+	file = malloc(fsize);
+
 	if (file == NULL) {
 		rc = ENOMEM;
 		ERROR("Error %d: malloc(%d) bytes for file name\n", rc,
@@ -554,7 +569,11 @@ getxattrs(void)
 	(void) gettimeofday(&start, NULL);
 
 	for (i = 1; i <= files; i++) {
-		(void) sprintf(file, "%s/file-%d", path, i);
+		if (snprintf(file, fsize, "%s/file-%d", path, i) >= fsize) {
+			rc = EINVAL;
+			ERROR("Error %d: path too long\n", rc);
+			goto out;
+		}
 
 		if (nth && ((i % nth) == 0))
 			fprintf(stdout, "getxattr: %s\n", file);
@@ -615,8 +634,10 @@ unlink_files(void)
 	char *file = NULL;
 	struct timeval start, stop;
 	double seconds;
+	size_t fsize;
 
-	file = malloc(PATH_MAX);
+	fsize = PATH_MAX;
+	file = malloc(fsize);
 	if (file == NULL) {
 		rc = ENOMEM;
 		ERROR("Error %d: malloc(%d) bytes for file name\n",
@@ -627,7 +648,11 @@ unlink_files(void)
 	(void) gettimeofday(&start, NULL);
 
 	for (i = 1; i <= files; i++) {
-		(void) sprintf(file, "%s/file-%d", path, i);
+		if (snprintf(file, fsize, "%s/file-%d", path, i) >= fsize) {
+			rc = EINVAL;
+			ERROR("Error %d: path too long\n", rc);
+			goto out;
+		}
 
 		if (nth && ((i % nth) == 0))
 			fprintf(stdout, "unlink: %s\n", file);

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/socket.c
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/socket.c
@@ -30,13 +30,16 @@ main(int argc, char *argv[])
 	struct sockaddr_un sock;
 	int fd;
 	char *path;
-
+	size_t size;
 	if (argc != 2) {
 		fprintf(stderr, "usage: %s /path/to/socket\n", argv[0]);
 		exit(1);
 	}
 	path = argv[1];
-	strncpy(sock.sun_path, (char *)path, sizeof (sock.sun_path));
+	size =  sizeof (sock.sun_path);
+	strncpy(sock.sun_path, (char *)path, size - 1);
+	sock.sun_path[size - 1] = '\0';
+
 	sock.sun_family = AF_UNIX;
 	if ((fd = socket(AF_UNIX, SOCK_DGRAM, 0)) == -1) {
 		perror("socket");


### PR DESCRIPTION
### Description
Fix a bunch of (mostly) sprintf/snprintf truncation compiler warnings that show up on Fedora 28 (GCC 8.0.1).

### Motivation and Context
Closes: #7361

### How Has This Been Tested?
Ran `make` on Fedora 28 VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
