### PR TITLE
Fedora 28: Fix "file is executable, but no shebang" warnings

### DIFF
--- a/contrib/initramfs/scripts/Makefile.am
+++ b/contrib/initramfs/scripts/Makefile.am
@@ -1,6 +1,6 @@
 scriptsdir = $(datarootdir)/initramfs-tools/scripts
 
-scripts_SCRIPTS = \
+scripts_DATA = \
 	zfs
 
 SUBDIRS = local-top
@@ -8,7 +8,7 @@ SUBDIRS = local-top
 EXTRA_DIST = \
 	$(top_srcdir)/contrib/initramfs/scripts/zfs.in
 
-$(scripts_SCRIPTS):%:%.in
+$(scripts_DATA):%:%.in
 	-$(SED) -e 's,@sbindir\@,$(sbindir),g' \
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \
 		$< >'$@'

--- a/tests/runfiles/Makefile.am
+++ b/tests/runfiles/Makefile.am
@@ -1,2 +1,2 @@
 pkgdatadir = $(datadir)/@PACKAGE@/runfiles
-dist_pkgdata_SCRIPTS = *.run
+dist_pkgdata_DATA = *.run

--- a/tests/test-runner/include/Makefile.am
+++ b/tests/test-runner/include/Makefile.am
@@ -1,4 +1,6 @@
 pkgdatadir = $(datadir)/@PACKAGE@/test-runner/include
 dist_pkgdata_SCRIPTS = \
-	logapi.shlib \
+	logapi.shlib
+
+dist_pkgdata_DATA = \
 	stf.shlib

--- a/tests/zfs-tests/include/Makefile.am
+++ b/tests/zfs-tests/include/Makefile.am
@@ -1,5 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/include
-dist_pkgdata_SCRIPTS = \
+dist_pkgdata_DATA = \
 	blkdev.shlib \
 	commands.cfg \
 	default.cfg \

--- a/tests/zfs-tests/tests/functional/acl/Makefile.am
+++ b/tests/zfs-tests/tests/functional/acl/Makefile.am
@@ -1,5 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/acl
-dist_pkgdata_SCRIPTS = \
+dist_pkgdata_DATA = \
 	acl.cfg \
 	acl_common.kshlib
 

--- a/tests/zfs-tests/tests/functional/atime/Makefile.am
+++ b/tests/zfs-tests/tests/functional/atime/Makefile.am
@@ -1,9 +1,11 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/atime
 dist_pkgdata_SCRIPTS = \
-	atime.cfg \
-	atime_common.kshlib \
 	cleanup.ksh \
 	setup.ksh \
 	atime_001_pos.ksh \
 	atime_002_neg.ksh \
 	atime_003_pos.ksh
+
+dist_pkgdata_DATA = \
+	atime.cfg \
+	atime_common.kshlib

--- a/tests/zfs-tests/tests/functional/cache/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cache/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cache
 dist_pkgdata_SCRIPTS = \
-	cache.cfg \
-	cache.kshlib \
 	cleanup.ksh \
 	setup.ksh \
 	cache_001_pos.ksh \
@@ -15,3 +13,7 @@ dist_pkgdata_SCRIPTS = \
 	cache_009_pos.ksh \
 	cache_010_neg.ksh \
 	cache_011_pos.ksh
+
+dist_pkgdata_DATA = \
+	cache.cfg \
+	cache.kshlib

--- a/tests/zfs-tests/tests/functional/cachefile/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cachefile/Makefile.am
@@ -2,9 +2,11 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cachefile
 dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	setup.ksh \
-	cachefile.cfg \
-	cachefile.kshlib \
 	cachefile_001_pos.ksh \
 	cachefile_002_pos.ksh \
 	cachefile_003_pos.ksh \
 	cachefile_004_pos.ksh
+
+dist_pkgdata_DATA = \
+	cachefile.cfg \
+	cachefile.kshlib

--- a/tests/zfs-tests/tests/functional/casenorm/Makefile.am
+++ b/tests/zfs-tests/tests/functional/casenorm/Makefile.am
@@ -3,8 +3,6 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
 	case_all_values.ksh \
-	casenorm.cfg \
-	casenorm.kshlib \
 	insensitive_formd_delete.ksh \
 	insensitive_formd_lookup.ksh \
 	insensitive_none_delete.ksh \
@@ -21,3 +19,7 @@ dist_pkgdata_SCRIPTS = \
 	sensitive_formd_lookup.ksh \
 	sensitive_none_delete.ksh \
 	sensitive_none_lookup.ksh
+
+dist_pkgdata_DATA = \
+	casenorm.cfg \
+	casenorm.kshlib

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/Makefile.am
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/Makefile.am
@@ -3,39 +3,41 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	setup.ksh \
 	tst.args_to_lua.ksh \
-	tst.args_to_lua.out \
-	tst.args_to_lua.zcp \
-	tst.divide_by_zero.err \
 	tst.divide_by_zero.ksh \
-	tst.divide_by_zero.zcp \
 	tst.exists.ksh \
-	tst.exists.zcp \
 	tst.integer_illegal.ksh \
 	tst.integer_overflow.ksh \
 	tst.language_functions_neg.ksh \
 	tst.language_functions_pos.ksh \
 	tst.large_prog.ksh \
