### PR TITLE
zfs_ioc_unload_key can drop extra spa ref

### DIFF
--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -469,8 +469,10 @@ dsl_crypto_can_set_keylocation(const char *dsname, const char *keylocation)
 		goto out;
 
 	ret = dsl_dir_hold(dp, dsname, FTAG, &dd, NULL);
-	if (ret != 0)
+	if (ret != 0) {
+		dd = NULL;
 		goto out;
+	}
 
 	/* if dd is not encrypted, the value may only be "none" */
 	if (dd->dd_crypto_obj == 0) {
@@ -778,8 +780,10 @@ spa_keystore_load_wkey(const char *dsname, dsl_crypto_params_t *dcp,
 
 	/* hold the dsl dir */
 	ret = dsl_dir_hold(dp, dsname, FTAG, &dd, NULL);
-	if (ret != 0)
+	if (ret != 0) {
+		dd = NULL;
 		goto error;
+	}
 
 	/* initialize the wkey's ddobj */
 	wkey->wk_ddobj = dd->dd_object;
@@ -904,8 +908,10 @@ spa_keystore_unload_wkey(const char *dsname)
 	}
 
 	ret = dsl_dir_hold(dp, dsname, FTAG, &dd, NULL);
-	if (ret != 0)
+	if (ret != 0) {
+		dd = NULL;
 		goto error;
+	}
 
 	/* unload the wkey */
 	ret = spa_keystore_unload_wkey_impl(dp->dp_spa, dd->dd_object);
@@ -1205,8 +1211,10 @@ spa_keystore_change_key_check(void *arg, dmu_tx_t *tx)
 
 	/* hold the dd */
 	ret = dsl_dir_hold(dp, skcka->skcka_dsname, FTAG, &dd, NULL);
-	if (ret != 0)
+	if (ret != 0) {
+		dd = NULL;
 		goto error;
+	}
 
 	/* verify that the dataset is encrypted */
 	if (dd->dd_crypto_obj == 0) {

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -501,7 +501,8 @@ dsl_dir_hold(dsl_pool_t *dp, const char *name, void *tag,
 	}
 	if (tailp != NULL)
 		*tailp = next;
-	*ddp = dd;
+	if (err == 0)
+		*ddp = dd;
 error:
 	kmem_free(buf, ZFS_MAX_DATASET_NAME_LEN);
 	return (err);


### PR DESCRIPTION
### Motivation and Context
The underlying `spa_keystore_*` routines will drop a reference on the spa if the supplied dataset name does not exist.

### Description
The code below will  reproduce the issue and cause a kernel assertion panic in debug builds.The fix is simple, when `dsl_dir_hold()` returns an error, the `dsl_dir_t` return value cannot be trusted.

```
int
main(int argc, const char *argv[])
{
	if (argc != 2) {
		(void) fprintf(stderr, "usage: %s <dataset>\n", argv[0]);
		exit(2);
	}

	(void) libzfs_core_init();
	int fd = open("/dev/zfs", O_RDWR);
	if (fd < 0)
		exit(2);

	for (int i = 0; i < 25; i++)
		(void) lzc_unload_key(argv[1]);

	(void) close(fd);
	libzfs_core_fini();

	return (0);
}
```
which will result in this panic:
```
[ 9718.672715] Call Trace:
[ 9718.672720]  dump_stack+0x63/0x8b
[ 9718.672727]  spl_dumpstack+0x29/0x30 [spl]
[ 9718.672730]  spl_panic+0xc8/0x110 [spl]
[ 9718.672738]  ? spl_panic+0x5/0x110 [spl]
[ 9718.672741]  ? spl_kmem_free+0x33/0x40 [spl]
[ 9718.672783]  spa_close+0x7d/0x80 [zfs]
[ 9718.672813]  dsl_pool_rele+0x29/0x30 [zfs]
[ 9718.672836]  spa_keystore_unload_wkey+0x72/0x150 [zfs]
[ 9718.672865]  zfs_ioc_unload_key+0x5b/0x60 [zfs]
[ 9718.672893]  zfsdev_ioctl+0x6d6/0xa00 [zfs]
[ 9718.672899]  do_vfs_ioctl+0xa8/0x630
[ 9718.672901]  ? do_vfs_ioctl+0x5/0x630
[ 9718.672903]  ? do_vfs_ioctl+0x630/0x630
[ 9718.672905]  SyS_ioctl+0x79/0x90
[ 9718.672908]  do_syscall_64+0x73/0x130
[ 9718.672911]  entry_SYSCALL_64_after_hwframe+0x3d/0xa2
```

### How Has This Been Tested?
ZTS for cli_root
ztest
manually with the above reproducible case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
