### PR TITLE
Stack overflow when destroying deeply nested clones

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -120,7 +120,7 @@ tags = ['functional', 'cli_root', 'zfs_change-key']
 tests = ['zfs_clone_001_neg', 'zfs_clone_002_pos', 'zfs_clone_003_pos',
     'zfs_clone_004_pos', 'zfs_clone_005_pos', 'zfs_clone_006_pos',
     'zfs_clone_007_pos', 'zfs_clone_008_neg', 'zfs_clone_009_neg',
-    'zfs_clone_010_pos', 'zfs_clone_encrypted']
+    'zfs_clone_010_pos', 'zfs_clone_encrypted', 'zfs_clone_deeply_nested']
 tags = ['functional', 'cli_root', 'zfs_clone']
 
 [tests/functional/cli_root/zfs_copies]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/Makefile.am
@@ -12,4 +12,5 @@ dist_pkgdata_SCRIPTS = \
 	zfs_clone_008_neg.ksh \
 	zfs_clone_009_neg.ksh \
 	zfs_clone_010_pos.ksh \
-	zfs_clone_encrypted.ksh
+	zfs_clone_encrypted.ksh \
+	zfs_clone_deeply_nested.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_deeply_nested.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_deeply_nested.ksh
@@ -1,0 +1,69 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Deeply nested clones can be created and destroyed successfully
+#
+# STRATEGY:
+# 1. Create a deeply nested chain of clones
+# 2. Verify we can promote and destroy datasets in the chain without issues
+# NOTE:
+# Ported from scripts used to reproduce issue #3959 and #7279
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	destroy_dataset "$clonesfs" "-rRf"
+}
+log_onexit cleanup
+
+log_assert "Deeply nested clones should be created and destroyed without issues"
+
+snapname='snap'
+snaprename='temporary-snap'
+clonesfs="$TESTPOOL/$TESTFS1"
+
+# NOTE: set mountpoint=none to avoid mount/umount calls and speed up the process
+log_must zfs create -o mountpoint=none $clonesfs
+log_must zfs create $clonesfs/0
+dsname="$clonesfs/0@$snapname"
+log_must zfs snapshot $dsname
+
+# 1. Create a deeply nested chain of clones
+for c in {1..250}; do
+	log_must zfs clone $dsname $clonesfs/$c
+	dsname="$clonesfs/$c@$snapname"
+	log_must zfs snapshot $dsname
+done
+
+# 2. Verify we can promote and destroy datasets in the chain without issues
+for c in {0..249}; do
+	log_must zfs rename $clonesfs/$c@$snapname $clonesfs/$c@$snaprename
+	log_must zfs promote $clonesfs/$((c+1))
+	log_must zfs destroy -r $clonesfs/$c
+	log_must zfs destroy $clonesfs/$((c+1))@$snaprename
+done
+
+log_pass "Deeply nested clones can be created and destroyed successfully"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7279, kill one more bug on the 0.8.0 milestone

### Context

Destroying deeply nested clones can overflow the stack:

From a local Linux builder:

