### PR TITLE
[WIP] Permit ZVOL creation by unprivileged users

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -1108,6 +1108,7 @@ zfs_secpolicy_create_clone(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 	char	parentname[ZFS_MAX_DATASET_NAME_LEN];
 	int	error;
 	char	*origin;
+	uint32_t	type;
 
 	if ((error = zfs_get_parent(zc->zc_name, parentname,
 	    sizeof (parentname))) != 0)
@@ -1121,6 +1122,12 @@ zfs_secpolicy_create_clone(zfs_cmd_t *zc, nvlist_t *innvl, cred_t *cr)
 	if ((error = zfs_secpolicy_write_perms(parentname,
 	    ZFS_DELEG_PERM_CREATE, cr)) != 0)
 		return (error);
+
+	/* Mount permission is not required for a ZVOL */
+	if (nvlist_lookup_int32(innvl, "type", &type) != 0)
+		return (SET_ERROR(EINVAL));
+	if (type == DMU_OST_ZVOL)
+		return (0);
 
 	return (zfs_secpolicy_write_perms(parentname,
 	    ZFS_DELEG_PERM_MOUNT, cr));


### PR DESCRIPTION
### Description
`zfs create` always checks for `mount` permission which by extensions requires the user to have `CAP_SYS_ADMIN` privileges. This makes much less sense for a ZVOL than a filesystem.

### Motivation and Context
I've done this locally for a "SAN" appliance I made so the service can run without root privileges as much as possible.

### How Has This Been Tested?
Currently not as I had to reimplement the code. Build test only at this point.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
