### PR TITLE
OpenZFS 8906 - uts: illumos rootfs should support salted cksum

### DIFF
--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -14,7 +14,7 @@
 .\" CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
-.TH ZPOOL-FEATURES 5 "Aug 27, 2013"
+.TH ZPOOL-FEATURES 5 "Jun 8, 2018"
 .SH NAME
 zpool\-features \- ZFS pool feature descriptions
 .SH DESCRIPTION
@@ -248,8 +248,9 @@ immediately activate the \fBlz4_compress\fR feature on the underlying
 pool using the \fBzfs\fR(1M) command. Also, all newly written metadata
 will be compressed with \fBlz4\fR algorithm. Since this feature is not
 read-only compatible, this operation will render the pool unimportable
-on systems without support for the \fBlz4_compress\fR feature. Booting
-off of \fBlz4\fR-compressed root pools is supported.
+on systems without support for the \fBlz4_compress\fR feature.
+
+Booting off of \fBlz4\fR-compressed root pools is supported.
 
 This feature becomes \fBactive\fR as soon as it is enabled and will
 never return to being \fBenabled\fB.
@@ -598,8 +599,7 @@ can turn on the \fBsha512\fR checksum on any dataset using the
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBsha512\fR are destroyed.
 
-Booting off of pools utilizing SHA-512/256 is supported (provided that
-the updated GRUB stage2 module is installed).
+Booting off of pools utilizing SHA-512/256 is supported.
 
 .RE
 
@@ -633,9 +633,7 @@ can turn on the \fBskein\fR checksum on any dataset using the
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBskein\fR are destroyed.
 
-Booting off of pools using \fBskein\fR is \fBNOT\fR supported
--- any attempt to enable \fBskein\fR on a root pool will fail with an
-error.
+Booting off of pools using \fBskein\fR is supported.
 
 .RE
 
@@ -675,9 +673,7 @@ can turn on the \fBedonr\fR checksum on any dataset using the
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBedonr\fR are destroyed.
 
-Booting off of pools using \fBedonr\fR is \fBNOT\fR supported
--- any attempt to enable \fBedonr\fR on a root pool will fail with an
-error.
+Booting off of pools using \fBedonr\fR is supported.
 
 .RE
 

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -30,7 +30,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright 2018 Joyent, Inc.
 .\"
-.Dd January 10, 2018
+.Dd July 13, 2018
 .Dt ZFS 8 SMM
 .Os Linux
 .Sh NAME
@@ -1184,15 +1184,14 @@ The
 and
 .Sy edonr
 checksum algorithms require enabling the appropriate features on the pool.
+These algorithms are not supported by GRUB and should not be set on the
+.Sy bootfs
+filesystem when using GRUB to boot the system.
 Please see
 .Xr zpool-features 5
 for more information on these algorithms.
 .Pp
 Changing this property affects only newly-written data.
-.Pp
-Salted checksum algorithms
-.Pq Cm edonr , skein
-are currently not supported for any filesystem on the boot pools.
 .It Xo
 .Sy compression Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy gzip Ns | Ns
 .Sy gzip- Ns Em N Ns | Ns Sy lz4 Ns | Ns Sy lzjb Ns | Ns Sy zle

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4130,16 +4130,7 @@ zfs_check_settable(const char *dsname, nvpair_t *pair, cred_t *cr)
 
 		if ((err = spa_open(dsname, &spa, FTAG)) != 0)
 			return (err);
-		/*
-		 * Salted checksums are not supported on root pools.
-		 */
-		if (spa_bootfs(spa) != 0 &&
-		    intval < ZIO_CHECKSUM_FUNCTIONS &&
-		    (zio_checksum_table[intval].ci_flags &
-		    ZCHECKSUM_FLAG_SALTED)) {
-			spa_close(spa, FTAG);
-			return (SET_ERROR(ERANGE));
-		}
+
 		if (!spa_feature_is_enabled(spa, feature)) {
 			spa_close(spa, FTAG);
 			return (SET_ERROR(ENOTSUP));


### PR DESCRIPTION
### Description

Porting notes:
* As of grub-2.02 these checksums are not supported.  However, as
  pointed out in #6501 there are alternates see the issue for
  addition discussion.

### Motivation and Context

OpenZFS-issue: https://illumos.org/issues/8906
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/7dec52f
Issue #6501

### How Has This Been Tested?

Locally built, untested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
