### PR TITLE
Add tunables for channel programs

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
  * Copyright 2012 Milan Jurik. All rights reserved.
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
  * Copyright (c) 2013 Steven Hartland.  All rights reserved.
@@ -7308,24 +7308,10 @@ zfs_do_channel_program(int argc, char **argv)
 			}
 
 			if (c == 't') {
-				if (arg > ZCP_MAX_INSTRLIMIT || arg == 0) {
-					(void) fprintf(stderr, gettext(
-					    "Invalid instruction limit: "
-					    "%s\n"), optarg);
-					return (1);
-				} else {
-					instrlimit = arg;
-				}
+				instrlimit = arg;
 			} else {
 				ASSERT3U(c, ==, 'm');
-				if (arg > ZCP_MAX_MEMLIMIT || arg == 0) {
-					(void) fprintf(stderr, gettext(
-					    "Invalid memory limit: "
-					    "%s\n"), optarg);
-					return (1);
-				} else {
-					memlimit = arg;
-				}
+				memlimit = arg;
 			}
 			break;
 		}

--- a/include/sys/zcp.h
+++ b/include/sys/zcp.h
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2016, 2018 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_ZCP_H
@@ -33,8 +33,8 @@ extern "C" {
 
 #define	ZCP_RUN_INFO_KEY "runinfo"
 
-extern uint64_t zfs_lua_max_instrlimit;
-extern uint64_t zfs_lua_max_memlimit;
+extern unsigned long zfs_lua_max_instrlimit;
+extern unsigned long zfs_lua_max_memlimit;
 
 int zcp_argerror(lua_State *, int, const char *, ...);
 

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1,6 +1,7 @@
 '\" te
 .\" Copyright (c) 2013 by Turbo Fredriksson <turbo@bayour.com>. All rights reserved.
 .\" Copyright (c) 2017 Datto Inc.
+.\" Copyright (c) 2018 by Delphix. All rights reserved.
 .\" The contents of this file are subject to the terms of the Common Development
 .\" and Distribution License (the "License").  You may not use this file except
 .\" in compliance with the License. You can obtain a copy of the license at
@@ -1558,6 +1559,30 @@ Largest data block to write to zil. Larger blocks will be treated as if the
 dataset being written to had the property setting \fBlogbias=throughput\fR.
 .sp
 Default value: \fB32,768\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_lua_max_instrlimit\fR (ulong)
+.ad
+.RS 12n
+The maximum execution time limit that can be set for a ZFS channel program,
+specified as a number of Lua instructions.
+.sp
+Default value: \fB100,000,000\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_lua_max_memlimit\fR (ulong)
+.ad
+.RS 12n
+The maximum memory limit that can be set for a ZFS channel program, specified
+in bytes.
+.sp
+Default value: \fB104,857,600\fR.
 .RE
 
 .sp

--- a/module/zfs/zcp.c
+++ b/module/zfs/zcp.c
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2016, 2018 by Delphix. All rights reserved.
  */
 
 /*
@@ -108,8 +108,8 @@
 #define	ZCP_NVLIST_MAX_DEPTH 20
 
 uint64_t zfs_lua_check_instrlimit_interval = 100;
-uint64_t zfs_lua_max_instrlimit = ZCP_MAX_INSTRLIMIT;
-uint64_t zfs_lua_max_memlimit = ZCP_MAX_MEMLIMIT;
+unsigned long zfs_lua_max_instrlimit = ZCP_MAX_INSTRLIMIT;
+unsigned long zfs_lua_max_memlimit = ZCP_MAX_MEMLIMIT;
 
 /*
  * Forward declarations for mutually recursive functions
@@ -1417,3 +1417,15 @@ zcp_parse_args(lua_State *state, const char *fname, const zcp_arg_t *pargs,
 		zcp_parse_pos_args(state, fname, pargs, kwargs);
 	}
 }
+
+#if defined(_KERNEL)
+/* BEGIN CSTYLED */
+module_param(zfs_lua_max_instrlimit, ulong, 0644);
+MODULE_PARM_DESC(zfs_lua_max_instrlimit,
+	"Max instruction limit that can be specified for a channel program");
+
+module_param(zfs_lua_max_memlimit, ulong, 0644);
+MODULE_PARM_DESC(zfs_lua_max_memlimit,
+	"Max memory limit that can be specified for a channel program");
+/* END CSTYLED */
+#endif

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.memory_limit.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.memory_limit.ksh
@@ -61,12 +61,12 @@ log_mustnot_checkerror_program "Memory limit exhausted" -m 1 $TESTPOOL - <<-EOF
 	return s
 EOF
 
-log_mustnot_checkerror_program "Invalid memory limit" \
-    -m 1000000000000 $TESTPOOL - <<-EOF
+log_mustnot_checkerror_program "Invalid instruction or memory limit" \
+    -m 200000000 $TESTPOOL - <<-EOF
 	return 1;
 EOF
 
-log_mustnot_checkerror_program "Invalid memory limit" \
+log_mustnot_checkerror_program "Return value too large" \
     -m 9223372036854775808 $TESTPOOL - <<-EOF
 	return 1;
 EOF


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This patch adds tunables for modifying the maximum memory limit and maximum instruction limit that can be specified when running a channel program.

On Illumos, a channel program making use of increased limits has to be invoked through libzfs_core rather than by using the `zfs program` command, because the `zfs` command exits with an error if the limit specified is greater than the hard-coded default maximum. Because on Linux the tunables are officially documented, I wanted to make sure that if these tunables were modified, the additional time/memory could be used via the `zfs program` command, so I removed these checks from the command. Instead, we just rely on the checks in the kernel to reject programs which specify limits which are too large.

The only downside to this is that the error message when trying to run a program with a too-large limit becomes slightly less specific. Instead of
> Invalid memory limit: 200000000

we would now get
> Channel program execution failed:
> Invalid instruction or memory limit.

or, if the amount of memory specified was so large that a buffer for the return value couldn't be allocated
> Channel program execution failed:
> Return value too large.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This provides tunables equivalent to ones which exist on Illumos already.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Increased and decreased the tunables, and checked that the kernel correctly ran or rejected channel programs according to whether the limits specified were within or greater than the max limits.

```
$ ./scripts/zfs-tests.sh -T channel_program
...
Results Summary
PASS	  50

Running Time:	00:01:16
Percent passed:	100.0%
Log directory:	/var/tmp/test_results/20180609T233228
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
