### PR TITLE
Add testing checking copying of many small files

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -600,7 +600,7 @@ tests = ['umount_001', 'umountall_001']
 tags = ['functional', 'mount']
 
 [tests/functional/mv_files]
-tests = ['mv_files_001_pos', 'mv_files_002_pos']
+tests = ['mv_files_001_pos', 'mv_files_002_pos', 'random_creation']
 tags = ['functional', 'mv_files']
 
 [tests/functional/nestedfs]

--- a/tests/zfs-tests/tests/functional/mv_files/Makefile.am
+++ b/tests/zfs-tests/tests/functional/mv_files/Makefile.am
@@ -3,7 +3,8 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
 	mv_files_001_pos.ksh \
-	mv_files_002_pos.ksh
+	mv_files_002_pos.ksh \
+	random_creation.ksh
 
 dist_pkgdata_DATA = \
 	mv_files.cfg \

--- a/tests/zfs-tests/tests/functional/mv_files/mv_files.cfg
+++ b/tests/zfs-tests/tests/functional/mv_files/mv_files.cfg
@@ -44,3 +44,7 @@ export NEWDIR_ACROSS_FS=$TESTDIR_TGT/newdir
 export MVNUMFILES=2000 # <number of files to start>
 export MVNUMINCR=1000  # <number of files to be increased to>
 export GANGPIDS=50 	# <number of limit for parallel background running process>
+
+# controls the "random_creation" test
+export RC_PASS1=65536 # <number of files to create in the first directory>
+export RC_PASS2=8192  # <process this many files into the second directory

--- a/tests/zfs-tests/tests/functional/mv_files/random_creation.ksh
+++ b/tests/zfs-tests/tests/functional/mv_files/random_creation.ksh
@@ -1,0 +1,48 @@
+#!/bin/ksh -p
+
+source "${STF_SUITE}/include/libtest.shlib"
+source "${STF_SUITE}/tests/functional/mv_files/mv_files.cfg"
+
+# This will test the #7401 regression.
+log_assert "Check that creating many files quickly is safe"
+
+DIR="${TESTDIR}/RANDOM_SMALL"
+
+log_must mkdir "${DIR}"
+
+count=0
+for i in $(shuf -i 1-"${RC_PASS1}") ; do
+    if ! touch "${DIR}/${i}" ; then
+	    log_fail "error creating ${i} after ${count} files"
+    fi
+    count=$((count+1))
+done
+
+visible="$(find "${DIR}" -type f|wc -l)"
+
+log_must [ "${visible}" -eq "${RC_PASS1}" ]
+
+log_assert "Check that creating them in another order is safe"
+
+DIR1="${TESTDIR}/RANDOM2"
+
+log_must mv "${DIR}" "${DIR1}"
+
+log_must mkdir "${DIR}"
+
+count=0
+for i in $(cd "${DIR1}" ; ls -U . ) ; do
+    if ! touch "${DIR}/${i}" ; then
+	    log_fail "error creating ${i} after ${count} files"
+    fi
+    count=$((count+1))
+    [ "${count}" -eq "${RC_PASS2}" ] && break
+done
+
+visible="$(find "${DIR}" -type f|wc -l)"
+
+if [ "${visible}" -eq "${RC_PASS2}" ] ; then
+    log_pass "Created all ${RC_PASS2} files"
+else
+    log_fail "Number of created files ${visible} is not ${RC_PASS2}"
+fi


### PR DESCRIPTION
Issue #7401 identified data loss when many small files are being copied. Add tests to check for this, and other similar conditions.


<!--- Provide a general summary of your changes in the Title above -->
I have not interacted with automatic testing infrastructure, so this is a WIP.

Adds a `cp` functional test, the original reproducer; a `random_creation` test that naturally uses the native list order from ZFS to create the ZAP hash collision; and a direct test, with a specific sequence that has been demonstrated to cause the hash collision.

### Description
<!--- Describe your changes in detail -->

~~Maybe I should also add some cache options?~~This does not appear to be important, though should we consider this for future bugs?

### How Has This Been Tested?
This is a test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
- [x] **This is a new test.**

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
