### PR TITLE
Avoid `make distclean` removing 0 sized __init__.py

### DIFF
--- a/contrib/pyzfs/libzfs_core/test/__init__.py
+++ b/contrib/pyzfs/libzfs_core/test/__init__.py
@@ -1,0 +1,1 @@
+# `make distclean` deletes files with size 0. This comment is to avoid that.


### PR DESCRIPTION
\_\_init\_\_.py used by Python packages typically has nothing in it
including contrib/pyzfs/libzfs_core/test/\_\_init\_\_.py, however this
causes `make distclean` to delete the file.

This is the only file with size 0, and it seems reasonable to have
a comment to avoid being deleted, rather than trying to modify
distclean behavior.

 \# find . -size 0
 ./contrib/pyzfs/libzfs_core/test/\_\_init\_\_.py
 \# ./autogen.sh ; ./configure ; make -j8
 \# make distclean
 \# ls contrib/pyzfs/libzfs_core/test/\_\_init\_\_.py
 ls: cannot access 'contrib/pyzfs/libzfs_core/test/\_\_init\_\_.py': No such file or directory
 \# git diff
 diff --git a/contrib/pyzfs/libzfs_core/test/\_\_init\_\_.py b/contrib/pyzfs/libzfs_core/test/\_\_init\_\_.py
 deleted file mode 100644

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
`make distclean` deletes a file managed by Git for being size 0.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Don't delete a file managed by Git.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
