### PR TITLE
Avoid Linux hung task message in ZTHR

### DIFF
--- a/module/zfs/zthr.c
+++ b/module/zfs/zthr.c
@@ -189,7 +189,7 @@ zthr_procedure(void *arg)
 			mutex_enter(&t->zthr_lock);
 		} else {
 			/* go to sleep */
-			cv_wait(&t->zthr_cv, &t->zthr_lock);
+			cv_wait_sig(&t->zthr_cv, &t->zthr_lock);
 		}
 	}
 	mutex_exit(&t->zthr_lock);


### PR DESCRIPTION
### Description
s/cv_wait/cv_timedwait/ in zthr_procedure().

### Motivation and Context
Avoid triggering the Linux kernel "hung task" warning

### How Has This Been Tested?
Ran the "removal" set of tests in ZTS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
