### PR TITLE
Clean up kshlib file shebangs

### DIFF
--- a/tests/test-runner/include/Makefile.am
+++ b/tests/test-runner/include/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/test-runner/include
-dist_pkgdata_SCRIPTS = \
-	logapi.shlib
 
 dist_pkgdata_DATA = \
+	logapi.shlib \
 	stf.shlib

--- a/tests/test-runner/include/logapi.shlib
+++ b/tests/test-runner/include/logapi.shlib
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #

--- a/tests/zfs-tests/include/zpool_script.shlib
+++ b/tests/zfs-tests/include/zpool_script.shlib
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # Common functions used by the zpool_status and zpool_iostat tests for running
 # scripts with the -c option.

--- a/tests/zfs-tests/tests/functional/cachefile/cachefile.kshlib
+++ b/tests/zfs-tests/tests/functional/cachefile/cachefile.kshlib
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #

--- a/tests/zfs-tests/tests/functional/channel_program/Makefile.am
+++ b/tests/zfs-tests/tests/functional/channel_program/Makefile.am
@@ -3,4 +3,4 @@ SUBDIRS = \
 	synctask_core
 
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/channel_program
-dist_pkgdata_SCRIPTS = channel_common.kshlib
+dist_pkgdata_DATA = channel_common.kshlib

--- a/tests/zfs-tests/tests/functional/channel_program/channel_common.kshlib
+++ b/tests/zfs-tests/tests/functional/channel_program/channel_common.kshlib
@@ -1,4 +1,3 @@
-#!/bin/ksh
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/Makefile.am
@@ -2,7 +2,6 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_load-k
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	zfs_load-key_common.kshlib \
 	zfs_load-key.ksh \
 	zfs_load-key_all.ksh \
 	zfs_load-key_file.ksh \
@@ -11,4 +10,5 @@ dist_pkgdata_SCRIPTS = \
 	zfs_load-key_recursive.ksh
 
 dist_pkgdata_DATA = \
-	zfs_load-key.cfg
+	zfs_load-key.cfg \
+	zfs_load-key_common.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_load-key/zfs_load-key_common.kshlib
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/Makefile.am
@@ -2,9 +2,11 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_even
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	zpool_events.cfg \
-	zpool_events.kshlib \
 	zpool_events_clear.ksh \
 	zpool_events_cliargs.ksh \
 	zpool_events_follow.ksh \
 	zpool_events_poolname.ksh
+
+dist_pkgdata_DATA = \
+	zpool_events.cfg \
+	zpool_events.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events.cfg
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events.kshlib
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/Makefile.am
@@ -1,5 +1,7 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_labelclear
 dist_pkgdata_SCRIPTS = \
-	labelclear.cfg \
 	zpool_labelclear_active.ksh \
 	zpool_labelclear_exported.ksh
+
+dist_pkgdata_DATA = \
+	labelclear.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
@@ -1,5 +1,3 @@
-#!/bin/ksh -p
-#
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen.cfg
@@ -1,5 +1,3 @@
-#!/bin/ksh -p
-
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.

--- a/tests/zfs-tests/tests/functional/fault/Makefile.am
+++ b/tests/zfs-tests/tests/functional/fault/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/fault
 dist_pkgdata_SCRIPTS = \
-	fault.cfg \
 	setup.ksh \
 	cleanup.ksh \
 	auto_online_001_pos.ksh \
@@ -10,3 +9,6 @@ dist_pkgdata_SCRIPTS = \
 	auto_spare_ashift.ksh \
 	auto_spare_multiple.ksh \
 	scrub_after_resilver.ksh
+
+dist_pkgdata_DATA = \
+	fault.cfg

--- a/tests/zfs-tests/tests/functional/fault/fault.cfg
+++ b/tests/zfs-tests/tests/functional/fault/fault.cfg
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #

--- a/tests/zfs-tests/tests/functional/write_dirs/Makefile.am
+++ b/tests/zfs-tests/tests/functional/write_dirs/Makefile.am
@@ -2,6 +2,8 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/write_dirs
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	write_dirs.cfg \
 	write_dirs_001_pos.ksh \
 	write_dirs_002_pos.ksh
+
+dist_pkgdata_DATA = \
+	write_dirs.cfg

--- a/tests/zfs-tests/tests/functional/write_dirs/write_dirs.cfg
+++ b/tests/zfs-tests/tests/functional/write_dirs/write_dirs.cfg
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #

--- a/tests/zfs-tests/tests/functional/zvol/zvol_ENOSPC/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_ENOSPC/Makefile.am
@@ -2,5 +2,7 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/zvol/zvol_ENOSPC
 dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	setup.ksh \
-	zvol_ENOSPC.cfg \
 	zvol_ENOSPC_001_pos.ksh
+
+dist_pkgdata_DATA = \
+	zvol_ENOSPC.cfg

--- a/tests/zfs-tests/tests/functional/zvol/zvol_ENOSPC/zvol_ENOSPC.cfg
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_ENOSPC/zvol_ENOSPC.cfg
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #

--- a/tests/zfs-tests/tests/functional/zvol/zvol_cli/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_cli/Makefile.am
@@ -2,7 +2,9 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/zvol/zvol_cli
 dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	setup.ksh \
-	zvol_cli.cfg \
 	zvol_cli_001_pos.ksh \
 	zvol_cli_002_pos.ksh \
 	zvol_cli_003_neg.ksh
+
+dist_pkgdata_DATA = \
+	zvol_cli.cfg

--- a/tests/zfs-tests/tests/functional/zvol/zvol_cli/zvol_cli.cfg
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_cli/zvol_cli.cfg
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/Makefile.am
@@ -1,6 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/zvol/zvol_misc
 dist_pkgdata_SCRIPTS = \
-	zvol_misc_common.kshlib \
 	cleanup.ksh \
 	setup.ksh \
 	zvol_misc_001_neg.ksh \
@@ -12,3 +11,7 @@ dist_pkgdata_SCRIPTS = \
 	zvol_misc_snapdev.ksh \
 	zvol_misc_volmode.ksh \
 	zvol_misc_zil.ksh
+
+dist_pkgdata_DATA = \
+	zvol_misc_common.kshlib
+

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_common.kshlib
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_common.kshlib
@@ -1,4 +1,3 @@
-#!/bin/ksh -p
 #
 # CDDL HEADER START
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Most kshlib files are imported by other scripts
and do not have a shebang at the top of their files.
Make all kshlib follow this convention.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Code clean up and consistency in the test suite.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Buildbot.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
