### PR TITLE
Fix preemptible warning in aggsum_add()

### DIFF
--- a/module/zfs/aggsum.c
+++ b/module/zfs/aggsum.c
@@ -183,8 +183,11 @@ aggsum_borrow(aggsum_t *as, int64_t delta, struct aggsum_bucket *asb)
 void
 aggsum_add(aggsum_t *as, int64_t delta)
 {
-	struct aggsum_bucket *asb =
-	    &as->as_buckets[CPU_SEQID % as->as_numbuckets];
+	struct aggsum_bucket *asb;
+
+	kpreempt_disable();
+	asb = &as->as_buckets[CPU_SEQID % as->as_numbuckets];
+	kpreempt_enable();
 
 	for (;;) {
 		mutex_enter(&asb->asc_lock);


### PR DESCRIPTION
### Description

In the new aggsum counters the CPU_SEQID macro should be surrounded by
kpreempt_disable)() and kpreempt_enable() calls to prevent a Linux
kernel BUG warning.  The addsum_add() function use the cpuid to
minimize lock contention when selecting a bucket, after selection
the bucket is protected by a mutex and it is safe to reschedule the
process to a different processor at any time.

### Motivation and Context

Issue #7609

### How Has This Been Tested?

Locally built.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
