### PR TITLE
Fix zfs incremental send remove '-o' properties

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -4041,7 +4041,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		goto out;
 	}
 
-	if (top_zfs && *top_zfs == NULL)
+	if (top_zfs && (*top_zfs == NULL || strcmp(*top_zfs, name) == 0))
 		toplevel = B_TRUE;
 	if (drrb->drr_type == DMU_OST_ZVOL) {
 		type = ZFS_TYPE_VOLUME;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
This change should correctly identify the top-level dataset in `zfs_receive_one()`. This was accidentally introduced in https://github.com/zfsonlinux/zfs/commit/bee7e4ff12c7170671606bcea33a6eef6cad5d58: the test case did not correctly verify this situation because it uses adjacent snapshots, basically testing `zfs send -i` instead of `zfs send -I`: this commit adds an additional intermediary snapshot to the test script.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When receiving an incremental send stream with intermediary snapshots `zfs_receive_one()` does not correctly identify the top-level dataset: consequently we restore said snapshots as if they were children
datasets in the hierarchy, forcing inheritance of any property received with `zfs send -o` and effectively removing any locally set value.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Reproducer:

```
# misc functions
function is_linux() {
   if [[ "$(uname)" == "Linux" ]]; then
      return 0
   else
      return 1
   fi
}
# setup
POOLNAME='testpool'
if is_linux; then
   TMPDIR='/var/tmp'
   mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   fallocate -l 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
else
   TMPDIR='/tmp'
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   mkfile 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
fi
#
zfs create -p testpool/fs/subfs
zfs snap -r testpool/fs@1
zfs snap -r testpool/fs@2
zfs snap -r testpool/fs@3
zfs snap -r testpool/fs@4
zfs send -R testpool/fs@1 | zfs recv testpool/recv
zfs send -RI testpool/fs@1 testpool/fs@2 | zfs recv -F -o ns:prop=val testpool/recv
zfs get ns:prop -o all -r testpool/recv
zfs set ns:prop=newval testpool/recv
zfs get ns:prop -o all -r testpool/recv
zfs send -RI testpool/fs@2 testpool/fs@4 | zfs recv -F -o ns:prop=val testpool/recv
zfs get ns:prop -o all -r testpool/recv
```

Output with current master:
```
root@linux:/usr/src/zfs# zfs send -RI testpool/fs@1 testpool/fs@2 | zfs recv -F -o ns:prop=val testpool/recv
root@linux:/usr/src/zfs# zfs get ns:prop -o all -r testpool/recv
NAME                   PROPERTY  VALUE    RECEIVED  SOURCE
testpool/recv          ns:prop   val      -         local
testpool/recv@1        ns:prop   val      -         inherited from testpool/recv
testpool/recv@2        ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs    ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs@1  ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs@2  ns:prop   val      -         inherited from testpool/recv
root@linux:/usr/src/zfs# zfs set ns:prop=newval testpool/recv
root@linux:/usr/src/zfs# zfs get ns:prop -o all -r testpool/recv
NAME                   PROPERTY  VALUE    RECEIVED  SOURCE
testpool/recv          ns:prop   newval   -         local
testpool/recv@1        ns:prop   newval   -         inherited from testpool/recv
testpool/recv@2        ns:prop   newval   -         inherited from testpool/recv
testpool/recv/subfs    ns:prop   newval   -         inherited from testpool/recv
testpool/recv/subfs@1  ns:prop   newval   -         inherited from testpool/recv
testpool/recv/subfs@2  ns:prop   newval   -         inherited from testpool/recv
root@linux:/usr/src/zfs# zfs send -RI testpool/fs@2 testpool/fs@4 | zfs recv -F -o ns:prop=val testpool/recv
root@linux:/usr/src/zfs# zfs get ns:prop -o all -r testpool/recv
NAME                   PROPERTY  VALUE    RECEIVED  SOURCE
testpool/recv          ns:prop   -        -         -
testpool/recv@1        ns:prop   -        -         -
testpool/recv@2        ns:prop   -        -         -
testpool/recv@3        ns:prop   -        -         -
testpool/recv@4        ns:prop   -        -         -
testpool/recv/subfs    ns:prop   -        -         -
testpool/recv/subfs@1  ns:prop   -        -         -
testpool/recv/subfs@2  ns:prop   -        -         -
testpool/recv/subfs@3  ns:prop   -        -         -
testpool/recv/subfs@4  ns:prop   -        -         -
root@linux:/usr/src/zfs# 
```

With patch applied:
```
root@linux:~# zfs send -RI testpool/fs@1 testpool/fs@2 | zfs recv -F -o ns:prop=val testpool/recv
root@linux:~# zfs get ns:prop -o all -r testpool/recv
NAME                   PROPERTY  VALUE    RECEIVED  SOURCE
testpool/recv          ns:prop   val      -         local
testpool/recv@1        ns:prop   val      -         inherited from testpool/recv
testpool/recv@2        ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs    ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs@1  ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs@2  ns:prop   val      -         inherited from testpool/recv
root@linux:~# zfs set ns:prop=newval testpool/recv
root@linux:~# zfs get ns:prop -o all -r testpool/recv
NAME                   PROPERTY  VALUE    RECEIVED  SOURCE
testpool/recv          ns:prop   newval   -         local
testpool/recv@1        ns:prop   newval   -         inherited from testpool/recv
testpool/recv@2        ns:prop   newval   -         inherited from testpool/recv
testpool/recv/subfs    ns:prop   newval   -         inherited from testpool/recv
testpool/recv/subfs@1  ns:prop   newval   -         inherited from testpool/recv
testpool/recv/subfs@2  ns:prop   newval   -         inherited from testpool/recv
root@linux:~# zfs send -RI testpool/fs@2 testpool/fs@4 | zfs recv -F -o ns:prop=val testpool/recv
root@linux:~# zfs get ns:prop -o all -r testpool/recv
NAME                   PROPERTY  VALUE    RECEIVED  SOURCE
testpool/recv          ns:prop   val      -         local
testpool/recv@1        ns:prop   val      -         inherited from testpool/recv
testpool/recv@2        ns:prop   val      -         inherited from testpool/recv
testpool/recv@3        ns:prop   val      -         inherited from testpool/recv
testpool/recv@4        ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs    ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs@1  ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs@2  ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs@3  ns:prop   val      -         inherited from testpool/recv
testpool/recv/subfs@4  ns:prop   val      -         inherited from testpool/recv
root@linux:~# 
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
