### PR TITLE
Remove libefi __linux__ wrappers

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -42,9 +42,7 @@
 #include <sys/dktp/fdisk.h>
 #include <sys/efi_partition.h>
 #include <sys/byteorder.h>
-#if defined(__linux__)
 #include <linux/fs.h>
-#endif
 
 static struct uuid_to_ptag {
 	struct uuid	uuid;
@@ -213,7 +211,6 @@ read_disk_info(int fd, diskaddr_t *capacity, uint_t *lbsize)
 static int
 efi_get_info(int fd, struct dk_cinfo *dki_info)
 {
-#if defined(__linux__)
 	char *path;
 	char *dev_path;
 	int rval = 0;
@@ -331,10 +328,7 @@ efi_get_info(int fd, struct dk_cinfo *dki_info)
 	}
 
 	free(dev_path);
-#else
-	if (ioctl(fd, DKIOCINFO, (caddr_t)dki_info) == -1)
-		goto error;
-#endif
+
 	return (0);
 error:
 	if (efi_debug)
@@ -374,7 +368,6 @@ efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
 	if (read_disk_info(fd, &capacity, &lbsize) != 0)
 		return (-1);
 
-#if defined(__linux__)
 	if (efi_get_info(fd, &dki_info) != 0)
 		return (-1);
 
@@ -385,7 +378,6 @@ efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
 	    (dki_info.dki_ctype == DKC_VBD) ||
 	    (dki_info.dki_ctype == DKC_UNKNOWN))
 		return (-1);
-#endif
 
 	nblocks = NBLOCKS(nparts, lbsize);
 	if ((nblocks * lbsize) < EFI_MIN_ARRAY_SIZE + lbsize) {
@@ -481,7 +473,6 @@ efi_ioctl(int fd, int cmd, dk_efi_t *dk_ioc)
 {
 	void *data = dk_ioc->dki_data;
 	int error;
-#if defined(__linux__)
 	diskaddr_t capacity;
 	uint_t lbsize;
 
@@ -585,18 +576,13 @@ efi_ioctl(int fd, int cmd, dk_efi_t *dk_ioc)
 		errno = EIO;
 		return (-1);
 	}
-#else
-	dk_ioc->dki_data_64 = (uint64_t)(uintptr_t)data;
-	error = ioctl(fd, cmd, (void *)dk_ioc);
-	dk_ioc->dki_data = data;
-#endif
+
 	return (error);
 }
 
 int
 efi_rescan(int fd)
 {
-#if defined(__linux__)
 	int retry = 10;
 	int error;
 
@@ -609,7 +595,6 @@ efi_rescan(int fd)
 		}
 		usleep(50000);
 	}
-#endif
 
 	return (0);
 }


### PR DESCRIPTION
### Description

The ZoL version of libefi has been modified for Linux in several places outside the existing __linux__ wrappers.  Remove them to make the code easier to read and so as not to mislead anyone that these are the sole modifications for Linux.

### Motivation and Context

Code cleanup.

### How Has This Been Tested?

No functional change.  Locally built pending full ZTS run from the bots.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
