### PR TITLE
Fix inverted check for --enable-pyzfs

### DIFF
--- a/config/always-pyzfs.m4
+++ b/config/always-pyzfs.m4
@@ -47,7 +47,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 		[enable_pyzfs=check])
 
 	AM_PATH_PYTHON([2.7], [], [
-		AS_IF([test ! "x$enable_pyzfs" = xyes], [
+		AS_IF([test "x$enable_pyzfs" = xyes], [
 			AC_MSG_ERROR("python >= 2.7 is not installed")
 		], [test ! "x$enable_pyzfs" = xno], [
 			enable_pyzfs=no


### PR DESCRIPTION
### Description
The `--{en,dis}able-pyzfs` check is backwards. Fix that.

Fixes default builds on RHEL/CentOS 6

### Motivation and Context
```
# sh configure --disable-pyzfs
...
checking whether host toolchain supports AVX512VL... no
checking for target asm dir... asm-x86_64
checking for a Python interpreter with version >= 2.7... none
configure: error: "python >= 2.7 is not installed"
# sh configure
...
checking whether host toolchain supports AVX512VL... no
checking for target asm dir... asm-x86_64
checking for a Python interpreter with version >= 2.7... none
configure: error: "python >= 2.7 is not installed"
# sh configure --enable-pyzfs
...
checking whether host toolchain supports AVX512VL... no
checking for target asm dir... asm-x86_64
checking for a Python interpreter with version >= 2.7... none
checking for udev directories... /lib/udev;/lib/udev/rules.d
checking for systemd support... no
....
(success)
```
Wat?


### How Has This Been Tested?
Tested manually running `configure` with `disable`, `enable`, and no setting specified both with and without a python2.7 package available on the `$PATH`.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
