### PR TITLE
Add pyzfs build directories to gitignore

### DIFF
--- a/contrib/pyzfs/.gitignore
+++ b/contrib/pyzfs/.gitignore
@@ -1,0 +1,2 @@
+build
+pyzfs.egg-info

--- a/contrib/pyzfs/Makefile.am
+++ b/contrib/pyzfs/Makefile.am
@@ -32,6 +32,7 @@ install-exec-local:
 	--verbose
 
 clean:	clean-local
+	rm -rf build/ pyzfs.egg-info/
 
 clean-local:
 


### PR DESCRIPTION
The recent addition of pyzfs do not include the generated 'build'
and 'pyzfs.egg-info' directories in the pyzfs .gitignore. This
patch simply corrects this problem.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
