### PR TITLE
Add rwsem_tryupgrade for 4.9.20-rt16 kernel

### DIFF
--- a/include/spl/sys/rwlock.h
+++ b/include/spl/sys/rwlock.h
@@ -172,7 +172,7 @@ RW_LOCK_HELD(krwlock_t *rwp)
 }
 
 /*
- * The following functions must be a #define	and not static inline.
+ * The following functions must be a #define and not static inline.
  * This ensures that the native linux semaphore functions (down/up)
  * will be correctly located in the users code which is important
  * for the built in kernel lock analysis tools
@@ -188,10 +188,10 @@ RW_LOCK_HELD(krwlock_t *rwp)
 	spl_rw_set_type(rwp, type);					\
 })
 
-#define	rw_destroy(rwp)							\
-({									\
-	VERIFY(!RW_LOCK_HELD(rwp));					\
-})
+/*
+ * The Linux rwsem implementation does not require a matching destroy.
+ */
+#define	rw_destroy(rwp)		((void) 0)
 
 #define	rw_tryenter(rwp, rw)						\
 ({									\

--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -744,7 +744,7 @@ vn_file_cache_destructor(void *buf, void *cdrarg)
 int
 spl_vn_init(void)
 {
-	vn_file_lock = __SPIN_LOCK_UNLOCKED(vn_file_lock);
+	spin_lock_init(&vn_file_lock);
 
 	vn_cache = kmem_cache_create("spl_vn_cache",
 	    sizeof (struct vnode), 64, vn_cache_constructor,


### PR DESCRIPTION
### Description

The RT rwsem implementation was changed to allow multiple readers
as of the 4.9.20-rt16 patch set.  This results in a build failure
because the existing implementation was forced to directly access
the rwsem strucgture which has changed.

While this could be accommodated by adding additional compatibility
code.  This patch resolves the build issue by simply assuming the
rwsem can never be upgraded.  This functionality is a performance
optimization and all callers must already handle this case.

### Motivation and Context

zfsonlinux/spl#611

### How Has This Been Tested?

Locally built, which isn't saying much.  But it should work @clefru, @kernelOfTruth, or @steven-omaha would you be able to test that this resolves the build issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
