### PR TITLE
Fix kernel unaligned access on sparc64

### DIFF
--- a/include/spl/sys/isa_defs.h
+++ b/include/spl/sys/isa_defs.h
@@ -210,6 +210,14 @@
 
 #include <sys/byteorder.h>
 
+/*
+ * CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS will be defined by the Linux
+ * kernel for architectures which support efficient unaligned access.
+ */
+#if defined(CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS)
+#define	HAVE_EFFICIENT_UNALIGNED_ACCESS
+#endif
+
 #if defined(__LITTLE_ENDIAN) && !defined(_LITTLE_ENDIAN)
 #define	_LITTLE_ENDIAN __LITTLE_ENDIAN
 #endif

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -55,6 +55,7 @@ extern "C" {
 #endif
 
 #define	_SUNOS_VTOC_16
+#define	HAVE_EFFICIENT_UNALIGNED_ACCESS
 
 /* i386 arch specific defines */
 #elif defined(__i386) || defined(__i386__)
@@ -76,6 +77,7 @@ extern "C" {
 #endif
 
 #define	_SUNOS_VTOC_16
+#define	HAVE_EFFICIENT_UNALIGNED_ACCESS
 
 /* powerpc arch specific defines */
 #elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__)
@@ -99,6 +101,7 @@ extern "C" {
 #endif
 
 #define	_SUNOS_VTOC_16
+#define	HAVE_EFFICIENT_UNALIGNED_ACCESS
 
 /* arm arch specific defines */
 #elif defined(__arm) || defined(__arm__) || defined(__aarch64__)
@@ -128,6 +131,10 @@ extern "C" {
 #endif
 
 #define	_SUNOS_VTOC_16
+
+#if defined(__ARM_FEATURE_UNALIGNED)
+#define	HAVE_EFFICIENT_UNALIGNED_ACCESS
+#endif
 
 /* sparc arch specific defines */
 #elif defined(__sparc) || defined(__sparc__)

--- a/module/icp/algs/modes/ccm.c
+++ b/module/icp/algs/modes/ccm.c
@@ -28,7 +28,7 @@
 #include <sys/crypto/common.h>
 #include <sys/crypto/impl.h>
 
-#if defined(__i386) || defined(__amd64)
+#ifdef HAVE_EFFICIENT_UNALIGNED_ACCESS
 #include <sys/byteorder.h>
 #define	UNALIGNED_POINTERS_PERMITTED
 #endif


### PR DESCRIPTION
### Description

Update the SA_COPY_DATA macro to check if architecture supports
efficient unaligned memory accesses at compile time.  Otherwise
fallback to using the sa_copy_data() function.

The kernel provided CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS is
used to determine availability in kernel space.  In user space
the x86_64, x86, powerpc, and sometimes arm architectures will
define the HAVE_EFFICIENT_UNALIGNED_ACCESS macro.

### Motivation and Context

Issue #7642

### How Has This Been Tested?

Locally built and verified functionality for x86_64.  Pending build results from the bots for other architectures.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
