### PR TITLE
Fix calloc(3) arguments order

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -218,7 +218,7 @@ efi_get_info(int fd, struct dk_cinfo *dki_info)
 
 	memset(dki_info, 0, sizeof (*dki_info));
 
-	path = calloc(PATH_MAX, 1);
+	path = calloc(1, PATH_MAX);
 	if (path == NULL)
 		goto error;
 
@@ -403,7 +403,7 @@ efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
 	length = sizeof (struct dk_gpt) +
 	    sizeof (struct dk_part) * (nparts - 1);
 
-	if ((*vtoc = calloc(length, 1)) == NULL)
+	if ((*vtoc = calloc(1, length)) == NULL)
 		return (-1);
 
 	vptr = *vtoc;
@@ -440,7 +440,7 @@ efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
 	nparts = EFI_MIN_ARRAY_SIZE / sizeof (efi_gpe_t);
 	length = (int) sizeof (struct dk_gpt) +
 	    (int) sizeof (struct dk_part) * (nparts - 1);
-	if ((*vtoc = calloc(length, 1)) == NULL)
+	if ((*vtoc = calloc(1, length)) == NULL)
 		return (VT_ERROR);
 
 	(*vtoc)->efi_nparts = nparts;

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -61,7 +61,7 @@ register_fstype(const char *name, const sa_share_ops_t *ops)
 {
 	sa_fstype_t *fstype;
 
-	fstype = calloc(sizeof (sa_fstype_t), 1);
+	fstype = calloc(1, sizeof (sa_fstype_t));
 
 	if (fstype == NULL)
 		return (NULL);
@@ -83,7 +83,7 @@ sa_init(int init_service)
 {
 	sa_handle_impl_t impl_handle;
 
-	impl_handle = calloc(sizeof (struct sa_handle_impl), 1);
+	impl_handle = calloc(1, sizeof (struct sa_handle_impl));
 
 	if (impl_handle == NULL)
 		return (NULL);
@@ -713,7 +713,7 @@ alloc_share(const char *sharepath)
 {
 	sa_share_impl_t impl_share;
 
-	impl_share = calloc(sizeof (struct sa_share_impl), 1);
+	impl_share = calloc(1, sizeof (struct sa_share_impl));
 
 	if (impl_share == NULL)
 		return (NULL);
@@ -725,7 +725,7 @@ alloc_share(const char *sharepath)
 		return (NULL);
 	}
 
-	impl_share->fsinfo = calloc(sizeof (sa_share_fsinfo_t), fstypes_count);
+	impl_share->fsinfo = calloc(fstypes_count, sizeof (sa_share_fsinfo_t));
 
 	if (impl_share->fsinfo == NULL) {
 		free(impl_share->sharepath);

--- a/lib/libspl/mkdirp.c
+++ b/lib/libspl/mkdirp.c
@@ -166,7 +166,7 @@ simplify(const char *str)
 
 	mbPathlen = strlen(mbPath);
 
-	if ((wcPath = calloc(sizeof (wchar_t), mbPathlen+1)) == NULL) {
+	if ((wcPath = calloc(mbPathlen+1, sizeof (wchar_t))) == NULL) {
 		free(mbPath);
 		return (NULL);
 	}

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -466,7 +466,7 @@ make_dataset_handle(libzfs_handle_t *hdl, const char *path)
 {
 	zfs_cmd_t zc = {"\0"};
 
-	zfs_handle_t *zhp = calloc(sizeof (zfs_handle_t), 1);
+	zfs_handle_t *zhp = calloc(1, sizeof (zfs_handle_t));
 
 	if (zhp == NULL)
 		return (NULL);
@@ -493,7 +493,7 @@ make_dataset_handle(libzfs_handle_t *hdl, const char *path)
 zfs_handle_t *
 make_dataset_handle_zc(libzfs_handle_t *hdl, zfs_cmd_t *zc)
 {
-	zfs_handle_t *zhp = calloc(sizeof (zfs_handle_t), 1);
+	zfs_handle_t *zhp = calloc(1, sizeof (zfs_handle_t));
 
 	if (zhp == NULL)
 		return (NULL);
@@ -510,7 +510,7 @@ make_dataset_handle_zc(libzfs_handle_t *hdl, zfs_cmd_t *zc)
 zfs_handle_t *
 make_dataset_simple_handle_zc(zfs_handle_t *pzhp, zfs_cmd_t *zc)
 {
-	zfs_handle_t *zhp = calloc(sizeof (zfs_handle_t), 1);
+	zfs_handle_t *zhp = calloc(1, sizeof (zfs_handle_t));
 
 	if (zhp == NULL)
 		return (NULL);
@@ -527,7 +527,7 @@ make_dataset_simple_handle_zc(zfs_handle_t *pzhp, zfs_cmd_t *zc)
 zfs_handle_t *
 zfs_handle_dup(zfs_handle_t *zhp_orig)
 {
-	zfs_handle_t *zhp = calloc(sizeof (zfs_handle_t), 1);
+	zfs_handle_t *zhp = calloc(1, sizeof (zfs_handle_t));
 
 	if (zhp == NULL)
 		return (NULL);
@@ -607,7 +607,7 @@ zfs_handle_t *
 make_bookmark_handle(zfs_handle_t *parent, const char *path,
     nvlist_t *bmark_props)
 {
-	zfs_handle_t *zhp = calloc(sizeof (zfs_handle_t), 1);
+	zfs_handle_t *zhp = calloc(1, sizeof (zfs_handle_t));
 
 	if (zhp == NULL)
 		return (NULL);

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1673,7 +1673,7 @@ zpool_clear_label(int fd)
 		return (0);
 	size = P2ALIGN_TYPED(statbuf.st_size, sizeof (vdev_label_t), uint64_t);
 
-	if ((label = calloc(sizeof (vdev_label_t), 1)) == NULL)
+	if ((label = calloc(1, sizeof (vdev_label_t))) == NULL)
 		return (-1);
 
 	for (l = 0; l < VDEV_LABELS; l++) {

--- a/tests/zfs-tests/cmd/mkfile/mkfile.c
+++ b/tests/zfs-tests/cmd/mkfile/mkfile.c
@@ -194,7 +194,7 @@ main(int argc, char **argv)
 				if (buf)
 					free(buf);
 				bufsz = (size_t)st.st_blksize;
-				buf = calloc(bufsz, 1);
+				buf = calloc(1, bufsz);
 				if (buf == NULL) {
 					(void) fprintf(stderr, gettext(
 					    "Could not allocate buffer of"


### PR DESCRIPTION
calloc(3) takes `nelem` (or `nmemb` in glibc) first, and then size of
elememnts.  No difference expected for having these in reverse order,
however should follow the standard.

http://pubs.opengroup.org/onlinepubs/009695399/functions/calloc.html

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
Properly call calloc(3).
<!--- Describe your changes in detail -->

### Motivation and Context
calloc(3) is designed to take number of elements first, and then size.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
