### PR TITLE
ZTS: Fix reservation_001_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/reservation/reservation_001_pos.sh
+++ b/tests/zfs-tests/tests/functional/reservation/reservation_001_pos.sh
@@ -54,7 +54,7 @@ verify_runnable "both"
 function cleanup
 {
 	for obj in $OBJ_LIST; do
-		datasetexists $obj && log_must zfs destroy -f $obj
+		destroy_dataset $obj
 	done
 }
 


### PR DESCRIPTION
### Motivation and Context

Resolve all false positives observed when running ZTS.

http://build.zfsonlinux.org/builders/Ubuntu%2018.04%20x86_64%20%28TEST%29/builds/850/steps/shell_9/logs/summary

```
Test: /usr/share/zfs/zfs-tests/tests/functional/reservation/reservation_001_pos (run as root) [00:00] [FAIL]
07:34:44.73 ASSERTION: Verify that to set a reservation on a filesystem or volume must  use value smaller than space available property of pool
07:34:44.78 SUCCESS: zfs create -V 973021184 testpool/testvol8653
07:34:44.80 SUCCESS: zfs set reservation=none testpool/testvol8653
07:34:44.81 SUCCESS: zfs set refreservation=none testpool/testvol8653
07:34:44.84 SUCCESS: zfs create -s -V 15568404480 testpool/testvol2-8653
07:34:44.91 SUCCESS: zfs set reservation=3886816256 testpool/testfs
07:34:44.96 SUCCESS: zfs set reservation=none testpool/testfs
07:34:44.99 SUCCESS: zero_reservation testpool/testfs
07:34:45.01 SUCCESS: within_limits 3892059136 3892052992 10485760
07:34:45.05 SUCCESS: zfs set reservation=967778304 testpool/testvol8653
07:34:45.09 SUCCESS: zfs set reservation=none testpool/testvol8653
07:34:45.12 SUCCESS: zero_reservation testpool/testvol8653
07:34:45.13 SUCCESS: within_limits 3892052992 3892054528 10485760
07:34:45.18 SUCCESS: zfs set reservation=3886811648 testpool/testvol2-8653
07:34:45.23 SUCCESS: zfs set reservation=none testpool/testvol2-8653
07:34:45.26 SUCCESS: zero_reservation testpool/testvol2-8653
07:34:45.27 SUCCESS: within_limits 3892054528 3892048384 10485760
07:34:45.28 Successfully set reservation on filesystem and volume
07:34:45.28 NOTE: Performing local cleanup via log_onexit (cleanup)
07:34:45.29 ERROR: zfs destroy -f testpool/testvol8653 exited 1
07:34:45.29 cannot destroy 'testpool/testvol8653': dataset is busy
```

### Description

It's possible for an unrelated process, like blkid, to have the
volume open when 'zfs destroy' is run.  Switch the cleanup function
to the destroy_dataset() helper which handles this case by retrying
the destroy when the dataset is busy.

### How Has This Been Tested?

Local ZTS run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
