### PR TITLE
ZTS: Update O_TMPFILE support check

### DIFF
--- a/tests/zfs-tests/tests/functional/tmpfile/setup.ksh
+++ b/tests/zfs-tests/tests/functional/tmpfile/setup.ksh
@@ -31,9 +31,12 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-if ! $STF_SUITE/tests/functional/tmpfile/tmpfile_test /tmp; then
-	log_unsupported "The kernel doesn't support O_TMPFILE."
+DISK=${DISKS%% *}
+default_setup_noexit $DISK
+
+if ! $STF_SUITE/tests/functional/tmpfile/tmpfile_test $TESTDIR; then
+	default_cleanup_noexit
+	log_unsupported "The kernel/filesystem doesn't support O_TMPFILE"
 fi
 
-DISK=${DISKS%% *}
-default_setup $DISK
+log_pass

--- a/tests/zfs-tests/tests/functional/tmpfile/tmpfile_test.c
+++ b/tests/zfs-tests/tests/functional/tmpfile/tmpfile_test.c
@@ -36,13 +36,14 @@ main(int argc, char *argv[])
 
 	fd = open(argv[1], O_TMPFILE | O_WRONLY, 0666);
 	if (fd < 0) {
-		/*
-		 * Only fail on EISDIR. If we get EOPNOTSUPP, that means
-		 * kernel support O_TMPFILE, but the path at argv[1] doesn't.
-		 */
 		if (errno == EISDIR) {
-			fprintf(stderr, "kernel doesn't support O_TMPFILE\n");
+			fprintf(stderr,
+			    "The kernel doesn't support O_TMPFILE\n");
 			return (1);
+		} else if (errno == EOPNOTSUPP) {
+			fprintf(stderr,
+			    "The filesystem doesn't support O_TMPFILE\n");
+			return (2);
 		}
 		perror("open");
 	} else {


### PR DESCRIPTION
### Description
 
In CentOS 7.5 the kernel provided a compatibility wrapper to support O_TMPFILE.  This results in the test setup script correctly detecting kernel support.  But the ZFS module was built without O_TMPFILE support due to the non-standard CentOS kernel interface. 
    
Handle this case by updating the setup check to fail either when the kernel or the ZFS module fail to provide support.  The reason will be clearly logged in the test results.

### Motivation and Context

Fix test failures with CentOS 7.5.

### How Has This Been Tested?

Locally on CentOS 7.5.  Pending results from bots on other distributions.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
