### PR TITLE
Fix 'zpool create -t <tempname>'

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -317,7 +317,7 @@ tests = ['zpool_create_001_pos', 'zpool_create_002_pos',
     'zpool_create_features_001_pos', 'zpool_create_features_002_pos',
     'zpool_create_features_003_pos', 'zpool_create_features_004_neg',
     'zpool_create_features_005_pos',
-    'create-o_ashift']
+    'create-o_ashift', 'zpool_create_tempname']
 tags = ['functional', 'cli_root', 'zpool_create']
 
 [tests/functional/cli_root/zpool_destroy]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/Makefile.am
@@ -32,7 +32,8 @@ dist_pkgdata_SCRIPTS = \
 	zpool_create_features_003_pos.ksh \
 	zpool_create_features_004_neg.ksh \
 	zpool_create_features_005_pos.ksh \
-	create-o_ashift.ksh
+	create-o_ashift.ksh \
+	zpool_create_tempname.ksh
 
 dist_pkgdata_DATA = \
 	zpool_create.cfg \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_tempname.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_tempname.ksh
@@ -1,0 +1,68 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zpool create -t <tempname>' can create a pool with the specified temporary
+# name. The pool should be present in the namespace as <tempname> until exported
+#
+# STRATEGY:
+# 1. Create a pool with '-t' option
+# 2. Verify the pool is created with the specified temporary name
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	destroy_pool $TESTPOOL
+	destroy_pool $TEMPPOOL
+
+}
+
+log_assert "'zpool create -t <tempname>' can create a pool with the specified" \
+	" temporary name."
+log_onexit cleanup
+
+TEMPPOOL="tempname.$$"
+typeset poolprops=('comment=text' 'ashift=12' 'listsnapshots=on' 'autoexpand=on'
+    'autoreplace=on' 'delegation=off' 'failmode=continue')
+typeset fsprops=('canmount=off' 'mountpoint=none' 'utf8only=on'
+    'casesensitivity=mixed' 'version=1' 'normalization=formKD')
+
+for poolprop in "${poolprops[@]}"; do
+	for fsprop in "${fsprops[@]}"; do
+		# 1. Create a pool with '-t' option
+		log_must zpool create $TESTPOOL -t $TEMPPOOL \
+			-O $fsprop -o $poolprop $DISKS
+		# 2. Verify the pool is created with the specified temporary name
+		log_must poolexists $TEMPPOOL
+		log_mustnot poolexists $TESTPOOL
+		propname="$(awk -F= '{print $1}' <<< $fsprop)"
+		propval="$(awk -F= '{print $2}' <<< $fsprop)"
+		log_must test "$(get_prop $propname $TEMPPOOL)" == "$propval"
+		propname="$(awk -F= '{print $1}' <<< $poolprop)"
+		propval="$(awk -F= '{print $2}' <<< $poolprop)"
+		log_must test "$(get_pool_prop $propname $TEMPPOOL)" == "$propval"
+		# Cleanup
+		destroy_pool $TEMPPOOL
+	done
+done
+
+log_pass "'zpool create -t <tempname>' successfully creates pools with" \
+	" temporary names"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
Creating a pool with a temporary name fails when we also specify custom dataset properties: this is because we mistakenly call `zfs_set_prop_nvlist()` on the "real" pool name which, as expected,
cannot be found because the SPA is present in the namespace with the temporary name.

Fix this by specifying the correct pool name when setting the dataset properties.

~~To be honest this PR is just an excuse to borrow the Debian9 test builder to debug zfs_diff_timestamp failure (#7503) since i cannot reproduce it on my local builder.~~ EDIT: Found the issue.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7502

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on local Debian builder: without this change `zfs_set_prop_nvlist()` returns ENOENT because we use the "real" (instead of temporary) pool name which cannot be found in the SPA namespace.

```
root@linux:~# stap -d zfs -e '
> probe
> module("zfs").function("zfs_ioc_pool_create").call,
> module("zfs").function("spa_create").call,
> module("zfs").function("zfs_set_prop_nvlist").call
> {
>    printf(" -> %s (%s)\n", ppfunc(), $$parms$$);
> }
> probe
> module("zfs").function("zfs_ioc_pool_create").return,
> module("zfs").function("spa_create").return,
> module("zfs").function("zfs_set_prop_nvlist").return
> {
>    printf(" <- %s (%s)\n", ppfunc(), $$return$$);
> }' -c "zpool create -f -O canmount=off -O mountpoint=none -R /mnt/$POOLNAME-temp -t $POOLNAME-temp $POOLNAME $TMPDIR/zpool_$POOLNAME.dat"
cannot create 'testpool': no such pool or dataset
WARNING: Child process exited with status 1
 -> zfs_ioc_pool_create (zc={.zc_name="testpool", .zc_nvlist_src=13685376, .zc_nvlist_src_size=1308, .zc_nvlist_dst=0, .zc_nvlist_dst_size=0, .zc_nvlist_dst_filled=0, .zc_pad2=0, .zc_history=0, .zc_value="", .zc_string="", .zc_guid=0, .zc_nvlist_conf=13679104, .zc_nvlist_conf_size=236, .zc_cookie=0, .zc_objset_type=0, .zc_perm_action=0, .zc_history_len=0, .zc_history_offset=0, .zc_obj=0, .zc_iflags=0, .zc_share={.z_exportdata=0, .z_sharedata=0, .z_sharetype=0, .z_sharemax=0}, .zc_objset_stats={.dds_num_clones=0, .dds_creation_txg=)
 -> spa_create (pool="testpool" nvroot={.nvl_version=0, .nvl_nvflag=1, .nvl_priv=18446612133132553664, .nvl_flag=0, .nvl_pad=0} props={.nvl_version=0, .nvl_nvflag=1, .nvl_priv=18446612133132553344, .nvl_flag=0, .nvl_pad=0} zplprops={.nvl_version=0, .nvl_nvflag=1, .nvl_priv=18446612133132552064, .nvl_flag=0, .nvl_pad=0} dcp={.cp_cmd=0, .cp_crypt=0, .cp_keylocation=          (null), .cp_wkey=0x0})
 <- spa_create (return=0)
 -> zfs_set_prop_nvlist (dsname="testpool" source=8 nvl={.nvl_version=0, .nvl_nvflag=1, .nvl_priv=18446612133132551872, .nvl_flag=0, .nvl_pad=0} errlist=ERROR)
 <- zfs_set_prop_nvlist (return=2)
 <- zfs_ioc_pool_create (return=2)
WARNING: Number of errors: 0, skipped probes: 2
WARNING: /usr/bin/staprun exited with status: 1
Pass 5: run failed.  [man error::pass5]
root@linux:~# zpool list
NAME            SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
testpool-temp   112M    93K   112M         -     0%     0%  1.00x  ONLINE  /mnt/testpool-temp
root@linux:~# 
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
