### PR TITLE
External-issue: LX-971 Profiling for perf tests

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -84,6 +84,7 @@ export SYSTEM_FILES='arp
     openssl
     parted
     pax
+    perf
     pgrep
     ping
     pkill

--- a/tests/zfs-tests/tests/perf/regression/random_reads.ksh
+++ b/tests/zfs-tests/tests/perf/regression/random_reads.ksh
@@ -85,9 +85,12 @@ log_must fio $FIO_SCRIPTS/mkfiles.fio
 lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 if is_linux; then
-        export collect_scripts=("zpool iostat -lpvyL $PERFPOOL 1" "zpool.iostat"
-            "vmstat 1" "vmstat" "mpstat -P ALL 1" "mpstat" "iostat -dxyz 1"
-            "iostat")
+	typeset perf_record_cmd="perf record -F 99 -a -g -q \
+	    -o /dev/stdout -- sleep ${PERF_RUNTIME}"
+
+	export collect_scripts=("zpool iostat -lpvyL $PERFPOOL 1" "zpool.iostat"
+	    "vmstat 1" "vmstat" "mpstat -P ALL 1" "mpstat" "iostat -dxyz 1"
+	    "iostat" "$perf_record_cmd" "perf")
 else
 	export collect_scripts=("$PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
 	    "vmstat 1" "vmstat" "mpstat 1" "mpstat" "iostat -xcnz 1" "iostat")

--- a/tests/zfs-tests/tests/perf/regression/random_readwrite.ksh
+++ b/tests/zfs-tests/tests/perf/regression/random_readwrite.ksh
@@ -85,9 +85,12 @@ log_must fio $FIO_SCRIPTS/mkfiles.fio
 lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 if is_linux; then
+	typeset perf_record_cmd="perf record -F 99 -a -g -q \
+	    -o /dev/stdout -- sleep ${PERF_RUNTIME}"
+
 	export collect_scripts=("zpool iostat -lpvyL $PERFPOOL 1" "zpool.iostat"
 	    "vmstat 1" "vmstat" "mpstat -P ALL 1" "mpstat" "iostat -dxyz 1"
-	    "iostat")
+	    "iostat" "$perf_record_cmd" "perf")
 else
 	export collect_scripts=("$PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
 	    "vmstat 1" "vmstat" "mpstat 1" "mpstat" "iostat -xcnz 1" "iostat")

--- a/tests/zfs-tests/tests/perf/regression/random_writes.ksh
+++ b/tests/zfs-tests/tests/perf/regression/random_writes.ksh
@@ -77,9 +77,12 @@ fi
 lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 if is_linux; then
+	typeset perf_record_cmd="perf record -F 99 -a -g -q \
+	    -o /dev/stdout -- sleep ${PERF_RUNTIME}"
+
 	export collect_scripts=("zpool iostat -lpvyL $PERFPOOL 1" "zpool.iostat"
 	    "vmstat 1" "vmstat" "mpstat -P ALL 1" "mpstat" "iostat -dxyz 1"
-	    "iostat")
+	    "iostat" "$perf_record_cmd" "perf")
 else
 	export collect_scripts=("$PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
 	    "vmstat 1" "vmstat" "mpstat 1" "mpstat" "iostat -xcnz 1" "iostat")

--- a/tests/zfs-tests/tests/perf/regression/sequential_reads.ksh
+++ b/tests/zfs-tests/tests/perf/regression/sequential_reads.ksh
@@ -85,9 +85,13 @@ log_must fio $FIO_SCRIPTS/mkfiles.fio
 lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 if is_linux; then
