### PR TITLE
Support Debian DKMS builds

### DIFF
--- a/scripts/dkms.mkconf
+++ b/scripts/dkms.mkconf
@@ -25,7 +25,22 @@ PACKAGE_CONFIG="${pkgcfg}"
 PRE_BUILD="configure
   --prefix=/usr
   --with-config=kernel
-  --with-linux=\${kernel_source_dir}
+  --with-linux=\$(
+    case \`lsb_release -is\` in
+      (Debian|Devuan)
+        if [[ -e \${kernel_source_dir/%build/source} ]]
+        then
+          echo \${kernel_source_dir/%build/source}
+        else
+          # A kpkg exception for Proxmox 2.0
+          echo \${kernel_source_dir}
+        fi
+      ;;
+      (*)
+        echo \${kernel_source_dir}
+      ;;
+    esac
+  )
   --with-linux-obj=\${kernel_source_dir}
   --with-spl=\${source_tree}/spl-\${PACKAGE_VERSION}
   --with-spl-obj=\${dkms_tree}/spl/\${PACKAGE_VERSION}/\${kernelver}/\${arch}


### PR DESCRIPTION
### Description

`scripts/dkms.mkconf` calls `configure` with `--with-linux=${kernel_source_dir}`, but Debian puts it kernel source at `/lib/modules/<version>/source`. This patch adds the same logic to the DKMS file produced by `scripts/dkms.mkconf` that Debian has shipped in its official ZFS packaging: at DKMS build time, it checks if the system is a Debian system, and adjusts the path accordingly.

### Motivation and Context
This should address the build failures in #7358  and #7540.

### How Has This Been Tested?
I've built and installed the DKMS package from this on a machine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
