### PR TITLE
zfs receive -o / -x support for encryption properties

### DIFF
--- a/contrib/pyzfs/libzfs_core/bindings/libzfs_core.py
+++ b/contrib/pyzfs/libzfs_core/bindings/libzfs_core.py
@@ -108,9 +108,9 @@ CDEF = """
     int lzc_receive_resumable(const char *, nvlist_t *, const char *,
         boolean_t, boolean_t, int);
     int lzc_receive_with_cmdprops(const char *, nvlist_t *, nvlist_t *,
-        const char *, boolean_t, boolean_t, boolean_t, int,
-        const dmu_replay_record_t *, int, uint64_t *, uint64_t *, uint64_t *,
-        nvlist_t **);
+        uint8_t *, uint_t, const char *, boolean_t, boolean_t,
+        boolean_t, int, const dmu_replay_record_t *, int, uint64_t *,
+        uint64_t *, uint64_t *, nvlist_t **);
     int lzc_receive_with_header(const char *, nvlist_t *, const char *,
         boolean_t, boolean_t, boolean_t, int, const dmu_replay_record_t *);
     int lzc_release(nvlist_t *, nvlist_t **);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -527,7 +527,7 @@ extern nvlist_t *zfs_get_clones_nvl(zfs_handle_t *);
  */
 extern int zfs_crypto_get_encryption_root(zfs_handle_t *, boolean_t *, char *);
 extern int zfs_crypto_create(libzfs_handle_t *, char *, nvlist_t *, nvlist_t *,
-    uint8_t **, uint_t *);
+    boolean_t stdin_available, uint8_t **, uint_t *);
 extern int zfs_crypto_clone_check(libzfs_handle_t *, zfs_handle_t *, char *,
     nvlist_t *);
 extern int zfs_crypto_attempt_load_keys(libzfs_handle_t *, char *);

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -93,7 +93,7 @@ int lzc_receive_one(const char *, nvlist_t *, const char *, boolean_t,
     boolean_t, boolean_t, int, const struct dmu_replay_record *, int,
     uint64_t *, uint64_t *, uint64_t *, nvlist_t **);
 int lzc_receive_with_cmdprops(const char *, nvlist_t *, nvlist_t *,
-    const char *, boolean_t, boolean_t, boolean_t, int,
+    uint8_t *, uint_t, const char *, boolean_t, boolean_t, boolean_t, int,
     const struct dmu_replay_record *, int, uint64_t *, uint64_t *,
     uint64_t *, nvlist_t **);
 

--- a/include/sys/dmu_send.h
+++ b/include/sys/dmu_send.h
@@ -30,6 +30,7 @@
 #define	_DMU_SEND_H
 
 #include <sys/inttypes.h>
+#include <sys/dsl_crypt.h>
 #include <sys/spa.h>
 
 struct vnode;
@@ -72,8 +73,9 @@ typedef struct dmu_recv_cookie {
 } dmu_recv_cookie_t;
 
 int dmu_recv_begin(char *tofs, char *tosnap,
-    struct dmu_replay_record *drr_begin,
-    boolean_t force, boolean_t resumable, char *origin, dmu_recv_cookie_t *drc);
+    struct dmu_replay_record *drr_begin, boolean_t force, boolean_t resumable,
+    nvlist_t *localprops, nvlist_t *hidden_args, char *origin,
+    dmu_recv_cookie_t *drc);
 int dmu_recv_stream(dmu_recv_cookie_t *drc, struct vnode *vp, offset_t *voffp,
     int cleanup_fd, uint64_t *action_handlep);
 int dmu_recv_end(dmu_recv_cookie_t *drc, void *owner);

--- a/include/sys/dsl_crypt.h
+++ b/include/sys/dsl_crypt.h
@@ -202,7 +202,7 @@ int dsl_dataset_promote_crypt_check(dsl_dir_t *target, dsl_dir_t *origin);
 void dsl_dataset_promote_crypt_sync(dsl_dir_t *target, dsl_dir_t *origin,
     dmu_tx_t *tx);
 int dmu_objset_create_crypt_check(dsl_dir_t *parentdd,
-    dsl_crypto_params_t *dcp);
+    dsl_crypto_params_t *dcp, boolean_t *will_encrypt);
 void dsl_dataset_create_crypt_sync(uint64_t dsobj, dsl_dir_t *dd,
     struct dsl_dataset *origin, dsl_crypto_params_t *dcp, dmu_tx_t *tx);
 uint64_t dsl_crypto_key_create_sync(uint64_t crypt, dsl_wrapping_key_t *wkey,

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -3731,8 +3731,8 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 	}
 
 	(void) parent_name(path, parent, sizeof (parent));
-	if (zfs_crypto_create(hdl, parent, props, NULL, &wkeydata,
-	    &wkeylen) != 0) {
+	if (zfs_crypto_create(hdl, parent, props, NULL, B_TRUE,
+	    &wkeydata, &wkeylen) != 0) {
 		nvlist_free(props);
 		return (zfs_error(hdl, EZFS_CRYPTOFAILED, errbuf));
 	}

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -1224,7 +1224,7 @@ zpool_create(libzfs_handle_t *hdl, const char *pool, nvlist_t *nvroot,
 		    (nvlist_alloc(&zc_props, NV_UNIQUE_NAME, 0) != 0)) {
 			goto create_failed;
 		}
-		if (zfs_crypto_create(hdl, NULL, zc_fsprops, props,
+		if (zfs_crypto_create(hdl, NULL, zc_fsprops, props, B_TRUE,
 		    &wkeydata, &wkeylen) != 0) {
 			zfs_error(hdl, EZFS_CRYPTOFAILED, msg);
 			goto create_failed;

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -3912,6 +3912,34 @@ results if the same property is specified in multiple
 or
 .Fl x
 options.
+.Pp
+The
+.Fl o
+option may also be used to override encryption properties upon initial
+receive. This allows unencrypted streams to be received as encrypted datasets.
+To cause the received dataset (or root dataset of a recursive stream) to be
+received as an encryption root, specify encryption properties in the same
+manner as is required for
+.Nm
+.Cm create .
+For instance:
+.Bd -literal
+# zfs send tank/test@snap1 | zfs recv -o encryption=on -o keyformat=passphrase -o keylocation=file:///path/to/keyfile
+.Ed
+.Pp
+Note that
+.Op Fl o Ar keylocation Ns = Ns Ar prompt
+may not be specified here, since stdin is already being utilized for the send
+stream. Once the receive has completed, you can use
+.Nm
+.Cm set
+to change this setting after the fact. Similarly, you can receive a dataset as
+an encrypted child by specifying
+.Op Fl x Ar encryption
+to force the property to be inherited. Overriding encryption properties (except
+for
+.Sy keylocation Ns )
+is not possible with raw send streams.
 .It Fl s
 If the receive is interrupted, save the partially received state, rather
 than deleting it.

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1118,7 +1118,7 @@ dmu_objset_create_check(void *arg, dmu_tx_t *tx)
 		return (SET_ERROR(EEXIST));
 	}
 
-	error = dmu_objset_create_crypt_check(pdd, doca->doca_dcp);
+	error = dmu_objset_create_crypt_check(pdd, doca->doca_dcp, NULL);
 	if (error != 0) {
 		dsl_dir_rele(pdd, FTAG);
 		return (error);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -1526,18 +1526,17 @@ typedef struct dmu_recv_begin_arg {
 	const char *drba_origin;
 	dmu_recv_cookie_t *drba_cookie;
 	cred_t *drba_cred;
+	dsl_crypto_params_t *drba_dcp;
 	uint64_t drba_snapobj;
 } dmu_recv_begin_arg_t;
 
 static int
 recv_begin_check_existing_impl(dmu_recv_begin_arg_t *drba, dsl_dataset_t *ds,
-    uint64_t fromguid)
+    uint64_t fromguid, uint64_t featureflags)
 {
 	uint64_t val;
 	int error;
 	dsl_pool_t *dp = ds->ds_dir->dd_pool;
-	struct drr_begin *drrb = drba->drba_cookie->drc_drrb;
-	uint64_t featureflags = DMU_GET_FEATUREFLAGS(drrb->drr_versioninfo);
 	boolean_t encrypted = ds->ds_dir->dd_crypto_obj != 0;
 	boolean_t raw = (featureflags & DMU_BACKUP_FEATURE_RAW) != 0;
 
@@ -1624,6 +1623,13 @@ recv_begin_check_existing_impl(dmu_recv_begin_arg_t *drba, dsl_dataset_t *ds,
 		if ((!encrypted && raw) || encrypted)
 			return (SET_ERROR(EINVAL));
 
+		if ((featureflags & DMU_BACKUP_FEATURE_RAW) == 0) {
+			error = dmu_objset_create_crypt_check(
+			    ds->ds_dir->dd_parent, drba->drba_dcp);
+			if (error != 0)
+				return (error);
+		}
+
 		drba->drba_snapobj = 0;
 	}
 
@@ -1690,7 +1696,7 @@ dmu_recv_begin_check(void *arg, dmu_tx_t *tx)
 	    !spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_LARGE_DNODE))
 		return (SET_ERROR(ENOTSUP));
 
-	if ((featureflags & DMU_BACKUP_FEATURE_RAW)) {
+	if (featureflags & DMU_BACKUP_FEATURE_RAW) {
 		/* raw receives require the encryption feature */
 		if (!spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_ENCRYPTION))
 			return (SET_ERROR(ENOTSUP));
@@ -1708,7 +1714,8 @@ dmu_recv_begin_check(void *arg, dmu_tx_t *tx)
 			return (SET_ERROR(EINVAL));
 		}
 
-		error = recv_begin_check_existing_impl(drba, ds, fromguid);
+		error = recv_begin_check_existing_impl(drba, ds, fromguid,
+		    featureflags);
 		dsl_dataset_rele_flags(ds, dsflags, FTAG);
 	} else if (error == ENOENT) {
 		/* target fs does not exist; must be a full backup or clone */
@@ -1737,6 +1744,16 @@ dmu_recv_begin_check(void *arg, dmu_tx_t *tx)
 		error = dsl_dataset_hold_flags(dp, buf, dsflags, FTAG, &ds);
 		if (error != 0)
 			return (error);
+
+		if ((featureflags & DMU_BACKUP_FEATURE_RAW) == 0 &&
+		    drba->drba_origin == NULL) {
+			error = dmu_objset_create_crypt_check(ds->ds_dir,
+			    drba->drba_dcp);
+			if (error != 0) {
+				dsl_dataset_rele_flags(ds, dsflags, FTAG);
+				return (error);
+			}
+		}
 
 		/*
 		 * Check filesystem and snapshot limits before receiving. We'll
@@ -1801,15 +1818,27 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 	ds_hold_flags_t dsflags = 0;
 	int error;
 	uint64_t crflags = 0;
-	dsl_crypto_params_t *dcpp = NULL;
-	dsl_crypto_params_t dcp = { 0 };
+	dsl_crypto_params_t dummy_dcp = { 0 };
+	dsl_crypto_params_t *dcp = drba->drba_dcp;
 
 	if (drrb->drr_flags & DRR_FLAG_CI_DATA)
 		crflags |= DS_FLAG_CI_DATASET;
-	if ((featureflags & DMU_BACKUP_FEATURE_RAW) == 0) {
+
+	if ((featureflags & DMU_BACKUP_FEATURE_RAW) == 0)
 		dsflags |= DS_HOLD_FLAG_DECRYPT;
-	} else {
-		dcp.cp_cmd = DCP_CMD_RAW_RECV;
+
+	/*
+	 * Raw, non-incremental recvs always use a dummy dcp with
+	 * the raw cmd set. Raw incremental recvs do not use a dcp
+	 * since the encryption parameters are already set in stone.
+	 */
+	if (dcp == NULL && drba->drba_snapobj == 0 &&
+	    drba->drba_origin == NULL) {
+		ASSERT3P(dcp, ==, NULL);
+		dcp = &dummy_dcp;
+
+		if (featureflags & DMU_BACKUP_FEATURE_RAW)
+			dcp->cp_cmd = DCP_CMD_RAW_RECV;
 	}
 
 	error = dsl_dataset_hold_flags(dp, tofs, dsflags, FTAG, &ds);
@@ -1820,13 +1849,11 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		if (drba->drba_snapobj != 0) {
 			VERIFY0(dsl_dataset_hold_obj(dp,
 			    drba->drba_snapobj, FTAG, &snap));
-		} else {
-			/* we use the dcp whenever we are not making a clone */
-			dcpp = &dcp;
+			ASSERT3P(dcp, ==, NULL);
 		}
 
 		dsobj = dsl_dataset_create_sync(ds->ds_dir, recv_clone_name,
-		    snap, crflags, drba->drba_cred, dcpp, tx);
+		    snap, crflags, drba->drba_cred, dcp, tx);
 		if (drba->drba_snapobj != 0)
 			dsl_dataset_rele(snap, FTAG);
 		dsl_dataset_rele_flags(ds, dsflags, FTAG);
@@ -1840,19 +1867,18 @@ dmu_recv_begin_sync(void *arg, dmu_tx_t *tx)
 		if (drba->drba_origin != NULL) {
 			VERIFY0(dsl_dataset_hold(dp, drba->drba_origin,
 			    FTAG, &origin));
-		} else {
-			/* we use the dcp whenever we are not making a clone */
-			dcpp = &dcp;
+			ASSERT3P(dcp, ==, NULL);
 		}
 
 		/* Create new dataset. */
 		dsobj = dsl_dataset_create_sync(dd, strrchr(tofs, '/') + 1,
-		    origin, crflags, drba->drba_cred, dcpp, tx);
+		    origin, crflags, drba->drba_cred, dcp, tx);
 		if (origin != NULL)
 			dsl_dataset_rele(origin, FTAG);
 		dsl_dir_rele(dd, FTAG);
 		drba->drba_cookie->drc_newfs = B_TRUE;
 	}
+
 	VERIFY0(dsl_dataset_own_obj(dp, dsobj, dsflags, dmu_recv_tag, &newds));
 	VERIFY0(dmu_objset_from_ds(newds, &os));
 
@@ -2103,7 +2129,8 @@ dmu_recv_resume_begin_sync(void *arg, dmu_tx_t *tx)
  */
 int
 dmu_recv_begin(char *tofs, char *tosnap, dmu_replay_record_t *drr_begin,
-    boolean_t force, boolean_t resumable, char *origin, dmu_recv_cookie_t *drc)
+    boolean_t force, boolean_t resumable, nvlist_t *localprops,
+    nvlist_t *hidden_args, char *origin, dmu_recv_cookie_t *drc)
 {
 	dmu_recv_begin_arg_t drba = { 0 };
 
@@ -2139,9 +2166,33 @@ dmu_recv_begin(char *tofs, char *tosnap, dmu_replay_record_t *drr_begin,
 		    dmu_recv_resume_begin_check, dmu_recv_resume_begin_sync,
 		    &drba, 5, ZFS_SPACE_CHECK_NORMAL));
 	} else  {
-		return (dsl_sync_task(tofs,
+		int err;
+
+		/*
+		 * For non-raw, non-incremental, non-resuming receives the
+		 * user can specify encryption parameters on the command line
+		 * with "zfs recv -o". For these receives we create a dcp and
+		 * pass it to the sync task. Creating the dcp will implicitly
+		 * remove the encryption params from the localprops nvlist,
+		 * which avoids errors when trying to set these normally
+		 * read-only properties. Any other kind of receive that
+		 * attempts to set these properties will fail as a result.
+		 */
+		if ((DMU_GET_FEATUREFLAGS(drc->drc_drrb->drr_versioninfo) &
+		    DMU_BACKUP_FEATURE_RAW) == 0 &&
+		    origin == NULL && drc->drc_drrb->drr_fromguid == 0) {
+			err = dsl_crypto_params_create_nvlist(DCP_CMD_NONE,
+			    localprops, hidden_args, &drba.drba_dcp);
+			if (err != 0)
+				return (err);
+		}
+
+		err = dsl_sync_task(tofs,
 		    dmu_recv_begin_check, dmu_recv_begin_sync,
-		    &drba, 5, ZFS_SPACE_CHECK_NORMAL));
+		    &drba, 5, ZFS_SPACE_CHECK_NORMAL);
+		dsl_crypto_params_free(drba.drba_dcp, !!err);
+
+		return (err);
 	}
 }
 

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -1707,11 +1707,15 @@ dmu_objset_clone_crypt_check(dsl_dir_t *parentdd, dsl_dir_t *origindd)
 
 
 int
-dmu_objset_create_crypt_check(dsl_dir_t *parentdd, dsl_crypto_params_t *dcp)
+dmu_objset_create_crypt_check(dsl_dir_t *parentdd, dsl_crypto_params_t *dcp,
+    boolean_t *will_encrypt)
 {
 	int ret;
 	uint64_t pcrypt, crypt;
 	dsl_crypto_params_t dummy_dcp = { 0 };
+
+	if (will_encrypt != NULL)
+		*will_encrypt = B_FALSE;
 
 	if (dcp == NULL)
 		dcp = &dummy_dcp;
@@ -1750,10 +1754,13 @@ dmu_objset_create_crypt_check(dsl_dir_t *parentdd, dsl_crypto_params_t *dcp)
 		return (0);
 	}
 
+	if (will_encrypt != NULL)
+		*will_encrypt = B_TRUE;
+
 	/*
 	 * We will now definitely be encrypting. Check the feature flag. When
 	 * creating the pool the caller will check this for us since we won't
-	 * technically have the fetaure activated yet.
+	 * technically have the feature activated yet.
 	 */
 	if (parentdd != NULL &&
 	    !spa_feature_is_enabled(parentdd->dd_pool->dp_spa,

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -1711,6 +1711,10 @@ dmu_objset_create_crypt_check(dsl_dir_t *parentdd, dsl_crypto_params_t *dcp)
 {
 	int ret;
 	uint64_t pcrypt, crypt;
+	dsl_crypto_params_t dummy_dcp = { 0 };
+
+	if (dcp == NULL)
+		dcp = &dummy_dcp;
 
 	if (dcp->cp_cmd != DCP_CMD_NONE)
 		return (SET_ERROR(EINVAL));

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -4959,7 +4959,7 @@ spa_create_check_encryption_params(dsl_crypto_params_t *dcp,
 	    !has_encryption)
 		return (SET_ERROR(ENOTSUP));
 
-	return (dmu_objset_create_crypt_check(NULL, dcp));
+	return (dmu_objset_create_crypt_check(NULL, dcp, NULL));
 }
 
 /*

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -455,7 +455,7 @@ tests = ['zdb_001_neg', 'zfs_001_neg', 'zfs_allow_001_neg',
     'zpool_offline_001_neg', 'zpool_online_001_neg', 'zpool_remove_001_neg',
     'zpool_replace_001_neg', 'zpool_scrub_001_neg', 'zpool_set_001_neg',
     'zpool_status_001_neg', 'zpool_upgrade_001_neg', 'arcstat_001_pos',
-    'arc_summary_001_pos', 'arc_summary_002_neg', 
+    'arc_summary_001_pos', 'arc_summary_002_neg',
     'arc_summary3_001_pos', 'dbufstat_001_pos']
 user =
 tags = ['functional', 'cli_user', 'misc']
@@ -743,7 +743,8 @@ tests = ['rsend_001_pos', 'rsend_002_pos', 'rsend_003_pos', 'rsend_004_pos',
     'send-c_mixed_compression', 'send-c_stream_size_estimate', 'send-cD',
     'send-c_embedded_blocks', 'send-c_resume', 'send-cpL_varied_recsize',
     'send-c_recv_dedup', 'send_encrypted_files', 'send_encrypted_heirarchy',
-    'send_freeobjects', 'send_realloc_dnode_size', 'send_hole_birth']
+    'send_encrypted_props', 'send_freeobjects', 'send_realloc_dnode_size',
+    'send_hole_birth']
 tags = ['functional', 'rsend']
 
 [tests/functional/scrub_mirror]

--- a/tests/zfs-tests/tests/functional/rsend/Makefile.am
+++ b/tests/zfs-tests/tests/functional/rsend/Makefile.am
@@ -23,6 +23,7 @@ dist_pkgdata_SCRIPTS = \
 	rsend_024_pos.ksh \
 	send_encrypted_files.ksh \
 	send_encrypted_heirarchy.ksh \
+	send_encrypted_props.ksh \
 	send-cD.ksh \
 	send-c_embedded_blocks.ksh \
 	send-c_incremental.ksh \

--- a/tests/zfs-tests/tests/functional/rsend/send_encrypted_props.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_encrypted_props.ksh
@@ -1,0 +1,199 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2018 by Datto Inc. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/rsend/rsend.kshlib
+
+#
+# DESCRIPTION:
+# Verify that zfs properly handles encryption properties when receiving
+# send streams.
+#
+# STRATEGY:
+# 1. Create a few unencrypted and encrypted test datasets with some data
+# 2. Take snapshots of these datasets in preparation for sending
+# 3. Verify that 'zfs recv -o keylocation=prompt' fails
+# 4. Verify that 'zfs recv -x <encryption prop>' fails on a raw send stream
+# 5. Verify that encryption properties cannot be changed on incrementals
+# 6. Verify that a simple send can be received as an encryption root
+# 7. Verify that an unencrypted props send can be received as an
+#    encryption root
+# 8. Verify that an unencrypted recursive send can be received as an
+#    encryption root
+# 9. Verify that an unencrypted props send can be received as an
+#    encryption child
+# 10. Verify that an unencrypted recursive send can be received as an
+#     encryption child
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	destroy_dataset $TESTPOOL/recv "-r"
+	destroy_dataset $TESTPOOL/crypt "-r"
+	destroy_dataset $TESTPOOL/ds "-r"
+	[[ -f $sendfile ]] && log_must rm $sendfile
+	[[ -f $keyfile ]] && log_must rm $keyfile
+}
+log_onexit cleanup
+
+log_assert "'zfs recv' must properly handle encryption properties"
+
+typeset keyfile=/$TESTPOOL/pkey
+typeset sendfile=/$TESTPOOL/sendfile
+typeset snap=$TESTPOOL/ds@snap
+typeset esnap=$TESTPOOL/crypt@snap1
+typeset esnap2=$TESTPOOL/crypt@snap2
+
+log_must eval "echo 'password' > $keyfile"
+
+log_must zfs create $TESTPOOL/ds
+log_must zfs create $TESTPOOL/ds/ds1
+
+log_must zfs create -o encryption=on -o keyformat=passphrase \
+	-o keylocation=file://$keyfile $TESTPOOL/crypt
+log_must zfs create $TESTPOOL/crypt/ds1
+log_must zfs create -o keyformat=passphrase -o keylocation=file://$keyfile \
+	$TESTPOOL/crypt/ds2
+
+log_must mkfile 1M /$TESTPOOL/ds/$TESTFILE0
+log_must cp /$TESTPOOL/ds/$TESTFILE0 /$TESTPOOL/crypt/$TESTFILE0
+typeset cksum=$(md5sum /$TESTPOOL/ds/$TESTFILE0 | awk '{  print $1 }')
+
+log_must zfs snap -r $snap
+log_must zfs snap -r $esnap
+log_must zfs snap -r $esnap2
+
+# Embedded data is incompatible with encrypted datasets, so we cannot
+# allow embedded streams to be received.
+log_note "Must not be able to receive an embedded stream as encrypted"
+log_mustnot eval "zfs send -e $TESTPOOL/crypt/ds1 | zfs recv $TESTPOOL/recv"
+
+# We currently don't have an elegant and secure way to pass the passphrase
+# in via prompt because the send stream itself is using stdin.
+log_note "Must not be able to use 'keylocation=prompt' on receive"
+log_must eval "zfs send $snap > $sendfile"
+log_mustnot eval "zfs recv -o encryption=on -o keyformat=passphrase" \
+	"$TESTPOOL/recv < $sendfile"
+log_mustnot eval "zfs recv -o encryption=on -o keyformat=passphrase" \
+	"-o keylocation=prompt $TESTPOOL/recv < $sendfile"
+
+# Raw sends do not have access to the decrypted data so we cannot override
+# the encryption settings without losing the data.
+log_note "Must not be able to disable encryption properties on raw send"
+log_must eval "zfs send -w $esnap > $sendfile"
+log_mustnot eval "zfs recv -x encryption $TESTPOOL/recv < $sendfile"
+log_mustnot eval "zfs recv -x keyformat $TESTPOOL/recv < $sendfile"
+log_mustnot eval "zfs recv -x pbkdf2iters $TESTPOOL/recv < $sendfile"
+
+# Encryption properties are set upon creating the dataset. Changing them
+# afterwards requires using 'zfs change-key' or an update from a raw send.
+log_note "Must not be able to change encryption properties on incrementals"
+log_must eval "zfs send $esnap | zfs recv -o encryption=on" \
+	"-o keyformat=passphrase -o keylocation=file://$keyfile $TESTPOOL/recv"
+log_mustnot eval "zfs send -i $esnap $esnap2 |" \
+	"zfs recv -o encryption=aes-128-ccm $TESTPOOL/recv"
+log_mustnot eval "zfs send -i $esnap $esnap2 |" \
+	"zfs recv -o keyformat=hex $TESTPOOL/recv"
+log_mustnot eval "zfs send -i $esnap $esnap2 |" \
+	"zfs recv -o pbkdf2iters=100k $TESTPOOL/recv"
+log_must zfs destroy -r $TESTPOOL/recv
+
+# Test that we can receive a simple stream as an encryption root.
+log_note "Must be able to receive stream as encryption root"
+ds=$TESTPOOL/recv
+log_must eval "zfs send $snap > $sendfile"
+log_must eval "zfs recv -o encryption=on -o keyformat=passphrase" \
+	"-o keylocation=file://$keyfile $ds < $sendfile"
+log_must test "$(get_prop 'encryption' $ds)" == "aes-256-ccm"
+log_must test "$(get_prop 'encryptionroot' $ds)" == "$ds"
+log_must test "$(get_prop 'keyformat' $ds)" == "passphrase"
+log_must test "$(get_prop 'keylocation' $ds)" == "file://$keyfile"
+log_must test "$(get_prop 'mounted' $ds)" == "yes"
+recv_cksum=$(md5sum /$ds/$TESTFILE0 | awk '{ print $1 }')
+log_must test "$recv_cksum" == "$cksum"
+log_must zfs destroy -r $ds
+
+# Test that we can override encryption properties on a properties stream
+# of an unencrypted dataset, turning it into an encryption root.
+log_note "Must be able to receive stream with props as encryption root"
+ds=$TESTPOOL/recv
+log_must eval "zfs send -p $snap > $sendfile"
+log_must eval "zfs recv -o encryption=on -o keyformat=passphrase" \
+	"-o keylocation=file://$keyfile $ds < $sendfile"
+log_must test "$(get_prop 'encryption' $ds)" == "aes-256-ccm"
+log_must test "$(get_prop 'encryptionroot' $ds)" == "$ds"
+log_must test "$(get_prop 'keyformat' $ds)" == "passphrase"
+log_must test "$(get_prop 'keylocation' $ds)" == "file://$keyfile"
+log_must test "$(get_prop 'mounted' $ds)" == "yes"
+recv_cksum=$(md5sum /$ds/$TESTFILE0 | awk '{ print $1 }')
+log_must test "$recv_cksum" == "$cksum"
+log_must zfs destroy -r $ds
+
+# Test that we can override encryption properties on a recursive stream
+# of an unencrypted dataset, turning it into an encryption root. The root
+# dataset of the stream should become an encryption root with all children
+# inheriting from it.
+log_note "Must be able to receive recursive stream as encryption root"
+ds=$TESTPOOL/recv
+log_must eval "zfs send -R $snap > $sendfile"
+log_must eval "zfs recv -o encryption=on -o keyformat=passphrase" \
+	"-o keylocation=file://$keyfile $ds < $sendfile"
+log_must test "$(get_prop 'encryption' $ds)" == "aes-256-ccm"
+log_must test "$(get_prop 'encryptionroot' $ds)" == "$ds"
+log_must test "$(get_prop 'keyformat' $ds)" == "passphrase"
+log_must test "$(get_prop 'keylocation' $ds)" == "file://$keyfile"
+log_must test "$(get_prop 'mounted' $ds)" == "yes"
+recv_cksum=$(md5sum /$ds/$TESTFILE0 | awk '{ print $1 }')
+log_must test "$recv_cksum" == "$cksum"
+log_must zfs destroy -r $ds
+
+# Test that we can override an unencrypted properties stream's encryption
+# settings, receiving it as an encrypted child.
+log_note "Must be able to receive stream with props to encrypted child"
+ds=$TESTPOOL/crypt/recv
+log_must eval "zfs send -p $snap > $sendfile"
+log_must eval "zfs recv -x encryption $ds < $sendfile"
+log_must test "$(get_prop 'encryptionroot' $ds)" == "$TESTPOOL/crypt"
+log_must test "$(get_prop 'encryption' $ds)" == "aes-256-ccm"
+log_must test "$(get_prop 'keyformat' $ds)" == "passphrase"
+log_must test "$(get_prop 'mounted' $ds)" == "yes"
+recv_cksum=$(md5sum /$ds/$TESTFILE0 | awk '{ print $1 }')
+log_must test "$recv_cksum" == "$cksum"
+log_must zfs destroy -r $ds
+
+# Test that we can override an unencrypted recursive stream's encryption
+# settings, receiving all datasets as encrypted children.
+log_note "Must be able to receive recursive stream to encrypted child"
+ds=$TESTPOOL/crypt/recv
+log_must eval "zfs send -R $snap > $sendfile"
+log_must eval "zfs recv -x encryption $ds < $sendfile"
+log_must test "$(get_prop 'encryptionroot' $ds)" == "$TESTPOOL/crypt"
+log_must test "$(get_prop 'encryption' $ds)" == "aes-256-ccm"
+log_must test "$(get_prop 'keyformat' $ds)" == "passphrase"
+log_must test "$(get_prop 'mounted' $ds)" == "yes"
+recv_cksum=$(md5sum /$ds/$TESTFILE0 | awk '{ print $1 }')
+log_must test "$recv_cksum" == "$cksum"
+log_must zfs destroy -r $ds
+
+# Check that we haven't printed the key to the zpool history log
+log_mustnot eval "zpool history -i | grep -q 'wkeydata'"
+
+log_pass "'zfs recv' properly handles encryption properties"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
The `zfs receive -o / -x` code in userspace was modified to utilize the same code that is used for encrypted dataset creation in `libzfs_crypto.c` to verify the provided parameters and provide them to the kernel. In the kernel, the receive code parses these properties into a `dsl_crypto_params_t`, which is used to initialize the encrypted dataset.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Up until now, zfs recv -o / -x has not really had support for encryption properties. Attempting to modify any of them with this command would simply return an error. This change adds this functionality, which should make taking encrypted backups much easier, especially from existing unencrypted pools.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
The `send_encrypted_props` test has been added to exercise the new functionality.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
