### PR TITLE
ZTS: Test case reliability

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -231,6 +231,7 @@ maybe = {
         ['FAIL', rewind_reason],
     'cli_root/zpool_import/import_rewind_config_changed':
         ['FAIL', rewind_reason],
+    'cli_root/zpool_import/import_cache_device_replaced': ['FAIL', '7765'],
     'cli_root/zpool_import/zpool_import_missing_003_pos': ['SKIP', '6839'],
     'cli_root/zpool_remove/setup': ['SKIP', disk_reason],
     'cli_root/zpool_upgrade/zpool_upgrade_004_pos': ['FAIL', '6141'],
@@ -250,6 +251,7 @@ maybe = {
     'pyzfs/pyzfs_unittest': ['SKIP', python_deps_reason],
     'no_space/enospc_002_pos': ['FAIL', enospc_reason],
     'projectquota/setup': ['SKIP', exec_reason],
+    'redundancy/redundancy_004_neg': ['FAIL', '7290'],
     'reservation/reservation_008_pos': ['FAIL', '7741'],
     'reservation/reservation_018_pos': ['FAIL', '5642'],
     'rsend/rsend_019_pos': ['FAIL', '6086'],

--- a/tests/zfs-tests/tests/functional/replacement/replacement_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/replacement_001_pos.ksh
@@ -39,7 +39,7 @@
 # STRATEGY:
 #	1. Create multidisk pools (stripe/mirror/raidz) and
 #	   start some random I/O
-#	2. Replace a disk in the pool with anbother disk.
+#	2. Replace a disk in the pool with another disk.
 #	3. Verify the integrity of the file system and the resilvering.
 #
 
@@ -50,7 +50,7 @@ function cleanup
 	if [[ -n "$child_pids" ]]; then
 		for wait_pid in $child_pids
 		do
-		        kill $wait_pid
+			kill $wait_pid
 		done
 	fi
 
@@ -114,29 +114,28 @@ function replace_test
 	done
 	child_pids=""
 
-        log_must zpool export $TESTPOOL1
-        log_must zpool import -d $TESTDIR $TESTPOOL1
-        log_must zfs umount $TESTPOOL1/$TESTFS1
-        log_must zdb -cdui $TESTPOOL1/$TESTFS1
-        log_must zfs mount $TESTPOOL1/$TESTFS1
-
+	log_must zpool export $TESTPOOL1
+	log_must zpool import -d $TESTDIR $TESTPOOL1
+	log_must zfs umount $TESTPOOL1/$TESTFS1
+	log_must zdb -cdui $TESTPOOL1/$TESTFS1
+	log_must zfs mount $TESTPOOL1/$TESTFS1
 }
 
 specials_list=""
 i=0
 while [[ $i != 2 ]]; do
-        mkfile $MINVDEVSIZE $TESTDIR/$TESTFILE1.$i
-        specials_list="$specials_list $TESTDIR/$TESTFILE1.$i"
+	log_must truncate -s $MINVDEVSIZE $TESTDIR/$TESTFILE1.$i
+	specials_list="$specials_list $TESTDIR/$TESTFILE1.$i"
 
-        ((i = i + 1))
+	((i = i + 1))
 done
 
 #
 # Create a replacement disk special file.
 #
-mkfile $MINVDEVSIZE $TESTDIR/$REPLACEFILE
+log_must truncate -s $MINVDEVSIZE $TESTDIR/$REPLACEFILE
 
-for type in "" "raidz" "raidz1" "mirror"; do
+for type in "" "raidz" "mirror"; do
 	for op in "" "-f"; do
 		create_pool $TESTPOOL1 $type $specials_list
 		log_must zfs create $TESTPOOL1/$TESTFS1


### PR DESCRIPTION
### Motivation and Context

Reliable runs of the ZTS.

### Description

* Both cli_root/zpool_import/import_cache_device_replaced, and
  redundancy/redundancy_004_neg have been observed to fail for
  spurious reasons ~1% of the time.  Add them to the exception
  list and reference the open Github issue.

* Speed up replacement/replacement_001_pos to prevent it from
  exceeding the 10 minute per test limit and getting KILLED.
  File vdev creation switched to truncate -s, redundant raidz1
  testing pass dropped, fixed some minor formating issues.

### How Has This Been Tested?

Local ZTS run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
