### PR TITLE
Linux compat 4.16: blk_queue_flag_{set,clear}

### DIFF
--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -41,7 +41,7 @@ typedef unsigned __bitwise__ fmode_t;
 static inline void
 blk_queue_flag_set(unsigned int flag, struct request_queue *q)
 {
-	queue_flag_set_unlocked(flag, q);
+	queue_flag_set(flag, q);
 }
 #endif
 
@@ -49,7 +49,7 @@ blk_queue_flag_set(unsigned int flag, struct request_queue *q)
 static inline void
 blk_queue_flag_clear(unsigned int flag, struct request_queue *q)
 {
-	queue_flag_clear_unlocked(flag, q);
+	queue_flag_clear(flag, q);
 }
 #endif
 
@@ -72,16 +72,14 @@ static inline void
 blk_queue_set_write_cache(struct request_queue *q, bool wc, bool fua)
 {
 #if defined(HAVE_BLK_QUEUE_WRITE_CACHE_GPL_ONLY)
-	spin_lock_irq(q->queue_lock);
 	if (wc)
-		queue_flag_set(QUEUE_FLAG_WC, q);
+		blk_queue_flag_set(QUEUE_FLAG_WC, q);
 	else
-		queue_flag_clear(QUEUE_FLAG_WC, q);
+		blk_queue_flag_clear(QUEUE_FLAG_WC, q);
 	if (fua)
-		queue_flag_set(QUEUE_FLAG_FUA, q);
+		blk_queue_flag_set(QUEUE_FLAG_FUA, q);
 	else
-		queue_flag_clear(QUEUE_FLAG_FUA, q);
-	spin_unlock_irq(q->queue_lock);
+		blk_queue_flag_clear(QUEUE_FLAG_FUA, q);
 #elif defined(HAVE_BLK_QUEUE_WRITE_CACHE)
 	blk_queue_write_cache(q, wc, fua);
 #elif defined(HAVE_BLK_QUEUE_FLUSH_GPL_ONLY)


### PR DESCRIPTION
### Description

The HAVE_BLK_QUEUE_WRITE_CACHE_GPL_ONLY case was overlooked in
the original 10f88c5c commit because blk_queue_write_cache()
was available for the in-kernel builds.

Update the blk_queue_flag_{set,clear} wrappers to call the locked
versions to avoid confusion.  This is safe for all existing callers.

The blk_queue_set_write_cache() function has been updated to use
these wrappers.  This means setting/clearing both QUEUE_FLAG_WC
and QUEUE_FLAG_FUA is no longer atomic but this only done early
in zvol_alloc() prior to any requests so there is no issue.

### Motivation and Context

Issue #7428

### How Has This Been Tested?

Local build on Fedora Rawhide.  Pending full ZTS from buildbot.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
