### PR TITLE
Added metadata/dnode cache info to arc_summary

### DIFF
--- a/cmd/arc_summary/arc_summary.py
+++ b/cmd/arc_summary/arc_summary.py
@@ -204,10 +204,10 @@ def get_arc_summary(Kstat):
     arc_size = Kstat["kstat.zfs.misc.arcstats.size"]
     mru_size = Kstat["kstat.zfs.misc.arcstats.mru_size"]
     mfu_size = Kstat["kstat.zfs.misc.arcstats.mfu_size"]
-    dnode_size = Kstat["kstat.zfs.misc.arcstats.dnode_size"]
-    dnode_limit = Kstat["kstat.zfs.misc.arcstats.arc_dnode_limit"]
-    meta_size = Kstat["kstat.zfs.misc.arcstats.arc_meta_used"]
     meta_limit = Kstat["kstat.zfs.misc.arcstats.arc_meta_limit"]
+    meta_size = Kstat["kstat.zfs.misc.arcstats.arc_meta_used"]
+    dnode_limit = Kstat["kstat.zfs.misc.arcstats.arc_dnode_limit"]
+    dnode_size = Kstat["kstat.zfs.misc.arcstats.dnode_size"]
     target_max_size = Kstat["kstat.zfs.misc.arcstats.c_max"]
     target_min_size = Kstat["kstat.zfs.misc.arcstats.c_min"]
     target_size = Kstat["kstat.zfs.misc.arcstats.c"]
@@ -232,13 +232,13 @@ def get_arc_summary(Kstat):
         'per': fPerc(target_size, target_max_size),
         'num': fBytes(target_size),
     }