+	tst.libraries.ksh \
+	tst.memory_limit.ksh \
+	tst.nested_neg.ksh \
+	tst.nested_pos.ksh \
+	tst.nvlist_to_lua.ksh \
+	tst.recursive_neg.ksh \
+	tst.recursive_pos.ksh \
+	tst.return_large.ksh \
+	tst.return_nvlist_neg.ksh \
+	tst.return_nvlist_pos.ksh \
+	tst.return_recursive_table.ksh \
+	tst.timeout.ksh
+
+dist_pkgdata_DATA = \
+	tst.args_to_lua.out \
+	tst.args_to_lua.zcp \
+	tst.divide_by_zero.err \
+	tst.divide_by_zero.zcp \
+	tst.exists.zcp \
 	tst.large_prog.out \
 	tst.large_prog.zcp \
 	tst.lib_base.lua \
 	tst.lib_coroutine.lua \
 	tst.lib_strings.lua \
 	tst.lib_table.lua \
-	tst.libraries.ksh \
-	tst.memory_limit.ksh \
-	tst.nested_neg.ksh \
 	tst.nested_neg.zcp \
-	tst.nested_pos.ksh \
 	tst.nested_pos.zcp \
-	tst.nvlist_to_lua.ksh \
-	tst.recursive_neg.ksh \
-	tst.recursive_pos.ksh \
 	tst.recursive.zcp \
-	tst.return_large.ksh \
 	tst.return_large.zcp \
-	tst.return_nvlist_neg.ksh \
-	tst.return_nvlist_pos.ksh \
-	tst.return_recursive_table.ksh \
 	tst.return_recursive_table.zcp \
-	tst.timeout.ksh \
 	tst.timeout.zcp

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/Makefile.am
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/Makefile.am
@@ -6,16 +6,10 @@ dist_pkgdata_SCRIPTS = \
 	tst.destroy_snap.ksh \
 	tst.get_count_and_limit.ksh \
 	tst.get_index_props.ksh \
-	tst.get_index_props.out \
-	tst.get_index_props.zcp \
 	tst.get_mountpoint.ksh \
 	tst.get_neg.ksh \
 	tst.get_number_props.ksh \
-	tst.get_number_props.out \
-	tst.get_number_props.zcp \
 	tst.get_string_props.ksh \
-	tst.get_string_props.out \
-	tst.get_string_props.zcp \
 	tst.get_type.ksh \
 	tst.get_userquota.ksh \
 	tst.get_written.ksh \
@@ -26,16 +20,24 @@ dist_pkgdata_SCRIPTS = \
 	tst.list_user_props.ksh \
 	tst.parse_args_neg.ksh \
 	tst.promote_conflict.ksh \
-	tst.promote_conflict.zcp \
 	tst.promote_multiple.ksh \
 	tst.promote_simple.ksh \
 	tst.rollback_mult.ksh \
 	tst.rollback_one.ksh \
 	tst.snapshot_destroy.ksh \
-	tst.snapshot_destroy.zcp \
 	tst.snapshot_neg.ksh \
-	tst.snapshot_neg.zcp \
 	tst.snapshot_recursive.ksh \
+	tst.snapshot_simple.ksh
+
+dist_pkgdata_DATA = \
+	tst.get_index_props.out \
+	tst.get_index_props.zcp \
+	tst.get_number_props.out \
+	tst.get_number_props.zcp \
+	tst.get_string_props.out \
+	tst.get_string_props.zcp \
+	tst.promote_conflict.zcp \
+	tst.snapshot_destroy.zcp \
+	tst.snapshot_neg.zcp \
 	tst.snapshot_recursive.zcp \
-	tst.snapshot_simple.ksh \
 	tst.snapshot_simple.zcp

--- a/tests/zfs-tests/tests/functional/checksum/Makefile.am
+++ b/tests/zfs-tests/tests/functional/checksum/Makefile.am
@@ -8,13 +8,15 @@ AUTOMAKE_OPTIONS = subdir-objects
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/checksum
 
 dist_pkgdata_SCRIPTS = \
-	default.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	run_edonr_test.ksh \
 	run_sha2_test.ksh \
 	run_skein_test.ksh \
 	filetest_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	default.cfg
 
 pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/checksum
 

--- a/tests/zfs-tests/tests/functional/clean_mirror/Makefile.am
+++ b/tests/zfs-tests/tests/functional/clean_mirror/Makefile.am
@@ -1,10 +1,12 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/clean_mirror
 dist_pkgdata_SCRIPTS = \
-	clean_mirror_common.kshlib \
-	default.cfg \
         cleanup.ksh \
 	setup.ksh \
 	clean_mirror_001_pos.ksh \
 	clean_mirror_002_pos.ksh \
 	clean_mirror_003_pos.ksh \
 	clean_mirror_004_pos.ksh
+
+dist_pkgdata_DATA = \
+	clean_mirror_common.kshlib \
+	default.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/Makefile.am
@@ -1,5 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root
-dist_pkgdata_SCRIPTS = \
+dist_pkgdata_DATA = \
 	cli_common.kshlib
 
 SUBDIRS = \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_copies
 dist_pkgdata_SCRIPTS = \
-	zfs_copies.cfg \
-	zfs_copies.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_copies_001_pos.ksh \
@@ -10,3 +8,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_copies_004_neg.ksh \
 	zfs_copies_005_neg.ksh \
 	zfs_copies_006_pos.ksh
+
+dist_pkgdata_DATA = \
+	zfs_copies.cfg \
+	zfs_copies.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/Makefile.am
@@ -1,8 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_create
 dist_pkgdata_SCRIPTS = \
-	properties.kshlib \
-	zfs_create_common.kshlib \
-	zfs_create.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_create_001_pos.ksh \
@@ -21,3 +18,8 @@ dist_pkgdata_SCRIPTS = \
 	zfs_create_014_pos.ksh \
 	zfs_create_encrypted.ksh \
 	zfs_create_crypt_combos.ksh
