### PR TITLE
ZTS: delegate group path cleanup

### DIFF
--- a/tests/zfs-tests/tests/functional/delegate/delegate.cfg
+++ b/tests/zfs-tests/tests/functional/delegate/delegate.cfg
@@ -28,7 +28,7 @@
 # Copyright (c) 2013 by Delphix. All rights reserved.
 #
 
-export NISSTAFILE=/var/tmp/nis_state
+export NISSTAFILE=$TEST_BASE_DIR/nis_state
 
 export STAFF_GROUP=zfsgrp
 export STAFF1=staff1

--- a/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
+++ b/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
@@ -384,8 +384,8 @@ function verify_send
 	typeset -i ret=1
 
 	log_must zfs snapshot $snap
-	typeset bak_user=/tmp/bak.$user.$stamp
-	typeset bak_root=/tmp/bak.root.$stamp
+	typeset bak_user=$TEST_BASE_DIR/bak.$user.$stamp
+	typeset bak_root=$TEST_BASE_DIR/bak.root.$stamp
 
 	user_run $user eval "zfs send $snap > $bak_user"
 	log_must eval "zfs send $snap > $bak_root"
@@ -410,8 +410,8 @@ function verify_fs_receive
 	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
 	typeset newfs=$fs/newfs.$stamp
 	typeset newvol=$fs/newvol.$stamp
-	typeset bak_user=/tmp/bak.$user.$stamp
-	typeset bak_root=/tmp/bak.root.$stamp
+	typeset bak_user=$TEST_BASE_DIR/bak.$user.$stamp
+	typeset bak_root=$TEST_BASE_DIR/bak.root.$stamp
 
 	log_must zfs create $newfs
 	typeset datasets="$newfs"
@@ -895,7 +895,7 @@ function verify_fs_mount
 
 	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
 	typeset mntpt=$(get_prop mountpoint $fs)
-	typeset newmntpt=/tmp/mnt.$stamp
+	typeset newmntpt=$TEST_BASE_DIR/mnt.$stamp
 
 	if ismounted $fs ; then
 		user_run $user zfs unmount $fs
@@ -963,7 +963,7 @@ function verify_fs_mountpoint
 
 	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
 	typeset mntpt=$(get_prop mountpoint $fs)
-	typeset newmntpt=/tmp/mnt.$stamp
+	typeset newmntpt=$TEST_BASE_DIR/mnt.$stamp
 
 	if ! ismounted $fs ; then
 		user_run $user zfs set mountpoint=$newmntpt $fs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Continuing work on fixing paths within ZTS

### Description
<!--- Describe your changes in detail -->
removing hardcoded paths in delegate group tests

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Test VM is still out, but change is minor, should be fine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