-    output['arc_sizing']['meta_size'] = {
-        'per': fPerc(meta_size, meta_limit),
-        'num': fBytes(meta_size),
-    }
     output['arc_sizing']['meta_limit'] = {
         'per': fPerc(meta_limit, target_max_size),
         'num': fBytes(meta_limit),
+    }
+    output['arc_sizing']['meta_size'] = {
+        'per': fPerc(meta_size, meta_limit),
+        'num': fBytes(meta_size),
     }
     output['arc_sizing']['dnode_limit'] = {
         'per': fPerc(dnode_limit, meta_limit),

--- a/cmd/arc_summary/arc_summary.py
+++ b/cmd/arc_summary/arc_summary.py
@@ -204,6 +204,10 @@ def get_arc_summary(Kstat):
     arc_size = Kstat["kstat.zfs.misc.arcstats.size"]
     mru_size = Kstat["kstat.zfs.misc.arcstats.mru_size"]
     mfu_size = Kstat["kstat.zfs.misc.arcstats.mfu_size"]
+    dnode_size = Kstat["kstat.zfs.misc.arcstats.dnode_size"]
+    dnode_limit = Kstat["kstat.zfs.misc.arcstats.arc_dnode_limit"]
+    meta_size = Kstat["kstat.zfs.misc.arcstats.arc_meta_used"]
+    meta_limit = Kstat["kstat.zfs.misc.arcstats.arc_meta_limit"]
     target_max_size = Kstat["kstat.zfs.misc.arcstats.c_max"]
     target_min_size = Kstat["kstat.zfs.misc.arcstats.c_min"]
     target_size = Kstat["kstat.zfs.misc.arcstats.c"]
@@ -227,6 +231,22 @@ def get_arc_summary(Kstat):
     output['arc_sizing']['target_size'] = {
         'per': fPerc(target_size, target_max_size),
         'num': fBytes(target_size),
+    }
+    output['arc_sizing']['meta_size'] = {
+        'per': fPerc(meta_size, meta_limit),
+        'num': fBytes(meta_size),
+    }
+    output['arc_sizing']['meta_limit'] = {
+        'per': fPerc(meta_limit, target_max_size),
+        'num': fBytes(meta_limit),
+    }
+    output['arc_sizing']['dnode_limit'] = {
+        'per': fPerc(dnode_limit, meta_limit),
+        'num': fBytes(dnode_limit),
+    }
+    output['arc_sizing']['dnode_size'] = {
+        'per': fPerc(dnode_size, dnode_limit),
+        'num': fBytes(dnode_size),
     }
 
     # ARC Hash Breakdown
@@ -331,6 +351,26 @@ def _arc_summary(Kstat):
     sys.stdout.write("\tFrequently Used Cache Size:\t%s\t%s\n" % (
         arc['arc_size_break']['frequently_used_cache_size']['per'],
         arc['arc_size_break']['frequently_used_cache_size']['num'],
+        )
+    )
+    sys.stdout.write("\tMetadata Size (Hard Limit):\t%s\t%s\n" % (
+        arc['arc_sizing']['meta_limit']['per'],
+        arc['arc_sizing']['meta_limit']['num'],
+        )
+    )
+    sys.stdout.write("\tMetadata Size:\t\t\t%s\t%s\n" % (
+        arc['arc_sizing']['meta_size']['per'],
+        arc['arc_sizing']['meta_size']['num'],
+        )
+    )
+    sys.stdout.write("\tDnode Size (Hard Limit):\t%s\t%s\n" % (
+        arc['arc_sizing']['dnode_limit']['per'],
+        arc['arc_sizing']['dnode_limit']['num'],
+        )
+    )
+    sys.stdout.write("\tDnode Size:\t\t\t%s\t%s\n" % (
+        arc['arc_sizing']['dnode_size']['per'],
+        arc['arc_sizing']['dnode_size']['num'],
         )
     )
 

--- a/cmd/arc_summary/arc_summary3.py
+++ b/cmd/arc_summary/arc_summary3.py
@@ -109,10 +109,10 @@ def draw_graph(kstats_dict):
     arc_perc = f_perc(arc_stats['size'], arc_stats['c_max'])
     mfu_size = f_bytes(arc_stats['mfu_size'])
     mru_size = f_bytes(arc_stats['mru_size'])
-    dnode_size = f_bytes(arc_stats['dnode_size'])
-    dnode_limit = f_bytes(arc_stats['arc_dnode_limit'])
-    meta_size = f_bytes(arc_stats['arc_meta_used'])
     meta_limit = f_bytes(arc_stats['arc_meta_limit'])
+    meta_size = f_bytes(arc_stats['arc_meta_used'])
+    dnode_limit = f_bytes(arc_stats['arc_dnode_limit'])
+    dnode_size = f_bytes(arc_stats['dnode_size'])
 
     info_form = 'ARC: {0} ({1})  MFU: {2}  MRU: {3}  META: {4} ({5}) DNODE {6} ({7})'
     info_line = info_form.format(arc_size, arc_perc, mfu_size, mru_size,
@@ -488,10 +488,10 @@ def section_arc(kstats_dict):
     arc_min = arc_stats['c_min']
     mfu_size = arc_stats['mfu_size']
     mru_size = arc_stats['mru_size']
-    dnode_size = arc_stats['dnode_size']
-    dnode_limit = arc_stats['arc_dnode_limit']
-    meta_size = arc_stats['arc_meta_used']
     meta_limit = arc_stats['arc_meta_limit']
+    meta_size = arc_stats['arc_meta_used']
+    dnode_limit = arc_stats['arc_dnode_limit']
+    dnode_size = arc_stats['dnode_size']
     target_size_ratio = '{0}:1'.format(int(arc_max) // int(arc_min))
 
     prt_2('ARC size (current):',

--- a/cmd/arc_summary/arc_summary3.py
+++ b/cmd/arc_summary/arc_summary3.py
@@ -109,9 +109,14 @@ def draw_graph(kstats_dict):
     arc_perc = f_perc(arc_stats['size'], arc_stats['c_max'])
     mfu_size = f_bytes(arc_stats['mfu_size'])
     mru_size = f_bytes(arc_stats['mru_size'])
+    dnode_size = f_bytes(arc_stats['dnode_size'])
+    dnode_limit = f_bytes(arc_stats['arc_dnode_limit'])
+    meta_size = f_bytes(arc_stats['arc_meta_used'])
+    meta_limit = f_bytes(arc_stats['arc_meta_limit'])
 
-    info_form = 'ARC: {0} ({1})  MFU: {2}  MRU: {3}'
-    info_line = info_form.format(arc_size, arc_perc, mfu_size, mru_size)
+    info_form = 'ARC: {0} ({1})  MFU: {2}  MRU: {3}  META: {4} ({5}) DNODE {6} ({7})'
+    info_line = info_form.format(arc_size, arc_perc, mfu_size, mru_size,
+                                 meta_size, meta_limit, dnode_size, dnode_limit)
     info_spc = ' '*int((GRAPH_WIDTH-len(info_line))/2)
     info_line = GRAPH_INDENT+info_spc+info_line
 
@@ -483,6 +488,10 @@ def section_arc(kstats_dict):
     arc_min = arc_stats['c_min']
     mfu_size = arc_stats['mfu_size']
     mru_size = arc_stats['mru_size']
+    dnode_size = arc_stats['dnode_size']
+    dnode_limit = arc_stats['arc_dnode_limit']
+    meta_size = arc_stats['arc_meta_used']
+    meta_limit = arc_stats['arc_meta_limit']
     target_size_ratio = '{0}:1'.format(int(arc_max) // int(arc_min))
 
     prt_2('ARC size (current):',
@@ -498,6 +507,14 @@ def section_arc(kstats_dict):
            f_perc(mfu_size, caches_size), f_bytes(mfu_size))
     prt_i2('Most Recently Used (MRU) cache size:',
            f_perc(mru_size, caches_size), f_bytes(mru_size))
+    prt_i2('Metadata cache size (hard limit):',
+           f_perc(meta_limit, arc_max), f_bytes(meta_limit))
+    prt_i2('Metadata cache size (current):',
+           f_perc(meta_size, meta_limit), f_bytes(meta_size))
+    prt_i2('Dnode cache size (hard limit):',
+           f_perc(dnode_limit, meta_limit), f_bytes(dnode_limit))
+    prt_i2('Dnode cache size (current):',
+           f_perc(dnode_size, dnode_limit), f_bytes(dnode_size))
     print()
 
     print('ARC hash breakdown:')


### PR DESCRIPTION

### Motivation and Context
I had a couple of users come through IRC who were experiencing issues with metadata-intensive operations not ending up cached despite having quite a lot of available RAM for ARC, because a combination of arc_meta_limit and arc_dnode_limit meant they were constantly hitting the ceiling of dnodes in cache and evicting some.

I got tired of remembering the specific kstats to ask for every time, so I just plumbed it into arc_summary{,3}.

### Description
Added kstat harvesting and a few printout lines that look like this in arc_summary:
```
ARC Size Breakdown:
        Recently Used Cache Size:       24.39%  1.55    GiB
        Frequently Used Cache Size:     75.61%  4.81    GiB
        Metadata Size (Hard Limit):     75.00%  36.00   GiB
        Metadata Size:                  41.83%  15.06   GiB
        Dnode Size (Hard Limit):        50.00%  18.00   GiB
        Dnode Size:                     26.63%  4.79    GiB
```
and this in arc_summary3:
```
ARC size (current):                                    31.4 %   15.1 GiB
        Target size (adaptive):                        31.4 %   15.1 GiB
        Min size (hard limit):                          4.1 %    2.0 GiB
        Max size (high water):                           24:1   48.0 GiB
        Most Frequently Used (MFU) cache size:         75.6 %    4.8 GiB
        Most Recently Used (MRU) cache size:           24.4 %    1.6 GiB
        Metadata cache size (hard limit):              75.0 %   36.0 GiB
        Metadata cache size (current):                 41.8 %   15.1 GiB
        Dnode cache size (hard limit):                 50.0 %   18.0 GiB
        Dnode cache size (current):                    26.6 %    4.8 GiB

```

### How Has This Been Tested?
I've been running the modified arc_summary for about a week on my machine without any obvious hiccups; arc_summary3 I've occasionally tested, and not found any issues.

The only caveat is that at least on one occasion, I found dnode_size > arc_dnode_limit, and not because I adjusted arc_dnode_limit{,_by_percent}, so logically it will sometimes report over 100%; I don't know if this is a misunderstanding on my part of the respective kstats or something stranger, but it doesn't appear to be a bug in the code.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
