### PR TITLE
ZTS: largest_pool_001 path cleanup

### DIFF
--- a/tests/zfs-tests/tests/functional/largest_pool/largest_pool_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/largest_pool/largest_pool_001_pos.ksh
@@ -68,13 +68,13 @@ function parse_expected_output
 	esac
 
 	log_note "Detect zpool $TESTPOOL in this test machine."
-	log_must eval "zpool list $TESTPOOL > /tmp/j.$$"
-	log_must eval "grep $TESTPOOL /tmp/j.$$ | \
+	log_must eval "zpool list $TESTPOOL > $TEST_BASE_DIR/j.$$"
+	log_must eval "grep $TESTPOOL $TEST_BASE_DIR/j.$$ | \
 		awk '{print $2}' | grep $CHKUNIT"
 
 	log_note "Detect the file system in this test machine."
-	log_must eval "df -F zfs -h > /tmp/j.$$"
-	log_must eval "grep $TESTPOOL /tmp/j.$$ | \
+	log_must eval "df -F zfs -h > $TEST_BASE_DIR/j.$$"
+	log_must eval "grep $TESTPOOL $TEST_BASE_DIR/j.$$ | \
 		awk '{print $2}' | grep $CHKUNIT"
 
 	return 0
@@ -101,7 +101,7 @@ function cleanup
 
 	destroy_pool $TESTPOOL2
 
-	rm -f /tmp/j.* > /dev/null
+	rm -f $TEST_BASE_DIR/j.* > /dev/null
 }
 
 log_assert "The largest pool can be created and a dataset in that" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Continuing work on fixing paths within ZTS

### Description
<!--- Describe your changes in detail -->
Removing hardcoded paths in largest_pool_001

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Test VM is still out, but change is minor, should be fine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