+    typeset perf_record_cmd="perf record -F 99 -a -g -q \
+        -o /dev/stdout -- sleep ${PERF_RUNTIME}"
+
 	export collect_scripts=("zpool iostat -lpvyL $PERFPOOL 1" "zpool.iostat"
 	    "$PERF_SCRIPTS/prefetch_io.sh $PERFPOOL 1" "prefetch" "vmstat 1"
-	    "vmstat" "mpstat  -P ALL 1" "mpstat" "iostat -dxyz 1" "iostat")
+	    "vmstat" "mpstat  -P ALL 1" "mpstat" "iostat -dxyz 1" "iostat"
+	    "$perf_record_cmd" "perf")
 else
 	export collect_scripts=("$PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
 	    "$PERF_SCRIPTS/prefetch_io.d $PERFPOOL 1" "prefetch" "vmstat 1" "vmstat"

--- a/tests/zfs-tests/tests/perf/regression/sequential_reads_arc_cached.ksh
+++ b/tests/zfs-tests/tests/perf/regression/sequential_reads_arc_cached.ksh
@@ -75,9 +75,13 @@ log_must fio $FIO_SCRIPTS/mkfiles.fio
 lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 if is_linux; then
+	typeset perf_record_cmd="perf record -F 99 -a -g -q \
+	    -o /dev/stdout -- sleep ${PERF_RUNTIME}"
+
 	export collect_scripts=("zpool iostat -lpvyL $PERFPOOL 1" "zpool.iostat"
 	    "$PERF_SCRIPTS/prefetch_io.sh $PERFPOOL 1" "prefetch" "vmstat 1"
-	    "vmstat" "mpstat -P ALL 1" "mpstat" "iostat -dxyz 1" "iostat")
+	    "vmstat" "mpstat -P ALL 1" "mpstat" "iostat -dxyz 1" "iostat"
+	    "$perf_record_cmd" "perf")
 else
 	export collect_scripts=("$PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
 	    "$PERF_SCRIPTS/prefetch_io.d $PERFPOOL 1" "prefetch" "vmstat 1" "vmstat"

--- a/tests/zfs-tests/tests/perf/regression/sequential_reads_arc_cached_clone.ksh
+++ b/tests/zfs-tests/tests/perf/regression/sequential_reads_arc_cached_clone.ksh
@@ -91,9 +91,13 @@ export TESTFS=$PERFPOOL/$TESTCLONE
 lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 if is_linux; then
+	typeset perf_record_cmd="perf record -F 99 -a -g -q \
+	    -o /dev/stdout -- sleep ${PERF_RUNTIME}"
+
 	export collect_scripts=("zpool iostat -lpvyL $PERFPOOL 1" "zpool.iostat"
 	    "$PERF_SCRIPTS/prefetch_io.sh $PERFPOOL 1" "prefetch" "vmstat 1"
-	    "vmstat" "mpstat -P ALL 1" "mpstat" "iostat -dxyz 1" "iostat")
+	    "vmstat" "mpstat -P ALL 1" "mpstat" "iostat -dxyz 1" "iostat"
+	    "$perf_record_cmd" "perf")
 else
 	export collect_scripts=("$PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
 	    "$PERF_SCRIPTS/prefetch_io.d $PERFPOOL 1" "prefetch" "vmstat 1" "vmstat"

--- a/tests/zfs-tests/tests/perf/regression/sequential_reads_dbuf_cached.ksh
+++ b/tests/zfs-tests/tests/perf/regression/sequential_reads_dbuf_cached.ksh
@@ -77,9 +77,13 @@ log_must fio $FIO_SCRIPTS/mkfiles.fio
 lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 if is_linux; then
+	typeset perf_record_cmd="perf record -F 99 -a -g -q \
+	    -o /dev/stdout -- sleep ${PERF_RUNTIME}"
+
 	export collect_scripts=("zpool iostat -lpvyL $PERFPOOL 1" "zpool.iostat"
 	    "$PERF_SCRIPTS/prefetch_io.sh $PERFPOOL 1" "prefetch" "vmstat 1"
-	    "vmstat" "mpstat  -P ALL 1" "mpstat" "iostat -dxyz 1" "iostat")
+	    "vmstat" "mpstat  -P ALL 1" "mpstat" "iostat -dxyz 1" "iostat"
+	    "$perf_record_cmd" "perf")
 else
 	export collect_scripts=("kstat zfs:0 1" "kstat" "vmstat -T d 1" "vmstat"
 	    "mpstat -T d 1" "mpstat" "iostat -T d -xcnz 1" "iostat"

--- a/tests/zfs-tests/tests/perf/regression/sequential_writes.ksh
+++ b/tests/zfs-tests/tests/perf/regression/sequential_writes.ksh
@@ -77,9 +77,12 @@ fi
 lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 if is_linux; then
+	typeset perf_record_cmd="perf record -F 99 -a -g -q \
+	    -o /dev/stdout -- sleep ${PERF_RUNTIME}"
+
 	export collect_scripts=("zpool iostat -lpvyL $PERFPOOL 1" "zpool.iostat"
 	    "vmstat 1" "vmstat" "mpstat -P ALL 1" "mpstat" "iostat -dxyz 1"
-	    "iostat")
+	    "iostat" "$perf_record_cmd" "perf")
 else
 	export collect_scripts=("$PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
 	    "vmstat 1" "vmstat" "mpstat 1" "mpstat" "iostat -xcnz 1" "iostat")


### PR DESCRIPTION
Stack profiling is quite useful and Linux ZFS test suite does not
current collect that data.

Linux perf is a common tool for this purpose though the perf record
data file can be quite large. With this change, Linux ZFS perf tests
capture perf record data if perf is installed on the system and
PERF_DO_PROFILING environment variable is set.

Signed-off-by: Tony Nguyen <tony.nguyen@delphix.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options

Requires-builders: perf,build
-->

### Description

### Motivation and Context

### How Has This Been Tested?
- Normal ZFS perf run does not generate perf profiling data
- perf profiling data generated if running ZFS perf with PERF_DO_PROFILE set as below:
PERF_DO_PROFILE=1 nohup ./zfs-tests.sh -v -T perf  -r runfiles/perf-regression.run &

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
