### PR TITLE
Minor documentation, logging, and testing typos

### DIFF
--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -29,7 +29,7 @@ FSLIST="@sysconfdir@/zfs/zfs-list.cache"
 [ -d "${FSLIST}" ] || exit 0
 
 do_fail() {
-  printf 'zfs-mount-generator.sh: %s\n' "$*" > /dev/kmsg
+  printf 'zfs-mount-generator: %s\n' "$*" > /dev/kmsg
   exit 1
 }
 
@@ -103,13 +103,13 @@ process_line() {
     elif [ "${p_relatime}" = off ] ; then
       opts="${opts},atime,strictatime"
     else
-      printf 'zfs-mount-generator.sh: (%s) invalid relatime\n' \
+      printf 'zfs-mount-generator: (%s) invalid relatime\n' \
         "${dataset}" >/dev/kmsg
     fi
   elif [ "${p_atime}" = off ] ; then
     opts="${opts},noatime"
   else
-    printf 'zfs-mount-generator.sh: (%s) invalid atime\n' \
+    printf 'zfs-mount-generator: (%s) invalid atime\n' \
       "${dataset}" >/dev/kmsg
   fi
 
@@ -119,7 +119,7 @@ process_line() {
   elif [ "${p_devices}" = off ] ; then
     opts="${opts},nodev"
   else
-    printf 'zfs-mount-generator.sh: (%s) invalid devices\n' \
+    printf 'zfs-mount-generator: (%s) invalid devices\n' \
       "${dataset}" >/dev/kmsg
   fi
 
@@ -129,7 +129,7 @@ process_line() {
   elif [ "${p_exec}" = off ] ; then
     opts="${opts},noexec"
   else
-    printf 'zfs-mount-generator.sh: (%s) invalid exec\n' \
+    printf 'zfs-mount-generator: (%s) invalid exec\n' \
       "${dataset}" >/dev/kmsg
   fi
 
@@ -139,7 +139,7 @@ process_line() {
   elif [ "${p_readonly}" = off ] ; then
     opts="${opts},rw"
   else
-    printf 'zfs-mount-generator.sh: (%s) invalid readonly\n' \
+    printf 'zfs-mount-generator: (%s) invalid readonly\n' \
       "${dataset}" >/dev/kmsg
   fi
 
@@ -149,7 +149,7 @@ process_line() {
   elif [ "${p_setuid}" = off ] ; then
     opts="${opts},nosuid"
   else
-    printf 'zfs-mount-generator.sh: (%s) invalid setuid\n' \
+    printf 'zfs-mount-generator: (%s) invalid setuid\n' \
       "${dataset}" >/dev/kmsg
   fi
 
@@ -159,13 +159,13 @@ process_line() {
   elif [ "${p_nbmand}" = off ] ; then
     opts="${opts},nomand"
   else
-    printf 'zfs-mount-generator.sh: (%s) invalid nbmand\n' \
+    printf 'zfs-mount-generator: (%s) invalid nbmand\n' \
       "${dataset}" >/dev/kmsg
   fi
 
   # If the mountpoint has already been created, give it precedence.
   if [ -e "${dest_norm}/${mountfile}" ] ; then
-    printf 'zfs-mount-generator.sh: %s already exists\n' "${mountfile}" \
+    printf 'zfs-mount-generator: %s already exists\n' "${mountfile}" \
       >/dev/kmsg
     return
   fi

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1444,9 +1444,9 @@ Controls where the user's encryption key will be loaded from by default for
 commands such as
 .Nm zfs Cm load-key
 and
-.Nm zfs Cm mount Cm -l . This property is
-only set for encrypted datasets which are encryption roots. If unspecified, the
-default is
+.Nm zfs Cm mount Cm -l .
+This property is only set for encrypted datasets which are encryption roots. If
+unspecified, the default is
 .Sy prompt.
 .Pp
 Even though the encryption suite cannot be changed after dataset creation, the
@@ -2799,9 +2799,8 @@ property is
 .Po the default is
 .Sy off
 .Pc .
-The following fields are displayed,
-.Sy name Ns \&, Ns Sy used Ns \&, Ns Sy available Ns \&, Ns Sy referenced Ns \&, Ns
-.Sy mountpoint .
+The following fields are displayed:
+.Sy name Ns \&, Sy used Ns \&, Sy available Ns \&, Sy referenced Ns \&, Sy mountpoint Ns .
 .Bl -tag -width "-H"
 .It Fl H
 Used for scripting mode.

--- a/tests/zfs-tests/tests/perf/regression/random_writes_zil.ksh
+++ b/tests/zfs-tests/tests/perf/regression/random_writes_zil.ksh
@@ -1,4 +1,4 @@
-#!/usr/bin/ksh
+#!/bin/ksh
 
 #
 # This file and its contents are supplied under the terms of the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
This patch collects some minor inconsistencies and typos in the documentation, logging and testing infrastructure.

The path to ksh is made consistent, and changed to `/bin/ksh` in one test unit.

### Motivation and Context
cleanup

### How Has This Been Tested?
The man pages were tested by inspection. The change to the path to ksh matches convention in the other test units.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
