### PR TITLE
Allow inherited properties in zfs_check_settable()

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4112,7 +4112,6 @@ zfs_check_settable(const char *dsname, nvpair_t *pair, cred_t *cr)
 	{
 		spa_feature_t feature;
 		spa_t *spa;
-		uint64_t intval;
 		int err;
 
 		/* dedup feature version checks */
@@ -4120,22 +4119,23 @@ zfs_check_settable(const char *dsname, nvpair_t *pair, cred_t *cr)
 		    zfs_earlier_version(dsname, SPA_VERSION_DEDUP))
 			return (SET_ERROR(ENOTSUP));
 
-		if (nvpair_value_uint64(pair, &intval) != 0)
-			return (SET_ERROR(EINVAL));
+		if (nvpair_type(pair) == DATA_TYPE_UINT64 &&
+		    nvpair_value_uint64(pair, &intval) == 0) {
+			/* check prop value is enabled in features */
+			feature = zio_checksum_to_feature(
+			    intval & ZIO_CHECKSUM_MASK);
+			if (feature == SPA_FEATURE_NONE)
+				break;
 
-		/* check prop value is enabled in features */
-		feature = zio_checksum_to_feature(intval & ZIO_CHECKSUM_MASK);
-		if (feature == SPA_FEATURE_NONE)
-			break;
+			if ((err = spa_open(dsname, &spa, FTAG)) != 0)
+				return (err);
 
-		if ((err = spa_open(dsname, &spa, FTAG)) != 0)
-			return (err);
-
-		if (!spa_feature_is_enabled(spa, feature)) {
+			if (!spa_feature_is_enabled(spa, feature)) {
+				spa_close(spa, FTAG);
+				return (SET_ERROR(ENOTSUP));
+			}
 			spa_close(spa, FTAG);
-			return (SET_ERROR(ENOTSUP));
 		}
-		spa_close(spa, FTAG);
 		break;
 	}
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/receive-o-x_props_override.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/receive-o-x_props_override.ksh
@@ -122,15 +122,17 @@ log_must eval "zfs set '$userprop:snap'='$userval' $origsub@snap3"
 log_must eval "zfs send -R -I $orig@snap1 $orig@snap3 > $streamfile_incr"
 # Sets various combination of override and exclude options
 log_must eval "zfs recv -F -o atime=off -o '$userprop:dest2'='$userval' "\
-	"-o quota=123456789 -x compression -x '$userprop:orig' " \
-	"-x '$userprop:snap3' $dest < $streamfile_incr"
+	"-o quota=123456789 -o checksum=sha512 -x compression "\
+        "-x '$userprop:orig' -x '$userprop:snap3' $dest < $streamfile_incr"
 # Verify we can correctly override and exclude properties
 log_must eval "check_prop_source $dest copies 2 received"
 log_must eval "check_prop_source $dest atime off local"
 log_must eval "check_prop_source $dest '$userprop:dest2' '$userval' local"
 log_must eval "check_prop_source $dest quota 123456789 local"
+log_must eval "check_prop_source $dest checksum sha512 local"
 log_must eval "check_prop_inherit $destsub copies $dest"
 log_must eval "check_prop_inherit $destsub atime $dest"
+log_must eval "check_prop_inherit $destsub checksum $dest"
 log_must eval "check_prop_inherit $destsub '$userprop:dest2' $dest"
 log_must eval "check_prop_source $destsub quota 0 default"
 log_must eval "check_prop_source $destsub compression off default"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some properties ("checksum", "dedup") cause issues when received with `zfs recv -o`:
```
root@debug:~# modinfo -F version zfs
0.7.0-1489_gdae3e9ea2
root@debug:~# # setup
root@debug:~# POOLNAME='testpool'
root@debug:~# TMPDIR='/var/tmp'
root@debug:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@debug:~# zpool destroy $POOLNAME
root@debug:~# rm -f $TMPDIR/disk
root@debug:~# truncate -s 128m $TMPDIR/disk
root@debug:~# zpool create $POOLNAME $TMPDIR/disk
root@debug:~# #
root@debug:~# zfs create $POOLNAME/send
root@debug:~# zfs create $POOLNAME/send/sub
root@debug:~# zfs snap -r $POOLNAME/send@snap
root@debug:~# zfs send -R $POOLNAME/send@snap | zfs recv -Fv -o checksum=sha512 $POOLNAME/recv
receiving full stream of testpool/send@snap into testpool/recv@snap
received 46.4K stream in 1 seconds (46.4K/sec)
receiving full stream of testpool/send/sub@snap into testpool/recv/sub@snap
internal error: Invalid argument
Aborted (core dumped)
```
Fix https://github.com/zfsonlinux/zfs/issues/7755
Fix https://github.com/zfsonlinux/zfs/issues/7576

### Description
<!--- Describe your changes in detail -->
This change modifies how 'checksum' and 'dedup' properties are verified in `zfs_check_settable()` handling the case where they are explicitly inherited (nvpair type = DATA_TYPE_BOOLEAN) in the dataset hierarchy when receiving a recursive send stream.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Used systemtap to find where the error is coming from, tested fix on local development Debian8 running the updated `functional/cli_root/zfs_receive/receive-o-x_props_override` test case.

Slightly off topic question, does anyone know how to inspect nvlist/nvpair data structures from systemtap/dtrace?

```
root@debug:~# stap -e '
probe
module("zfs").function("zfs_set_prop_nvlist").call,
module("zfs").function("zfs_check_settable").call {
   printf(" -> %s %s\n", ppfunc(), $$parms$);
}
probe
module("zfs").function("zfs_set_prop_nvlist").return,
module("zfs").function("zfs_check_settable").return {
   printf(" <- %s %s\n", ppfunc(), $$return$);
}'
 -> zfs_set_prop_nvlist dsname="testpool/recv" source=32 nvl={.nvl_version=0, .nvl_nvflag=1, .nvl_priv=18446612135649350336, .nvl_flag=0, .nvl_pad=0} errlist={.nvl_version=0, .nvl_nvflag=1, .nvl_priv=18446612135986611072, .nvl_flag=0, .nvl_pad=0}
 <- zfs_set_prop_nvlist return=0
[...]
 -> zfs_set_prop_nvlist dsname="testpool/recv/sub" source=16 nvl={.nvl_version=0, .nvl_nvflag=1, .nvl_priv=18446612135487296384, .nvl_flag=0, .nvl_pad=0} errlist={.nvl_version=0, .nvl_nvflag=1, .nvl_priv=18446612135649339840, .nvl_flag=0, .nvl_pad=0}
 -> zfs_check_settable dsname="testpool/recv/sub" pair={.nvp_size=32, .nvp_name_sz=9, .nvp_reserve=0, .nvp_value_elem=0, .nvp_type=1} cr={.usage={...}, .uid={...}, .gid={...}, .suid={...}, .sgid={...}, .euid={...}, .egid={...}, .fsuid={...}, .fsgid={...}, .securebits=0, .cap_inheritable={...}, .cap_permitted={...}, .cap_effective={...}, .cap_bset={...}, .cap_ambient={...}, .jit_keyring='\000', .session_keyring=0x0, .process_keyring=0x0, .thread_keyring=0x0, .request_key_auth=0x0, .security=0x0, .user=0xffffffff81a41580, .user_ns
 <- zfs_check_settable return=22
 <- zfs_set_prop_nvlist return=22
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
