### PR TITLE
Correctly handle errors from kern_path() in zfsctl_snapdir_vget()

### DIFF
--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -1177,7 +1177,7 @@ zfsctl_snapdir_vget(struct super_block *sb, uint64_t objsetid, int gen,
 		goto out;
 
 	/* Trigger automount */
-	error = kern_path(mnt, LOOKUP_FOLLOW|LOOKUP_DIRECTORY, &path);
+	error = -kern_path(mnt, LOOKUP_FOLLOW|LOOKUP_DIRECTORY, &path);
 	if (error)
 		goto out;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
Fix #7764 

`zfsctl_snapdir_vget()` calls `kern_path()` and then returns any errors untouched, which is incorrect behavior. As a regular kernel function, `kern_path()` returns errors as negative errnos, such as `-ELOOP`, but ZFS code expects errors to be positive errnos, such as `ELOOP`. When these untouched negative errnos are returned to other ZFS functions, the functions incorrectly handle the results; in the case of #7764, this causes `zpl_fh_to_dentry()` to turn the negative error result into a positive number, which the kernel (in the form of `exportfs_decode_fh()`) considers to be a pointer and immediately panics on.

### Description

The fix is to negate the return value from `kern_path()`.

### How Has This Been Tested?

To test this fix, I built a Fedora 28 VM with the official 0.7.9 DKMS modules, verified that it paniced as a NFS server following the reproduction steps in #7764, and then hand-patched the DKMS source to negate the `kern_path()` return value. With my patched and rebuilt DKMS modules, the Fedora 28 NFS server didn't panic and clients just got the expected `ESTALE` errors.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
