### PR TITLE
Fix traverse_impl() kmem leak

### DIFF
--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -650,7 +650,7 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 			 */
 			if (!(td->td_flags & TRAVERSE_HARD) ||
 			    !(td->td_flags & TRAVERSE_PRE))
-				return (err);
+				goto out;
 		} else {
 			osp = buf->b_data;
 			traverse_zil(td, &osp->os_zil_header);
@@ -671,7 +671,7 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 	while (!pd->pd_exited)
 		cv_wait_sig(&pd->pd_cv, &pd->pd_mtx);
 	mutex_exit(&pd->pd_mtx);
-
+out:
 	mutex_destroy(&pd->pd_mtx);
 	cv_destroy(&pd->pd_cv);
 


### PR DESCRIPTION
### Motivation and Context

Memory leak detected during CI test runs which needs to be resolved.

http://build.zfsonlinux.org/builders/Ubuntu%2017.04%20x86_64%20Coverage%20%28TEST%29/builds/3202/steps/shell_9/logs/kmemleak

```
unreferenced object 0xffff880146494940 (size 32):
  comm "zpool", pid 6286, jiffies 4298484046 (age 21412.168s)
  hex dump (first 32 bytes):
    36 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  6...............
    ff ff ff ff ff ff ff ff 00 00 00 00 00 00 00 00  ................
  backtrace:
    [<ffffffff8185e02a>] kmemleak_alloc+0x7a/0x100
    [<ffffffff81303b6a>] __kmalloc_node+0x25a/0x4e0
    [<ffffffffa0a13aa0>] spl_kmem_alloc_impl+0xe0/0x180 [spl]
    [<ffffffffa0a13c26>] spl_kmem_alloc+0x66/0x80 [spl]
    [<ffffffffa0c34135>] traverse_impl+0xb5/0x6c0 [zfs]
    [<ffffffffa0c34c0c>] traverse_dataset_resume+0x7c/0xa0 [zfs]
    [<ffffffffa0c34c50>] traverse_dataset+0x20/0x30 [zfs]
    [<ffffffffa0c34e62>] traverse_pool+0x202/0x260 [zfs]
    [<ffffffffa0e3310a>] spa_load_verify+0x144/0x3a8 [zfs]
    [<ffffffffa0e333a2>] spa_ld_verify_pool_data+0x34/0x86 [zfs]
    [<ffffffffa0cbfa18>] spa_load_impl+0x348/0x5f0 [zfs]
    [<ffffffffa0cbfd0f>] spa_load+0x4f/0x120 [zfs]
    [<ffffffffa0cc1c30>] spa_load_retry+0xa0/0xb0 [zfs]
    [<ffffffffa0cc1de3>] spa_load_best+0x1a3/0x3c0 [zfs]
    [<ffffffffa0cc2370>] spa_import+0x370/0xbb0 [zfs]
    [<ffffffffa0d3cd8b>] zfs_ioc_pool_import+0x19b/0x1b0 [zfs]
```

### Description

The error path must free the memory allocated by this function or it will be leaked.  In practice, this would leak only a few bytes of memory under rare circumstances and thus is unlikely to have caused any real problems.  This issue was caught by the kmemleak.

### How Has This Been Tested?

Locally built and inspected, pending full CI results.  This condition is handled the same way in OpenZFS by virtue of the variables being on the stack instead of the heap.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
