### PR TITLE
ZTS: Improve zpool_scrub_004_pos reliability

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_004_pos.ksh
@@ -39,7 +39,9 @@
 # STRATEGY:
 #	1. Setup a mirror pool and filled with data.
 #	2. Detach one of devices
-#	3. Verify scrub failed until the resilver completed
+#	3. Create a file for the resilver to work on so it takes some time
+#	4. Export/import the pool to ensure the cache is dropped
+#	5. Verify scrub failed until the resilver completed
 #
 # NOTES:
 #	Artificially limit the scrub speed by setting the zfs_scan_vdev_limit
@@ -49,22 +51,26 @@
 function cleanup
 {
 	log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_DEFAULT
+	rm -f $mntpnt/extra
 }
 
 verify_runnable "global"
-
-# See issue: https://github.com/zfsonlinux/zfs/issues/5444
-if is_32bit; then
-	log_unsupported "Test case fails on 32-bit systems"
-fi
 
 log_onexit cleanup
 
 log_assert "Resilver prevent scrub from starting until the resilver completes"
 
+mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
 log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_SLOW
-log_must zpool detach $TESTPOOL $DISK2
-log_must zpool attach $TESTPOOL $DISK1 $DISK2
+
+while ! is_pool_resilvering $TESTPOOL; do
+	log_must zpool detach $TESTPOOL $DISK2
+	log_must file_write -b 1048576 -c 128 -o create -d 0 -f $mntpnt/extra
+	log_must zpool export $TESTPOOL
+	log_must zpool import $TESTPOOL
+	log_must zpool attach $TESTPOOL $DISK1 $DISK2
+done
+
 log_must is_pool_resilvering $TESTPOOL
 log_mustnot zpool scrub $TESTPOOL
 


### PR DESCRIPTION
### Description

It's possible for the `zpool attach` portion of this test case
to complete before the `zpool scrub` can be issued.  Update the
test case to force the resilvering phase to take longer.

### Motivation and Context

Issue #5444

### How Has This Been Tested?

Locally with ZTS.  Relying on buildbot to get an authoritative result.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
