### PR TITLE
OpenZFS 9245 - zfs-test failures: slog_013_pos and slog_014_pos

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2152,6 +2152,25 @@ function is_pool_removed #pool
 	return $?
 }
 
+function wait_for_degraded
+{
+	typeset pool=$1
+	typeset timeout=${2:-30}
+	typeset t0=$SECONDS
+
+	while :; do
+		[[ $(get_pool_prop health $pool) == "DEGRADED" ]] && break
+		log_note "$pool is not yet degraded."
+		sleep 1
+		if ((SECONDS - t0 > $timeout)); then
+			log_note "$pool not degraded after $timeout seconds."
+			return 1
+		fi
+	done
+
+	return 0
+}
+
 #
 # Use create_pool()/destroy_pool() to clean up the information in
 # in the given disk to avoid slice overlapping.

--- a/tests/zfs-tests/tests/functional/slog/slog.kshlib
+++ b/tests/zfs-tests/tests/functional/slog/slog.kshlib
@@ -33,12 +33,8 @@
 
 function cleanup
 {
-	if datasetexists $TESTPOOL ; then
-		log_must zpool destroy -f $TESTPOOL
-	fi
-	if datasetexists $TESTPOOL2 ; then
-		log_must zpool destroy -f $TESTPOOL2
-	fi
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	poolexists $TESTPOOL2 && destroy_pool $TESTPOOL2
 	rm -rf $TESTDIR
 }
 

--- a/tests/zfs-tests/tests/functional/slog/slog_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_014_pos.ksh
@@ -45,10 +45,8 @@ verify_runnable "global"
 
 log_assert "log device can survive when one of the pool device get corrupted."
 
-for type in "mirror" "raidz" "raidz2"
-do
-	for spare in "" "spare"
-	do
+for type in "mirror" "raidz" "raidz2"; do
+	for spare in "" "spare"; do
 		log_must zpool create $TESTPOOL $type $VDEV $spare $SDEV \
 			log $LDEV
 
@@ -64,14 +62,8 @@ do
 		fi
 		log_must zpool scrub $TESTPOOL
 		log_must display_status $TESTPOOL
-		log_must zpool status $TESTPOOL 2>&1 >/dev/null
 		log_must zpool offline $TESTPOOL $VDIR/a
-
-		zpool status -v $TESTPOOL | \
-			grep "state: DEGRADED" 2>&1 >/dev/null
-		if (( $? != 0 )); then
-			log_fail "pool $TESTPOOL status should be DEGRADED"
-		fi
+		log_must wait_for_degraded $TESTPOOL
 
 		zpool status -v $TESTPOOL | grep logs | \
 			grep "DEGRADED" 2>&1 >/dev/null


### PR DESCRIPTION
### Description

Test 13 would fail because of attempts to zpool destroy -f a pool that
was still busy. Changed those calls to destroy_pool which does a retry
loop, and the problem is no longer reproducible. Also removed some non
functional code in the test which is why it was originally commented out
by placing it after the call to log_pass.

Test 14 would fail because sometimes the check for a degraded pool would
complete before the pool had changed state. Changed the logic to check
in a loop with a timeout and the problem is no longer reproducible.

### Motivation and Context

OpenZFS-issue: https://illumos.org/issues/9245
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/8f323b5

### How Has This Been Tested?

Local ZTS run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
