### PR TITLE
ZTS: privilege group path cleanup

### DIFF
--- a/tests/zfs-tests/tests/functional/privilege/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/cleanup.ksh
@@ -37,10 +37,10 @@ fi
 
 verify_runnable "global"
 
-ZFS_USER=$(cat /tmp/zfs-privs-test-user.txt)
+ZFS_USER=$(cat $TEST_BASE_DIR/zfs-privs-test-user.txt)
 [[ -z $ZFS_USER ]] && log_fail "no ZFS_USER found"
 
-USES_NIS=$(cat /tmp/zfs-privs-test-nis.txt)
+USES_NIS=$(cat $TEST_BASE_DIR/zfs-privs-test-nis.txt)
 
 if [ "${USES_NIS}" == "true" ]
 then
@@ -49,7 +49,7 @@ fi
 
 userdel $ZFS_USER
 [[ -d /export/home/$ZFS_USER ]] && rm -rf /export/home/$ZFS_USER
-rm /tmp/zfs-privs-test-nis.txt
-rm /tmp/zfs-privs-test-user.txt
+rm $TEST_BASE_DIR/zfs-privs-test-nis.txt
+rm $TEST_BASE_DIR/zfs-privs-test-user.txt
 
 default_cleanup

--- a/tests/zfs-tests/tests/functional/privilege/privilege_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/privilege_001_pos.ksh
@@ -63,7 +63,7 @@ fi
 
 log_assert "The RBAC profile \"ZFS Storage Management\" works"
 
-ZFS_USER=$(cat /tmp/zfs-privs-test-user.txt)
+ZFS_USER=$(cat $TEST_BASE_DIR/zfs-privs-test-user.txt)
 
 # the user shouldn't be able to do anything initially
 log_mustnot user_run $ZFS_USER "zpool create $TESTPOOL $DISKS"

--- a/tests/zfs-tests/tests/functional/privilege/privilege_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/privilege_002_pos.ksh
@@ -66,7 +66,7 @@ fi
 
 log_assert "The RBAC profile \"ZFS File System Management\" works"
 
-ZFS_USER=$(cat /tmp/zfs-privs-test-user.txt)
+ZFS_USER=$(cat $TEST_BASE_DIR/zfs-privs-test-user.txt)
 
 # Set a $DATASET where we can create child files systems
 if is_global_zone; then

--- a/tests/zfs-tests/tests/functional/privilege/setup.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/setup.ksh
@@ -65,7 +65,7 @@ done
 log_must mkdir -p /export/home/$ZFS_USER
 log_must useradd -c "ZFS Privileges Test User" -d /export/home/$ZFS_USER $ZFS_USER
 
-echo $ZFS_USER > /tmp/zfs-privs-test-user.txt
-echo $USES_NIS > /tmp/zfs-privs-test-nis.txt
+echo $ZFS_USER > $TEST_BASE_DIR/zfs-privs-test-user.txt
+echo $USES_NIS > $TEST_BASE_DIR/zfs-privs-test-nis.txt
 
 log_pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Continuing work on fixing paths within ZTS

### Description
<!--- Describe your changes in detail -->
Removing hardcoded paths in privilege group tests

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Test VM is still out, but change is minor, should be fine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
