### PR TITLE
Tests delete home directories in /export/home

### DIFF
--- a/tests/zfs-tests/tests/functional/privilege/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/cleanup.ksh
@@ -31,9 +31,15 @@
 
 . $STF_SUITE/include/libtest.shlib
 
+if is_linux; then
+	log_unsupported "Privilege tests require pfexec command"
+fi
+
 verify_runnable "global"
 
 ZFS_USER=$(cat /tmp/zfs-privs-test-user.txt)
+[[ -z $ZFS_USER ]] && log_fail "no ZFS_USER found"
+
 USES_NIS=$(cat /tmp/zfs-privs-test-nis.txt)
 
 if [ "${USES_NIS}" == "true" ]


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
In the cleanup for the privilege tests, an empty variable, empty because the corresponding setup is skipped on Linux, results in `/export/home` being deleted. This patch adds an assertion that the variable is not empty, and causes the cleanup to be skipped on Linux as well.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This prevents home directories in `/export/home/` from being deleted by running zfs tests.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

```
$ ./scripts/zfs-tests.sh -T privilege
Test: /export/home/delphix/zfs/tests/zfs-tests/tests/functional/privilege/setup (run as root) [00:00] [SKIP]
Test: /export/home/delphix/zfs/tests/zfs-tests/tests/functional/privilege/privilege_001_pos (run as root) [00:00] [SKIP]
Test: /export/home/delphix/zfs/tests/zfs-tests/tests/functional/privilege/privilege_002_pos (run as root) [00:00] [SKIP]
Test: /export/home/delphix/zfs/tests/zfs-tests/tests/functional/privilege/cleanup (run as root) [00:00] [SKIP]

Results Summary
SKIP	   4

Running Time:	00:00:00
Percent passed:	0.0%
Log directory:	/var/tmp/test_results/20180608T180339
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
