### PR TITLE
copy-builtin: SPL must be in Kbuild first

### DIFF
--- a/copy-builtin
+++ b/copy-builtin
@@ -12,9 +12,11 @@ usage()
 KERNEL_DIR="$(readlink --canonicalize-existing "$1")"
 
 MODULES=()
+MODULES+="spl"
 for MODULE_DIR in module/*
 do
 	[ -d "$MODULE_DIR" ] || continue
+	[ "spl" = "${MODULE_DIR##*/}" ] && continue
 	MODULES+=("${MODULE_DIR##*/}")
 done
 


### PR DESCRIPTION
### Description
We modify copy-builtin to move spl to the start of Kbuild so that the kernel initializes it first.

### Motivation and Context
The recent SPL merge caused a regression in kernels with ZFS integrated
into the sources where our modules would be initialized in alphabetical
order, despite icp requiring the spl module be loaded first. This caused
kernels with ZFS builtin to fail to boot.

We resolve this by adding a special case for the spl that lists it
first. It is somewhat ugly, but it works.

### How Has This Been Tested?

I reproduced the issue using this script to make a Gentoo VM with / and /boot on ZFS that built ZFS into the kernel:

https://dev.gentoo.org/~ryao/make-gentoo-vm-kernel-builtin.sh

I then ran these commands to verify my fix worked:

```
# Get a root shell
sudo -i

# Find testpool's GUID
zpool import

# Import test pool
zpool import -R /tmp/tpool -t 8101631507272313703 tpool

# Copy patched file
cp /home/richard/devel/zfs/copy-builtin /tmp/tpool/var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/

# Start mount namespace and pivot_root into it, mounting the various things that tools need mounted.
unshare -m /bin/bash
pivot_root /tmp/tpool{,/tmp}
mount --rbind {/tmp,}/dev
mount --rbind {/tmp,}/sys
mount -t proc none /proc
umount -l /tmp

# Get a fresh shell and set PS1 so that I don't get confused and think it is a shell from my actual system.
exec bash
PS1="(gentoo-zfs) $PS1"

# Run the script and rebuild the initramfs
cd /tmp/tpool/var/tmp/portage/sys-fs/zfs-kmod-9999/work/zfs-kmod-9999/
./copy-builtin /usr/src/linux
genkernel all --makeopts=-j8 --no-clean --no-strip --no-mountboot --zfs --bootloader=grub2 --no-compress-initramfs

# Leave mount namespace environment
exit

# Export the pool and flush the page cache (XXX: Why didn't invalidate_bdev() handle this?)
zpool export tpool
echo 1 > /proc/sys/vm/drop_caches

# Set permissions for my user account on the zvol device and exit the root shell
chown richard:richard $(readlink /dev/zvol/rpool/test)
exit

# Watch QEMU boot
qemu-system-x86_64 --enable-kvm -smp 8,cores=4,threads=2,sockets=1 -cpu host -m 1024 -device ahci,id=ide -device ide-drive,bus=ide.2,drive=HDD -drive file=$(readlink /dev/zvol/rpool/test),id=HDD,if=none -serial mon:stdio
```

This confirmed that my change worked.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [x] Change has been approved by a ZFS on Linux member.