+
+dist_pkgdata_DATA = \
+	properties.kshlib \
+	zfs_create_common.kshlib \
+	zfs_create.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_destroy
 dist_pkgdata_SCRIPTS = \
-	zfs_destroy_common.kshlib \
-	zfs_destroy.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_destroy_001_pos.ksh \
@@ -20,3 +18,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_destroy_014_pos.ksh \
 	zfs_destroy_015_pos.ksh \
 	zfs_destroy_016_pos.ksh
+
+dist_pkgdata_DATA = \
+	zfs_destroy_common.kshlib \
+	zfs_destroy.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_get/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_get/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_get
 dist_pkgdata_SCRIPTS = \
-	zfs_get_common.kshlib \
-	zfs_get_list_d.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_get_001_pos.ksh \
@@ -14,3 +12,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_get_008_pos.ksh \
 	zfs_get_009_pos.ksh \
 	zfs_get_010_neg.ksh
+
+dist_pkgdata_DATA = \
+	zfs_get_common.kshlib \
+	zfs_get_list_d.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_load-key
 dist_pkgdata_SCRIPTS = \
-	zfs_load-key.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_load-key_common.kshlib \
@@ -10,3 +9,6 @@ dist_pkgdata_SCRIPTS = \
 	zfs_load-key_location.ksh \
 	zfs_load-key_noop.ksh \
 	zfs_load-key_recursive.ksh
+
+dist_pkgdata_DATA = \
+	zfs_load-key.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_mount/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_mount/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_mount
 dist_pkgdata_SCRIPTS = \
-	zfs_mount.cfg \
-	zfs_mount.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_mount_001_pos.ksh \
@@ -19,3 +17,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_mount_encrypted.ksh \
 	zfs_mount_all_001_pos.ksh \
 	zfs_mount_remount.ksh
+
+dist_pkgdata_DATA = \
+	zfs_mount.cfg \
+	zfs_mount.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_promote/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_promote/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_promote
 dist_pkgdata_SCRIPTS = \
-	zfs_promote.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_promote_001_pos.ksh \
@@ -12,3 +11,6 @@ dist_pkgdata_SCRIPTS = \
 	zfs_promote_007_neg.ksh \
 	zfs_promote_008_pos.ksh \
 	zfs_promote_encryptionroot.ksh
+
+dist_pkgdata_DATA = \
+	zfs_promote.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_rename
 dist_pkgdata_SCRIPTS = \
-	zfs_rename.cfg \
-	zfs_rename.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_rename_001_pos.ksh \
@@ -19,3 +17,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_rename_013_pos.ksh \
 	zfs_rename_encrypted_child.ksh \
 	zfs_rename_to_encrypted.ksh
+
+dist_pkgdata_DATA = \
+	zfs_rename.cfg \
+	zfs_rename.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/Makefile.am
@@ -1,10 +1,12 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_rollback
 dist_pkgdata_SCRIPTS = \
-	zfs_rollback.cfg \
-	zfs_rollback_common.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_rollback_001_pos.ksh \
 	zfs_rollback_002_pos.ksh \
 	zfs_rollback_003_neg.ksh \
 	zfs_rollback_004_neg.ksh
+
+dist_pkgdata_DATA = \
+	zfs_rollback.cfg \
+	zfs_rollback_common.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_send
 dist_pkgdata_SCRIPTS = \
-	zfs_send.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_send_001_pos.ksh \
@@ -14,3 +13,6 @@ dist_pkgdata_SCRIPTS = \
 	zfs_send_raw.ksh \
 	zfs_send_sparse.ksh \
 	zfs_send-b.ksh
+
+dist_pkgdata_DATA = \
+	zfs_send.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_set
 dist_pkgdata_SCRIPTS = \
-	zfs_set_common.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	cache_001_pos.ksh \
@@ -30,3 +29,6 @@ dist_pkgdata_SCRIPTS = \
 	zfs_set_002_neg.ksh \
 	zfs_set_003_neg.ksh \
 	zfs_set_keylocation.ksh
+
+dist_pkgdata_DATA = \
+	zfs_set_common.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_share
 dist_pkgdata_SCRIPTS = \
-	zfs_share.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_share_001_pos.ksh \
@@ -14,3 +13,6 @@ dist_pkgdata_SCRIPTS = \
 	zfs_share_009_neg.ksh \
 	zfs_share_010_neg.ksh \
 	zfs_share_011_pos.ksh
+
+dist_pkgdata_DATA = \
+	zfs_share.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_snapshot
 dist_pkgdata_SCRIPTS = \
-	zfs_snapshot.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_snapshot_001_neg.ksh \
@@ -12,3 +11,6 @@ dist_pkgdata_SCRIPTS = \
 	zfs_snapshot_007_neg.ksh \
 	zfs_snapshot_008_neg.ksh \
 	zfs_snapshot_009_pos.ksh
+
+dist_pkgdata_DATA = \
+	zfs_snapshot.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_unmount
 dist_pkgdata_SCRIPTS = \
-	zfs_unmount.cfg \
-	zfs_unmount.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_unmount_001_pos.ksh \
@@ -14,3 +12,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_unmount_008_neg.ksh \
 	zfs_unmount_009_pos.ksh \
 	zfs_unmount_all_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	zfs_unmount.cfg \
+	zfs_unmount.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_upgrade/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_upgrade
 dist_pkgdata_SCRIPTS = \
-	zfs_upgrade.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_upgrade_001_pos.ksh \
@@ -10,3 +9,6 @@ dist_pkgdata_SCRIPTS = \
 	zfs_upgrade_005_pos.ksh \
 	zfs_upgrade_006_neg.ksh \
 	zfs_upgrade_007_neg.ksh
