### PR TITLE
ZTS: Fix reservation_017_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/reservation/reservation_017_pos.sh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_017_pos.sh
@@ -55,7 +55,7 @@ function cleanup
 	typeset vol
 
 	for vol in $regvol $sparsevol; do
-		datasetexists $vol &&  log_must zfs destroy $vol
+		destroy_dataset $vol
 	done
 }
 log_onexit cleanup


### PR DESCRIPTION
### Motivation and Context

On rare occasions the reservation_017_pos test case will fail during
cleanup.  All of these false positives need to be resolved, so we can
always get reliably clean ZTS runs.

```
23:56:27.69 The volsize changes of sparse volumes are not reflected in the  reservation
23:56:27.69 NOTE: Performing local cleanup via log_onexit (cleanup)
23:56:27.70 ERROR: zfs destroy testpool/testvol32501 exited 1
23:56:27.70 cannot destroy 'testpool/testvol32501': dataset is busy
```

### Description

It's possible for an unrelated process, like blkid, to have the
volume open when 'zfs destroy' is run.  Switch the cleanup function
to the destroy_dataset() helper which handles this case by retrying
the destroy when the dataset is busy.

### How Has This Been Tested?

Verified by manually opening the block device during the test and
observing the retry.

```
Test: tests/functional/reservation/reservation_017_pos (run as root) [00:03] [PASS]
Test: tests/functional/reservation/reservation_017_pos (run as root) [00:18] [PASS]
Test: tests/functional/reservation/reservation_017_pos (run as root) [00:03] [PASS]
```

```
14:17:48.51 The volsize changes of sparse volumes are not reflected in the  reservation
14:17:48.51 NOTE: Performing local cleanup via log_onexit (cleanup)
14:17:48.62 ERROR: zfs destroy testpool/testvol27285 Retry in 1 seconds
14:17:48.62 cannot destroy 'testpool/testvol27285': dataset is busy
14:17:49.66 cannot destroy 'testpool/testvol27285': dataset is busy
14:17:49.66 ERROR: zfs destroy testpool/testvol27285 Retry in 2 seconds
14:17:51.69 ERROR: zfs destroy testpool/testvol27285 Retry in 4 seconds
14:17:51.69 cannot destroy 'testpool/testvol27285': dataset is busy
14:17:55.72 ERROR: zfs destroy testpool/testvol27285 Retry in 8 seconds
14:17:55.72 cannot destroy 'testpool/testvol27285': dataset is busy
14:18:03.80 SUCCESS: zfs destroy testpool/testvol27285
14:18:03.96 SUCCESS: zfs destroy testpool/testvol2-27285
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
