### PR TITLE
Unify behavior of deadman parameters

### DIFF
--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2225,12 +2225,56 @@ param_set_deadman_failmode(const char *val, zfs_kernel_param_t *kp)
 	    strcmp(val, "panic"))
 		return (SET_ERROR(-EINVAL));
 
-	mutex_enter(&spa_namespace_lock);
-	while ((spa = spa_next(spa)) != NULL)
-		spa_set_deadman_failmode(spa, val);
-	mutex_exit(&spa_namespace_lock);
+	if (spa_mode_global != 0) {
+		mutex_enter(&spa_namespace_lock);
+		while ((spa = spa_next(spa)) != NULL)
+			spa_set_deadman_failmode(spa, val);
+		mutex_exit(&spa_namespace_lock);
+	}
 
 	return (param_set_charp(val, kp));
+}
+
+static int
+param_set_deadman_ziotime(const char *val, zfs_kernel_param_t *kp)
+{
+	spa_t *spa = NULL;
+	int error;
+
+	error = param_set_ulong(val, kp);
+	if (error < 0)
+		return (SET_ERROR(error));
+
+	if (spa_mode_global != 0) {
+		mutex_enter(&spa_namespace_lock);
+		while ((spa = spa_next(spa)) != NULL)
+			spa->spa_deadman_ziotime =
+			    MSEC2NSEC(zfs_deadman_ziotime_ms);
+		mutex_exit(&spa_namespace_lock);
+	}
+
+	return (0);
+}
+
+static int
+param_set_deadman_synctime(const char *val, zfs_kernel_param_t *kp)
+{
+	spa_t *spa = NULL;
+	int error;
+
+	error = param_set_ulong(val, kp);
+	if (error < 0)
+		return (SET_ERROR(error));
+
+	if (spa_mode_global != 0) {
+		mutex_enter(&spa_namespace_lock);
+		while ((spa = spa_next(spa)) != NULL)
+			spa->spa_deadman_synctime =
+			    MSEC2NSEC(zfs_deadman_synctime_ms);
+		mutex_exit(&spa_namespace_lock);
+	}
+
+	return (0);
 }
 
 /* Namespace manipulation */
@@ -2322,11 +2366,13 @@ module_param(zfs_free_leak_on_eio, int, 0644);
 MODULE_PARM_DESC(zfs_free_leak_on_eio,
 	"Set to ignore IO errors during free and permanently leak the space");
 
-module_param(zfs_deadman_synctime_ms, ulong, 0644);
+module_param_call(zfs_deadman_synctime_ms, param_set_deadman_synctime,
+    param_get_ulong, &zfs_deadman_synctime_ms, 0644);
 MODULE_PARM_DESC(zfs_deadman_synctime_ms,
 	"Pool sync expiration time in milliseconds");
 
-module_param(zfs_deadman_ziotime_ms, ulong, 0644);
+module_param_call(zfs_deadman_ziotime_ms, param_set_deadman_ziotime,
+    param_get_ulong, &zfs_deadman_ziotime_ms, 0644);
 MODULE_PARM_DESC(zfs_deadman_ziotime_ms,
 	"IO expiration time in milliseconds");
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Add a handler for changes to the `zfs_deadman_synctime_ms` and `zfs_deadman_ziotime_ms`.  Also, avoid taking the `spa_namespace_loc` until `spa_init()` has been called.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The zfs_deadman_failmode, zfs_deadman_ziotime_ms and
zfs_deadman_synctime_ms paramaters are stored per-pool.  However, only
the zfs_deadman_failmode updates the per-pool state when it's change.
This patch gives adds the same behavior to the other two for consistency.

Also, in all 3 three cases, only update the per-pool parameters if
spa_init() has actually been called in order to avoid panicking when
trying to take a lock on the spa_namespace_lock mutex.




<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually changed the parameters following pool import and verify that they have taken effect.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
