### PR TITLE
Fedora 28: Exclude python scripts from RPM shebang check

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -38,6 +38,16 @@
 %bcond_with    asan
 %bcond_with    systemd
 
+# Python permits the !/usr/bin/python shebang for scripts that are cross
+# compatible between python2 and python3, but Fedora 28 does not.  Fedora
+# wants us to choose python3 for cross-compatible scripts.  Since we want
+# to support python2 and python3 users, exclude our scripts from Fedora 28's
+# RPM build check, so that we don't get a bunch of build warnings.
+#
+# Details: https://github.com/zfsonlinux/zfs/issues/7360
+#
+%global __brp_mangle_shebangs_exclude_from arc_summary.py|arcstat.py|dbufstat.py|test-runner.py
+
 # Generic enable switch for systemd
 %if %{with systemd}
 %define _systemd 1


### PR DESCRIPTION
### Description
The newest Fedora packaging rules print warnings for scripts using the `/usr/bin/python` shebang:
```
    *** WARNING: mangling shebang in /usr/bin/arc_summary.py from #!/usr/bin/python to #!/usr/bin/python2. This will become an ERROR, fix it manually!
```
Fedora wants all cross compatible scripts to pick python3.  Since we don't want our users to have to pick a specific version of python, we exclude our scripts from the RPM shebang check.

### Motivation and Context
Closes: #7360

### How Has This Been Tested?
Saw build warnings go away when running `make pkg-utils` on Fedora 28.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
