### PR TITLE
Fedora 28: Fix misc bounds check compiler warnings

### DIFF
--- a/lib/libshare/smb.c
+++ b/lib/libshare/smb.c
@@ -219,7 +219,7 @@ smb_enable_share_one(const char *sharename, const char *sharepath)
 	int rc;
 
 	/* Support ZFS share name regexp '[[:alnum:]_-.: ]' */
-	strncpy(name, sharename, sizeof (name));
+	strlcpy(name, sharename, sizeof (name));
 	name [sizeof (name)-1] = '\0';
 
 	pos = name;

--- a/module/icp/core/kcf_mech_tabs.c
+++ b/module/icp/core/kcf_mech_tabs.c
@@ -321,7 +321,7 @@ kcf_create_mech_entry(kcf_ops_class_t class, char *mechname)
 		mutex_enter(&(me_tab[i].me_mutex));
 		if (me_tab[i].me_name[0] == 0) {
 			/* Found an empty spot */
-			(void) strncpy(me_tab[i].me_name, mechname,
+			(void) strlcpy(me_tab[i].me_name, mechname,
 			    CRYPTO_MAX_MECH_NAME);
 			me_tab[i].me_name[CRYPTO_MAX_MECH_NAME-1] = '\0';
 			me_tab[i].me_mechid = KCF_MECHID(class, i);

--- a/tests/zfs-tests/tests/functional/ctime/ctime.c
+++ b/tests/zfs-tests/tests/functional/ctime/ctime.c
@@ -155,7 +155,7 @@ do_link(const char *pfile)
 		return (-1);
 	}
 
-	strncpy(pfile_copy, pfile, sizeof (pfile_copy));
+	strncpy(pfile_copy, pfile, sizeof (pfile_copy)-1);
 	pfile_copy[sizeof (pfile_copy) - 1] = '\0';
 	/*
 	 * Figure out source file directory name, and create


### PR DESCRIPTION
### Motivation and Context

Some warnings were left on #7368 

This closes issue #7826 

### Description

Mostly I changed occurrences of strncpy that aborted compilation.

### How Has This Been Tested?

`./autogen.sh && ./configure --enable-debuginfo --enable-silent-rules --enable-dependency-tracking --enable-asan --enable-debug --enable-debug-kmem && make -j 12`


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
