### PR TITLE
zpool reopen should detect expanded devices

### DIFF
--- a/include/sys/vdev_disk.h
+++ b/include/sys/vdev_disk.h
@@ -23,10 +23,22 @@
  * Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  * Written by Brian Behlendorf <behlendorf1@llnl.gov>.
  * LLNL-CODE-403049.
+ * Copyright (c) 2018 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_VDEV_DISK_H
 #define	_SYS_VDEV_DISK_H
+
+/*
+ * Don't start the slice at the default block of 34; many storage
+ * devices will use a stripe width of 128k, other vendors prefer a 1m
+ * alignment.  It is best to play it safe and ensure a 1m alignment
+ * given 512B blocks.  When the block size is larger by a power of 2
+ * we will still be 1m aligned.  Some devices are sensitive to the
+ * partition ending alignment as well.
+ */
+#define	NEW_START_BLOCK		2048
+#define	PARTITION_END_ALIGNMENT	2048
 
 #ifdef _KERNEL
 #include <sys/vdev.h>

--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018 by Delphix. All rights reserved.
  */
 
 #include <stdio.h>
@@ -1154,13 +1155,30 @@ efi_use_whole_disk(int fd)
 
 	/*
 	 * Find the last physically non-zero partition.
-	 * This is the reserved partition.
+	 * This should be the reserved partition.
 	 */
 	for (i = 0; i < efi_label->efi_nparts; i ++) {
 		if (resv_start < efi_label->efi_parts[i].p_start) {
 			resv_start = efi_label->efi_parts[i].p_start;
 			resv_index = i;
 		}
+	}
+
+	/*
+	 * Verify that we've found the reserved partition by checking
+	 * that it looks the way it did when we created it in zpool_label_disk.
+	 * If we've found the incorrect partition, then we know that this
+	 * device was reformatted and no longer is soley used by ZFS.
+	 */
+	if ((efi_label->efi_parts[resv_index].p_size != EFI_MIN_RESV_SIZE) ||
+	    (efi_label->efi_parts[resv_index].p_tag != V_RESERVED) ||
+	    (resv_index != 8)) {
+		if (efi_debug) {
+			(void) fprintf(stderr,
+			    "efi_use_whole_disk: wholedisk not available\n");
+		}
+		efi_free(efi_label);
+		return (VT_ENOSPC);
 	}
 
 	/*

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  * Copyright (c) 2017 Datto Inc.
  * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
@@ -44,6 +44,7 @@
 #include <sys/systeminfo.h>
 #include <sys/vtoc.h>
 #include <sys/zfs_ioctl.h>
+#include <sys/vdev_disk.h>
 #include <dlfcn.h>
 
 #include "zfs_namecheck.h"
@@ -924,17 +925,6 @@ zpool_prop_get_feature(zpool_handle_t *zhp, const char *propname, char *buf,
 
 	return (0);
 }
-
-/*
- * Don't start the slice at the default block of 34; many storage
- * devices will use a stripe width of 128k, other vendors prefer a 1m
- * alignment.  It is best to play it safe and ensure a 1m alignment
- * given 512B blocks.  When the block size is larger by a power of 2
- * we will still be 1m aligned.  Some devices are sensitive to the
- * partition ending alignment as well.
- */
-#define	NEW_START_BLOCK		2048
-#define	PARTITION_END_ALIGNMENT	2048
 
 /*
  * Validate the given pool name, optionally putting an extended error message in

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Toomas Soome <tsoome@me.com>
@@ -3493,7 +3493,6 @@ vdev_get_stats_ex(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 			    vd->vdev_max_asize - vd->vdev_asize,
 			    1ULL << tvd->vdev_ms_shift);
 		}
-		vs->vs_esize = vd->vdev_max_asize - vd->vdev_asize;
 		if (vd->vdev_aux == NULL && vd == vd->vdev_top &&
 		    vdev_is_concrete(vd)) {
 			vs->vs_fragmentation = vd->vdev_mg->mg_fragmentation;

--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -23,7 +23,7 @@
  * Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  * Rewritten for Linux by Brian Behlendorf <behlendorf1@llnl.gov>.
  * LLNL-CODE-403049.
- * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -34,9 +34,13 @@
 #include <sys/fs/zfs.h>
 #include <sys/zio.h>
 #include <linux/mod_compat.h>
+#include <linux/msdos_fs.h>
 
 char *zfs_vdev_scheduler = VDEV_SCHEDULER;
 static void *zfs_vdev_holder = VDEV_HOLDER;
+
+/* size of the "reserved" partition, in blocks */
+#define	EFI_MIN_RESV_SIZE	(16 * 1024)
 
 /*
  * Virtual device vector for disks.
@@ -81,17 +85,39 @@ vdev_bdev_mode(int smode)
 }
 #endif /* HAVE_OPEN_BDEV_EXCLUSIVE */
 
