### PR TITLE
Fix issues with raw sends and receive_write_byref()

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1267,7 +1267,6 @@ dbuf_read_verify_dnode_crypt(dmu_buf_impl_t *db, uint32_t flags)
 	    !DMU_OT_IS_ENCRYPTED(dn->dn_bonustype))))
 		err = 0;
 
-
 	DB_DNODE_EXIT(db);
 
 	return (err);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1622,6 +1622,7 @@ dmu_copy_from_buf(objset_t *os, uint64_t object, uint64_t offset,
 	dmu_buf_t *dst_handle;
 	dmu_buf_impl_t *dstdb;
 	dmu_buf_impl_t *srcdb = (dmu_buf_impl_t *)handle;
+	dmu_object_type_t type;
 	arc_buf_t *abuf;
 	uint64_t datalen;
 	boolean_t byteorder;
@@ -1637,11 +1638,15 @@ dmu_copy_from_buf(objset_t *os, uint64_t object, uint64_t offset,
 	dstdb = (dmu_buf_impl_t *)dst_handle;
 	datalen = arc_buf_size(srcdb->db_buf);
 
+	DB_DNODE_ENTER(dstdb);
+	type = DB_DNODE(dstdb)->dn_type;
+	DB_DNODE_EXIT(dstdb);
+
 	/* allocated an arc buffer that matches the type of srcdb->db_buf */
 	if (arc_is_encrypted(srcdb->db_buf)) {
 		arc_get_raw_params(srcdb->db_buf, &byteorder, salt, iv, mac);
 		abuf = arc_loan_raw_buf(os->os_spa, dmu_objset_id(os),
-		    byteorder, salt, iv, mac, DB_DNODE(dstdb)->dn_type,
+		    byteorder, salt, iv, mac, type,
 		    datalen, arc_buf_lsize(srcdb->db_buf),
 		    arc_get_compression(srcdb->db_buf));
 	} else {
@@ -1649,7 +1654,7 @@ dmu_copy_from_buf(objset_t *os, uint64_t object, uint64_t offset,
 		ASSERT3U(arc_get_compression(srcdb->db_buf),
 		    ==, ZIO_COMPRESS_OFF);
 		abuf = arc_loan_buf(os->os_spa,
-		    DMU_OT_IS_METADATA(DB_DNODE(dstdb)->dn_type), datalen);
+		    DMU_OT_IS_METADATA(type), datalen);
 	}
 
 	ASSERT3U(datalen, ==, arc_buf_size(abuf));

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -744,7 +744,7 @@ tests = ['rsend_001_pos', 'rsend_002_pos', 'rsend_003_pos', 'rsend_004_pos',
     'send-c_embedded_blocks', 'send-c_resume', 'send-cpL_varied_recsize',
     'send-c_recv_dedup', 'send_encrypted_files', 'send_encrypted_heirarchy',
     'send_encrypted_props', 'send_freeobjects', 'send_realloc_dnode_size',
-    'send_hole_birth']
+    'send_hole_birth', 'send-wDR_encrypted_zvol']
 tags = ['functional', 'rsend']
 
 [tests/functional/scrub_mirror]

--- a/tests/zfs-tests/tests/functional/rsend/Makefile.am
+++ b/tests/zfs-tests/tests/functional/rsend/Makefile.am
@@ -41,7 +41,8 @@ dist_pkgdata_SCRIPTS = \
 	send-cpL_varied_recsize.ksh \
 	send_freeobjects.ksh \
 	send_realloc_dnode_size.ksh \
-	send_hole_birth.ksh
+	send_hole_birth.ksh \
+	send-wDR_encrypted_zvol.ksh
 
 dist_pkgdata_DATA = \
 	rsend.cfg \

--- a/tests/zfs-tests/tests/functional/rsend/send-wDR_encrypted_zvol.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-wDR_encrypted_zvol.ksh
@@ -1,0 +1,93 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2018 by Datto Inc. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/rsend/rsend.kshlib
+
+#
+# DESCRIPTION:
+# Verify that zvols with dedup=on and encryption=on can be sent and received
+# with a deduplicated raw send stream.
+#
+# STRATEGY:
+# 1. Create a zvol with dedup and encryption on and put a filesystem on it
+# 2. Copy a file into the zvol a few times and take a snapshot
+# 3. Repeat step 2 a few times to create more snapshots
+# 4. Send all snapshots in a recursive, raw, deduplicated send stream
+# 5. Mount the received zvol and verify that all of the data there is correct
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	ismounted $recvmnt ext4 && log_must umount $recvmnt
+	ismounted $mntpnt ext4 && log_must umount $mntpnt
+	[[ -d $recvmnt ]] && log_must rm -rf $keyfile
+	[[ -d $mntpnt ]] && log_must rm -rf $keyfile
+	destroy_dataset $TESTPOOL/recv "-r"
+	destroy_dataset $TESTPOOL/$TESTVOL "-r"
+	[[ -f $keyfile ]] && log_must rm $keyfile
+	[[ -f $sendfile ]] && log_must rm $sendfile
+}
+log_onexit cleanup
+
+log_assert "Verify zfs can receive raw, recursive, and deduplicated send streams"
+
+typeset keyfile=/$TESTPOOL/pkey
+typeset snap_count=5
+typeset zdev=$ZVOL_DEVDIR/$TESTPOOL/$TESTVOL
+typeset mntpnt=$TESTDIR/$TESTVOL
+typeset recvdev=$ZVOL_DEVDIR/$TESTPOOL/recv
+typeset recvmnt=$TESTDIR/recvmnt
+typeset sendfile=$TESTDIR/sendfile
+
+log_must eval "echo 'password' > $keyfile"
+
+log_must zfs create -o dedup=on -o encryption=on -o keyformat=passphrase \
+	-o keylocation=file://$keyfile -V 128M $TESTPOOL/$TESTVOL
+log_must block_device_wait
+
+log_must eval "echo 'y' | newfs -t ext4 -v $zdev"
+log_must mkdir -p $mntpnt
+log_must mkdir -p $recvmnt
+log_must mount $zdev $mntpnt
+
+for ((i = 1; i <= $snap_count; i++)); do
+	log_must dd if=/dev/urandom of=$mntpnt/file bs=1M count=1
+	for ((j = 0; j < 10; j++)); do
+		log_must cp $mntpnt/file $mntpnt/file$j
+	done
+
+	log_must sync
+	log_must zfs snap $TESTPOOL/$TESTVOL@snap$i
+done
+
+log_must eval "zfs send -wDR $TESTPOOL/$TESTVOL@snap$snap_count > $sendfile"
+log_must eval "zfs recv $TESTPOOL/recv < $sendfile"
+log_must zfs load-key $TESTPOOL/recv
+log_must block_device_wait
+
+log_must mount $recvdev $recvmnt
+
+md5_1=$(cat $mntpnt/* | md5sum | awk '{print $1}')
+md5_2=$(cat $recvmnt/* | md5sum | awk '{print $1}')
+[[ "$md5_1" == "$md5_2" ]] || log_fail "md5 mismatch: $md5_1 != $md5_2"
+
+log_pass "zfs can receive raw, recursive, and deduplicated send streams"


### PR DESCRIPTION
This patch fixes 2 issues with raw, deduplicated send streams. The
first is that datasets who had been completely received earlier in
the stream were not still marked as raw receives. This caused
problems when newly received datasets attempted to fetch raw data
from these datasets without this flag set.

The second problem was that the arc freeze checksum code was not
consistent about which locks needed to be held while performing
its asserts. The code now guarantees that the hdr lock is held
when iterating through the linked list of buffers and the
b_freeze_lock is held when attempting to read or modify the
b_freeze_cksum. This is not strictly a problem with the write_byref
code, but it seems to be the only consistent code path to trigger
the issue.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Motivation and Context
Without this patch raw, deduplicated send streams would cause crashes.

### How Has This Been Tested?
`send-wDR_encrypted_zvol.ksh` has been added

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
