### PR TITLE
OpenZFS 9235 - rename zpool_rewind_policy_t to zpool_load_policy_t

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -5074,8 +5074,8 @@ main(int argc, char **argv)
 		    (dump_opt['X'] ? ZPOOL_EXTREME_REWIND : 0);
 
 	if (nvlist_alloc(&policy, NV_UNIQUE_NAME_TYPE, 0) != 0 ||
-	    nvlist_add_uint64(policy, ZPOOL_REWIND_REQUEST_TXG, max_txg) != 0 ||
-	    nvlist_add_uint32(policy, ZPOOL_REWIND_REQUEST, rewind) != 0)
+	    nvlist_add_uint64(policy, ZPOOL_LOAD_REQUEST_TXG, max_txg) != 0 ||
+	    nvlist_add_uint32(policy, ZPOOL_LOAD_REWIND_POLICY, rewind) != 0)
 		fatal("internal error: %s", strerror(ENOMEM));
 
 	error = 0;
@@ -5108,7 +5108,7 @@ main(int argc, char **argv)
 		if (error == 0) {
 
 			if (nvlist_add_nvlist(cfg,
-			    ZPOOL_REWIND_POLICY, policy) != 0) {
+			    ZPOOL_LOAD_POLICY, policy) != 0) {
 				fatal("can't open '%s': %s",
 				    target, strerror(ENOMEM));
 			}

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2667,8 +2667,9 @@ zpool_do_import(int argc, char **argv)
 
 	/* In the future, we can capture further policy and include it here */
 	if (nvlist_alloc(&policy, NV_UNIQUE_NAME, 0) != 0 ||
-	    nvlist_add_uint64(policy, ZPOOL_REWIND_REQUEST_TXG, txg) != 0 ||
-	    nvlist_add_uint32(policy, ZPOOL_REWIND_REQUEST, rewind_policy) != 0)
+	    nvlist_add_uint64(policy, ZPOOL_LOAD_REQUEST_TXG, txg) != 0 ||
+	    nvlist_add_uint32(policy, ZPOOL_LOAD_REWIND_POLICY,
+	    rewind_policy) != 0)
 		goto error;
 
 	/* check argument count */
@@ -2819,7 +2820,7 @@ zpool_do_import(int argc, char **argv)
 		if (do_destroyed && pool_state != POOL_STATE_DESTROYED)
 			continue;
 