```
[ 2728.241103]         Depth    Size   Location    (221 entries)
[ 2728.241103]         -----    ----   --------
[ 2728.243835]   0)    15664      48   mutex_lock+0x5/0x30
[ 2728.245671]   1)    15616       8   mutex_lock+0x5/0x30
[ 2728.247557]   2)    15608      96   aggsum_add+0x123/0x260 [zfs]
[ 2728.249551]   3)    15512      24   arc_space_consume+0x81/0xe0 [zfs]
[ 2728.251610]   4)    15488      16   buf_cons+0x66/0x70 [zfs]
[ 2728.253522]   5)    15472      24   spl_kmem_cache_alloc+0x131/0xc30 [spl]
[ 2728.255557]   6)    15448       8   stack_trace_call+0x49/0x80
[ 2728.257379]   7)    15440     136   stack_trace_call+0x49/0x80
[ 2728.259232]   8)    15304      88   arc_buf_alloc_impl+0xd2/0x730 [zfs]
[ 2728.261189]   9)    15216     112   arc_read_done+0x2a2/0xb10 [zfs]
[ 2728.263129]  10)    15104     128   zio_done+0x96d/0x1b90 [zfs]
[ 2728.265013]  11)    14976      80   zio_nowait+0x11a/0x300 [zfs]
[ 2728.265885]  12)    14896      40   arc_read+0xb80/0x1e80 [zfs]
[ 2728.267720]  13)    14856      24   ftrace_call+0x5/0x34
[ 2728.269544]  14)    14832     168   dbuf_read_done+0x0/0x2c0 [zfs]
[ 2728.271519]  15)    14664      32   dbuf_read+0x390/0x11a0 [zfs]
[ 2728.273510]  16)    14632     144   refcount_remove_many+0xf1/0x210 [zfs]
[ 2728.275551]  17)    14488      48   dmu_buf_hold+0x56/0x80 [zfs]
[ 2728.277502]  18)    14440     144   zap_lockdir+0x54/0x120 [zfs]
[ 2728.279451]  19)    14296     136   zap_cursor_retrieve+0x221/0x390 [zfs]
[ 2728.281511]  20)    14160     120   zap_value_search+0x8a/0xe0 [zfs]
[ 2728.283494]  21)    14040      48   dsl_dataset_get_snapname+0xb4/0x110 [zfs]
[ 2728.285606]  22)    13992      16   dsl_dataset_hold_obj_flags+0x8f2/0xbf0 [zfs]
[ 2728.287712]  23)    13976     192   ftrace_call+0x5/0x34
[ 2728.289568]  24)    13784      16   dsl_dataset_hold_obj_flags+0x9fc/0xbf0 [zfs]
[ 2728.291717]  25)    13768     192   ftrace_call+0x5/0x34
[ 2728.293651]  26)    13576      72   dsl_dataset_remove_clones_key.isra.4+0x124/0x1e0 [zfs]
[ 2728.297068]  27)    13504      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.299463]  28)    13432      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.301794]  29)    13360      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.305252]  30)    13288      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.307539]  31)    13216      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.309846]  32)    13144      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.313283]  33)    13072      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.315665]  34)    13000      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.319079]  35)    12928      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.321491]  36)    12856      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.323843]  37)    12784      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.326192]  38)    12712      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.327495]  39)    12640      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.329851]  40)    12568      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.333237]  41)    12496      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.335427]  42)    12424      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.337617]  43)    12352      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.339795]  44)    12280      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.341981]  45)    12208      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.345240]  46)    12136      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.347566]  47)    12064      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.349894]  48)    11992      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.353278]  49)    11920      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.355606]  50)    11848      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.357969]  51)    11776      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.361409]  52)    11704      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.365234]  53)    11632      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.369129]  54)    11560      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.373019]  55)    11488      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.375877]  56)    11416      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.379804]  57)    11344      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.383694]  58)    11272      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.387605]  59)    11200      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.391563]  60)    11128      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.395553]  61)    11056      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.399367]  62)    10984      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.403279]  63)    10912      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.407164]  64)    10840      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.411022]  65)    10768      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.413855]  66)    10696      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.417694]  67)    10624      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.421571]  68)    10552      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.425635]  69)    10480      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.429515]  70)    10408      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.433375]  71)    10336      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.437249]  72)    10264      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.441146]  73)    10192      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.445035]  74)    10120      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.447949]  75)    10048      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.451804]  76)     9976      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.455586]  77)     9904      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.459280]  78)     9832      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.461937]  79)     9760      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.465588]  80)     9688      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.469170]  81)     9616      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.471737]  82)     9544      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.475362]  83)     9472      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.479046]  84)     9400      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.481731]  85)     9328      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.485378]  86)     9256      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.487909]  87)     9184      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.491466]  88)     9112      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.493974]  89)     9040      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.495344]  90)     8968      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.497521]  91)     8896      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.499563]  92)     8824      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.501610]  93)     8752      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.503702]  94)     8680      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.505816]  95)     8608      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.507936]  96)     8536      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.511221]  97)     8464      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.513589]  98)     8392      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.517006]  99)     8320      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.519445] 100)     8248      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.521889] 101)     8176      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.527096] 102)     8104      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.529425] 103)     8032      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.530809] 104)     7960      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.533261] 105)     7888      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.535702] 106)     7816      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.537947] 107)     7744      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.541206] 108)     7672      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.543499] 109)     7600      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.545787] 110)     7528      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.549120] 111)     7456      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.551466] 112)     7384      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.553915] 113)     7312      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.557399] 114)     7240      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.559857] 115)     7168      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.563334] 116)     7096      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.565699] 117)     7024      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.569116] 118)     6952      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.571528] 119)     6880      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.575111] 120)     6808      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.577761] 121)     6736      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.581468] 122)     6664      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.585127] 123)     6592      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.587818] 124)     6520      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.591598] 125)     6448      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.595371] 126)     6376      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.599187] 127)     6304      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.603032] 128)     6232      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.607020] 129)     6160      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.609633] 130)     6088      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.613291] 131)     6016      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.615923] 132)     5944      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.619609] 133)     5872      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.623426] 134)     5800      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.627182] 135)     5728      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.629972] 136)     5656      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.633709] 137)     5584      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.637054] 138)     5512      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.639369] 139)     5440      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.641580] 140)     5368      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.643823] 141)     5296      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.647066] 142)     5224      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.649291] 143)     5152      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.651580] 144)     5080      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.653882] 145)     5008      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.657278] 146)     4936      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.659629] 147)     4864      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.663050] 148)     4792      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.665518] 149)     4720      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.667881] 150)     4648      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.671306] 151)     4576      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.673644] 152)     4504      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.677025] 153)     4432      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.679400] 154)     4360      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.681760] 155)     4288      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.685183] 156)     4216      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.687545] 157)     4144      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.689905] 158)     4072      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.693397] 159)     4000      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.695658] 160)     3928      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.696905] 161)     3856      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.699185] 162)     3784      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.701437] 163)     3712      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.703638] 164)     3640      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.705841] 165)     3568      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.709055] 166)     3496      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.711236] 167)     3424      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.713455] 168)     3352      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.715843] 169)     3280      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.719664] 170)     3208      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.723549] 171)     3136      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.727309] 172)     3064      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.731193] 173)     2992      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.733960] 174)     2920      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.737765] 175)     2848      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.741566] 176)     2776      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.745396] 177)     2704      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.749206] 178)     2632      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.751971] 179)     2560      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.755819] 180)     2488      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.759578] 181)     2416      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.763378] 182)     2344      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.767290] 183)     2272      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.771132] 184)     2200      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.773910] 185)     2128      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.777686] 186)     2056      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.781498] 187)     1984      72   dsl_dataset_remove_clones_key.isra.4+0x18a/0x1e0 [zfs]
[ 2728.785336] 188)     1912     136   dsl_destroy_snapshot_sync_impl+0x4e0/0x1090 [zfs]
[ 2728.787937] 189)     1776      16   dsl_destroy_snapshot_check+0x0/0x90 [zfs]
[ 2728.791503] 190)     1760      56   dsl_destroy_snapshot_sync+0x65/0xd0 [zfs]
[ 2728.795023] 191)     1704       8   zcp_sync_task+0xb6/0xd0 [zfs]
[ 2728.797348] 192)     1696      56   dsl_destroy_snapshot_sync+0x0/0xd0 [zfs]
[ 2728.799913] 193)     1640      56   zcp_synctask_destroy+0x89/0x110 [zfs]
[ 2728.803375] 194)     1584      32   zcp_synctask_wrapper+0xc5/0x160 [zfs]
[ 2728.805820] 195)     1552      40   zcp_synctask_wrapper+0x0/0x160 [zfs]
[ 2728.809284] 196)     1512       8   luaD_precall+0x276/0x3b0 [zlua]
[ 2728.811655] 197)     1504      56   luaD_precall+0x5/0x3b0 [zlua]
[ 2728.815090] 198)     1448      40   luaV_execute+0x594/0x13b0 [zlua]
[ 2728.817497] 199)     1408       8   luaD_precall+0x39c/0x3b0 [zlua]
[ 2728.819804] 200)     1400      56   luaV_execute+0x5/0x13b0 [zlua]
[ 2728.823088] 201)     1344      32   luaD_call+0x9c/0xc0 [zlua]
[ 2728.825292] 202)     1312      24   luaD_rawrunprotected+0x68/0xa0 [zlua]
[ 2728.827647] 203)     1288      80   f_call+0x0/0x20 [zlua]
[ 2728.829757] 204)     1208      24   luaD_rawrunprotected+0x54/0xa0 [zlua]
[ 2728.833123] 205)     1184      64   luaD_pcall+0x35/0x90 [zlua]
[ 2728.835359] 206)     1120      72   lua_pcallk+0x89/0x120 [zlua]
[ 2728.837627] 207)     1048     136   zcp_eval_impl+0x15d/0x410 [zfs]
[ 2728.839977] 208)      912      32   dsl_sync_task_sync+0x10b/0x110 [zfs]
[ 2728.843572] 209)      880     128   dsl_pool_sync+0x45c/0x720 [zfs]
[ 2728.845897] 210)      752      24   spa_sync+0x79a/0x17f0 [zfs]
[ 2728.849100] 211)      728     128   ftrace_call+0x5/0x34
[ 2728.851167] 212)      600      64   __wake_up+0x34/0x50
[ 2728.853393] 213)      536       8   txg_sync_thread+0x2e6/0x580 [zfs]
[ 2728.855454] 214)      528     152   check_cfs_rq_runtime+0x5/0x50
[ 2728.857488] 215)      376      32   txg_sync_thread+0x0/0x580 [zfs]
[ 2728.859546] 216)      344      32   thread_generic_wrapper+0x7e/0xc0 [spl]
[ 2728.861664] 217)      312       8   thread_generic_wrapper+0x0/0xc0 [spl]
[ 2728.863746] 218)      304     128   kthread+0xdf/0x100
[ 2728.865576] 219)      176      48   ret_from_fork+0x22/0x40
[ 2728.867466] 220)      128     128   kthread+0x0/0x100
[ 2728.869299] ------------[ cut here ]------------
[ 2728.871008] kernel BUG at kernel/trace/trace_stack.c:195!
[ 2728.871863] invalid opcode: 0000 [#1] SMP 
[ 2728.873717] Dumping ftrace buffer:
[ 2728.875287]    (ftrace buffer empty)
```

