### PR TITLE
Fix in-kernel builds of zfs for issue 7868

### DIFF
--- a/include/sys/zfs_sysfs.h
+++ b/include/sys/zfs_sysfs.h
@@ -35,6 +35,7 @@ void zfs_sysfs_fini(void);
 #define	zfs_sysfs_init()
 #define	zfs_sysfs_fini()
 
+boolean_t zfs_mod_supported(const char *, const char *);
 #endif
 
 #define	ZFS_SYSFS_POOL_PROPERTIES	"properties.pool"
@@ -43,5 +44,7 @@ void zfs_sysfs_fini(void);
 #define	ZFS_SYSFS_POOL_FEATURES		"features.pool"
 
 #define	ZFS_SYSFS_DIR			"/sys/module/zfs"
+/* Alternate location when ZFS is built as part of the kernel (rare) */
+#define	ZFS_SYSFS_ALT_DIR		"/sys/fs/zfs"
 
 #endif	/* _SYS_ZFS_SYSFS_H */

--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -81,20 +81,8 @@ zfs_mod_supported_prop(const char *name, zfs_type_t type)
 #if defined(_KERNEL) || defined(LIB_ZPOOL_BUILD)
 	return (B_TRUE);
 #else
-	struct stat64 statbuf;
-	char *path;
-	boolean_t supported = B_FALSE;
-	int len;
-
-	len = asprintf(&path, "%s/%s/%s", ZFS_SYSFS_DIR,
-	    (type == ZFS_TYPE_POOL) ? ZFS_SYSFS_POOL_PROPERTIES :
-	    ZFS_SYSFS_DATASET_PROPERTIES, name);
-
-	if (len > 0) {
-		supported = !!(stat64(path, &statbuf) == 0);
-		free(path);
-	}
-	return (supported);
+	return (zfs_mod_supported(type == ZFS_TYPE_POOL ?
+	    ZFS_SYSFS_POOL_PROPERTIES : ZFS_SYSFS_DATASET_PROPERTIES, name));
 #endif
 }
 

--- a/module/zfs/zfs_sysfs.c
+++ b/module/zfs/zfs_sysfs.c
@@ -570,11 +570,16 @@ zfs_sysfs_properties_init(zfs_mod_kobj_t *zfs_kobj, struct kobject *parent,
 void
 zfs_sysfs_init(void)
 {
-	struct kobject *parent =
-	    &(((struct module *)(THIS_MODULE))->mkobj).kobj;
+	struct kobject *parent;
+#if defined(CONFIG_ZFS) && !defined(CONFIG_ZFS_MODULE)
+	parent = kobject_create_and_add("zfs", fs_kobj);
+#else
+	parent = &(((struct module *)(THIS_MODULE))->mkobj).kobj;
+#endif
 	int err;
 
-	ASSERT(parent != NULL);
+	if (parent == NULL)
+		return;
 
 	err = zfs_kernel_features_init(&kernel_features_kobj, parent);
 	if (err)


### PR DESCRIPTION
### Motivation and Context
The recent sysfs zfs properties feature breaks the in-kernel builds of zfs (sans module).

### Description
For in-kernel builds, there is no `/sys/module/zfs` to act as a parent for the properties.  So for those builds we use `/sys/fs/zfs` which is only possible for GPL-ONLY.

Also updated the `zfs_mod_supported()` check in libzfs so that the property supported checks work in either context.

### How Has This Been Tested?
ZTS: zfs_sysfs
ztest

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