+
+dist_pkgdata_DATA = \
+	zfs_upgrade.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_add
 dist_pkgdata_SCRIPTS = \
-	zpool_add.cfg \
-	zpool_add.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_add_001_pos.ksh \
@@ -17,3 +15,7 @@ dist_pkgdata_SCRIPTS = \
 	add-o_ashift.ksh \
 	add_prop_ashift.ksh \
 	add_nested_replacing_spare.ksh
+
+dist_pkgdata_DATA = \
+	zpool_add.cfg \
+	zpool_add.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/Makefile.am
@@ -1,9 +1,11 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_clear
 dist_pkgdata_SCRIPTS = \
-	zpool_clear.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_clear_001_pos.ksh \
 	zpool_clear_002_neg.ksh \
 	zpool_clear_003_neg.ksh \
 	zpool_clear_readonly.ksh
+
+dist_pkgdata_DATA = \
+	zpool_clear.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_create
 dist_pkgdata_SCRIPTS = \
-	zpool_create.cfg \
-	zpool_create.shlib \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_create_001_pos.ksh \
@@ -35,3 +33,7 @@ dist_pkgdata_SCRIPTS = \
 	zpool_create_features_004_neg.ksh \
 	zpool_create_features_005_pos.ksh \
 	create-o_ashift.ksh
+
+dist_pkgdata_DATA = \
+	zpool_create.cfg \
+	zpool_create.shlib

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/Makefile.am
@@ -1,6 +1,8 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_destroy
 dist_pkgdata_SCRIPTS = \
-	zpool_destroy.cfg \
 	zpool_destroy_001_pos.ksh \
 	zpool_destroy_002_pos.ksh \
 	zpool_destroy_003_neg.ksh
+
+dist_pkgdata_DATA = \
+	zpool_destroy.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/Makefile.am
@@ -1,9 +1,11 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_expand
 dist_pkgdata_SCRIPTS = \
-	zpool_expand.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_expand_001_pos.ksh \
 	zpool_expand_002_pos.ksh \
 	zpool_expand_003_neg.ksh \
 	zpool_expand_004_pos.ksh
+
+dist_pkgdata_DATA = \
+	zpool_expand.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/Makefile.am
@@ -2,8 +2,10 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_expo
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	zpool_export.cfg \
 	zpool_export_001_pos.ksh \
 	zpool_export_002_pos.ksh \
 	zpool_export_003_neg.ksh \
 	zpool_export_004_pos.ksh
+
+dist_pkgdata_DATA = \
+	zpool_export.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/Makefile.am
@@ -1,9 +1,11 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_get
 dist_pkgdata_SCRIPTS = \
-	zpool_get.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_get_001_pos.ksh \
 	zpool_get_002_pos.ksh \
 	zpool_get_003_pos.ksh \
 	zpool_get_004_neg.ksh
+
+dist_pkgdata_DATA = \
+	zpool_get.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_import
 dist_pkgdata_SCRIPTS = \
-	zpool_import.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_import_001_pos.ksh \
@@ -34,5 +33,7 @@ BLOCKFILES = \
 	unclean_export.dat.bz2 \
 	cryptv0.dat.bz2
 
-dist_pkgdata_DATA = $(BLOCKFILES)
+dist_pkgdata_DATA = $(BLOCKFILES) \
+	zpool_import.cfg
+
 EXTRA_DIST = $(BLOCKFILES)

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_remove/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_remove/Makefile.am
@@ -1,8 +1,10 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_remove
 dist_pkgdata_SCRIPTS = \
-	zpool_remove.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_remove_001_neg.ksh \
 	zpool_remove_002_pos.ksh \
 	zpool_remove_003_pos.ksh
+
+dist_pkgdata_DATA = \
+	zpool_remove.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/Makefile.am
@@ -2,11 +2,13 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_reop
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	zpool_reopen.cfg \
-	zpool_reopen.shlib \
 	zpool_reopen_001_pos.ksh \
 	zpool_reopen_002_pos.ksh \
 	zpool_reopen_003_pos.ksh \
 	zpool_reopen_004_pos.ksh \
 	zpool_reopen_005_pos.ksh \
 	zpool_reopen_006_neg.ksh
+
+dist_pkgdata_DATA = \
+	zpool_reopen.cfg \
+	zpool_reopen.shlib

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_scrub
 dist_pkgdata_SCRIPTS = \
-	zpool_scrub.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_scrub_001_neg.ksh \
@@ -10,3 +9,6 @@ dist_pkgdata_SCRIPTS = \
 	zpool_scrub_005_pos.ksh \
 	zpool_scrub_encrypted_unloaded.ksh \
 	zpool_scrub_offline_device.ksh
+
+dist_pkgdata_DATA = \
+	zpool_scrub.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_upgrade/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_upgrade
 dist_pkgdata_SCRIPTS = \
-	zpool_upgrade.cfg \
-	zpool_upgrade.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_upgrade_001_pos.ksh \
@@ -68,5 +66,8 @@ BLOCKFILES = \
 	zfs-pool-v999.dat.bz2 \
 	zfs-pool-vBROKEN.dat.bz2
 
-dist_pkgdata_DATA = $(BLOCKFILES)
+dist_pkgdata_DATA = $(BLOCKFILES) \
+	zpool_upgrade.cfg \
+	zpool_upgrade.kshlib
+
 EXTRA_DIST = $(BLOCKFILES)