From `mdb` on my Illumos devel box:

```
> ::msgbuf
MESSAGE                                                               
ffffff000a3b9170 zfs:dsl_dataset_get_snapname+96 ()
ffffff000a3b9260 zfs:dsl_dataset_hold_obj+8d0 ()
ffffff000a3b9350 zfs:dsl_dataset_hold_obj+82c ()
ffffff000a3b9520 zfs:dsl_dataset_remove_clones_key+10f ()
ffffff000a3b96f0 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3b98c0 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3b9a90 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3b9c60 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3b9e30 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3ba000 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3ba1d0 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3ba3a0 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3ba570 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3ba740 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3ba910 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3baae0 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bacb0 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bae80 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bb050 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bb220 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bb3f0 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bb5c0 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bb790 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bb960 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bbb30 zfs:dsl_dataset_remove_clones_key+17c ()
ffffff000a3bbd00 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bbed0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bc0a0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bc270 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bc440 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bc610 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bc7e0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bc9b0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bcb80 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bcd50 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bcf20 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bd0f0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bd2c0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bd490 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bd660 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bd830 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bda00 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bdbd0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bdda0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bdf70 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3be140 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3be310 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3be4e0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3be6b0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3be880 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bea50 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bec20 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bedf0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3befc0 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf190 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf360 zfs:dsl_dataset_remove_clones_key+17c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf430 zfs:dsl_destroy_snapshot_sync_impl+56c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf480 zfs:dsl_destroy_snapshot_sync+60 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf500 zfs:zcp_sync_task+d5 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf560 zfs:zcp_synctask_destroy+8b ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf5d0 zfs:zcp_synctask_wrapper+d3 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf640 zfs:luaD_precall+1fd ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf6d0 zfs:luaV_execute+355 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf710 zfs:luaD_call+88 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf730 zfs:f_call+1d ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf7d0 zfs:luaD_rawrunprotected+69 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf850 zfs:luaD_pcall+55 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf8d0 zfs:lua_pcallk+7c ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf980 zfs:zcp_eval_impl+15f ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf9b0 zfs:zcp_eval_sync+64 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bf9f0 zfs:dsl_sync_task_sync+10a ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bfa80 zfs:dsl_pool_sync+3a3 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bfb50 zfs:spa_sync+4e6 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bfc20 zfs:txg_sync_thread+260 ()
Warning: stack in the dump buffer may be incomplete
ffffff000a3bfc30 unix:thread_start+8 ()
Warning: stack in the dump buffer may be incomplete

panic[cpu1]/thread=ffffff000a3bfc40: 
BAD TRAP: type=8 (#df Double fault) rp=ffffff025df1af10 addr=0
> ffffff000a3bfc40::findstack -v
stack pointer for thread ffffff000a3bfc40: ffffff000a3b8010
  ffffff000a3b8150 page_get_mnode_freelist+0x80(0, 23, 3, 0, 202004b)
  ffffff000a3b8220 page_get_freelist+0x1a8(fffffffffc01fe60, ffffff02a5f63000, ffffff000a3b8330, ffffff02a5f63000, 1000, 4b, fffffffffbc4b680)
  ffffff000a3b8310 page_create_va+0x57e(fffffffffc01fe60, ffffff02a5f63000, 1000, 53, ffffff000a3b8330, ffffff02a5f63000)
  ffffff000a3b83d0 segkmem_page_create+0xa4(ffffff02a5f63000, 1000, 4, fffffffffc01fe60)
  ffffff000a3b8470 segkmem_xalloc+0x98(ffffff024a802000, 0, 1000, 4, 0, fffffffffb8ba620, fffffffffc01fe60)
  ffffff000a3b84e0 segkmem_alloc_vn+0x5e(ffffff024a802000, 1000, 4, fffffffffc01fe60)
  ffffff000a3b8510 segkmem_alloc+0x20(ffffff024a802000, 1000, 4)
  ffffff000a3b8660 vmem_xalloc+0x629(ffffff024a803000, 1000, 1000, 0, 0, 0, 0, ffffff0200000004)
  ffffff000a3b86e0 vmem_alloc+0x145(ffffff024a803000, 1000, 4)
  ffffff000a3b8770 kmem_slab_create+0xaf(ffffff024a8239c8, 4)
  ffffff000a3b87f0 kmem_slab_alloc+0x18d(ffffff024a8239c8, 4)
  ffffff000a3b8850 kmem_cache_alloc+0x283(ffffff024a8239c8, 4)
  ffffff000a3b88e0 kmem_slab_create+0x21d(ffffff0257d049c8, 4)
  ffffff000a3b8960 kmem_slab_alloc+0x18d(ffffff0257d049c8, 4)
  ffffff000a3b89c0 kmem_cache_alloc+0x283(ffffff0257d049c8, 4)
  ffffff000a3b89f0 zio_buf_alloc+0x5b(2d)
  ffffff000a3b8a30 abd_borrow_buf+0xba(ffffff027834ad80, 2d)
  ffffff000a3b8a70 abd_borrow_buf_copy+0x23(ffffff027834ad80, 2d)
  ffffff000a3b8ae0 zio_decompress_data+0x48(f, ffffff027834ad80, ffffff02aac02000, 2d, 200)
  ffffff000a3b8b40 zio_decompress+0x89(ffffff025682f418, ffffff027834ab40, 200)
  ffffff000a3b8b70 zio_pop_transforms+0x7a(ffffff025682f418)
  ffffff000a3b8c10 zio_done+0x2d8(ffffff025682f418)
  ffffff000a3b8c50 zio_execute+0xfa(ffffff025682f418)
  ffffff000a3b8c80 zio_nowait+0x67(ffffff025682f418)
  ffffff000a3b8d80 arc_read+0xd2b(ffffff02568d8040, ffffff02874ef000, ffffff0292953e40, fffffffff782e910, ffffff0271daa600, 0, 80, ffffff000a3b8dec, ffffff000a3b8dc0)
  ffffff000a3b8e40 dbuf_read_impl+0x4bc(ffffff0271daa600, ffffff02568d8040, a)
  ffffff000a3b8eb0 dbuf_read+0xf9(ffffff0271daa600, 0, a)
  ffffff000a3b8f20 dmu_buf_hold+0x78(ffffff026932b500, 257, 0, 0, ffffff000a3b8f58, 1)
  ffffff000a3b8fc0 zap_lockdir+0x5b(ffffff026932b500, 257, 0, 1, 1, 0, 0, ffffff000a3b9088)
  ffffff000a3b9060 zap_cursor_retrieve+0x19d(ffffff000a3b9080, ffffff026bddf9c0)
  ffffff000a3b9120 zap_value_search+0xaa(ffffff026932b500, 257, 25b, 0, ffffff02aa55022e)
  ffffff000a3b9170 dsl_dataset_get_snapname+0x96(ffffff02aa54fdc0)
  ffffff000a3b9260 dsl_dataset_hold_obj+0x8d0(ffffff0268e13340, 25b, ffffff02aa550440, ffffff02aa550598)
  ffffff000a3b9350 dsl_dataset_hold_obj+0x82c(ffffff0268e13340, 256, fffffffff7977890, ffffff000a3b93a8)
  ffffff000a3b9520 dsl_dataset_remove_clones_key+0x10f(ffffff02aa551140, c, ffffff028444b700)
  ffffff000a3b96f0 dsl_dataset_remove_clones_key+0x17c(ffffff02aa552080, c, ffffff028444b700)
  ffffff000a3b98c0 dsl_dataset_remove_clones_key+0x17c(ffffff02aa552d80, c, ffffff028444b700)
  ffffff000a3b9a90 dsl_dataset_remove_clones_key+0x17c(ffffff02aa553a80, c, ffffff028444b700)
  ffffff000a3b9c60 dsl_dataset_remove_clones_key+0x17c(ffffff02aa554780, c, ffffff028444b700)
  ffffff000a3b9e30 dsl_dataset_remove_clones_key+0x17c(ffffff02aa5556c0, c, ffffff028444b700)
  ffffff000a3ba000 dsl_dataset_remove_clones_key+0x17c(ffffff02aa5563c0, c, ffffff028444b700)
  ffffff000a3ba1d0 dsl_dataset_remove_clones_key+0x17c(ffffff02aa5570c0, c, ffffff028444b700)
  ffffff000a3ba3a0 dsl_dataset_remove_clones_key+0x17c(ffffff02aa558000, c, ffffff028444b700)
  ffffff000a3ba570 dsl_dataset_remove_clones_key+0x17c(ffffff02aa558d00, c, ffffff028444b700)
  ffffff000a3ba740 dsl_dataset_remove_clones_key+0x17c(ffffff02aa559a00, c, ffffff028444b700)
  ffffff000a3ba910 dsl_dataset_remove_clones_key+0x17c(ffffff02aa55a700, c, ffffff028444b700)
  ffffff000a3baae0 dsl_dataset_remove_clones_key+0x17c(ffffff02aa55b900, c, ffffff028444b700)
  ffffff000a3bacb0 dsl_dataset_remove_clones_key+0x17c(ffffff02aa55c600, c, ffffff028444b700)
  ffffff000a3bae80 dsl_dataset_remove_clones_key+0x17c(ffffff02aa55d300, c, ffffff028444b700)
  ffffff000a3bb050 dsl_dataset_remove_clones_key+0x17c(ffffff02aa55e240, c, ffffff028444b700)
  ffffff000a3bb220 dsl_dataset_remove_clones_key+0x17c(ffffff02aa55ef40, c, ffffff028444b700)
  ffffff000a3bb3f0 dsl_dataset_remove_clones_key+0x17c(ffffff02aa55fc40, c, ffffff028444b700)
  ffffff000a3bb5c0 dsl_dataset_remove_clones_key+0x17c(ffffff02aa560940, c, ffffff028444b700)
  ffffff000a3bb790 dsl_dataset_remove_clones_key+0x17c(ffffff028479e880, c, ffffff028444b700)
  ffffff000a3bb960 dsl_dataset_remove_clones_key+0x17c(ffffff028479f580, c, ffffff028444b700)
  ffffff000a3bbb30 dsl_dataset_remove_clones_key+0x17c(ffffff02847a0280, c, ffffff028444b700)
  ffffff000a3bbd00 dsl_dataset_remove_clones_key+0x17c(ffffff02847a11c0, c, ffffff028444b700)
  ffffff000a3bbed0 dsl_dataset_remove_clones_key+0x17c(ffffff02847a1ec0, c, ffffff028444b700)
  ffffff000a3bc0a0 dsl_dataset_remove_clones_key+0x17c(ffffff02847a2bc0, c, ffffff028444b700)
  ffffff000a3bc270 dsl_dataset_remove_clones_key+0x17c(ffffff02847a38c0, c, ffffff028444b700)
  ffffff000a3bc440 dsl_dataset_remove_clones_key+0x17c(ffffff02847a4800, c, ffffff028444b700)
  ffffff000a3bc610 dsl_dataset_remove_clones_key+0x17c(ffffff02847a5500, c, ffffff028444b700)
  ffffff000a3bc7e0 dsl_dataset_remove_clones_key+0x17c(ffffff02847a6200, c, ffffff028444b700)
  ffffff000a3bc9b0 dsl_dataset_remove_clones_key+0x17c(ffffff02847a7140, c, ffffff028444b700)
  ffffff000a3bcb80 dsl_dataset_remove_clones_key+0x17c(ffffff02847a7e40, c, ffffff028444b700)
  ffffff000a3bcd50 dsl_dataset_remove_clones_key+0x17c(ffffff02847a8b40, c, ffffff028444b700)
  ffffff000a3bcf20 dsl_dataset_remove_clones_key+0x17c(ffffff02847a9840, c, ffffff028444b700)
  ffffff000a3bd0f0 dsl_dataset_remove_clones_key+0x17c(ffffff02847aa780, c, ffffff028444b700)
  ffffff000a3bd2c0 dsl_dataset_remove_clones_key+0x17c(ffffff02847ab480, c, ffffff028444b700)
  ffffff000a3bd490 dsl_dataset_remove_clones_key+0x17c(ffffff02847ac180, c, ffffff028444b700)
  ffffff000a3bd660 dsl_dataset_remove_clones_key+0x17c(ffffff02847ad0c0, c, ffffff028444b700)
  ffffff000a3bd830 dsl_dataset_remove_clones_key+0x17c(ffffff02847addc0, c, ffffff028444b700)
  ffffff000a3bda00 dsl_dataset_remove_clones_key+0x17c(ffffff02847aeac0, c, ffffff028444b700)
  ffffff000a3bdbd0 dsl_dataset_remove_clones_key+0x17c(ffffff02847af7c0, c, ffffff028444b700)
  ffffff000a3bdda0 dsl_dataset_remove_clones_key+0x17c(ffffff02847b0700, c, ffffff028444b700)
  ffffff000a3bdf70 dsl_dataset_remove_clones_key+0x17c(ffffff02847b1400, c, ffffff028444b700)
  ffffff000a3be140 dsl_dataset_remove_clones_key+0x17c(ffffff02847b2100, c, ffffff028444b700)
  ffffff000a3be310 dsl_dataset_remove_clones_key+0x17c(ffffff02847b3040, c, ffffff028444b700)
  ffffff000a3be4e0 dsl_dataset_remove_clones_key+0x17c(ffffff02847b3d40, c, ffffff028444b700)
  ffffff000a3be6b0 dsl_dataset_remove_clones_key+0x17c(ffffff02847b4a40, c, ffffff028444b700)
  ffffff000a3be880 dsl_dataset_remove_clones_key+0x17c(ffffff02847b5740, c, ffffff028444b700)
  ffffff000a3bea50 dsl_dataset_remove_clones_key+0x17c(ffffff02847b6680, c, ffffff028444b700)
  ffffff000a3bec20 dsl_dataset_remove_clones_key+0x17c(ffffff02713357c0, c, ffffff028444b700)
  ffffff000a3bedf0 dsl_dataset_remove_clones_key+0x17c(ffffff02847b8700, c, ffffff028444b700)
  ffffff000a3befc0 dsl_dataset_remove_clones_key+0x17c(ffffff027133e080, c, ffffff028444b700)
  ffffff000a3bf190 dsl_dataset_remove_clones_key+0x17c(ffffff02847b7a00, c, ffffff028444b700)
  ffffff000a3bf360 dsl_dataset_remove_clones_key+0x17c(ffffff0271c39800, c, ffffff028444b700)
  ffffff000a3bf430 dsl_destroy_snapshot_sync_impl+0x56c(ffffff0271c39800, 0, ffffff028444b700)
  ffffff000a3bf480 dsl_destroy_snapshot_sync+0x60(ffffff000a3bf510, ffffff028444b700)
  ffffff000a3bf500 zcp_sync_task+0xd5(ffffff0269327f08, fffffffff786a330, fffffffff786bae0, ffffff000a3bf510, 1, ffffff02777dc248)
  ffffff000a3bf560 zcp_synctask_destroy+0x8b(ffffff0269327f08, 1, ffffff0280877490)
  ffffff000a3bf5d0 zcp_synctask_wrapper+0xd3(ffffff0269327f08)
  ffffff000a3bf640 luaD_precall+0x1fd()
  ffffff000a3bf6d0 luaV_execute+0x355()
  ffffff000a3bf710 luaD_call+0x88()
  ffffff000a3bf730 f_call+0x1d(ffffff0269327f08, ffffff000a3bf870)
  ffffff000a3bf7d0 luaD_rawrunprotected+0x69()
  ffffff000a3bf850 luaD_pcall+0x55()
  ffffff000a3bf8d0 lua_pcallk+0x7c(ffffff0269327f08, 1, ffffffff, 1, 0, 0)
  ffffff000a3bf980 zcp_eval_impl+0x15f(ffffff028444b700, 1, ffffff0008e54990)
  ffffff000a3bf9b0 zcp_eval_sync+0x64(ffffff0008e54990, ffffff028444b700)
  ffffff000a3bf9f0 dsl_sync_task_sync+0x10a(ffffff0008e54850, ffffff028444b700)
  ffffff000a3bfa80 dsl_pool_sync+0x3a3(ffffff0268e13340, 162)
  ffffff000a3bfb50 spa_sync+0x4e6(ffffff02874ef000, 162)
  ffffff000a3bfc20 txg_sync_thread+0x260(ffffff0268e13340)
  ffffff000a3bfc30 thread_start+8()
> ffffff0271c39800::print dsl_dataset_t ds_snapname
ds_snapname = [ "zfs-cleanup-temp" ]
> 
```


### Description
<!--- Describe your changes in detail -->
Fix this issue by converting `dsl_dataset_remove_clones_key()` from recursive to iterative.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
The following copy/pastable script reproduce the issue:

```
# misc functions
function is_linux() {
   if [[ "$(uname)" == "Linux" ]]; then
      return 0
   else
      return 1
   fi
}
# setup
POOLNAME='testpool'
if is_linux; then
   TMPDIR='/var/tmp'
   mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   fallocate -l 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
else
   TMPDIR='/tmp'
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   mkfile 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
fi

zfs set mountpoint=legacy $POOLNAME
zfs create -p $POOLNAME/clones/0
snap="ro"
name="$POOLNAME/clones/0@$snap"
zfs snap $name

for c in {1..170}; do
  zfs clone $name $POOLNAME/clones/$c
  name="$POOLNAME/clones/$c@$snap"
  zfs snap $name
done

zfs rename $POOLNAME/clones/1@ro $POOLNAME/clones/1@zfs-cleanup-temp
zfs promote $POOLNAME/clones/2
zfs destroy -r $POOLNAME/clones/1
zfs destroy $POOLNAME/clones/2@zfs-cleanup-temp # panic
```
A new test is added to the ZTS based on said reproducer to exercise this patch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
