### PR TITLE
ZTS: Fix EBUSY volume destroy failures

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -216,8 +216,6 @@ maybe = {
     'cli_root/zdb/zdb_006_pos': ['FAIL', known_reason],
     'cli_root/zfs_get/zfs_get_004_pos': ['FAIL', known_reason],
     'cli_root/zfs_get/zfs_get_009_pos': ['SKIP', '5479'],
-    'cli_root/zfs_receive/receive-o-x_props_override':
-        ['FAIL', known_reason],
     'cli_root/zfs_rename/zfs_rename_006_pos': ['FAIL', '5647'],
     'cli_root/zfs_rename/zfs_rename_009_neg': ['FAIL', '5648'],
     'cli_root/zfs_rollback/zfs_rollback_001_pos': ['FAIL', '6415'],

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_fs.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_fs.ksh
@@ -22,7 +22,7 @@ fs=$TESTPOOL/$TESTFS/testchild
 
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy $fs
+	destroy_dataset $fs
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_snap.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_snap.ksh
@@ -22,7 +22,7 @@ snap=$TESTPOOL/$TESTFS@$TESTSNAP
 
 function cleanup
 {
-	datasetexists $snap && log_must zfs destroy $snap
+	destroy_dataset $snap
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_count_and_limit.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_count_and_limit.ksh
@@ -29,7 +29,7 @@ snap=$fs@$TESTSNAP
 
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy -R $fs
+	destroy_dataset $fs "-R"
 	log_must rm -rf $fs/foo
 	log_must rm -rf $fs/bar
 }

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_index_props.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_index_props.ksh
@@ -27,7 +27,7 @@ fs=$TESTPOOL/$TESTFS/testchild
 snap=$fs@$TESTSNAP
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy -R $fs
+	destroy_dataset $fs "-R"
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_mountpoint.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_mountpoint.ksh
@@ -31,8 +31,8 @@ mnt2=/$fs/mnt2
 
 function cleanup
 {
-	datasetexists $clone && log_must zfs destroy $clone
-	datasetexists $fs && log_must zfs destroy -R $fs
+	destroy_dataset $clone
+	destroy_dataset $fs "-R"
 	log_must rm -rf $mnt1
 	log_must rm -rf $mnt2
 }

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_neg.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_neg.ksh
@@ -25,7 +25,7 @@ verify_runnable "global"
 fs=$TESTPOOL/$TESTFS/testchild
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy $fs
+	destroy_dataset $fs
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_number_props.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_number_props.ksh
@@ -30,8 +30,8 @@ vol=$TESTPOOL/$TESTVOL
 
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy -R $fs
-	datasetexists $vol && log_must zfs destroy $vol
+	destroy_dataset $fs "-R"
+	destroy_dataset $vol
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_type.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_type.ksh
@@ -28,9 +28,9 @@ snap=$fs@$TESTSNAP
 vol=$TESTPOOL/$TESTVOL
 function cleanup
 {
-	datasetexists $snap && log_must zfs destroy $snap
-	datasetexists $fs && log_must zfs destroy $fs
-	datasetexists $vol && log_must zfs destroy $vol
+	destroy_dataset $snap
+	destroy_dataset $fs
+	destroy_dataset $vol
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_userquota.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_userquota.ksh
@@ -31,8 +31,8 @@ groupid='456'
 
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy $fs
-	datasetexists $fs1 && log_must zfs destroy $fs1
+	destroy_dataset $fs
+	destroy_dataset $fs1
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_written.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_written.ksh
@@ -30,7 +30,7 @@ dir=/$fs/dir
 
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy -R $fs
+	destroy_dataset $fs "-R"
 	log_must rm -rf $dir
 }
 

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_children.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_children.ksh
@@ -32,10 +32,10 @@ TESTCHILD3=$TESTCHILD-3
 
 function cleanup
 {
-	datasetexists $TESTCHILD && log_must zfs destroy $TESTCHILD
-	datasetexists $TESTCHILD1 && log_must zfs destroy $TESTCHILD1
-	datasetexists $TESTCHILD2 && log_must zfs destroy $TESTCHILD2
-	datasetexists $TESTCHILD3 && log_must zfs destroy $TESTCHILD3
+	destroy_dataset $TESTCHILD
+	destroy_dataset $TESTCHILD1
+	destroy_dataset $TESTCHILD2
+	destroy_dataset $TESTCHILD3
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_clones.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_clones.ksh
@@ -27,8 +27,7 @@ log_assert "Listing zfs clones should work correctly."
 
 function cleanup
 {
-	datasetexists $TESTPOOL/$TESTFS@$TESTSNAP && \
-	    log_must zfs destroy -R $TESTPOOL/$TESTFS@$TESTSNAP
+	destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP "-R"
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_snapshots.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_snapshots.ksh
@@ -27,14 +27,10 @@ log_assert "Listing zfs snapshots should work correctly."
 
 function cleanup
 {
-	datasetexists $TESTPOOL/$TESTFS@$TESTSNAP && \
-	    log_must zfs destroy $TESTPOOL/$TESTFS@$TESTSNAP
-	datasetexists $TESTPOOL/$TESTFS@$TESTSNAP1 && \
-	    log_must zfs destroy $TESTPOOL/$TESTFS@$TESTSNAP1
-	datasetexists $TESTPOOL/$TESTFS@$TESTSNAP2 && \
-	    log_must zfs destroy $TESTPOOL/$TESTFS@$TESTSNAP2
-	datasetexists $TESTPOOL/$TESTFS@$TESTSNAP3 && \
-	    log_must zfs destroy $TESTPOOL/$TESTFS@$TESTSNAP3
+	destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP
+	destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP1
+	destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP2
+	destroy_dataset $TESTPOOL/$TESTFS@$TESTSNAP3
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_system_props.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_system_props.ksh
@@ -28,9 +28,9 @@ snap=$fs@$TESTSNAP
 vol=$TESTPOOL/$TESTVOL
 function cleanup
 {
-	datasetexists $snap && log_must zfs destroy $snap
-	datasetexists $fs && log_must zfs destroy $fs
-	datasetexists $vol && log_must zfs destroy $vol
+	destroy_dataset $snap
+	destroy_dataset $fs
+	destroy_dataset $vol
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.promote_conflict.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.promote_conflict.ksh
@@ -32,7 +32,7 @@ snap=promote_conflict_snap
 function cleanup
 {
     for to_destroy in $fs $clone; do
-        datasetexists $to_destroy && log_must zfs destroy -R $to_destroy
+        destroy_dataset $to_destroy "-R"
     done
 }
 

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.promote_multiple.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.promote_multiple.ksh
@@ -32,7 +32,7 @@ snap2=$clone1@testchild_snap2
 function cleanup
 {
     for to_destroy in $fs $clone1 $clone2; do
-        datasetexists $to_destroy && log_must zfs destroy -R $to_destroy
+        destroy_dataset $to_destroy "-R"
     done
 }
 

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.promote_simple.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.promote_simple.ksh
@@ -30,7 +30,7 @@ snap=$fs@$TESTSNAP
 function cleanup
 {
     for to_destroy in $fs $clone; do
-        datasetexists $to_destroy && log_must zfs destroy -R $to_destroy
+        destroy_dataset $to_destroy "-R"
     done
 }
 

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.rollback_mult.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.rollback_mult.ksh
@@ -24,8 +24,7 @@ file=$TESTDIR/$TESTFILE0
 
 function cleanup
 {
-	datasetexists $snap1 && log_must zfs destroy $snap1 && \
-	    log_must rm $file
+	destroy_dataset $snap1 && log_must rm $file
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.rollback_one.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.rollback_one.ksh
@@ -23,9 +23,7 @@ file=$TESTDIR/$TESTFILE0
 
 function cleanup
 {
-	datasetexists $snap && log_must zfs destroy $snap && \
-	    log_must rm $file
-
+	destroy_dataset $snap && log_must rm $file
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.snapshot_destroy.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.snapshot_destroy.ksh
@@ -26,7 +26,7 @@ fs=$TESTPOOL/$TESTFS/testchild
 
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy -R $fs
+	destroy_dataset $fs "-R"
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.snapshot_neg.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.snapshot_neg.ksh
@@ -28,7 +28,7 @@ fs2=$TESTPOOL/$TESTFS/testchild2
 function cleanup
 {
 	for fs in $fs1 $fs2; do
-		datasetexists $fs && log_must zfs destroy -R $fs
+		destroy_dataset $fs "-R"
 	done
 }
 

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.snapshot_recursive.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.snapshot_recursive.ksh
@@ -28,7 +28,7 @@ snapname=snap
 
 function cleanup
 {
-	datasetexists $rootfs && log_must zfs destroy -R $rootfs
+	destroy_dataset $rootfs "-R"
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.snapshot_simple.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.snapshot_simple.ksh
@@ -27,7 +27,7 @@ snapname=testsnap
 
 function cleanup
 {
-	datasetexists $fs && log_must zfs destroy -R $fs
+	destroy_dataset $fs "-R"
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_002_pos.ksh
@@ -47,9 +47,7 @@ function cleanup
 {
 	typeset -i j=0
 	while [[ $j -lt ${#size[*]} ]]; do
-		if datasetexists $TESTPOOL/${TESTVOL}${size[j]}; then
-			log_must zfs destroy $TESTPOOL/${TESTVOL}${size[j]}
-		fi
+		destroy_dataset $TESTPOOL/${TESTVOL}${size[j]}
 		((j = j + 1))
 	done
 }

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/receive-o-x_props_override.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/receive-o-x_props_override.ksh
@@ -268,7 +268,7 @@ log_must zfs snapshot $orig@snap1
 log_must eval "zfs send $orig@snap1 > $streamfile_full"
 log_mustnot eval "zfs receive -x atime $dest < $streamfile_full"
 log_mustnot eval "zfs receive -o atime=off $dest < $streamfile_full"
-log_must zfs destroy -r -f $orig
+log_must_busy zfs destroy -r -f $orig
 log_must zfs create $orig
 log_must zfs create -V 128K -s $origsub
 log_must zfs snapshot -r $orig@snap1
@@ -279,8 +279,9 @@ log_must eval "check_prop_source $dest atime off local"
 log_must eval "check_prop_source $destsub type volume -"
 log_must eval "check_prop_source $destsub atime - -"
 # Cleanup
-log_must zfs destroy -r -f $orig
-log_must zfs destroy -r -f $dest
+block_device_wait
+log_must_busy zfs destroy -r -f $orig
+log_must_busy zfs destroy -r -f $dest
 
 #
 # 3.8 Verify 'zfs recv -x|-o' works correctly when used in conjunction with -d


### PR DESCRIPTION
### Motivation and Context

Continue chipping away at test cases which sometimes fail due to a
volume being busy when the destroy is issued.  This PRs gets a few
more instances which I've observed in the CI logs, there are likely more.

### Description

It's possible for an unrelated process, like blkid, to have the
volume open when 'zfs destroy' is run.  Switch the cleanup functions
to the destroy_dataset() helper which handles this case by retrying
the destroy when the dataset is busy.  This was done not only for
volumes but also for file systems for consistency.

### How Has This Been Tested?

Locally tested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
