### PR TITLE
Adapted pull #7463 to v0.6.5.11: RHEL 7.5 compat FMODE_KABI_ITERATE

### DIFF
--- a/config/kernel-vfs-iterate.m4
+++ b/config/kernel-vfs-iterate.m4
@@ -23,16 +23,27 @@ AC_DEFUN([ZFS_AC_KERNEL_VFS_ITERATE], [
 		dnl #
 		dnl # 3.11 API change
 		dnl #
+		dnl # RHEL 7.5 compatibility; the fops.iterate() method was
+		dnl # added to the file_operations structure but in order to
+		dnl # maintain KABI compatibility all callers must set
+		dnl # FMODE_KABI_ITERATE which is checked in iterate_dir().
+		dnl # When detected ignore this interface and fallback to
+		dnl # to using fops.readdir() to retain KABI compatibility.
+		dnl #
 		AC_MSG_CHECKING([whether fops->iterate() is available])
 		ZFS_LINUX_TRY_COMPILE([
 			#include <linux/fs.h>
-			int iterate(struct file *filp, struct dir_context * context)
-			    { return 0; }
+			int iterate(struct file *filp,
+			    struct dir_context *context) { return 0; }
 
 			static const struct file_operations fops
 			    __attribute__ ((unused)) = {
 				.iterate	 = iterate,
 			};
+
+			//#if defined(FMODE_KABI_ITERATE)
+			//#error "RHEL 7.5, FMODE_KABI_ITERATE interface"
+			//#endif
 		],[
 		],[
 			AC_MSG_RESULT(yes)
@@ -44,8 +55,8 @@ AC_DEFUN([ZFS_AC_KERNEL_VFS_ITERATE], [
 			AC_MSG_CHECKING([whether fops->readdir() is available])
 			ZFS_LINUX_TRY_COMPILE([
 				#include <linux/fs.h>
-				int readdir(struct file *filp, void *entry, filldir_t func)
-				    { return 0; }
+				int readdir(struct file *filp, void *entry,
+				    filldir_t func) { return 0; }
 
 				static const struct file_operations fops
 				    __attribute__ ((unused)) = {
@@ -57,7 +68,7 @@ AC_DEFUN([ZFS_AC_KERNEL_VFS_ITERATE], [
 				AC_DEFINE(HAVE_VFS_READDIR, 1,
 					  [fops->readdir() is available])
 			],[
-				AC_MSG_ERROR(no; file a bug report with ZFSOnLinux)
+				AC_MSG_ERROR(no; file a bug report with ZoL)
 			])
 		])
 	])

--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -52,7 +52,7 @@ extern int zfs_mkdir(struct inode *dip, char *dirname, vattr_t *vap,
     struct inode **ipp, cred_t *cr, int flags, vsecattr_t *vsecp);
 extern int zfs_rmdir(struct inode *dip, char *name, struct inode *cwd,
     cred_t *cr, int flags);
-extern int zfs_readdir(struct inode *ip, struct dir_context *ctx, cred_t *cr);
+extern int zfs_readdir(struct inode *ip, zpl_dir_context_t *ctx, cred_t *cr);
 extern int zfs_fsync(struct inode *ip, int syncflag, cred_t *cr);
 extern int zfs_getattr(struct inode *ip, vattr_t *vap, int flag, cred_t *cr);
 extern int zfs_getattr_fast(struct inode *ip, struct kstat *sp);

--- a/include/sys/zpl.h
+++ b/include/sys/zpl.h
@@ -125,27 +125,34 @@ extern const struct inode_operations zpl_ops_shares;
 
 #if defined(HAVE_VFS_ITERATE) || defined(HAVE_VFS_ITERATE_SHARED)
 
-#define	DIR_CONTEXT_INIT(_dirent, _actor, _pos) {	\
+#define	ZPL_DIR_CONTEXT_INIT(_dirent, _actor, _pos) {	\
 	.actor = _actor,				\
 	.pos = _pos,					\
 }
 
+typedef struct dir_context zpl_dir_context_t;
+
+#define	zpl_dir_emit		dir_emit
+#define	zpl_dir_emit_dot	dir_emit_dot
+#define	zpl_dir_emit_dotdot	dir_emit_dotdot
+#define	zpl_dir_emit_dots	dir_emit_dots
+
 #else
 
-typedef struct dir_context {
+typedef struct zpl_dir_context {
 	void *dirent;
 	const filldir_t actor;
 	loff_t pos;
-} dir_context_t;
+} zpl_dir_context_t;
 
-#define	DIR_CONTEXT_INIT(_dirent, _actor, _pos) {	\
+#define	ZPL_DIR_CONTEXT_INIT(_dirent, _actor, _pos) {	\
 	.dirent = _dirent,				\
 	.actor = _actor,				\
 	.pos = _pos,					\
 }
 
 static inline bool
-dir_emit(struct dir_context *ctx, const char *name, int namelen,
+zpl_dir_emit(zpl_dir_context_t *ctx, const char *name, int namelen,
     uint64_t ino, unsigned type)
 {
 	return (ctx->actor(ctx->dirent, name, namelen, ctx->pos, ino, type)
@@ -153,29 +160,29 @@ dir_emit(struct dir_context *ctx, const char *name, int namelen,
 }
 
 static inline bool
-dir_emit_dot(struct file *file, struct dir_context *ctx)
+zpl_dir_emit_dot(struct file *file, zpl_dir_context_t *ctx)
 {
 	return (ctx->actor(ctx->dirent, ".", 1, ctx->pos,
 	    file->f_path.dentry->d_inode->i_ino, DT_DIR) == 0);
 }
 
 static inline bool
-dir_emit_dotdot(struct file *file, struct dir_context *ctx)
+zpl_dir_emit_dotdot(struct file *file, zpl_dir_context_t *ctx)
 {
 	return (ctx->actor(ctx->dirent, "..", 2, ctx->pos,
 	    parent_ino(file->f_path.dentry), DT_DIR) == 0);
 }
 
 static inline bool
-dir_emit_dots(struct file *file, struct dir_context *ctx)
+zpl_dir_emit_dots(struct file *file, zpl_dir_context_t *ctx)
 {
 	if (ctx->pos == 0) {
-		if (!dir_emit_dot(file, ctx))
+		if (!zpl_dir_emit_dot(file, ctx))
 			return (false);
 		ctx->pos = 1;
 	}
 	if (ctx->pos == 1) {
-		if (!dir_emit_dotdot(file, ctx))
+		if (!zpl_dir_emit_dotdot(file, ctx))
 			return (false);
 		ctx->pos = 2;
 	}

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2010,7 +2010,7 @@ EXPORT_SYMBOL(zfs_rmdir);
  */
 /* ARGSUSED */
 int
-zfs_readdir(struct inode *ip, struct dir_context *ctx, cred_t *cr)
+zfs_readdir(struct inode *ip, zpl_dir_context_t *ctx, cred_t *cr)
 {
 	znode_t		*zp = ITOZ(ip);
 	zfs_sb_t	*zsb = ITOZSB(ip);
@@ -2115,7 +2115,7 @@ zfs_readdir(struct inode *ip, struct dir_context *ctx, cred_t *cr)
 			type = ZFS_DIRENT_TYPE(zap.za_first_integer);
 		}
 
-		done = !dir_emit(ctx, zap.za_name, strlen(zap.za_name),
+		done = !zpl_dir_emit(ctx, zap.za_name, strlen(zap.za_name),
 		    objnum, type);
 		if (done)
 			break;

--- a/module/zfs/zpl_ctldir.c
+++ b/module/zfs/zpl_ctldir.c
@@ -50,18 +50,18 @@ zpl_common_open(struct inode *ip, struct file *filp)
  * Get root directory contents.
  */
 static int
-zpl_root_iterate(struct file *filp, struct dir_context *ctx)
+zpl_root_iterate(struct file *filp, zpl_dir_context_t *ctx)
 {
 	zfs_sb_t *zsb = ITOZSB(filp->f_path.dentry->d_inode);
 	int error = 0;
 
 	ZFS_ENTER(zsb);
 
-	if (!dir_emit_dots(filp, ctx))
+	if (!zpl_dir_emit_dots(filp, ctx))
 		goto out;
 
 	if (ctx->pos == 2) {
-		if (!dir_emit(ctx, ZFS_SNAPDIR_NAME, strlen(ZFS_SNAPDIR_NAME),
+		if (!zpl_dir_emit(ctx, ZFS_SNAPDIR_NAME, strlen(ZFS_SNAPDIR_NAME),
 		    ZFSCTL_INO_SNAPDIR, DT_DIR))
 			goto out;
 
@@ -69,7 +69,7 @@ zpl_root_iterate(struct file *filp, struct dir_context *ctx)
 	}
 
 	if (ctx->pos == 3) {
-		if (!dir_emit(ctx, ZFS_SHAREDIR_NAME, strlen(ZFS_SHAREDIR_NAME),
+		if (!zpl_dir_emit(ctx, ZFS_SHAREDIR_NAME, strlen(ZFS_SHAREDIR_NAME),
 		    ZFSCTL_INO_SHARES, DT_DIR))
 			goto out;
 
@@ -85,7 +85,8 @@ out:
 static int
 zpl_root_readdir(struct file *filp, void *dirent, filldir_t filldir)
 {
-	struct dir_context ctx = DIR_CONTEXT_INIT(dirent, filldir, filp->f_pos);
+	zpl_dir_context_t ctx =
+	    ZPL_DIR_CONTEXT_INIT(dirent, filldir, filp->f_pos);
 	int error;
 
 	error = zpl_root_iterate(filp, &ctx);
@@ -93,7 +94,7 @@ zpl_root_readdir(struct file *filp, void *dirent, filldir_t filldir)
 
 	return (error);
 }
-#endif /* HAVE_VFS_ITERATE */
+#endif /* !HAVE_VFS_ITERATE && !HAVE_VFS_ITERATE_SHARED */
 
 /*
  * Get root directory attributes.
@@ -248,7 +249,7 @@ zpl_snapdir_lookup(struct inode *dip, struct dentry *dentry,
 }
 
 static int
-zpl_snapdir_iterate(struct file *filp, struct dir_context *ctx)
+zpl_snapdir_iterate(struct file *filp, zpl_dir_context_t *ctx)
 {
 	zfs_sb_t *zsb = ITOZSB(filp->f_path.dentry->d_inode);
 	fstrans_cookie_t cookie;
@@ -260,7 +261,7 @@ zpl_snapdir_iterate(struct file *filp, struct dir_context *ctx)
 	ZFS_ENTER(zsb);
 	cookie = spl_fstrans_mark();
 
-	if (!dir_emit_dots(filp, ctx))
+	if (!zpl_dir_emit_dots(filp, ctx))
 		goto out;
 
 	pos = ctx->pos;
@@ -272,7 +273,7 @@ zpl_snapdir_iterate(struct file *filp, struct dir_context *ctx)
 		if (error)
 			goto out;
 
-		if (!dir_emit(ctx, snapname, strlen(snapname),
+		if (!zpl_dir_emit(ctx, snapname, strlen(snapname),
 		    ZFSCTL_INO_SHARES - id, DT_DIR))
 			goto out;
 
@@ -292,7 +293,8 @@ out:
 static int
 zpl_snapdir_readdir(struct file *filp, void *dirent, filldir_t filldir)
 {
-	struct dir_context ctx = DIR_CONTEXT_INIT(dirent, filldir, filp->f_pos);
+	zpl_dir_context_t ctx =
+	    ZPL_DIR_CONTEXT_INIT(dirent, filldir, filp->f_pos);
 	int error;
 
 	error = zpl_snapdir_iterate(filp, &ctx);
@@ -300,7 +302,7 @@ zpl_snapdir_readdir(struct file *filp, void *dirent, filldir_t filldir)
 
 	return (error);
 }
-#endif /* HAVE_VFS_ITERATE */
+#endif /* !HAVE_VFS_ITERATE && !HAVE_VFS_ITERATE_SHARED */
 
 static int
 zpl_snapdir_rename2(struct inode *sdip, struct dentry *sdentry,
@@ -462,7 +464,7 @@ zpl_shares_lookup(struct inode *dip, struct dentry *dentry,
 }
 
 static int
-zpl_shares_iterate(struct file *filp, struct dir_context *ctx)
+zpl_shares_iterate(struct file *filp, zpl_dir_context_t *ctx)
 {
 	fstrans_cookie_t cookie;
 	cred_t *cr = CRED();
@@ -474,7 +476,7 @@ zpl_shares_iterate(struct file *filp, struct dir_context *ctx)
 	cookie = spl_fstrans_mark();
 
 	if (zsb->z_shares_dir == 0) {
-		dir_emit_dots(filp, ctx);
+		zpl_dir_emit_dots(filp, ctx);
 		goto out;
 	}
 
@@ -499,7 +501,8 @@ out:
 static int
 zpl_shares_readdir(struct file *filp, void *dirent, filldir_t filldir)
 {
-	struct dir_context ctx = DIR_CONTEXT_INIT(dirent, filldir, filp->f_pos);
+	zpl_dir_context_t ctx =
+	    ZPL_DIR_CONTEXT_INIT(dirent, filldir, filp->f_pos);
 	int error;
 
 	error = zpl_shares_iterate(filp, &ctx);
@@ -507,7 +510,7 @@ zpl_shares_readdir(struct file *filp, void *dirent, filldir_t filldir)
 
 	return (error);
 }
-#endif /* HAVE_VFS_ITERATE */
+#endif /* !HAVE_VFS_ITERATE && !HAVE_VFS_ITERATE_SHARED */
 
 /* ARGSUSED */
 static int


### PR DESCRIPTION
This is an adaptation of pull #7453 to 0.6.5 branch, in order to allow building v0.6.5.11+ under redhat/centos 7.5

### How Has This Been Tested?

Tested under vagrant and baremetal configuration using centos 7.5 (kernel 3.10.0-862.9.1.el7.x86_64). Ensuring directory listing works fine. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
