### PR TITLE
ZTS: fix DEV_DSKDIR trim from disk

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2006,7 +2006,7 @@ function check_hotspare_state # pool disk state{inuse,avail}
 function wait_hotspare_state # pool disk state timeout
 {
 	typeset pool=$1
-	typeset disk=${2#$/DEV_DSKDIR/}
+	typeset disk=${2#*$DEV_DSKDIR/}
 	typeset state=$3
 	typeset timeout=${4:-60}
 	typeset -i i=0
@@ -2050,7 +2050,7 @@ function check_slog_state # pool disk state{online,offline,unavail}
 function check_vdev_state # pool disk state{online,offline,unavail}
 {
 	typeset pool=$1
-	typeset disk=${2#$/DEV_DSKDIR/}
+	typeset disk=${2#*$DEV_DSKDIR/}
 	typeset state=$3
 
 	cur_state=$(get_device_state $pool $disk)
@@ -2069,7 +2069,7 @@ function check_vdev_state # pool disk state{online,offline,unavail}
 function wait_vdev_state # pool disk state timeout
 {
 	typeset pool=$1
-	typeset disk=${2#$/DEV_DSKDIR/}
+	typeset disk=${2#*$DEV_DSKDIR/}
 	typeset state=$3
 	typeset timeout=${4:-60}
 	typeset -i i=0


### PR DESCRIPTION
Signed-off-by: Richard Elling <Richard.Elling@RichardElling.com>

<!--- Provide a general summary of your changes in the Title above -->
In ZTS libtest.shlib, there are several helper functions that observe the
state of a vdev. If a full pathname is provided, such as `/dev/sda` then
the `/dev/` portion needs to be stripped for comparison to the `zpool status`
output. The current method for stripping does not work. The proposed fix
should work.
```
$ DEV_DSKDIR=/dev
$ DISK=/dev/sda
$ echo ${DISK#$/DEV_DSKDIR/}
/dev/sda
$ # proposed fix
$ echo ${DISK#*$DEV_DSKDIR/}
sda
```

Unless you are testing with full pathnames for DISKS, you might not notice
this change, which is perhaps why it has been broken for so long...
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
Sometimes we do want to test with `DISKS=/dev/sda` and these functions 
should do the right thing.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
Manual testing

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
