### PR TITLE
7865 zpool split can create a corrupted pool

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -22,8 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
- * Copyright (c) 2015, Nexenta Systems, Inc.  All rights reserved.
- * Copyright (c) 2013, 2014, Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018, Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
@@ -6485,7 +6484,8 @@ spa_vdev_split_mirror(spa_t *spa, char *newname, nvlist_t *config,
 			break;
 		}
 
-		if (vdev_dtl_required(vml[c])) {
+		if (vdev_dtl_required(vml[c]) ||
+		    vdev_resilver_needed(vml[c], NULL, NULL)) {
 			error = SET_ERROR(EBUSY);
 			break;
 		}

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -432,7 +432,8 @@ tags = ['functional', 'cli_root', 'zpool_set']
 
 [tests/functional/cli_root/zpool_split]
 tests = ['zpool_split_cliargs', 'zpool_split_devices',
-    'zpool_split_encryption', 'zpool_split_props', 'zpool_split_vdevs']
+    'zpool_split_encryption', 'zpool_split_props', 'zpool_split_vdevs',
+    'zpool_split_resilver']
 tags = ['functional', 'cli_root', 'zpool_split']
 
 [tests/functional/cli_root/zpool_status]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/Makefile.am
@@ -9,4 +9,5 @@ dist_pkgdata_SCRIPTS = \
 	zpool_split_devices.ksh \
 	zpool_split_encryption.ksh \
 	zpool_split_props.ksh \
-	zpool_split_vdevs.ksh
+	zpool_split_vdevs.ksh \
+	zpool_split_resilver.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_resilver.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_resilver.ksh
@@ -1,0 +1,109 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018, Nexenta Systems, Inc.  All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zpool split' should fail if resilver in progress for a disk
+#
+# STRATEGY:
+# The first scenario:
+# 1. Create a mirror pool
+# 2. Offline the first VDEV
+# 3. Put some data
+# 4. Online the first VDEV
+# 5. Verify 'zpool split' must fail
+#
+# The second scenario:
+# 1. Create a mirror pool
+# 2. Offline the second VDEV
+# 3. Put some data
+# 4. Online the second VDEV
+# 5. Verify 'zpool split' must fail
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zinject -c all
+	destroy_pool $TESTPOOL
+	destroy_pool $TESTPOOL2
+	rm -f $DEVICE1 $DEVICE2
+}
+
+function setup_mirror
+{
+	truncate -s $DEVSIZE $DEVICE1
+	truncate -s $DEVSIZE $DEVICE2
+	log_must zpool create -f $TESTPOOL mirror $DEVICE1 $DEVICE2
+}
+
+function zpool_split #disk_to_be_offline/online
+{
+	typeset disk=$1
+
+	setup_mirror
+
+	# offline a disk, so it will not be fully sync before split
+	log_must zpool offline $TESTPOOL $disk
+
+	# Create 2G of additional data
+	mntpnt=$(get_prop mountpoint $TESTPOOL)
+	log_must file_write -b 2097152 -c 1024 -o create -d 0 -f $mntpnt/biggerfile
+	log_must sync
+
+	# slow-down resilvering, so it will not finish too early
+	log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_SLOW
+	log_must zinject -d $DEVICE1 -D 50:1 $TESTPOOL
+	log_must zinject -d $DEVICE2 -D 50:1 $TESTPOOL
+
+	log_must zpool online $TESTPOOL $disk
+
+	typeset i=0
+	while ! is_pool_resilvering $TESTPOOL; do
+		if (( i > 10 )); then
+			log_fail "resilvering is not started"
+		fi
+		((i += 1))
+		sleep 1
+	done
+
+	log_mustnot zpool split $TESTPOOL $TESTPOOL2
+
+	log_must set_tunable64 zfs_scan_vdev_limit $ZFS_SCAN_VDEV_LIMIT_DEFAULT
+}
+
+log_assert "Verify 'zpool split' will fail if resilver in progress for a disk"
+log_onexit cleanup
+
+DEVSIZE='3g'
+DEVICE1="$TEST_BASE_DIR/device-1"
+DEVICE2="$TEST_BASE_DIR/device-2"
+
+ZFS_SCAN_VDEV_LIMIT_SLOW=$((128*1024))
+ZFS_SCAN_VDEV_LIMIT_DEFAULT=$(get_tunable zfs_scan_vdev_limit)
+
+log_note "Verify ZFS prevents main pool curruption during 'split'"
+zpool_split $DEVICE1
+
+cleanup
+
+log_note "Verify ZFS prevents new pool curruption during 'split'"
+zpool_split $DEVICE2
+
+log_pass "'zpool split' failed as expected"


### PR DESCRIPTION
Signed-off-by: Roman Strashkin <roman.strashkin@nexenta.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#7865 

### Description
<!--- Describe your changes in detail -->
Added vdev_resilver_needed() to be detachable VDEVs are fully sync, so that after `split` the new pool will not be corrupted.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Create a mirrored pool, offline the second device in the mirror, write data to the pool, online second device and use the device to split the pool. `split` needs to be executed before the resilvering has completed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