--- a/tests/zfs-tests/tests/functional/cli_user/misc/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_user/misc
 dist_pkgdata_SCRIPTS = \
-	misc.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	zdb_001_neg.ksh \
@@ -49,3 +48,6 @@ dist_pkgdata_SCRIPTS = \
 	arc_summary_002_neg.ksh \
 	arc_summary3_001_pos.ksh \
 	dbufstat_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	misc.cfg

--- a/tests/zfs-tests/tests/functional/cli_user/zfs_list/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_user/zfs_list/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_user/zfs_list
 dist_pkgdata_SCRIPTS = \
-	zfs_list.cfg \
-	zfs_list.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	zfs_list_001_pos.ksh \
@@ -10,3 +8,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_list_004_neg.ksh \
 	zfs_list_007_pos.ksh \
 	zfs_list_008_neg.ksh
+
+dist_pkgdata_DATA = \
+	zfs_list.cfg \
+	zfs_list.kshlib

--- a/tests/zfs-tests/tests/functional/compression/Makefile.am
+++ b/tests/zfs-tests/tests/functional/compression/Makefile.am
@@ -1,9 +1,11 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/compression
 dist_pkgdata_SCRIPTS = \
-	compress.cfg \
 	cleanup.ksh \
 	setup.ksh \
 	compress_001_pos.ksh \
 	compress_002_pos.ksh \
 	compress_003_pos.ksh \
 	compress_004_pos.ksh
+
+dist_pkgdata_DATA = \
+	compress.cfg

--- a/tests/zfs-tests/tests/functional/deadman/Makefile.am
+++ b/tests/zfs-tests/tests/functional/deadman/Makefile.am
@@ -1,5 +1,7 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/deadman
 dist_pkgdata_SCRIPTS = \
-	deadman.cfg \
 	deadman_sync.ksh \
 	deadman_zio.ksh
+
+dist_pkgdata_DATA = \
+	deadman.cfg

--- a/tests/zfs-tests/tests/functional/delegate/Makefile.am
+++ b/tests/zfs-tests/tests/functional/delegate/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/delegate
 dist_pkgdata_SCRIPTS = \
-	delegate.cfg \
-	delegate_common.kshlib \
 	cleanup.ksh \
 	setup.ksh \
 	zfs_allow_001_pos.ksh \
@@ -24,3 +22,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_unallow_006_pos.ksh \
 	zfs_unallow_007_neg.ksh \
 	zfs_unallow_008_neg.ksh
+
+dist_pkgdata_DATA = \
+	delegate.cfg \
+	delegate_common.kshlib

--- a/tests/zfs-tests/tests/functional/devices/Makefile.am
+++ b/tests/zfs-tests/tests/functional/devices/Makefile.am
@@ -1,9 +1,11 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/devices
 dist_pkgdata_SCRIPTS = \
-	devices.cfg \
-	devices_common.kshlib \
 	cleanup.ksh \
 	setup.ksh \
 	devices_001_pos.ksh \
 	devices_002_neg.ksh \
 	devices_003_pos.ksh
+
+dist_pkgdata_DATA = \
+	devices.cfg \
+	devices_common.kshlib

--- a/tests/zfs-tests/tests/functional/events/Makefile.am
+++ b/tests/zfs-tests/tests/functional/events/Makefile.am
@@ -2,8 +2,10 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/events
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	events.cfg \
-	events_common.kshlib \
 	events_001_pos.ksh \
 	events_002_pos.ksh \
 	zed_rc_filter.ksh
+
+dist_pkgdata_DATA = \
+	events.cfg \
+	events_common.kshlib

--- a/tests/zfs-tests/tests/functional/grow_pool/Makefile.am
+++ b/tests/zfs-tests/tests/functional/grow_pool/Makefile.am
@@ -2,5 +2,7 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/grow_pool
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	grow_pool.cfg \
 	grow_pool_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	grow_pool.cfg

--- a/tests/zfs-tests/tests/functional/grow_replicas/Makefile.am
+++ b/tests/zfs-tests/tests/functional/grow_replicas/Makefile.am
@@ -1,4 +1,6 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/grow_replicas
 dist_pkgdata_SCRIPTS = \
-	grow_replicas.cfg \
 	grow_replicas_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	grow_replicas.cfg

--- a/tests/zfs-tests/tests/functional/history/Makefile.am
+++ b/tests/zfs-tests/tests/functional/history/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/history
 dist_pkgdata_SCRIPTS = \
-	history.cfg \
-	history_common.kshlib \
 	cleanup.ksh \
 	setup.ksh \
 	history_001_pos.ksh \
@@ -13,7 +11,11 @@ dist_pkgdata_SCRIPTS = \
 	history_007_pos.ksh \
 	history_008_pos.ksh \
 	history_009_pos.ksh \
-	history_010_pos.ksh \
+	history_010_pos.ksh
+
+dist_pkgdata_DATA = \
+	history.cfg \
+	history_common.kshlib \
 	i386.migratedpool.DAT.Z \
 	i386.orig_history.txt \
 	sparc.migratedpool.DAT.Z \

--- a/tests/zfs-tests/tests/functional/inheritance/Makefile.am
+++ b/tests/zfs-tests/tests/functional/inheritance/Makefile.am
@@ -1,8 +1,10 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/inheritance
 dist_pkgdata_SCRIPTS = \
-	inherit.kshlib \
 	cleanup.ksh \
-	inherit_001_pos.ksh \
+	inherit_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	inherit.kshlib \
 	config001.cfg \
 	config002.cfg \
 	config003.cfg \

