### PR TITLE
ZTS: Fix zfs_create_007_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_007_pos.ksh
@@ -49,10 +49,8 @@ verify_runnable "global"
 
 function cleanup
 {
-        datasetexists $TESTPOOL/$TESTVOL && \
-                log_must zfs destroy -f $TESTPOOL/$TESTVOL
-	datasetexists $TESTPOOL/$TESTVOL1 && \
-		log_must zfs destroy -f $TESTPOOL/$TESTVOL1
+	destroy_dataset $TESTPOOL/$TESTVOL
+	destroy_dataset $TESTPOOL/$TESTVOL1
 }
 
 log_onexit cleanup


### PR DESCRIPTION
### Motivation and Context

Resolve all false positives observed when running ZTS.

http://build.zfsonlinux.org/builders/CentOS%206%20x86_64%20%28TEST%29/builds/3471/steps/shell_9/logs/summary

```
Test: /usr/share/zfs/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_007_pos (run as root) [00:00] [FAIL]
18:05:23.35 ASSERTION: 'zfs create -o property=value -V size volume' can successfully 	   create a ZFS volume with correct property set.
18:05:23.59 SUCCESS: zfs create -o volblocksize=16384 -o compression=lzjb -o readonly=on -o local:department=123 -V 150m testpool/testvol
18:05:23.77 SUCCESS: zfs create -s -o volblocksize=16384 -o compression=lzjb -o readonly=on -o local:department=123 -V 150m testpool/testvol1
18:05:23.83 'zfs create -o property=value -V size volume' can successfully 	   create a ZFS volume with correct property set.
18:05:23.83 NOTE: Performing local cleanup via log_onexit (cleanup)
18:05:23.93 SUCCESS: zfs destroy -f testpool/testvol
18:05:23.94 cannot destroy 'testpool/testvol1': dataset is busy
18:05:23.94 ERROR: zfs destroy -f testpool/testvol1 exited 1
```

### Description

It's possible for an unrelated process, like blkid, to have the
volume open when 'zfs destroy' is run.  Switch the cleanup function
to the destroy_dataset() helper which handles this case by retrying
the destroy when the dataset is busy.

### How Has This Been Tested?

Local ZTS run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
