### PR TITLE
RHEL 7.5 compat: FMODE_KABI_ITERATE

### DIFF
--- a/config/kernel-vfs-iterate.m4
+++ b/config/kernel-vfs-iterate.m4
@@ -23,16 +23,27 @@ AC_DEFUN([ZFS_AC_KERNEL_VFS_ITERATE], [
 		dnl #
 		dnl # 3.11 API change
 		dnl #
+		dnl # RHEL 7.5 compatibility; the fops.iterate() method was
+		dnl # added to the file_operations structure but in order to
+		dnl # maintain KABI compatibility all callers must set
+		dnl # FMODE_KABI_ITERATE which is checked in iterate_dir().
+		dnl # When detected ignore this interface and fallback to
+		dnl # to using fops.readdir() to retain KABI compatibility.
+		dnl #
 		AC_MSG_CHECKING([whether fops->iterate() is available])
 		ZFS_LINUX_TRY_COMPILE([
 			#include <linux/fs.h>
-			int iterate(struct file *filp, struct dir_context * context)
-			    { return 0; }
+			int iterate(struct file *filp,
+			    struct dir_context *context) { return 0; }
 
 			static const struct file_operations fops
 			    __attribute__ ((unused)) = {
 				.iterate	 = iterate,
 			};
+
+			#if defined(FMODE_KABI_ITERATE)
+			#error "RHEL 7.5, FMODE_KABI_ITERATE interface"
+			#endif
 		],[
 		],[
 			AC_MSG_RESULT(yes)
@@ -44,8 +55,8 @@ AC_DEFUN([ZFS_AC_KERNEL_VFS_ITERATE], [
 			AC_MSG_CHECKING([whether fops->readdir() is available])
 			ZFS_LINUX_TRY_COMPILE([
 				#include <linux/fs.h>
-				int readdir(struct file *filp, void *entry, filldir_t func)
-				    { return 0; }
+				int readdir(struct file *filp, void *entry,
+				    filldir_t func) { return 0; }
 
 				static const struct file_operations fops
 				    __attribute__ ((unused)) = {
@@ -57,7 +68,7 @@ AC_DEFUN([ZFS_AC_KERNEL_VFS_ITERATE], [
 				AC_DEFINE(HAVE_VFS_READDIR, 1,
 					  [fops->readdir() is available])
 			],[
-				AC_MSG_ERROR(no; file a bug report with ZFSOnLinux)
+				AC_MSG_ERROR(no; file a bug report with ZoL)
 			])
 		])
 	])

--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -54,7 +54,7 @@ extern int zfs_mkdir(struct inode *dip, char *dirname, vattr_t *vap,
     struct inode **ipp, cred_t *cr, int flags, vsecattr_t *vsecp);
 extern int zfs_rmdir(struct inode *dip, char *name, struct inode *cwd,
     cred_t *cr, int flags);
-extern int zfs_readdir(struct inode *ip, struct dir_context *ctx, cred_t *cr);
+extern int zfs_readdir(struct inode *ip, zpl_dir_context_t *ctx, cred_t *cr);
 extern int zfs_fsync(struct inode *ip, int syncflag, cred_t *cr);
 extern int zfs_getattr(struct inode *ip, vattr_t *vap, int flag, cred_t *cr);
 extern int zfs_getattr_fast(struct inode *ip, struct kstat *sp);

--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -125,56 +125,63 @@ extern const struct inode_operations zpl_ops_shares;
 
 #if defined(HAVE_VFS_ITERATE) || defined(HAVE_VFS_ITERATE_SHARED)
 
-#define	DIR_CONTEXT_INIT(_dirent, _actor, _pos) {	\
+#define	ZPL_DIR_CONTEXT_INIT(_dirent, _actor, _pos) {	\
 	.actor = _actor,				\
 	.pos = _pos,					\
 }
 
+typedef struct dir_context zpl_dir_context_t;
+
+#define	zpl_dir_emit		dir_emit
+#define	zpl_dir_emit_dot	dir_emit_dot
+#define	zpl_dir_emit_dotdot	dir_emit_dotdot
+#define	zpl_dir_emit_dots	dir_emit_dots
+
 #else
 
-typedef struct dir_context {
+typedef struct zpl_dir_context {
 	void *dirent;
 	const filldir_t actor;
 	loff_t pos;
-} dir_context_t;
+} zpl_dir_context_t;
 
-#define	DIR_CONTEXT_INIT(_dirent, _actor, _pos) {	\
+#define	ZPL_DIR_CONTEXT_INIT(_dirent, _actor, _pos) {	\
 	.dirent = _dirent,				\
 	.actor = _actor,				\
 	.pos = _pos,					\
 }
 
 static inline bool
-dir_emit(struct dir_context *ctx, const char *name, int namelen,
+zpl_dir_emit(zpl_dir_context_t *ctx, const char *name, int namelen,
     uint64_t ino, unsigned type)
 {
 	return (!ctx->actor(ctx->dirent, name, namelen, ctx->pos, ino, type));
 }
 
 static inline bool
-dir_emit_dot(struct file *file, struct dir_context *ctx)
+zpl_dir_emit_dot(struct file *file, zpl_dir_context_t *ctx)
 {
 	return (ctx->actor(ctx->dirent, ".", 1, ctx->pos,
 	    file_inode(file)->i_ino, DT_DIR) == 0);
 }
 
 static inline bool
-dir_emit_dotdot(struct file *file, struct dir_context *ctx)
+zpl_dir_emit_dotdot(struct file *file, zpl_dir_context_t *ctx)
 {
 	return (ctx->actor(ctx->dirent, "..", 2, ctx->pos,
 	    parent_ino(file_dentry(file)), DT_DIR) == 0);
 }
 
 static inline bool
-dir_emit_dots(struct file *file, struct dir_context *ctx)
+zpl_dir_emit_dots(struct file *file, zpl_dir_context_t *ctx)
 {
 	if (ctx->pos == 0) {
-		if (!dir_emit_dot(file, ctx))
+		if (!zpl_dir_emit_dot(file, ctx))
 			return (false);
 		ctx->pos = 1;
 	}
 	if (ctx->pos == 1) {
-		if (!dir_emit_dotdot(file, ctx))
+		if (!zpl_dir_emit_dotdot(file, ctx))
 			return (false);
 		ctx->pos = 2;
 	}

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2273,7 +2273,7 @@ out:
  */
 /* ARGSUSED */
 int
-zfs_readdir(struct inode *ip, struct dir_context *ctx, cred_t *cr)
+zfs_readdir(struct inode *ip, zpl_dir_context_t *ctx, cred_t *cr)
 {
 	znode_t		*zp = ITOZ(ip);
 	zfsvfs_t	*zfsvfs = ITOZSB(ip);
@@ -2378,7 +2378,7 @@ zfs_readdir(struct inode *ip, struct dir_context *ctx, cred_t *cr)
 			type = ZFS_DIRENT_TYPE(zap.za_first_integer);
 		}
 
-		done = !dir_emit(ctx, zap.za_name, strlen(zap.za_name),
+		done = !zpl_dir_emit(ctx, zap.za_name, strlen(zap.za_name),
 		    objnum, type);
 		if (done)
 			break;

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -76,7 +76,7 @@ zpl_release(struct inode *ip, struct file *filp)
 }
 
 static int
-zpl_iterate(struct file *filp, struct dir_context *ctx)
+zpl_iterate(struct file *filp, zpl_dir_context_t *ctx)
 {
 	cred_t *cr = CRED();
 	int error;
@@ -96,7 +96,8 @@ zpl_iterate(struct file *filp, struct dir_context *ctx)
 static int
 zpl_readdir(struct file *filp, void *dirent, filldir_t filldir)
 {
-	struct dir_context ctx = DIR_CONTEXT_INIT(dirent, filldir, filp->f_pos);
+	zpl_dir_context_t ctx =
+	    ZPL_DIR_CONTEXT_INIT(dirent, filldir, filp->f_pos);
 	int error;
 
 	error = zpl_iterate(filp, &ctx);
@@ -104,7 +105,7 @@ zpl_readdir(struct file *filp, void *dirent, filldir_t filldir)
 
 	return (error);
 }
-#endif /* HAVE_VFS_ITERATE */
+#endif /* !HAVE_VFS_ITERATE && !HAVE_VFS_ITERATE_SHARED */
 
 #if defined(HAVE_FSYNC_WITH_DENTRY)
 /*
@@ -965,7 +966,7 @@ const struct file_operations zpl_file_operations = {
 const struct file_operations zpl_dir_file_operations = {
 	.llseek		= generic_file_llseek,
 	.read		= generic_read_dir,
-#ifdef HAVE_VFS_ITERATE_SHARED
+#if defined(HAVE_VFS_ITERATE_SHARED)
 	.iterate_shared	= zpl_iterate,
 #elif defined(HAVE_VFS_ITERATE)
 	.iterate	= zpl_iterate,


### PR DESCRIPTION
### Description

As of RHEL 7.5 the mainline fops.iterate() method was added to
the file_operations structure.

This wouldn't have been a problem however in order to maintain
KABI compatibility it was added to the very end of the structure.
Callers intending to use this extended interface were additionally
required to set the FMODE_KABI_ITERATE flag on the file struct
when opening the directory.

Update the ZPL to set this RHEL specific flag when required.
Using this interface will mean that kmods built for RHEL 7.5
will not work on 7.4 without being rebuilt.

### Motivation and Context

Issue #7460

### How Has This Been Tested?

Local run of the ZTS using the 3.10.0-862.el7.x86_64 kernel. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
