### PR TITLE
ZTS: Fix zfs_create_013_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_013_pos.ksh
@@ -48,8 +48,7 @@ function cleanup
 {
 	typeset -i j=0
 	while [[ $j -lt ${#size[*]} ]]; do
-		datasetexists $TESTPOOL/${LONGFSNAME}${size[j]} && \
-		    log_must zfs destroy $TESTPOOL/${LONGFSNAME}${size[j]}
+		destroy_dataset $TESTPOOL/${LONGFSNAME}${size[j]}
 		((j = j + 1))
 	done
 }


### PR DESCRIPTION
### Motivation and Context

Resolve another rare, but observed, ZTS failure.

```
1
8:23:25.01 'zfs create -s -V <size> <volume>' works as expected.
18:23:25.01 NOTE: Performing local cleanup via log_onexit (cleanup)
18:23:25.10 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567898k
18:23:25.20 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567898K
18:23:25.31 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891m
18:23:25.41 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891M
18:23:25.47 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891mb
18:23:25.58 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891mB
18:23:25.66 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891Mb
18:23:25.75 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891MB
18:23:25.86 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891g
18:23:25.97 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891G
18:23:26.06 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891p
18:23:26.14 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891P
18:23:26.25 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891gb
18:23:26.36 SUCCESS: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891gB
18:23:26.37 cannot destroy 'testpool/fsysname50charslong_0123456789012345678901234567891Gb': dataset is busy
18:23:26.37 ERROR: zfs destroy testpool/fsysname50charslong_0123456789012345678901234567891Gb exited 1
```

http://build.zfsonlinux.org/builders/CentOS%206%20x86_64%20%28TEST%29/builds/3679/steps/shell_9/logs/summary

### Description

It's possible for an unrelated process, like blkid, to have the
volume open when 'zfs destroy' is run.  Switch the cleanup function
to the destroy_dataset() helper which handles this case by retrying
the destroy when the dataset is busy.

### How Has This Been Tested?

Locally ran the test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