--- a/tests/zfs-tests/tests/functional/inuse/Makefile.am
+++ b/tests/zfs-tests/tests/functional/inuse/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/inuse
 dist_pkgdata_SCRIPTS = \
-	inuse.cfg \
 	setup.ksh \
 	inuse_001_pos.ksh \
 	inuse_003_pos.ksh \
@@ -10,3 +9,6 @@ dist_pkgdata_SCRIPTS = \
 	inuse_007_pos.ksh \
 	inuse_008_pos.ksh \
 	inuse_009_pos.ksh
+
+dist_pkgdata_DATA = \
+	inuse.cfg

--- a/tests/zfs-tests/tests/functional/largest_pool/Makefile.am
+++ b/tests/zfs-tests/tests/functional/largest_pool/Makefile.am
@@ -1,4 +1,6 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/largest_pool
 dist_pkgdata_SCRIPTS = \
-	largest_pool.cfg \
 	largest_pool_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	largest_pool.cfg

--- a/tests/zfs-tests/tests/functional/migration/Makefile.am
+++ b/tests/zfs-tests/tests/functional/migration/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/migration
 dist_pkgdata_SCRIPTS = \
-	migration.cfg \
-	migration.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	migration_001_pos.ksh \
@@ -16,3 +14,7 @@ dist_pkgdata_SCRIPTS = \
 	migration_010_pos.ksh \
 	migration_011_pos.ksh \
 	migration_012_pos.ksh
+
+dist_pkgdata_DATA = \
+	migration.cfg \
+	migration.kshlib

--- a/tests/zfs-tests/tests/functional/mmap/Makefile.am
+++ b/tests/zfs-tests/tests/functional/mmap/Makefile.am
@@ -2,7 +2,9 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/mmap
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	mmap.cfg \
 	mmap_read_001_pos.ksh \
 	mmap_write_001_pos.ksh \
 	mmap_libaio_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	mmap.cfg

--- a/tests/zfs-tests/tests/functional/mmp/Makefile.am
+++ b/tests/zfs-tests/tests/functional/mmp/Makefile.am
@@ -11,6 +11,8 @@ dist_pkgdata_SCRIPTS = \
 	mmp_write_uberblocks.ksh \
 	mmp_reset_interval.ksh \
 	setup.ksh \
-	cleanup.ksh \
+	cleanup.ksh
+
+dist_pkgdata_DATA = \
 	mmp.kshlib \
 	mmp.cfg

--- a/tests/zfs-tests/tests/functional/mv_files/Makefile.am
+++ b/tests/zfs-tests/tests/functional/mv_files/Makefile.am
@@ -1,8 +1,10 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/mv_files
 dist_pkgdata_SCRIPTS = \
-	mv_files.cfg \
-	mv_files_common.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	mv_files_001_pos.ksh \
 	mv_files_002_pos.ksh
+
+dist_pkgdata_DATA = \
+	mv_files.cfg \
+	mv_files_common.kshlib

--- a/tests/zfs-tests/tests/functional/no_space/Makefile.am
+++ b/tests/zfs-tests/tests/functional/no_space/Makefile.am
@@ -1,8 +1,10 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/no_space
 dist_pkgdata_SCRIPTS = \
-	enospc.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	enospc_001_pos.ksh \
 	enospc_002_pos.ksh \
 	enospc_003_pos.ksh
+
+dist_pkgdata_DATA = \
+	enospc.cfg

--- a/tests/zfs-tests/tests/functional/nopwrite/Makefile.am
+++ b/tests/zfs-tests/tests/functional/nopwrite/Makefile.am
@@ -2,7 +2,6 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/nopwrite
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	nopwrite.shlib \
 	nopwrite_copies.ksh \
 	nopwrite_mtime.ksh \
 	nopwrite_negative.ksh \
@@ -11,3 +10,6 @@ dist_pkgdata_SCRIPTS = \
 	nopwrite_sync.ksh \
 	nopwrite_varying_compression.ksh \
 	nopwrite_volume.ksh
+
+dist_pkgdata_DATA = \
+	nopwrite.shlib

--- a/tests/zfs-tests/tests/functional/online_offline/Makefile.am
+++ b/tests/zfs-tests/tests/functional/online_offline/Makefile.am
@@ -1,8 +1,10 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/online_offline
 dist_pkgdata_SCRIPTS = \
-	online_offline.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	online_offline_001_pos.ksh \
 	online_offline_002_neg.ksh \
 	online_offline_003_neg.ksh
+
+dist_pkgdata_DATA = \
+	online_offline.cfg

--- a/tests/zfs-tests/tests/functional/projectquota/Makefile.am
+++ b/tests/zfs-tests/tests/functional/projectquota/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/projectquota
 dist_pkgdata_SCRIPTS = \
-	projectquota.cfg \
-	projectquota_common.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	projectid_001_pos.ksh \
@@ -23,3 +21,7 @@ dist_pkgdata_SCRIPTS = \
 	projecttree_001_pos.ksh \
 	projecttree_002_pos.ksh \
 	projecttree_003_neg.ksh
+
+dist_pkgdata_DATA = \
+	projectquota.cfg \
+	projectquota_common.kshlib

--- a/tests/zfs-tests/tests/functional/quota/Makefile.am
+++ b/tests/zfs-tests/tests/functional/quota/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/quota
 dist_pkgdata_SCRIPTS = \
-	quota.cfg \
-	quota.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	quota_001_pos.ksh \
@@ -10,3 +8,7 @@ dist_pkgdata_SCRIPTS = \
 	quota_004_pos.ksh \
 	quota_005_pos.ksh \
 	quota_006_neg.ksh
