### PR TITLE
Add libaio-devel BuildRequires

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -203,6 +203,7 @@ Requires:       acl
 Requires:       sudo
 Requires:       sysstat
 Requires:       libaio
+BuildRequires:  libaio-devel
 AutoReqProv:    no
 
 %description test


### PR DESCRIPTION
### Motivation and Context

The `zfs-test` package should include all binaries needed to for a full ZTS run.

Issue #7821

### Description

The `zfs-test` package needs a build requirement on the `libaio-devel` package.  Without it ./configure will correctly determine that `mmap_libaio` cannot be built and it will be skipped.

### How Has This Been Tested?

Locally build zfs-test package, verified `mmap_libaio` is built and included.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
