### PR TITLE
Added recalculation of ARC stats mid-eviction to avoid pathology

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4658,6 +4658,13 @@ arc_adjust(void)
 	}
 
 	/*
+	 * Re-sum ARC stats after the first round of evictions.
+	 */
+	asize = aggsum_value(&arc_size);
+	ameta = aggsum_value(&arc_meta_used);
+
+
+	/*
 	 * Adjust MFU size
 	 *
 	 * Now that we've tried to evict enough from the MRU to get its


### PR DESCRIPTION
### Motivation and Context
Was uncovered coincidentally by someone else while we were looking into #7820, and while it looked compelling, was not the issue for that particular fire.

### Description
Re-adds a recalculation step for the ARC stats after the MRU eviction so that we don't pathologically attempt to evict the MFU.

Just a simple port of the simple patch that markj@freebsd.org provided.

(see [here](https://lists.freebsd.org/pipermail/freebsd-fs/2018-August/026632.html) and [here](https://openzfs.topicbox.com/groups/developer/T10a105c53bcce15c-M8152dc2430a5ea4e625ad564/potential-bug-recently-introduced-in-arcadjust-that-leads-to-unintended-pressure-on-mfu-eventually-leading-to-dramatic-reduction-in-its-size) for the FreeBSD-FS and OpenZFS-developer mailing list discussions, respectively.)

### How Has This Been Tested?
So far, it compiled and ran without breaking my test VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