+
+dist_pkgdata_DATA = \
+	quota.cfg \
+	quota.kshlib

--- a/tests/zfs-tests/tests/functional/redundancy/Makefile.am
+++ b/tests/zfs-tests/tests/functional/redundancy/Makefile.am
@@ -1,10 +1,12 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/redundancy
 dist_pkgdata_SCRIPTS = \
-	redundancy.cfg \
-	redundancy.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	redundancy_001_pos.ksh \
 	redundancy_002_pos.ksh \
 	redundancy_003_pos.ksh \
 	redundancy_004_neg.ksh
+
+dist_pkgdata_DATA = \
+	redundancy.cfg \
+	redundancy.kshlib

--- a/tests/zfs-tests/tests/functional/refreserv/Makefile.am
+++ b/tests/zfs-tests/tests/functional/refreserv/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/refreserv
 dist_pkgdata_SCRIPTS = \
-	refreserv.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	refreserv_001_pos.ksh \
@@ -8,3 +7,6 @@ dist_pkgdata_SCRIPTS = \
 	refreserv_003_pos.ksh \
 	refreserv_004_pos.ksh \
 	refreserv_005_pos.ksh
+
+dist_pkgdata_DATA = \
+	refreserv.cfg

--- a/tests/zfs-tests/tests/functional/replacement/Makefile.am
+++ b/tests/zfs-tests/tests/functional/replacement/Makefile.am
@@ -1,8 +1,10 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/replacement
 dist_pkgdata_SCRIPTS = \
-	replacement.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	replacement_001_pos.ksh \
 	replacement_002_pos.ksh \
 	replacement_003_pos.ksh
+
+dist_pkgdata_DATA = \
+	replacement.cfg

--- a/tests/zfs-tests/tests/functional/reservation/Makefile.am
+++ b/tests/zfs-tests/tests/functional/reservation/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/reservation
 dist_pkgdata_SCRIPTS = \
-	reservation.cfg \
-	reservation.shlib \
 	setup.ksh \
 	cleanup.ksh \
 	reservation_001_pos.sh \
@@ -22,3 +20,7 @@ dist_pkgdata_SCRIPTS = \
 	reservation_016_pos.sh \
 	reservation_017_pos.sh \
 	reservation_018_pos.sh
+
+dist_pkgdata_DATA = \
+	reservation.cfg \
+	reservation.shlib

--- a/tests/zfs-tests/tests/functional/rsend/Makefile.am
+++ b/tests/zfs-tests/tests/functional/rsend/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/rsend
 dist_pkgdata_SCRIPTS = \
-	rsend.cfg \
-	rsend.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	rsend_001_pos.ksh \
@@ -42,3 +40,7 @@ dist_pkgdata_SCRIPTS = \
 	send-cpL_varied_recsize.ksh \
 	send_freeobjects.ksh \
 	send_realloc_dnode_size.ksh
+
+dist_pkgdata_DATA = \
+	rsend.cfg \
+	rsend.kshlib

--- a/tests/zfs-tests/tests/functional/scrub_mirror/Makefile.am
+++ b/tests/zfs-tests/tests/functional/scrub_mirror/Makefile.am
@@ -1,10 +1,12 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/scrub_mirror
 dist_pkgdata_SCRIPTS = \
-	default.cfg \
-	scrub_mirror_common.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	scrub_mirror_001_pos.ksh \
 	scrub_mirror_002_pos.ksh \
 	scrub_mirror_003_pos.ksh \
 	scrub_mirror_004_pos.ksh
+
+dist_pkgdata_DATA = \
+	default.cfg \
+	scrub_mirror_common.kshlib

--- a/tests/zfs-tests/tests/functional/slog/Makefile.am
+++ b/tests/zfs-tests/tests/functional/slog/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/slog
 dist_pkgdata_SCRIPTS = \
-	slog.cfg \
-	slog.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	slog_001_pos.ksh \
@@ -21,3 +19,7 @@ dist_pkgdata_SCRIPTS = \
 	slog_015_neg.ksh \
 	slog_replay_fs.ksh \
 	slog_replay_volume.ksh
+
+dist_pkgdata_DATA = \
+	slog.cfg \
+	slog.kshlib

--- a/tests/zfs-tests/tests/functional/snapshot/Makefile.am
+++ b/tests/zfs-tests/tests/functional/snapshot/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/snapshot
 dist_pkgdata_SCRIPTS = \
-	snapshot.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	clone_001_pos.ksh \
@@ -24,3 +23,6 @@ dist_pkgdata_SCRIPTS = \
 	snapshot_015_pos.ksh \
 	snapshot_016_pos.ksh \
 	snapshot_017_pos.ksh
+
+dist_pkgdata_DATA = \
+	snapshot.cfg

--- a/tests/zfs-tests/tests/functional/snapused/Makefile.am
+++ b/tests/zfs-tests/tests/functional/snapused/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/snapused
 dist_pkgdata_SCRIPTS = \
-	snapused.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	snapused_001_pos.ksh \
@@ -8,3 +7,6 @@ dist_pkgdata_SCRIPTS = \
 	snapused_003_pos.ksh \
 	snapused_004_pos.ksh \
 	snapused_005_pos.ksh
+
+dist_pkgdata_DATA = \
+	snapused.kshlib

--- a/tests/zfs-tests/tests/functional/sparse/Makefile.am
+++ b/tests/zfs-tests/tests/functional/sparse/Makefile.am
@@ -1,6 +1,8 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/sparse
 dist_pkgdata_SCRIPTS = \
-	sparse.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	sparse_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	sparse.cfg