-		verify(nvlist_add_nvlist(config, ZPOOL_REWIND_POLICY,
+		verify(nvlist_add_nvlist(config, ZPOOL_LOAD_POLICY,
 		    policy) == 0);
 
 		if (argc == 0) {
@@ -5878,8 +5879,10 @@ zpool_do_clear(int argc, char **argv)
 
 	/* In future, further rewind policy choices can be passed along here */
 	if (nvlist_alloc(&policy, NV_UNIQUE_NAME, 0) != 0 ||
-	    nvlist_add_uint32(policy, ZPOOL_REWIND_REQUEST, rewind_policy) != 0)
+	    nvlist_add_uint32(policy, ZPOOL_LOAD_REWIND_POLICY,
+	    rewind_policy) != 0) {
 		return (1);
+	}
 
 	pool = argv[0];
 	device = argc == 2 ? argv[1] : NULL;

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -413,7 +413,7 @@ typedef struct importargs {
 	int unique : 1;		/* does 'poolname' already exist?	*/
 	int exists : 1;		/* set on return if pool already exists	*/
 	int scan : 1;		/* prefer scanning to libblkid cache    */
-	nvlist_t *policy;	/* rewind policy (rewind txg, etc.)	*/
+	nvlist_t *policy;	/* load policy (max txg, rewind, etc.)	*/
 } importargs_t;
 
 extern nvlist_t *zpool_search_import(libzfs_handle_t *, importargs_t *);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -570,7 +570,7 @@ typedef enum zfs_key_location {
 #define	ZPL_VERSION_USERSPACE		ZPL_VERSION_4
 #define	ZPL_VERSION_SA			ZPL_VERSION_5
 
-/* Rewind request information */
+/* Rewind policy information */
 #define	ZPOOL_NO_REWIND		1  /* No policy - default behavior */
 #define	ZPOOL_NEVER_REWIND	2  /* Do not search for best txg or rewind */
 #define	ZPOOL_TRY_REWIND	4  /* Search for best txg, but do not rewind */
@@ -579,12 +579,12 @@ typedef enum zfs_key_location {
 #define	ZPOOL_REWIND_MASK	28 /* All the possible rewind bits */
 #define	ZPOOL_REWIND_POLICIES	31 /* All the possible policy bits */
 
-typedef struct zpool_rewind_policy {
-	uint32_t	zrp_request;	/* rewind behavior requested */
-	uint64_t	zrp_maxmeta;	/* max acceptable meta-data errors */
-	uint64_t	zrp_maxdata;	/* max acceptable data errors */
-	uint64_t	zrp_txg;	/* specific txg to load */
-} zpool_rewind_policy_t;
+typedef struct zpool_load_policy {
+	uint32_t	zlp_rewind;	/* rewind policy requested */
+	uint64_t	zlp_maxmeta;	/* max acceptable meta-data errors */
+	uint64_t	zlp_maxdata;	/* max acceptable data errors */
+	uint64_t	zlp_txg;	/* specific txg to load */
+} zpool_load_policy_t;
 
 /*
  * The following are configuration names used in the nvlist describing a pool's
@@ -722,12 +722,12 @@ typedef struct zpool_rewind_policy {
 #define	ZPOOL_CONFIG_FRU		"fru"
 #define	ZPOOL_CONFIG_AUX_STATE		"aux_state"
 
-/* Rewind policy parameters */
-#define	ZPOOL_REWIND_POLICY		"rewind-policy"
-#define	ZPOOL_REWIND_REQUEST		"rewind-request"
-#define	ZPOOL_REWIND_REQUEST_TXG	"rewind-request-txg"
-#define	ZPOOL_REWIND_META_THRESH	"rewind-meta-thresh"
-#define	ZPOOL_REWIND_DATA_THRESH	"rewind-data-thresh"
+/* Pool load policy parameters */
+#define	ZPOOL_LOAD_POLICY		"load-policy"
+#define	ZPOOL_LOAD_REWIND_POLICY	"load-rewind-policy"
+#define	ZPOOL_LOAD_REQUEST_TXG		"load-request-txg"
+#define	ZPOOL_LOAD_META_THRESH		"load-meta-thresh"
+#define	ZPOOL_LOAD_DATA_THRESH		"load-data-thresh"
 
 /* Rewind data discovered */
 #define	ZPOOL_CONFIG_LOAD_TIME		"rewind_txg_ts"

--- a/include/zfs_comutil.h
+++ b/include/zfs_comutil.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  */
 
 #ifndef	_ZFS_COMUTIL_H
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 extern boolean_t zfs_allocatable_devs(nvlist_t *);
-extern void zpool_get_rewind_policy(nvlist_t *, zpool_rewind_policy_t *);
+extern void zpool_get_load_policy(nvlist_t *, zpool_load_policy_t *);
 
 extern int zfs_zpl_version_map(int spa_version);
 extern int zfs_spa_version_map(int zpl_version);

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1232,7 +1232,7 @@ get_configs(libzfs_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 		}
 
 		if (policy != NULL) {
-			if (nvlist_add_nvlist(config, ZPOOL_REWIND_POLICY,
+			if (nvlist_add_nvlist(config, ZPOOL_LOAD_POLICY,
 			    policy) != 0)
 				goto nomem;
 		}

--- a/module/zcommon/zfs_comutil.c
+++ b/module/zcommon/zfs_comutil.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -65,17 +65,17 @@ zfs_allocatable_devs(nvlist_t *nv)
 }
 
 void
-zpool_get_rewind_policy(nvlist_t *nvl, zpool_rewind_policy_t *zrpp)
+zpool_get_load_policy(nvlist_t *nvl, zpool_load_policy_t *zlpp)
 {
 	nvlist_t *policy;
 	nvpair_t *elem;
 	char *nm;
 
 	/* Defaults */
-	zrpp->zrp_request = ZPOOL_NO_REWIND;
-	zrpp->zrp_maxmeta = 0;
-	zrpp->zrp_maxdata = UINT64_MAX;
-	zrpp->zrp_txg = UINT64_MAX;
+	zlpp->zlp_rewind = ZPOOL_NO_REWIND;
+	zlpp->zlp_maxmeta = 0;
+	zlpp->zlp_maxdata = UINT64_MAX;
+	zlpp->zlp_txg = UINT64_MAX;
 
 	if (nvl == NULL)
 		return;
@@ -83,24 +83,24 @@ zpool_get_rewind_policy(nvlist_t *nvl, zpool_rewind_policy_t *zrpp)
 	elem = NULL;
 	while ((elem = nvlist_next_nvpair(nvl, elem)) != NULL) {
 		nm = nvpair_name(elem);
-		if (strcmp(nm, ZPOOL_REWIND_POLICY) == 0) {
+		if (strcmp(nm, ZPOOL_LOAD_POLICY) == 0) {
 			if (nvpair_value_nvlist(elem, &policy) == 0)
-				zpool_get_rewind_policy(policy, zrpp);
+				zpool_get_load_policy(policy, zlpp);
 			return;
-		} else if (strcmp(nm, ZPOOL_REWIND_REQUEST) == 0) {
-			if (nvpair_value_uint32(elem, &zrpp->zrp_request) == 0)
-				if (zrpp->zrp_request & ~ZPOOL_REWIND_POLICIES)
-					zrpp->zrp_request = ZPOOL_NO_REWIND;
-		} else if (strcmp(nm, ZPOOL_REWIND_REQUEST_TXG) == 0) {
-			(void) nvpair_value_uint64(elem, &zrpp->zrp_txg);
-		} else if (strcmp(nm, ZPOOL_REWIND_META_THRESH) == 0) {
-			(void) nvpair_value_uint64(elem, &zrpp->zrp_maxmeta);
-		} else if (strcmp(nm, ZPOOL_REWIND_DATA_THRESH) == 0) {
-			(void) nvpair_value_uint64(elem, &zrpp->zrp_maxdata);
+		} else if (strcmp(nm, ZPOOL_LOAD_REWIND_POLICY) == 0) {
+			if (nvpair_value_uint32(elem, &zlpp->zlp_rewind) == 0)
+				if (zlpp->zlp_rewind & ~ZPOOL_REWIND_POLICIES)
+					zlpp->zlp_rewind = ZPOOL_NO_REWIND;
+		} else if (strcmp(nm, ZPOOL_LOAD_REQUEST_TXG) == 0) {
+			(void) nvpair_value_uint64(elem, &zlpp->zlp_txg);
+		} else if (strcmp(nm, ZPOOL_LOAD_META_THRESH) == 0) {
+			(void) nvpair_value_uint64(elem, &zlpp->zlp_maxmeta);
+		} else if (strcmp(nm, ZPOOL_LOAD_DATA_THRESH) == 0) {
+			(void) nvpair_value_uint64(elem, &zlpp->zlp_maxdata);
 		}
 	}
-	if (zrpp->zrp_request == 0)
-		zrpp->zrp_request = ZPOOL_NO_REWIND;
+	if (zlpp->zlp_rewind == 0)
+		zlpp->zlp_rewind = ZPOOL_NO_REWIND;
 }
 
 typedef struct zfs_version_spa_map {
@@ -206,7 +206,7 @@ const char *zfs_history_event_names[ZFS_NUM_LEGACY_HISTORY_EVENTS] = {
 
 #if defined(_KERNEL)
 EXPORT_SYMBOL(zfs_allocatable_devs);
-EXPORT_SYMBOL(zpool_get_rewind_policy);
+EXPORT_SYMBOL(zpool_get_load_policy);
 EXPORT_SYMBOL(zfs_zpl_version_map);
 EXPORT_SYMBOL(zfs_spa_version_map);
 EXPORT_SYMBOL(zfs_history_event_names);


### PR DESCRIPTION
### Description

We want to be able to pass various settings during import/open of a
pool, which are not only related to rewind. Instead of adding a new
policy and duplicate a bunch of code, we should just rename
rewind_policy to a more generic term like load_policy.

For instance, we'd like to set spa->spa_import_flags from the nvlist,
rather from a flags parameter passed to spa_import as in some cases we
want those flags not only for the import case, but also for the open
case. One such flag could be ZFS_IMPORT_MISSING_LOG (as used in zdb)
which would allow zfs to open a pool when logs are missing.

### Motivation and Context

Pull in upstream fixes.

### How Has This Been Tested?

Locally built, pending full builtbot results.

**NOTE** This patch changes the user/kernel interface by renaming the `ZPOOL_REWIND_*/rewind_*` names and values to `ZPOOL_LOAD_*/load-`.  We should consider either sticking with the existing string values, or adding some fallback compatibility code.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
