### PR TITLE
Ignore *.o.ur-safe build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Normal rules
 #
 *.[oa]
+*.o.ur-safe
 *.lo
 *.la
 *.mod.c

--- a/man/man8/.gitignore
+++ b/man/man8/.gitignore
@@ -1,1 +1,2 @@
 /zed.8
+/zfs-mount-generator.8

--- a/module/.gitignore
+++ b/module/.gitignore
@@ -6,6 +6,7 @@
 .*.cmd
 .*.d
 
+/.cache.mk
 /.tmp_versions
 /Module.markers
 /Module.symvers

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -54,6 +54,8 @@ clean:
 	if [ -f @LINUX_SYMBOLS@ ]; then $(RM) @LINUX_SYMBOLS@; fi
 	if [ -f Module.markers ]; then $(RM) Module.markers; fi
 
+	find . -name '*.ur-safe' -type f -print | xargs $(RM)
+
 modules_install:
 	@# Install the kernel modules
 	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` $@ \


### PR DESCRIPTION
### Description

Generated when building on Ubuntu 18.04.  Also ignore the new
dynamically generated zfs-mount-generator.8 man page, and the
module/.cache.mk file.

### Motivation and Context

`git status` should be clean.  Ignore expected build products.

### How Has This Been Tested?

In a tree with zfs built.

```
$ git status
On branch ur-safe
nothing to commit, working tree clean
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
