### PR TITLE
ZTS: clean up leftover ibackup_trunc files

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_raw_incremental.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_raw_incremental.ksh
@@ -49,14 +49,15 @@ function cleanup
 		log_must zfs destroy -r $TESTPOOL/$TESTFS2
 
 	[[ -f $ibackup ]] && log_must rm -f $ibackup
+	[[ -f $ibackup_trunc ]] && log_must rm -f $ibackup_trunc
 }
 
 log_onexit cleanup
 
 log_assert "ZFS should receive streams from raw incremental sends"
 
-typeset ibackup="/var/tmp/ibackup.$$"
-typeset ibackup_trunc="/var/tmp/ibackup_trunc.$$"
+typeset ibackup="$TEST_BASE_DIR/ibackup.$$"
+typeset ibackup_trunc="$TEST_BASE_DIR/ibackup_trunc.$$"
 typeset passphrase="password"
 typeset passphrase2="password2"
 typeset snap1="$TESTPOOL/$TESTFS1@snap1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
zfs_receive_raw_incremental did not clean up ibackup_trunc.* files left over from running the test.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cleans up /var/tmp a little 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
