### PR TITLE
Fix arcstat.py handling of unsupported options

### DIFF
--- a/cmd/arcstat/arcstat.py
+++ b/cmd/arcstat/arcstat.py
@@ -285,7 +285,7 @@ def init():
             ]
         )
     except getopt.error as msg:
-        sys.stderr.write(msg)
+        sys.stderr.write("Error: %s\n" % str(msg))
         usage()
         opts = None
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Running `arcstat.py` with an unsupported option does not print the expected error and usage message:

```
root@linux:/usr/src/zfs# ./cmd/arcstat/arcstat.py -y
Traceback (most recent call last):
  File "./cmd/arcstat/arcstat.py", line 463, in <module>
    main()
  File "./cmd/arcstat/arcstat.py", line 436, in main
    init()
  File "./cmd/arcstat/arcstat.py", line 288, in init
    sys.stderr.write(msg)
TypeError: expected a character buffer object
root@linux:/usr/src/zfs# 
```

### Description
<!--- Describe your changes in detail -->
This change allows the arcstat.py script to handle unsupported options gracefully and print both error and usage messages when one such option is provided:

```
root@linux:/usr/src/zfs# ./cmd/arcstat/arcstat.py -y
Error: option -y not recognized
Usage: arcstat.py [-hvx] [-f fields] [-o file] [-s string] [interval [count]]

	 -h : Print this help message
	 -v : List all possible field headers and definitions
	 -x : Print extended stats
	 -f : Specify specific fields to print (see -v)
	 -o : Redirect output to the specified file
	 -s : Override default field separator with custom character or string

Examples:
	arcstat.py -o /tmp/a.log 2 10
	arcstat.py -s "," -o /tmp/a.log 2 10
	arcstat.py -v
	arcstat.py -f time,hit%,dh%,ph%,mh% 1

root@linux:/usr/src/zfs# 
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
