### PR TITLE
Linux 4.14 compat: blk_queue_stackable()

### DIFF
--- a/config/kernel-elevator-change.m4
+++ b/config/kernel-elevator-change.m4
@@ -1,6 +1,6 @@
 dnl #
-dnl # 2.6.36 API change
-dnl # Verify the elevator_change() symbol is available.
+dnl # 2.6.36 API, exported elevator_change() symbol
+dnl # 4.12 API, removed elevator_change() symbol
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_ELEVATOR_CHANGE], [
 	AC_MSG_CHECKING([whether elevator_change() is available])

--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -107,17 +107,6 @@ blk_queue_set_write_cache(struct request_queue *q, bool wc, bool fua)
 #endif
 
 /*
- * 2.6.27 API change,
- * The blk_queue_stackable() queue flag was added in 2.6.27 to handle dm
- * stacking drivers.  Prior to this request stacking drivers were detected
- * by checking (q->request_fn == NULL), for earlier kernels we revert to
- * this legacy behavior.
- */
-#ifndef blk_queue_stackable
-#define	blk_queue_stackable(q)	((q)->request_fn == NULL)
-#endif
-
-/*
  * 2.6.34 API change,
  * The blk_queue_max_hw_sectors() function replaces blk_queue_max_sectors().
  */


### PR DESCRIPTION
### Description

The `blk_queue_stackable()` function was replaced in the 4.14 kernel by `queue_is_rq_based()`, commit torvalds/linux@5fdee212.  This change resulted in the default elevator being used which can negatively
impact performance.

Rather than adding additional compatibility code to detect the new interface unconditionally attempt to set the elevator.  Since we expect this to fail for block devices without an elevator the error message has been moved in to `zfs_dbgmsg()`.

Finally, it was observed that the `elevator_change()` was removed from the 4.12 kernel, commit torvalds/linux@c033269.  Update the comment to clearly specify which are expected to export the
elevator_change() symbol.

### Motivation and Context

Setting the scheduler to noop is important to maintain good performance for many workloads.

### How Has This Been Tested?

Locally built, and expected performance improvement verified by @ahrens.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
