### PR TITLE
Remove ASSERT() in l2arc_apply_transforms()

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -8450,11 +8450,11 @@ l2arc_apply_transforms(spa_t *spa, arc_buf_hdr_t *hdr, uint64_t asize,
 	 * shared buffer or to reallocate the buffer to match asize.
 	 */
 	if (HDR_HAS_RABD(hdr) && asize != psize) {
-		ASSERT3U(size, ==, psize);
+		ASSERT3U(asize, >=, psize);
 		to_write = abd_alloc_for_io(asize, ismd);
-		abd_copy(to_write, hdr->b_crypt_hdr.b_rabd, size);
-		if (size != asize)
-			abd_zero_off(to_write, size, asize - size);
+		abd_copy(to_write, hdr->b_crypt_hdr.b_rabd, psize);
+		if (psize != asize)
+			abd_zero_off(to_write, psize, asize - psize);
 		goto out;
 	}
 


### PR DESCRIPTION
### Description
The ASSERT was erroneously copied from the next section of code.
The buffer's size should be expanded from "psize" to "asize" if necessary.


### Motivation and Context
The ASSERT was triggered during testing of the device evacuation patches.

### How Has This Been Tested?
Multiple 8-hour runs of ztest no longer trigger the ASSERT.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
