### PR TITLE
Fix zfs_sysfs_live test failure

### DIFF
--- a/module/zfs/zfs_sysfs.c
+++ b/module/zfs/zfs_sysfs.c
@@ -294,9 +294,11 @@ zprop_sysfs_show(const char *attr_name, const zprop_desc_t *property,
 			    property->pd_strdefault : "";
 			break;
 		case PROP_TYPE_INDEX:
-			(void) zprop_index_to_string(property->pd_propnum,
+			if (zprop_index_to_string(property->pd_propnum,
 			    property->pd_numdefault, &show_str,
-			    property->pd_types);
+			    property->pd_types) != 0) {
+				show_str = "";
+			}
 			break;
 		default:
 			return (0);


### PR DESCRIPTION
### Motivation and Context
The ZTS `zfs_sysfs_live` test fails occasionally due to an unitialized string on an error path.

### Description
 The fix checks for an error to make sure the string is always initialized.

### How Has This Been Tested?
run the ZTS for  zfs_sysfs set of tests
manually check the zfs module sysfs property values

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
