### PR TITLE
ZTS: history path cleanup

### DIFF
--- a/tests/zfs-tests/tests/functional/history/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/history/cleanup.ksh
@@ -31,8 +31,6 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-[[ -f $OLD_HISTORY ]] && rm -f $OLD_HISTORY
-[[ -f $TMP_HISTORY ]] && rm -f $TMP_HISTORY
-[[ -f $NEW_HISTORY ]] && rm -f $NEW_HISTORY
+rm -f $TEST_BASE_DIR/{old,tmp,new}_history.*
 
 default_cleanup

--- a/tests/zfs-tests/tests/functional/history/history.cfg
+++ b/tests/zfs-tests/tests/functional/history/history.cfg
@@ -32,9 +32,9 @@ export ZFSROOT=
 
 export MPOOL=mpool.$$
 
-export OLD_HISTORY=/tmp/old_history.$$
-export TMP_HISTORY=/tmp/tmp_history.$$
-export NEW_HISTORY=/tmp/new_history.$$
+export OLD_HISTORY=$TEST_BASE_DIR/old_history.$$
+export TMP_HISTORY=$TEST_BASE_DIR/tmp_history.$$
+export NEW_HISTORY=$TEST_BASE_DIR/new_history.$$
 
 export MIGRATEDPOOLNAME=${MIGRATEDPOOLNAME:-history_pool}
 export TIMEZONE=${TIMEZONE:-US/Mountain}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
History tests were hard coded to use /tmp and didn't clean up
properly after testing.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Further cleanup of /tmp

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Local testbot

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [x] Change has been approved by a ZFS on Linux member.
