### PR TITLE
OpenZFS 9443 - panic when scrub a v10 pool

### DIFF
--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -2166,7 +2166,8 @@ dsl_scan_visitds(dsl_scan_t *scn, uint64_t dsobj, dmu_tx_t *tx)
 	 * block-sharing rules don't apply to it.
 	 */
 	if (!dsl_dataset_is_snapshot(ds) &&
-	    ds->ds_dir != dp->dp_origin_snap->ds_dir) {
+	    (dp->dp_origin_snap == NULL ||
+	    ds->ds_dir != dp->dp_origin_snap->ds_dir)) {
 		objset_t *os;
 		if (dmu_objset_from_ds(ds, &os) != 0) {
 			goto out;


### PR DESCRIPTION
### Description

While expanding stored pools, we ran into a panic using an old pool.
    
Steps to reproduce:
    
  $ sudo zpool create -o version=2 test c2t1d0
  $ sudo cp /etc/passwd /test/foo
  $ sudo zpool attach test c2t1d0 c2t2d0
    
We'll get this panic:
    
  ffffff000fc0e5e0 unix:real_mode_stop_cpu_stage2_end+b27c ()
  ffffff000fc0e6f0 unix:trap+dc8 ()
  ffffff000fc0e700 unix:cmntrap+e6 ()
  ffffff000fc0e860 zfs:dsl_scan_visitds+1ff ()
  ffffff000fc0ea20 zfs:dsl_scan_visit+fe ()
  ffffff000fc0ea80 zfs:dsl_scan_sync+1b3 ()
  ffffff000fc0eb60 zfs:spa_sync+435 ()
  ffffff000fc0ec20 zfs:txg_sync_thread+23f ()
  ffffff000fc0ec30 unix:thread_start+8 ()
    
The problem is a bad trap accessing a NULL pointer. We're looking for
the dp_origin_snap of a dsl_pool_t, but version 2 didn't have that. The
system will go into a reboot loop at this point, and the dump won't be
accessible except by removing the cache file from within the recovery
environment.
    
This impacts any sort of scrub or resilver on version <11 pools, e.g.:
    
  $ zpool create -o version=10 test c2t1d0
  $ zpool scrub tes

### Motivation and Context

OpenZFS-issue: https://illumos.org/issues/9443

### How Has This Been Tested?

Locally built and inspected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.