### PR TITLE
ZTS: fix reservation_013_pos integer overflow

### DIFF
--- a/tests/zfs-tests/tests/functional/reservation/reservation_013_pos.sh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_013_pos.sh
@@ -75,9 +75,9 @@ space_avail=$(get_prop available $TESTPOOL)
 [[ $? -ne 0 ]] && \
     log_fail "Unable to get space available property for $TESTPOOL"
 
-((resv_set = space_avail / 5))
+typeset -il resv_set=space_avail/5
 resv_set=$(floor_volsize $resv_set)
-((sparse_vol_set_size = space_avail * 5))
+typeset -il sparse_vol_set_size=space_avail*5
 sparse_vol_set_size=$(floor_volsize $sparse_vol_set_size)
 
 # When initially created, a regular volume's reservation property is set


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
When using large disks the integers for calculating sizes can
overflow past 2**31.  Changing to long integers with typeset
should correct this.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#4444 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Local testbot with 40GB disks attached

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