--- a/tests/zfs-tests/tests/functional/truncate/Makefile.am
+++ b/tests/zfs-tests/tests/functional/truncate/Makefile.am
@@ -5,10 +5,12 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/truncate
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	truncate.cfg \
 	truncate_001_pos.ksh \
 	truncate_002_pos.ksh \
 	truncate_timestamps.ksh
+
+dist_pkgdata_DATA = \
+	truncate.cfg
 
 pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/truncate
 

--- a/tests/zfs-tests/tests/functional/upgrade/Makefile.am
+++ b/tests/zfs-tests/tests/functional/upgrade/Makefile.am
@@ -1,7 +1,9 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/upgrade
 dist_pkgdata_SCRIPTS = \
-	upgrade_common.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	upgrade_userobj_001_pos.ksh \
 	upgrade_projectquota_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	upgrade_common.kshlib

--- a/tests/zfs-tests/tests/functional/user_namespace/Makefile.am
+++ b/tests/zfs-tests/tests/functional/user_namespace/Makefile.am
@@ -2,6 +2,8 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/user_namespace
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	user_namespace_common.kshlib \
-	user_namespace.cfg \
 	user_namespace_001.ksh
+
+dist_pkgdata_DATA = \
+	user_namespace_common.kshlib \
+	user_namespace.cfg

--- a/tests/zfs-tests/tests/functional/userquota/Makefile.am
+++ b/tests/zfs-tests/tests/functional/userquota/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/userquota
 dist_pkgdata_SCRIPTS = \
-	userquota.cfg \
-	userquota_common.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	groupspace_001_pos.ksh \
@@ -23,3 +21,7 @@ dist_pkgdata_SCRIPTS = \
 	userspace_001_pos.ksh \
 	userspace_002_pos.ksh \
 	userspace_003_pos.ksh
+
+dist_pkgdata_DATA = \
+	userquota.cfg \
+	userquota_common.kshlib

--- a/tests/zfs-tests/tests/functional/vdev_zaps/Makefile.am
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/Makefile.am
@@ -8,5 +8,7 @@ dist_pkgdata_SCRIPTS = \
 	vdev_zaps_004_pos.ksh \
 	vdev_zaps_005_pos.ksh \
 	vdev_zaps_006_pos.ksh \
-	vdev_zaps_007_pos.ksh \
+	vdev_zaps_007_pos.ksh
+
+dist_pkgdata_DATA = \
 	vdev_zaps.kshlib

--- a/tests/zfs-tests/tests/functional/xattr/Makefile.am
+++ b/tests/zfs-tests/tests/functional/xattr/Makefile.am
@@ -1,9 +1,7 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/xattr
 dist_pkgdata_SCRIPTS = \
-	xattr_common.kshlib \
 	setup.ksh \
 	cleanup.ksh \
-	xattr.cfg \
 	xattr_001_pos.ksh \
 	xattr_002_neg.ksh \
 	xattr_003_neg.ksh \
@@ -16,4 +14,8 @@ dist_pkgdata_SCRIPTS = \
 	xattr_010_neg.ksh \
 	xattr_011_pos.ksh \
 	xattr_012_pos.ksh \
-	xattr_013_pos.ksh 
+	xattr_013_pos.ksh
+
+dist_pkgdata_DATA = \
+	xattr_common.kshlib \
+	xattr.cfg

--- a/tests/zfs-tests/tests/functional/zvol/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/Makefile.am
@@ -1,5 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/zvol
-dist_pkgdata_SCRIPTS = \
+dist_pkgdata_DATA = \
 	zvol.cfg \
 	zvol_common.shlib
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/zvol/zvol_swap
 dist_pkgdata_SCRIPTS = \
-	zvol_swap.cfg \
 	cleanup.ksh \
 	setup.ksh \
 	zvol_swap_001_pos.ksh \
@@ -9,3 +8,6 @@ dist_pkgdata_SCRIPTS = \
 	zvol_swap_004_pos.ksh \
 	zvol_swap_005_pos.ksh \
 	zvol_swap_006_pos.ksh
+
+dist_pkgdata_DATA = \
+	zvol_swap.cfg

--- a/tests/zfs-tests/tests/perf/Makefile.am
+++ b/tests/zfs-tests/tests/perf/Makefile.am
@@ -1,5 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/perf
-dist_pkgdata_SCRIPTS = perf.shlib
+dist_pkgdata_DATA = perf.shlib
 
 SUBDIRS = \
 	fio \

--- a/tests/zfs-tests/tests/perf/fio/Makefile.am
+++ b/tests/zfs-tests/tests/perf/fio/Makefile.am
@@ -1,5 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/perf/fio
-dist_pkgdata_SCRIPTS = \
+dist_pkgdata_DATA = \
 	mkfiles.fio \
 	random_reads.fio \
 	random_readwrite.fio \


### PR DESCRIPTION
### Description
Fedora 28's RPM build checks warn when executable files don't have a shebang line:
```
*** WARNING: ./tests/zfs-tests/tests/functional/mv_files/mv_files_common.kshlib is executable but has empty or no shebang, removing executable bit
*** WARNING: ./tests/zfs-tests/tests/functional/mv_files/mv_files.cfg is executable but has empty or no shebang, removing executable bit
```
 These warnings are caused when we (incorrectly) include data & config files in the `_SCRIPTS` automake lines. Files in `_SCRIPTS` are marked executable by automake. This patch fixes the issue by including non-executable scripts in a `_DATA` line instead.

### Motivation and Context
Closes: #7359

### How Has This Been Tested?
Tested `make pkg-utils` on a Fedora 28 VM and no longer saw the warnings.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
