### PR TITLE
Cause autogen.sh to fail if autoreconf fails

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-autoreconf -fiv
+autoreconf -fiv || exit 1
 rm -Rf autom4te.cache


### PR DESCRIPTION
### Description
This change simply detects if autoreconf fails, and if so, causes autogen.sh to fail as well.

### Motivation and Context
When doing development, it's possible to forget to add Makefiles or other components to the repository, or to forget to create them at all. If this happens, autoreconf can notice the problem and fail. However, we don't detect this failure. As a result, automated builds will often proceed without knowing anything is wrong, producing obscure and confusing failures later in the build process.

### How Has This Been Tested?
This patch has been tested by adding a dependency but not creating the relevant Makefile, and verifying that an automated build fails in a more appropriate place. It has also been tested on builds that should succeed, and it does.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
