### PR TITLE
OpenZFS 9191 -  dump vdev tree to zfs_dbgmsg when spa load fails due …

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1888,6 +1888,7 @@ spa_check_for_missing_logs(spa_t *spa)
 
 		if (idx > 0) {
 			spa_load_failed(spa, "some log devices are missing");
+			vdev_dbgmsg_print_tree(rvd, 2);
 			return (SET_ERROR(ENXIO));
 		}
 	} else {
@@ -1899,6 +1900,7 @@ spa_check_for_missing_logs(spa_t *spa)
 				spa_set_log_state(spa, SPA_LOG_CLEAR);
 				spa_load_note(spa, "some log devices are "
 				    "missing, ZIL is dropped.");
+				vdev_dbgmsg_print_tree(rvd, 2);
 				break;
 			}
 		}


### PR DESCRIPTION
### Description

Add vdev_print_tree() in spa_check_for_missing_logs() when some log
devices are missing to ease debugging

### Motivation and Context

Pull in upstream fixes.

### How Has This Been Tested?

Pending buildbot results.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
