### PR TITLE
ZTS: Fix zfs_diff_timestamp

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_timestamp.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_timestamp.ksh
@@ -75,7 +75,7 @@ log_must zfs snapshot "$TESTSNAP2"
 # 3. Verify 'zfs diff -t' correctly display timestamps
 typeset -i count=0
 log_must eval "zfs diff -t $TESTSNAP1 $TESTSNAP2 > $FILEDIFF"
-awk '{print substr($1,0,index($1,".")-1)" "$NF}' < "$FILEDIFF" | while read line
+awk '{print substr($1,1,index($1,".")-1)" "$NF}' < "$FILEDIFF" | while read line
 do
 	read ctime file <<< "$line"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
When using `mawk` instead of `gawk` "zfs_diff_timestamp" fails consistently: this is due to a subtle difference in how mawk handles `substr()`.

From `awk(1)`:

> Finally, here is how mawk handles exceptional cases not discussed in the AWK book or the Posix draft.  It is unsafe to assume consistency across awks and safe to skip to the next section.
> substr(s,  i,  n) returns the characters of s in the intersection of the closed interval [1, length(s)] and the half-open interval [i, i+n).  When this intersection is empty, the empty string is returned; so substr("ABC", 1, 0) = "" and substr("ABC", -4, 6) = "A".


To support running "zfs_diff_timestamp" with both `gawk` and `mawk` change the second parameter passed to `substr()`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7503

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on local Debian9 builder, removing `gawk` and installing `mawk`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