+/* The capacity (in bytes) of a bdev that is available to be used by a vdev */
 static uint64_t
-bdev_capacity(struct block_device *bdev)
+bdev_capacity(struct block_device *bdev, boolean_t wholedisk)
 {
 	struct hd_struct *part = bdev->bd_part;
+	uint64_t sectors = get_capacity(bdev->bd_disk);
+	/* If there are no paritions, return the entire device capacity */
+	if (part == NULL)
+		return (sectors << SECTOR_BITS);
 
-	/* The partition capacity referenced by the block device */
-	if (part)
-		return (part->nr_sects << 9);
+	/*
+	 * If there are partitions, decide if we are using a `wholedisk`
+	 * layout (composed of part1 and part9) or just a single partition.
+	 */
+	if (wholedisk) {
+		/* Verify the expected device layout */
+		ASSERT3P(bdev, !=, bdev->bd_contains);
+		/*
+		 * Sectors used by the EFI partition (part9) as well as
+		 * partion alignment.
+		 */
+		uint64_t used = EFI_MIN_RESV_SIZE + NEW_START_BLOCK +
+		    PARTITION_END_ALIGNMENT;
 
-	/* Otherwise assume the full device capacity */
-	return (get_capacity(bdev->bd_disk) << 9);
+		/* Space available to the vdev, i.e. the size of part1 */
+		if (sectors <= used)
+			return (0);
+		uint64_t available = sectors - used;
+		return (available << SECTOR_BITS);
+	} else {
+		/* The partition capacity referenced by the block device */
+		return (part->nr_sects << SECTOR_BITS);
+	}
 }
 
 static void
@@ -330,9 +356,7 @@ skip_open:
 	v->vdev_nonrot = blk_queue_nonrot(bdev_get_queue(vd->vd_bdev));
 
 	/* Physical volume size in bytes */
-	*psize = bdev_capacity(vd->vd_bdev);
-
-	/* TODO: report possible expansion size */
+	*psize = bdev_capacity(vd->vd_bdev, v->vdev_wholedisk);
 	*max_psize = *psize;
 
 	/* Based on the minimum sector size set the block size */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->    
Update `bdev_capacity` to have wholedisk vdevs query the size of the underlying block device (correcting for the size of the efi parition and partition alignment) and therefore detect expanded space.

Correct `vdev_get_stats_ex` so that the expandsize is aligned to metaslab size and new space is only reported if it is large enough for a new metaslab.
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
`vdev_disk_open` uses the partition size to determine the device size (even if it’s a whole-disk vdev), and therefore doesn't notice if the device has grown. Calling `get_capacity` on the block device itself gives the total size of the device, expansion and all. This entire capacity isn’t actually available to the vdev - we need to correct for the size of the EFI boot label partition and the partition alignment space.

zfs should only be reporting new space if there’s enough of it to allocate a new metaslab. This merge https://github.com/zfsonlinux/zfs/commit/0f676dc228862ce0b4f9e27d06d394e9cbaa32e3  from openzfs should have fixed that, but line 2924 was left in place, meaning that esize is overwritten after it was aligned.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In theory you should be able to resize a device, call `zpool reopen`, see additional expandsize with `zpool list -v` and then add that space to the vdev with `zpool online -e`. On Linux, the new size is not detected. This change corrects this by addressing the issues described in the previous section.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
These changes were tested by running the device expansion workflows described above on ZoL installations running on vmware, aws and azure.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [x] Change has been approved by a ZFS on Linux member.
