### PR TITLE
Fix inst_num overflow in qat_crypt.c

### DIFF
--- a/module/zfs/qat_compress.c
+++ b/module/zfs/qat_compress.c
@@ -71,9 +71,8 @@ qat_dc_clean(void)
 {
 	Cpa16U buff_num = 0;
 	Cpa16U num_inter_buff_lists = 0;
-	Cpa16U i = 0;
 
-	for (i = 0; i < num_inst; i++) {
+	for (Cpa16U i = 0; i < num_inst; i++) {
 		cpaDcStopInstance(dc_inst_handles[i]);
 		QAT_PHYS_CONTIG_FREE(session_handles[i]);
 		/* free intermediate buffers  */
@@ -111,7 +110,6 @@ qat_dc_init(void)
 	Cpa16U buff_num = 0;
 	Cpa32U buff_meta_size = 0;
 	CpaDcSessionSetupData sd = {0};
-	Cpa16U i;
 
 	status = cpaDcGetNumInstances(&num_inst);
 	if (status != CPA_STATUS_SUCCESS)
@@ -128,7 +126,7 @@ qat_dc_init(void)
 	if (status != CPA_STATUS_SUCCESS)
 		return (-1);
 
-	for (i = 0; i < num_inst; i++) {
+	for (Cpa16U i = 0; i < num_inst; i++) {
 		cpaDcSetAddressTranslation(dc_inst_handles[i],
 		    (void*)virt_to_phys);
 
@@ -286,7 +284,7 @@ qat_compress_impl(qat_compress_dir_t dir, char *src, int src_len,
 	    num_add_buf * sizeof (struct page *)) != CPA_STATUS_SUCCESS)
 		goto fail;
 
-	i = atomic_inc_32_nv(&inst_num) % num_inst;
+	i = (Cpa32U)atomic_inc_32_nv(&inst_num) % num_inst;
 	dc_inst_handle = dc_inst_handles[i];
 	session_handle = session_handles[i];
 

--- a/module/zfs/qat_crypt.c
+++ b/module/zfs/qat_crypt.c
@@ -47,7 +47,7 @@
 
 #define	MAX_PAGE_NUM			1024
 
-static Cpa16U inst_num = 0;
+static Cpa32U inst_num = 0;
 static Cpa16U num_inst = 0;
 static CpaInstanceHandle cy_inst_handles[QAT_CRYPT_MAX_INSTANCES];
 static boolean_t qat_crypt_init_done = B_FALSE;
@@ -93,7 +93,7 @@ qat_checksum_use_accel(size_t s_len)
 void
 qat_crypt_clean(void)
 {
-	for (Cpa32U i = 0; i < num_inst; i++)
+	for (Cpa16U i = 0; i < num_inst; i++)
 		cpaCyStopInstance(cy_inst_handles[i]);
 
 	num_inst = 0;
@@ -103,7 +103,6 @@ qat_crypt_clean(void)
 int
 qat_crypt_init(void)
 {
-	Cpa32U i;
 	CpaStatus status = CPA_STATUS_FAIL;
 
 	status = cpaCyGetNumInstances(&num_inst);
@@ -121,7 +120,7 @@ qat_crypt_init(void)
 	if (status != CPA_STATUS_SUCCESS)
 		return (-1);
 
-	for (i = 0; i < num_inst; i++) {
+	for (Cpa16U i = 0; i < num_inst; i++) {
 		status = cpaCySetAddressTranslation(cy_inst_handles[i],
 		    (void *)virt_to_phys);
 		if (status != CPA_STATUS_SUCCESS)
@@ -322,7 +321,7 @@ qat_crypt(qat_encrypt_dir_t dir, uint8_t *src_buf, uint8_t *dst_buf,
 		QAT_STAT_INCR(decrypt_total_in_bytes, enc_len);
 	}
 
-	i = atomic_inc_32_nv(&inst_num) % num_inst;
+	i = (Cpa32U)atomic_inc_32_nv(&inst_num) % num_inst;
 	cy_inst_handle = cy_inst_handles[i];
 
 	status = qat_init_crypt_session_ctx(dir, cy_inst_handle,
@@ -468,7 +467,7 @@ qat_checksum(uint64_t cksum, uint8_t *buf, uint64_t size, zio_cksum_t *zcp)
 	QAT_STAT_BUMP(cksum_requests);
 	QAT_STAT_INCR(cksum_total_in_bytes, size);
 
-	i = atomic_inc_32_nv(&inst_num) % num_inst;
+	i = (Cpa32U)atomic_inc_32_nv(&inst_num) % num_inst;
 	cy_inst_handle = cy_inst_handles[i];
 
 	status = qat_init_checksum_session_ctx(cy_inst_handle,


### PR DESCRIPTION
### Description

This patch fixes the same issue which was previously addressed in
6051.  The variable "inst_num" was of the incorrect type and
"atomic_inc_32_nv()" could cause an overflow damaging its neighbor.

Fix a few types for num_inst for clarity.

### Motivation and Context

https://github.com/zfsonlinux/zfs/commit/cf63739191b6cac629d053930a4aea592bca3819#r28641683

### How Has This Been Tested?

Visual inspection.  @tcaputi @wli5 can you please review and test this fix since you have the needed hardware.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
