### PR TITLE
Add zfs_arc_shrinker_enabled module option

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -869,6 +869,21 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
+\fBzfs_arc_shrinker_enabled\fR (int)
+.ad
+.RS 12n
+When enabled kswapd can request that the ARC size be reduced in order to
+maintain a minimum amount of free memory on the system.  When disabled these
+requests will not be honored.  This option never prevents direct memory
+reclaim if the kernel requests it.  This option is experimental and
+provided for performance analysis.  It is enabled by default.
+.sp
+Default value: \fB1\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_arc_pc_percent\fR (uint)
 .ad
 .RS 12n


### PR DESCRIPTION
### Motivation and Context

Investigate ARC collapse described in issue #7820.  

### Description

The idea here is to allow the `arc_reclaim` thread to solely manage
the indirect memory reclaim from the ARC.  Only direct memory reclaim
requests by the kernel will result in memory being freed.  These
indicate that the kernel needs memory immediately and should not
be ignored by the ARC.

When disabled this should prevent the ARC from collapsing due to
the shrinker.  By default, the indirect shrinker remains enabling
and there is no change is behavior pending performance results.

### How Has This Been Tested?

Locally built, pending additional performance analysis.  Submitted to buildbot for additional test coverage.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
