### PR TITLE
zpool should detect invalid fsproperty on create

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -536,7 +536,6 @@ add_prop_list(const char *propname, char *propval, nvlist_t **props,
     boolean_t poolprop)
 {
 	zpool_prop_t prop = ZPOOL_PROP_INVAL;
-	zfs_prop_t fprop;
 	nvlist_t *proplist;
 	const char *normnm;
 	char *strval;
@@ -580,10 +579,18 @@ add_prop_list(const char *propname, char *propval, nvlist_t **props,
 		else
 			normnm = zpool_prop_to_name(prop);
 	} else {
-		if ((fprop = zfs_name_to_prop(propname)) != ZPROP_INVAL) {
-			normnm = zfs_prop_to_name(fprop);
-		} else {
+		zfs_prop_t fsprop = zfs_name_to_prop(propname);
+
+		if (zfs_prop_valid_for_type(fsprop, ZFS_TYPE_FILESYSTEM,
+		    B_FALSE)) {
+			normnm = zfs_prop_to_name(fsprop);
+		} else if (zfs_prop_user(propname) ||
+		    zfs_prop_userquota(propname)) {
 			normnm = propname;
+		} else {
+			(void) fprintf(stderr, gettext("property '%s' is "
+			    "not a valid filesystem property\n"), propname);
+			return (2);
 		}
 	}
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_003_pos.ksh
@@ -38,7 +38,8 @@
 # actually creating the pool.
 #
 # STRATEGY:
-# 1. Create storage pool with -n option
+# 1. Create storage pool with -n option; this should only work when valid
+#    properties are specified on the command line
 # 2. Verify the pool has not been actually created
 #
 
@@ -67,20 +68,39 @@ if is_mpath_device $DISK; then
 	partition_disk $SIZE $disk 1
 fi
 
-#
-# Make sure disk is clean before we use it
-#
-create_pool $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE0} > $tmpfile
-destroy_pool $TESTPOOL
+typeset vspec="${disk}${SLICE_PREFIX}${SLICE0}"
+typeset goodprops=('' '-o comment=text' '-O checksum=on' '-O ns:prop=value')
+typeset badprops=('-o ashift=9999' '-O doesnotexist=on' '-O volsize=10M')
 
-zpool create -n  $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE0} > $tmpfile
+# Verify zpool create -n with valid pool-level and fs-level options
+for prop in "${goodprops[@]}"
+do
+	#
+	# Make sure disk is clean before we use it
+	#
+	create_pool $TESTPOOL $vspec > $tmpfile
+	destroy_pool $TESTPOOL
 
-poolexists $TESTPOOL && \
-        log_fail "'zpool create -n <pool> <vspec> ...' fail."
+	log_must eval "zpool create -n $prop $TESTPOOL $vspec > $tmpfile"
 
-str="would create '$TESTPOOL' with the following layout:"
-cat $tmpfile | grep "$str" >/dev/null 2>&1
-(( $? != 0 )) && \
-        log_fail "'zpool create -n <pool> <vspec>...' is executed as unexpected."
+	poolexists $TESTPOOL && \
+		log_fail "'zpool create -n <pool> <vspec> ...' fail."
+
+	str="would create '$TESTPOOL' with the following layout:"
+	grep "$str" $tmpfile >/dev/null 2>&1 || \
+		log_fail "'zpool create -n <pool> <vspec>...' is executed as unexpected."
+done
+
+# Verify zpool create -n with invalid options
+for prop in "${badprops[@]}"
+do
+	#
+	# Make sure disk is clean before we use it
+	#
+	create_pool $TESTPOOL $vspec > $tmpfile
+	destroy_pool $TESTPOOL
+
+	log_mustnot zpool create -n $prop $TESTPOOL $vspec
+done
 
 log_pass "'zpool create -n <pool> <vspec>...' success."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7620

### Description
<!--- Describe your changes in detail -->
This change improve the handling of invalid filesystem properties when specified at pool creation: this is useful when 'zpool create -n' (dry run) is executed to detect invalid fs-level options (-O) before the actual command is run.

~NOTE: this is still Work in Progress.~

 * ~Need to add test case to the ZTS~ (the only occurrence of `zpool create -n` i could find is in "zpool_create_003_pos.ksh": i should probably update the existing test case instead of adding a new one). EDIT: done
 * ~Need to detect invalid dataset properties for volumes~ (`zpool create -n -O volsize=<n>` should fail). EDIT: done

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Manual run on local builder:

```
root@linux:~# POOLNAME='testpool'
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:~# zpool destroy $POOLNAME
cannot open 'testpool': no such pool
root@linux:~# rm -f $TMPDIR/disk*
root@linux:~# truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
root@linux:~# 
root@linux:~# zpool create -n -O doesnotexist=on $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
property 'doesnotexist' is not a valid filesystem property
root@linux:~# echo $?
1
root@linux:~# zpool create -n -O org.zfsonlinux:doesnotexist=on $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
would create 'testpool' with the following layout:

	testpool
	  /var/tmp/zpool_testpool.dat
root@linux:~# echo $?
0
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
