### PR TITLE
Reduce zdb output when pool contains checkpoint

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -4738,7 +4738,8 @@ verify_checkpoint_vdev_spacemaps(spa_t *checkpoint, spa_t *current)
 		    space_map_length(checkpoint_sm) / sizeof (uint64_t);
 		VERIFY0(space_map_iterate(checkpoint_sm,
 		    verify_checkpoint_sm_entry_cb, &vcsec));
-		dump_spacemap(current->spa_meta_objset, checkpoint_sm);
+		if (dump_opt['m'] > 3)
+			dump_spacemap(current->spa_meta_objset, checkpoint_sm);
 		space_map_close(checkpoint_sm);
 	}
 
@@ -4920,7 +4921,8 @@ verify_checkpoint(spa_t *spa)
 		 */
 		(void) printf("\nPartially discarded checkpoint "
 		    "state found:\n");
-		dump_leftover_checkpoint_blocks(spa);
+		if (dump_opt['m'] > 3)
+			dump_leftover_checkpoint_blocks(spa);
 		return (0);
 	} else if (error != 0) {
 		(void) printf("lookup error %d when looking for "


### PR DESCRIPTION
### Description

When running zdb without additional arguments against a pool containing
a checkpoint the entire checkpoint spacemap should not be dumped.  Make
this behavior conditional upon passing the -mmmm option as described in
the zdb(8) man page.

     -mmmm   Display every spacemap record.

### Motivation and Context

Keep the size of the ZTS log files manageable so they're relatively easy to read.

### How Has This Been Tested?

Manual testing to verify the log messages are only printed when passed `-mmmm`.

Reduced the size of the `zpool_checkpoint` logs from 25M to 748K.

```
$ du -h  /var/tmp/test_results/20180710T134551/pool_checkpoint | tail -1
25M     /var/tmp/test_results/20180710T134551/pool_checkpoint\

$ du -h  /var/tmp/test_results/20180710T143330/pool_checkpoint | tail -1
748K    /var/tmp/test_results/20180710T143330/pool_checkpoint
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
