### PR TITLE
Revert "OpenZFS 9036 - zfs: duplicate 'const' declaration specifier"

### DIFF
--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -136,8 +136,8 @@ vdev_indirect_mapping_size(vdev_indirect_mapping_t *vim)
 static int
 dva_mapping_overlap_compare(const void *v_key, const void *v_array_elem)
 {
-	const uint64_t *key = v_key;
-	const vdev_indirect_mapping_entry_phys_t *array_elem =
+	const uint64_t * const key = v_key;
+	const vdev_indirect_mapping_entry_phys_t * const array_elem =
 	    v_array_elem;
 	uint64_t src_offset = DVA_MAPPING_GET_SRC_OFFSET(array_elem);
 


### PR DESCRIPTION
This reverts commit cbb893321545c2c9052787b556c9375fcb103979.

The original change in OpenZFS 9036 did remove duplicate 'const'
specifiers, but the ZoL port had already done what *should* have been
done in OpenZFS 9036, which is to make the pointers themselves const.
The port of the change to ZoL ended up doing an unnecessary removal
of the constness of the pointers. Undo that.

Signed-off-by: Ari Sundholm <ari@tuxera.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Undo the port of OpenZFS 9036.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The change which is being undone here was both incorrect and unnecessary in the ZoL port, as the 'const' specifiers removed were by no means duplicate. Unlike in OpenZFS, the pointers themselves were const in ZoL, which is arguably what should have been done in OpenZFS 9036 in the first place.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Not tested, as this is a trivial revert back to code that was already known to work.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
