### PR TITLE
OpenZFS 9328, 9329

### DIFF
--- a/module/zfs/dmu_object.c
+++ b/module/zfs/dmu_object.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2017 by Delphix. All rights reserved.
  * Copyright 2014 HybridCluster. All rights reserved.
  */
 
@@ -381,12 +381,19 @@ dmu_object_zapify(objset_t *mos, uint64_t object, dmu_object_type_t old_type,
 	}
 	ASSERT3U(dn->dn_type, ==, old_type);
 	ASSERT0(dn->dn_maxblkid);
+
+	/*
+	 * We must initialize the ZAP data before changing the type,
+	 * so that concurrent calls to *_is_zapified() can determine if
+	 * the object has been completely zapified by checking the type.
+	 */
+	mzap_create_impl(mos, object, 0, 0, tx);
+
 	dn->dn_next_type[tx->tx_txg & TXG_MASK] = dn->dn_type =
 	    DMU_OTN_ZAP_METADATA;
 	dnode_setdirty(dn, tx);
 	dnode_rele(dn, FTAG);
 
-	mzap_create_impl(mos, object, 0, 0, tx);
 
 	spa_feature_incr(dmu_objset_spa(mos),
 	    SPA_FEATURE_EXTENSIBLE_DATASET, tx);

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -58,9 +58,7 @@ static uint64_t zap_allocate_blocks(zap_t *zap, int nblocks);
 void
 fzap_byteswap(void *vbuf, size_t size)
 {
-	uint64_t block_type;
-
-	block_type = *(uint64_t *)vbuf;
+	uint64_t block_type = *(uint64_t *)vbuf;
 
 	if (block_type == ZBT_LEAF || block_type == BSWAP_64(ZBT_LEAF))
 		zap_leaf_byteswap(vbuf, size);
@@ -73,11 +71,6 @@ fzap_byteswap(void *vbuf, size_t size)
 void
 fzap_upgrade(zap_t *zap, dmu_tx_t *tx, zap_flags_t flags)
 {
-	dmu_buf_t *db;
-	zap_leaf_t *l;
-	int i;
-	zap_phys_t *zp;
-
 	ASSERT(RW_WRITE_HELD(&zap->zap_rwlock));
 	zap->zap_ismicro = FALSE;
 
@@ -87,7 +80,7 @@ fzap_upgrade(zap_t *zap, dmu_tx_t *tx, zap_flags_t flags)
 	mutex_init(&zap->zap_f.zap_num_entries_mtx, 0, MUTEX_DEFAULT, 0);
 	zap->zap_f.zap_block_shift = highbit64(zap->zap_dbuf->db_size) - 1;
 
-	zp = zap_f_phys(zap);
+	zap_phys_t *zp = zap_f_phys(zap);
 	/*
 	 * explicitly zero it since it might be coming from an
 	 * initialized microzap
@@ -106,17 +99,18 @@ fzap_upgrade(zap_t *zap, dmu_tx_t *tx, zap_flags_t flags)
 	zp->zap_flags = flags;
 
 	/* block 1 will be the first leaf */
-	for (i = 0; i < (1<<zp->zap_ptrtbl.zt_shift); i++)
+	for (int i = 0; i < (1<<zp->zap_ptrtbl.zt_shift); i++)
 		ZAP_EMBEDDED_PTRTBL_ENT(zap, i) = 1;
 
 	/*
 	 * set up block 1 - the first leaf
 	 */
-	VERIFY(0 == dmu_buf_hold(zap->zap_objset, zap->zap_object,
+	dmu_buf_t *db;
+	VERIFY0(dmu_buf_hold(zap->zap_objset, zap->zap_object,
 	    1<<FZAP_BLOCK_SHIFT(zap), FTAG, &db, DMU_READ_NO_PREFETCH));
 	dmu_buf_will_dirty(db, tx);
 
-	l = kmem_zalloc(sizeof (zap_leaf_t), KM_SLEEP);
+	zap_leaf_t *l = kmem_zalloc(sizeof (zap_leaf_t), KM_SLEEP);
 	l->l_dbuf = db;
 
 	zap_leaf_init(l, zp->zap_normflags != 0);
@@ -146,9 +140,7 @@ zap_table_grow(zap_t *zap, zap_table_phys_t *tbl,
     void (*transfer_func)(const uint64_t *src, uint64_t *dst, int n),
     dmu_tx_t *tx)
 {
-	uint64_t b, newblk;
-	dmu_buf_t *db_old, *db_new;
-	int err;
+	uint64_t newblk;
 	int bs = FZAP_BLOCK_SHIFT(zap);
 	int hepb = 1<<(bs-4);
 	/* hepb = half the number of entries in a block */
@@ -172,21 +164,23 @@ zap_table_grow(zap_t *zap, zap_table_phys_t *tbl,
 	 * Copy the ptrtbl from the old to new location.
 	 */
 
-	b = tbl->zt_blks_copied;
-	err = dmu_buf_hold(zap->zap_objset, zap->zap_object,
+	uint64_t b = tbl->zt_blks_copied;
+	dmu_buf_t *db_old;
+	int err = dmu_buf_hold(zap->zap_objset, zap->zap_object,
 	    (tbl->zt_blk + b) << bs, FTAG, &db_old, DMU_READ_NO_PREFETCH);
-	if (err)
+	if (err != 0)
 		return (err);
 
 	/* first half of entries in old[b] go to new[2*b+0] */
-	VERIFY(0 == dmu_buf_hold(zap->zap_objset, zap->zap_object,
+	dmu_buf_t *db_new;
+	VERIFY0(dmu_buf_hold(zap->zap_objset, zap->zap_object,
 	    (newblk + 2*b+0) << bs, FTAG, &db_new, DMU_READ_NO_PREFETCH));
 	dmu_buf_will_dirty(db_new, tx);
 	transfer_func(db_old->db_data, db_new->db_data, hepb);
 	dmu_buf_rele(db_new, FTAG);
 
 	/* second half of entries in old[b] go to new[2*b+1] */
-	VERIFY(0 == dmu_buf_hold(zap->zap_objset, zap->zap_object,
+	VERIFY0(dmu_buf_hold(zap->zap_objset, zap->zap_object,
 	    (newblk + 2*b+1) << bs, FTAG, &db_new, DMU_READ_NO_PREFETCH));
 	dmu_buf_will_dirty(db_new, tx);
 	transfer_func((uint64_t *)db_old->db_data + hepb,
@@ -221,22 +215,20 @@ static int
 zap_table_store(zap_t *zap, zap_table_phys_t *tbl, uint64_t idx, uint64_t val,
     dmu_tx_t *tx)
 {
-	int err;
-	uint64_t blk, off;
 	int bs = FZAP_BLOCK_SHIFT(zap);
-	dmu_buf_t *db;
 
 	ASSERT(RW_LOCK_HELD(&zap->zap_rwlock));
 	ASSERT(tbl->zt_blk != 0);
 
 	dprintf("storing %llx at index %llx\n", val, idx);
 
-	blk = idx >> (bs-3);
-	off = idx & ((1<<(bs-3))-1);
+	uint64_t blk = idx >> (bs-3);
+	uint64_t off = idx & ((1<<(bs-3))-1);
 
-	err = dmu_buf_hold(zap->zap_objset, zap->zap_object,
+	dmu_buf_t *db;
+	int err = dmu_buf_hold(zap->zap_objset, zap->zap_object,
 	    (tbl->zt_blk + blk) << bs, FTAG, &db, DMU_READ_NO_PREFETCH);
-	if (err)
+	if (err != 0)
 		return (err);
 	dmu_buf_will_dirty(db, tx);
 
@@ -249,7 +241,7 @@ zap_table_store(zap_t *zap, zap_table_phys_t *tbl, uint64_t idx, uint64_t val,
 		err = dmu_buf_hold(zap->zap_objset, zap->zap_object,
 		    (tbl->zt_nextblk + blk2) << bs, FTAG, &db2,
 		    DMU_READ_NO_PREFETCH);
-		if (err) {
+		if (err != 0) {
 			dmu_buf_rele(db, FTAG);
 			return (err);
 		}
@@ -268,27 +260,24 @@ zap_table_store(zap_t *zap, zap_table_phys_t *tbl, uint64_t idx, uint64_t val,
 static int
 zap_table_load(zap_t *zap, zap_table_phys_t *tbl, uint64_t idx, uint64_t *valp)
 {
-	uint64_t blk, off;
-	int err;
-	dmu_buf_t *db;
-	dnode_t *dn;
 	int bs = FZAP_BLOCK_SHIFT(zap);
 
 	ASSERT(RW_LOCK_HELD(&zap->zap_rwlock));
 
-	blk = idx >> (bs-3);
-	off = idx & ((1<<(bs-3))-1);
+	uint64_t blk = idx >> (bs-3);
+	uint64_t off = idx & ((1<<(bs-3))-1);
 
 	/*
 	 * Note: this is equivalent to dmu_buf_hold(), but we use
 	 * _dnode_enter / _by_dnode because it's faster because we don't
 	 * have to hold the dnode.
 	 */
-	dn = dmu_buf_dnode_enter(zap->zap_dbuf);
-	err = dmu_buf_hold_by_dnode(dn,
+	dnode_t *dn = dmu_buf_dnode_enter(zap->zap_dbuf);
+	dmu_buf_t *db;
+	int err = dmu_buf_hold_by_dnode(dn,
 	    (tbl->zt_blk + blk) << bs, FTAG, &db, DMU_READ_NO_PREFETCH);
 	dmu_buf_dnode_exit(zap->zap_dbuf);
-	if (err)
+	if (err != 0)
 		return (err);
 	*valp = ((uint64_t *)db->db_data)[off];
 	dmu_buf_rele(db, FTAG);
@@ -319,11 +308,10 @@ zap_table_load(zap_t *zap, zap_table_phys_t *tbl, uint64_t idx, uint64_t *valp)
 static void
 zap_ptrtbl_transfer(const uint64_t *src, uint64_t *dst, int n)
 {
-	int i;
-	for (i = 0; i < n; i++) {
+	for (int i = 0; i < n; i++) {
 		uint64_t lb = src[i];
-		dst[2*i+0] = lb;
-		dst[2*i+1] = lb;
+		dst[2 * i + 0] = lb;
+		dst[2 * i + 1] = lb;
 	}
 }
 
@@ -345,19 +333,16 @@ zap_grow_ptrtbl(zap_t *zap, dmu_tx_t *tx)
 		 * stored in the header block).  Give it its own entire
 		 * block, which will double the size of the ptrtbl.
 		 */
-		uint64_t newblk;
-		dmu_buf_t *db_new;
-		int err;
-
 		ASSERT3U(zap_f_phys(zap)->zap_ptrtbl.zt_shift, ==,
 		    ZAP_EMBEDDED_PTRTBL_SHIFT(zap));
 		ASSERT0(zap_f_phys(zap)->zap_ptrtbl.zt_blk);
 
-		newblk = zap_allocate_blocks(zap, 1);
-		err = dmu_buf_hold(zap->zap_objset, zap->zap_object,
+		uint64_t newblk = zap_allocate_blocks(zap, 1);
+		dmu_buf_t *db_new;
+		int err = dmu_buf_hold(zap->zap_objset, zap->zap_object,
 		    newblk << FZAP_BLOCK_SHIFT(zap), FTAG, &db_new,
 		    DMU_READ_NO_PREFETCH);
-		if (err)
+		if (err != 0)
 			return (err);
 		dmu_buf_will_dirty(db_new, tx);
 		zap_ptrtbl_transfer(&ZAP_EMBEDDED_PTRTBL_ENT(zap, 0),
@@ -392,9 +377,8 @@ zap_increment_num_entries(zap_t *zap, int delta, dmu_tx_t *tx)
 static uint64_t
 zap_allocate_blocks(zap_t *zap, int nblocks)
 {
-	uint64_t newblk;
 	ASSERT(RW_WRITE_HELD(&zap->zap_rwlock));
-	newblk = zap_f_phys(zap)->zap_freeblk;
+	uint64_t newblk = zap_f_phys(zap)->zap_freeblk;
 	zap_f_phys(zap)->zap_freeblk += nblocks;
 	return (newblk);
 }
@@ -411,7 +395,6 @@ zap_leaf_evict_sync(void *dbu)
 static zap_leaf_t *
 zap_create_leaf(zap_t *zap, dmu_tx_t *tx)
 {
-	void *winner;
 	zap_leaf_t *l = kmem_zalloc(sizeof (zap_leaf_t), KM_SLEEP);
 
 	ASSERT(RW_WRITE_HELD(&zap->zap_rwlock));
@@ -421,12 +404,11 @@ zap_create_leaf(zap_t *zap, dmu_tx_t *tx)
 	l->l_blkid = zap_allocate_blocks(zap, 1);
 	l->l_dbuf = NULL;
 
-	VERIFY(0 == dmu_buf_hold(zap->zap_objset, zap->zap_object,
+	VERIFY0(dmu_buf_hold(zap->zap_objset, zap->zap_object,
 	    l->l_blkid << FZAP_BLOCK_SHIFT(zap), NULL, &l->l_dbuf,
 	    DMU_READ_NO_PREFETCH));
 	dmu_buf_init_user(&l->l_dbu, zap_leaf_evict_sync, NULL, &l->l_dbuf);
-	winner = dmu_buf_set_user(l->l_dbuf, &l->l_dbu);
-	ASSERT(winner == NULL);
+	VERIFY3P(NULL, ==, dmu_buf_set_user(l->l_dbuf, &l->l_dbu));
 	dmu_buf_will_dirty(l->l_dbuf, tx);
 
 	zap_leaf_init(l, zap->zap_normflags != 0);
@@ -460,11 +442,9 @@ zap_put_leaf(zap_leaf_t *l)
 static zap_leaf_t *
 zap_open_leaf(uint64_t blkid, dmu_buf_t *db)
 {
-	zap_leaf_t *l, *winner;
-
 	ASSERT(blkid != 0);
 
-	l = kmem_zalloc(sizeof (zap_leaf_t), KM_SLEEP);
+	zap_leaf_t *l = kmem_zalloc(sizeof (zap_leaf_t), KM_SLEEP);
 	rw_init(&l->l_rwlock, NULL, RW_DEFAULT, NULL);
 	rw_enter(&l->l_rwlock, RW_WRITER);
 	l->l_blkid = blkid;
@@ -472,7 +452,7 @@ zap_open_leaf(uint64_t blkid, dmu_buf_t *db)
 	l->l_dbuf = db;
 
 	dmu_buf_init_user(&l->l_dbu, zap_leaf_evict_sync, NULL, &l->l_dbuf);
-	winner = dmu_buf_set_user(db, &l->l_dbu);
+	zap_leaf_t *winner = dmu_buf_set_user(db, &l->l_dbu);
 
 	rw_exit(&l->l_rwlock);
 	if (winner != NULL) {
@@ -510,9 +490,6 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
     zap_leaf_t **lp)
 {
 	dmu_buf_t *db;
-	zap_leaf_t *l;
-	int bs = FZAP_BLOCK_SHIFT(zap);
-	int err;
 
 	ASSERT(RW_LOCK_HELD(&zap->zap_rwlock));
 
@@ -526,11 +503,12 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	if (blkid == 0)
 		return (SET_ERROR(ENOENT));
 
+	int bs = FZAP_BLOCK_SHIFT(zap);
 	dnode_t *dn = dmu_buf_dnode_enter(zap->zap_dbuf);
-	err = dmu_buf_hold_by_dnode(dn,
+	int err = dmu_buf_hold_by_dnode(dn,
 	    blkid << bs, NULL, &db, DMU_READ_NO_PREFETCH);
 	dmu_buf_dnode_exit(zap->zap_dbuf);
-	if (err)
+	if (err != 0)
 		return (err);
 
 	ASSERT3U(db->db_object, ==, zap->zap_object);
@@ -538,7 +516,7 @@ zap_get_leaf_byblk(zap_t *zap, uint64_t blkid, dmu_tx_t *tx, krw_t lt,
 	ASSERT3U(db->db_size, ==, 1 << bs);
 	ASSERT(blkid != 0);
 
-	l = dmu_buf_get_user(db);
+	zap_leaf_t *l = dmu_buf_get_user(db);
 
 	if (l == NULL)
 		l = zap_open_leaf(blkid, db);
@@ -593,8 +571,7 @@ zap_set_idx_to_blk(zap_t *zap, uint64_t idx, uint64_t blk, dmu_tx_t *tx)
 static int
 zap_deref_leaf(zap_t *zap, uint64_t h, dmu_tx_t *tx, krw_t lt, zap_leaf_t **lp)
 {
-	uint64_t idx, blk;
-	int err;
+	uint64_t blk;
 
 	ASSERT(zap->zap_dbuf == NULL ||
 	    zap_f_phys(zap) == zap->zap_dbuf->db_data);
@@ -605,8 +582,9 @@ zap_deref_leaf(zap_t *zap, uint64_t h, dmu_tx_t *tx, krw_t lt, zap_leaf_t **lp)
 	    zap_f_phys(zap)->zap_magic != ZAP_MAGIC) {
 		return (SET_ERROR(EIO));
 	}
-	idx = ZAP_HASH_IDX(h, zap_f_phys(zap)->zap_ptrtbl.zt_shift);
-	err = zap_idx_to_blk(zap, idx, &blk);
+
+	uint64_t idx = ZAP_HASH_IDX(h, zap_f_phys(zap)->zap_ptrtbl.zt_shift);
+	int err = zap_idx_to_blk(zap, idx, &blk);
 	if (err != 0)
 		return (err);
 	err = zap_get_leaf_byblk(zap, blk, tx, lt, lp);
@@ -623,9 +601,7 @@ zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l,
 {
 	zap_t *zap = zn->zn_zap;
 	uint64_t hash = zn->zn_hash;
-	zap_leaf_t *nl;
-	int prefix_diff, i, err;
-	uint64_t sibling;
+	int err;
 	int old_prefix_len = zap_leaf_phys(l)->l_hdr.lh_prefix_len;
 
 	ASSERT3U(old_prefix_len, <=, zap_f_phys(zap)->zap_ptrtbl.zt_shift);
@@ -645,19 +621,19 @@ zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l,
 		err = zap_lockdir(os, object, tx, RW_WRITER,
 		    FALSE, FALSE, tag, &zn->zn_zap);
 		zap = zn->zn_zap;
-		if (err)
+		if (err != 0)
 			return (err);
 		ASSERT(!zap->zap_ismicro);
 
 		while (old_prefix_len ==
 		    zap_f_phys(zap)->zap_ptrtbl.zt_shift) {
 			err = zap_grow_ptrtbl(zap, tx);
-			if (err)
+			if (err != 0)
 				return (err);
 		}
 
 		err = zap_deref_leaf(zap, hash, tx, RW_WRITER, &l);
-		if (err)
+		if (err != 0)
 			return (err);
 
 		if (zap_leaf_phys(l)->l_hdr.lh_prefix_len != old_prefix_len) {
@@ -671,25 +647,26 @@ zap_expand_leaf(zap_name_t *zn, zap_leaf_t *l,
 	ASSERT3U(ZAP_HASH_IDX(hash, old_prefix_len), ==,
 	    zap_leaf_phys(l)->l_hdr.lh_prefix);
 
-	prefix_diff = zap_f_phys(zap)->zap_ptrtbl.zt_shift -
+	int prefix_diff = zap_f_phys(zap)->zap_ptrtbl.zt_shift -
 	    (old_prefix_len + 1);
-	sibling = (ZAP_HASH_IDX(hash, old_prefix_len + 1) | 1) << prefix_diff;
+	uint64_t sibling =
+	    (ZAP_HASH_IDX(hash, old_prefix_len + 1) | 1) << prefix_diff;
 
 	/* check for i/o errors before doing zap_leaf_split */
-	for (i = 0; i < (1ULL<<prefix_diff); i++) {
+	for (int i = 0; i < (1ULL << prefix_diff); i++) {
 		uint64_t blk;
-		err = zap_idx_to_blk(zap, sibling+i, &blk);
-		if (err)
+		err = zap_idx_to_blk(zap, sibling + i, &blk);
+		if (err != 0)
 			return (err);
 		ASSERT3U(blk, ==, l->l_blkid);
 	}
 
-	nl = zap_create_leaf(zap, tx);
+	zap_leaf_t *nl = zap_create_leaf(zap, tx);
 	zap_leaf_split(l, nl, zap->zap_normflags != 0);
 
 	/* set sibling pointers */
-	for (i = 0; i < (1ULL << prefix_diff); i++) {
-		err = zap_set_idx_to_blk(zap, sibling+i, nl->l_blkid, tx);
+	for (int i = 0; i < (1ULL << prefix_diff); i++) {
+		err = zap_set_idx_to_blk(zap, sibling + i, nl->l_blkid, tx);
 		ASSERT0(err); /* we checked for i/o errors above */
 	}
 
@@ -719,8 +696,6 @@ zap_put_leaf_maybe_grow_ptrtbl(zap_name_t *zn, zap_leaf_t *l,
 	zap_put_leaf(l);
 
 	if (leaffull || zap_f_phys(zap)->zap_ptrtbl.zt_nextblk) {
-		int err;
-
 		/*
 		 * We are in the middle of growing the pointer table, or
 		 * this leaf will soon make us grow it.
@@ -730,10 +705,10 @@ zap_put_leaf_maybe_grow_ptrtbl(zap_name_t *zn, zap_leaf_t *l,
 			uint64_t zapobj = zap->zap_object;
 
 			zap_unlockdir(zap, tag);
-			err = zap_lockdir(os, zapobj, tx,
+			int err = zap_lockdir(os, zapobj, tx,
 			    RW_WRITER, FALSE, FALSE, tag, &zn->zn_zap);
 			zap = zn->zn_zap;
-			if (err)
+			if (err != 0)
 				return;
 		}
 
@@ -774,9 +749,8 @@ fzap_checksize(uint64_t integer_size, uint64_t num_integers)
 static int
 fzap_check(zap_name_t *zn, uint64_t integer_size, uint64_t num_integers)
 {
-	int err;
-
-	if ((err = fzap_checkname(zn)) != 0)
+	int err = fzap_checkname(zn);
+	if (err != 0)
 		return (err);
 	return (fzap_checksize(integer_size, num_integers));
 }
@@ -790,10 +764,10 @@ fzap_lookup(zap_name_t *zn,
     char *realname, int rn_len, boolean_t *ncp)
 {
 	zap_leaf_t *l;
-	int err;
 	zap_entry_handle_t zeh;
 
-	if ((err = fzap_checkname(zn)) != 0)
+	int err = fzap_checkname(zn);
+	if (err != 0)
 		return (err);
 
 	err = zap_deref_leaf(zn->zn_zap, zn->zn_hash, NULL, RW_READER, &l);
@@ -889,7 +863,8 @@ fzap_update(zap_name_t *zn,
     void *tag, dmu_tx_t *tx)
 {
 	zap_leaf_t *l;
-	int err, create;
+	int err;
+	boolean_t create;
 	zap_entry_handle_t zeh;
 	zap_t *zap = zn->zn_zap;
 
@@ -942,9 +917,9 @@ fzap_length(zap_name_t *zn,
 	if (err != 0)
 		goto out;
 
-	if (integer_size)
+	if (integer_size != 0)
 		*integer_size = zeh.zeh_integer_size;
-	if (num_integers)
+	if (num_integers != 0)
 		*num_integers = zeh.zeh_num_integers;
 out:
 	zap_put_leaf(l);
@@ -973,15 +948,14 @@ fzap_remove(zap_name_t *zn, dmu_tx_t *tx)
 void
 fzap_prefetch(zap_name_t *zn)
 {
-	uint64_t idx, blk;
+	uint64_t blk;
 	zap_t *zap = zn->zn_zap;
-	int bs;
 
-	idx = ZAP_HASH_IDX(zn->zn_hash,
+	uint64_t idx = ZAP_HASH_IDX(zn->zn_hash,
 	    zap_f_phys(zap)->zap_ptrtbl.zt_shift);
 	if (zap_idx_to_blk(zap, idx, &blk) != 0)
 		return;
-	bs = FZAP_BLOCK_SHIFT(zap);
+	int bs = FZAP_BLOCK_SHIFT(zap);
 	dmu_prefetch(zap->zap_objset, zap->zap_object, 0, blk << bs, 1 << bs,
 	    ZIO_PRIORITY_SYNC_READ);
 }
@@ -1003,8 +977,8 @@ zap_create_link_dnsize(objset_t *os, dmu_object_type_t ot, uint64_t parent_obj,
 {
 	uint64_t new_obj;
 
-	VERIFY((new_obj = zap_create_dnsize(os, ot, DMU_OT_NONE, 0,
-	    dnodesize, tx)) > 0);
+	new_obj = zap_create_dnsize(os, ot, DMU_OT_NONE, 0, dnodesize, tx);
+	VERIFY(new_obj != 0);
 	VERIFY0(zap_add(os, parent_obj, name, sizeof (uint64_t), 1, &new_obj,
 	    tx));
 
@@ -1016,13 +990,12 @@ zap_value_search(objset_t *os, uint64_t zapobj, uint64_t value, uint64_t mask,
     char *name)
 {
 	zap_cursor_t zc;
-	zap_attribute_t *za;
 	int err;
 
 	if (mask == 0)
 		mask = -1ULL;
 
-	za = kmem_alloc(sizeof (zap_attribute_t), KM_SLEEP);
+	zap_attribute_t *za = kmem_alloc(sizeof (*za), KM_SLEEP);
 	for (zap_cursor_init(&zc, os, zapobj);
 	    (err = zap_cursor_retrieve(&zc, za)) == 0;
 	    zap_cursor_advance(&zc)) {
@@ -1032,7 +1005,7 @@ zap_value_search(objset_t *os, uint64_t zapobj, uint64_t value, uint64_t mask,
 		}
 	}
 	zap_cursor_fini(&zc);
-	kmem_free(za, sizeof (zap_attribute_t));
+	kmem_free(za, sizeof (*za));
 	return (err);
 }
 
@@ -1040,23 +1013,23 @@ int
 zap_join(objset_t *os, uint64_t fromobj, uint64_t intoobj, dmu_tx_t *tx)
 {
 	zap_cursor_t zc;
-	zap_attribute_t za;
-	int err;
+	int err = 0;
 
-	err = 0;
+	zap_attribute_t *za = kmem_alloc(sizeof (*za), KM_SLEEP);
 	for (zap_cursor_init(&zc, os, fromobj);
-	    zap_cursor_retrieve(&zc, &za) == 0;
+	    zap_cursor_retrieve(&zc, za) == 0;
 	    (void) zap_cursor_advance(&zc)) {
-		if (za.za_integer_length != 8 || za.za_num_integers != 1) {
+		if (za->za_integer_length != 8 || za->za_num_integers != 1) {
 			err = SET_ERROR(EINVAL);
 			break;
 		}
-		err = zap_add(os, intoobj, za.za_name,
-		    8, 1, &za.za_first_integer, tx);
-		if (err)
+		err = zap_add(os, intoobj, za->za_name,
+		    8, 1, &za->za_first_integer, tx);
+		if (err != 0)
 			break;
 	}
 	zap_cursor_fini(&zc);
+	kmem_free(za, sizeof (*za));
 	return (err);
 }
 
@@ -1065,23 +1038,23 @@ zap_join_key(objset_t *os, uint64_t fromobj, uint64_t intoobj,
     uint64_t value, dmu_tx_t *tx)
 {
 	zap_cursor_t zc;
-	zap_attribute_t za;
-	int err;
+	int err = 0;
 
-	err = 0;
+	zap_attribute_t *za = kmem_alloc(sizeof (*za), KM_SLEEP);
 	for (zap_cursor_init(&zc, os, fromobj);
-	    zap_cursor_retrieve(&zc, &za) == 0;
+	    zap_cursor_retrieve(&zc, za) == 0;
 	    (void) zap_cursor_advance(&zc)) {
-		if (za.za_integer_length != 8 || za.za_num_integers != 1) {
+		if (za->za_integer_length != 8 || za->za_num_integers != 1) {
 			err = SET_ERROR(EINVAL);
 			break;
 		}
-		err = zap_add(os, intoobj, za.za_name,
+		err = zap_add(os, intoobj, za->za_name,
 		    8, 1, &value, tx);
 		if (err != 0)
 			break;
 	}
 	zap_cursor_fini(&zc);
+	kmem_free(za, sizeof (*za));
 	return (err);
 }
 
@@ -1090,29 +1063,29 @@ zap_join_increment(objset_t *os, uint64_t fromobj, uint64_t intoobj,
     dmu_tx_t *tx)
 {
 	zap_cursor_t zc;
-	zap_attribute_t za;
-	int err;
+	int err = 0;
 
-	err = 0;
+	zap_attribute_t *za = kmem_alloc(sizeof (*za), KM_SLEEP);
 	for (zap_cursor_init(&zc, os, fromobj);
-	    zap_cursor_retrieve(&zc, &za) == 0;
+	    zap_cursor_retrieve(&zc, za) == 0;
 	    (void) zap_cursor_advance(&zc)) {
 		uint64_t delta = 0;
 
-		if (za.za_integer_length != 8 || za.za_num_integers != 1) {
+		if (za->za_integer_length != 8 || za->za_num_integers != 1) {
 			err = SET_ERROR(EINVAL);
 			break;
 		}
 
-		err = zap_lookup(os, intoobj, za.za_name, 8, 1, &delta);
+		err = zap_lookup(os, intoobj, za->za_name, 8, 1, &delta);
 		if (err != 0 && err != ENOENT)
 			break;
-		delta += za.za_first_integer;
-		err = zap_update(os, intoobj, za.za_name, 8, 1, &delta, tx);
-		if (err)
+		delta += za->za_first_integer;
+		err = zap_update(os, intoobj, za->za_name, 8, 1, &delta, tx);
+		if (err != 0)
 			break;
 	}
 	zap_cursor_fini(&zc);
+	kmem_free(za, sizeof (*za));
 	return (err);
 }
 
@@ -1177,12 +1150,11 @@ zap_increment(objset_t *os, uint64_t obj, const char *name, int64_t delta,
     dmu_tx_t *tx)
 {
 	uint64_t value = 0;
-	int err;
 
 	if (delta == 0)
 		return (0);
 
-	err = zap_lookup(os, obj, name, 8, 1, &value);
+	int err = zap_lookup(os, obj, name, 8, 1, &value);
 	if (err != 0 && err != ENOENT)
 		return (err);
 	value += delta;
@@ -1286,7 +1258,6 @@ again:
 static void
 zap_stats_ptrtbl(zap_t *zap, uint64_t *tbl, int len, zap_stats_t *zs)
 {
-	int i, err;
 	uint64_t lastblk = 0;
 
 	/*
@@ -1294,14 +1265,14 @@ zap_stats_ptrtbl(zap_t *zap, uint64_t *tbl, int len, zap_stats_t *zs)
 	 * can hold, then it'll be accounted for more than once, since
 	 * we won't have lastblk.
 	 */
-	for (i = 0; i < len; i++) {
+	for (int i = 0; i < len; i++) {
 		zap_leaf_t *l;
 
 		if (tbl[i] == lastblk)
 			continue;
 		lastblk = tbl[i];
 
-		err = zap_get_leaf_byblk(zap, tbl[i], NULL, RW_READER, &l);
+		int err = zap_get_leaf_byblk(zap, tbl[i], NULL, RW_READER, &l);
 		if (err == 0) {
 			zap_leaf_stats(zap, l, zs);
 			zap_put_leaf(l);
@@ -1341,14 +1312,12 @@ fzap_get_stats(zap_t *zap, zap_stats_t *zs)
 		zap_stats_ptrtbl(zap, &ZAP_EMBEDDED_PTRTBL_ENT(zap, 0),
 		    1 << ZAP_EMBEDDED_PTRTBL_SHIFT(zap), zs);
 	} else {
-		int b;
-
 		dmu_prefetch(zap->zap_objset, zap->zap_object, 0,
 		    zap_f_phys(zap)->zap_ptrtbl.zt_blk << bs,
 		    zap_f_phys(zap)->zap_ptrtbl.zt_numblks << bs,
 		    ZIO_PRIORITY_SYNC_READ);
 
-		for (b = 0; b < zap_f_phys(zap)->zap_ptrtbl.zt_numblks;
+		for (int b = 0; b < zap_f_phys(zap)->zap_ptrtbl.zt_numblks;
 		    b++) {
 			dmu_buf_t *db;
 			int err;


### PR DESCRIPTION
### Description

9328 zap code can take advantage of c99
9329 panic in zap_leaf_lookup() due to concurrent zapification

### Motivation and Context

Track OpenZFS fixes.

### How Has This Been Tested?

Locally built.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.