### PR TITLE
Fix 'zfs allow' for create time permissions

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -5476,7 +5476,6 @@ print_set_creat_perms(uu_avl_t *who_avl)
 		gettext("Create time permissions:\n"),
 		NULL
 	};
-	const char **title_ptr = sc_title;
 	who_perm_node_t *who_node = NULL;
 	int prev_weight = -1;
 
@@ -5490,7 +5489,7 @@ print_set_creat_perms(uu_avl_t *who_avl)
 		deleg_perm_node_t *deleg_node;
 
 		if (prev_weight != weight) {
-			(void) printf("%s", *title_ptr++);
+			(void) printf("%s", sc_title[weight]);
 			prev_weight = weight;
 		}
 

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -4039,7 +4039,8 @@ command restricts modifications of the global namespace to the root user.
 .Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
 .Ar setname Oc Ns ...
 .Ar filesystem Ns | Ns Ar volume
-.br
+.Xc
+.It Xo
 .Nm
 .Cm allow
 .Op Fl dl
@@ -4222,7 +4223,8 @@ and can be no more than 64 characters long.
 .Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
 .Ar setname Oc Ns ... Oc
 .Ar filesystem Ns | Ns Ar volume
-.br
+.Xc
+.It Xo
 .Nm
 .Cm unallow
 .Op Fl dlr

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -499,7 +499,7 @@ post =
 tags = ['functional', 'deadman']
 
 [tests/functional/delegate]
-tests = ['zfs_allow_001_pos', 'zfs_allow_002_pos',
+tests = ['zfs_allow_001_pos', 'zfs_allow_002_pos', 'zfs_allow_003_pos',
     'zfs_allow_004_pos', 'zfs_allow_005_pos', 'zfs_allow_006_pos',
     'zfs_allow_007_pos', 'zfs_allow_008_pos', 'zfs_allow_009_neg',
     'zfs_allow_010_pos', 'zfs_allow_011_neg', 'zfs_allow_012_neg',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7519

> I'm trying to allow "create time permissions", but the 'zfs allow -c' syntax isn't working. Instead, i get an empty permission set. I suspect the -s and -c options are getting confused somehow.

The comment reports `zfs allow -c` as not working, but i think the issue is just with how we _display_ create time permissions. We can verify that create time permissions are set correctly with `zdb`:

```
root@linux:~# # misc functions
root@linux:~# function is_linux() {
>    if [[ "$(uname)" == "Linux" ]]; then
>       return 0
>    else
>       return 1
>    fi
> }
root@linux:~# # setup
root@linux:~# POOLNAME='testpool'
root@linux:~# if is_linux; then
>    TMPDIR='/var/tmp'
>    mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/disk*
>    truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> else
>    TMPDIR='/tmp'
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/zpool_$POOLNAME.dat
>    mkfile 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> fi
root@linux:~# 
root@linux:~# zfs create $POOLNAME/fs
root@linux:~# zfs allow -c snapshot,destroy,mount $POOLNAME/fs
root@linux:~# zdb -dddd testpool | grep 'deleg_zapobj'
		deleg_zapobj = 0
		deleg_zapobj = 0
		deleg_zapobj = 0
		deleg_zapobj = 0
		deleg_zapobj = 77
root@linux:~# zdb -dddd testpool 77
Dataset mos [META], ID 0, cr_txg 4, 61.5K, 48 objects, rootbp DVA[0]=<0:18e00:200> DVA[1]=<0:1027000:200> DVA[2]=<0:1027200:200> [L0 DMU objset] fletcher4 lz4 unencrypted LE contiguous unique triple size=1000L/200P birth=9L/9P fill=48 cksum=1020b600b3:56927b55273:f82f203c7f18:1f6bd4de75ee02

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
        77    1   128K    512      0     512    512  100.00  DSL permissions
	dnode flags: USED_BYTES 
	dnode maxblkid: 0
	microzap: 512 bytes, 1 entries

		c-$ = 78 

root@linux:~# zdb -dddd testpool 78
Dataset mos [META], ID 0, cr_txg 4, 61.5K, 48 objects, rootbp DVA[0]=<0:18e00:200> DVA[1]=<0:1027000:200> DVA[2]=<0:1027200:200> [L0 DMU objset] fletcher4 lz4 unencrypted LE contiguous unique triple size=1000L/200P birth=9L/9P fill=48 cksum=1020b600b3:56927b55273:f82f203c7f18:1f6bd4de75ee02

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
        78    1   128K    512      0     512    512  100.00  DSL permissions
	dnode flags: USED_BYTES 
	dnode maxblkid: 0
	microzap: 512 bytes, 3 entries

		destroy = 0 
		mount = 0 
		snapshot = 0 

root@linux:~# 
```

### Description
<!--- Describe your changes in detail -->
When no permission set is defined for a dataset the create time permissions are incorrectly shown as if they were a permission set. This change simply correct how allow permissions are displayed.

This commit also fixes a small manpage formatting issue and adds the "zfs_allow_003_pos" test case to the ZFS Test Suite.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on local Debian8 builder:

```
root@linux:~# # misc functions
root@linux:~# function is_linux() {
>    if [[ "$(uname)" == "Linux" ]]; then
>       return 0
>    else
>       return 1
>    fi
> }
root@linux:~# # setup
root@linux:~# POOLNAME='testpool'
root@linux:~# if is_linux; then
>    TMPDIR='/var/tmp'
>    mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/disk*
>    truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> else
>    TMPDIR='/tmp'
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/zpool_$POOLNAME.dat
>    mkfile 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> fi
root@linux:~# 
root@linux:~# zfs create $POOLNAME/fs
root@linux:~# zfs allow -c snapshot,destroy,mount $POOLNAME/fs
root@linux:~# zfs allow $POOLNAME/fs
---- Permissions on testpool/fs --------------------------------------
Create time permissions:
	destroy,mount,snapshot
root@linux:~# 
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
