### PR TITLE
Fix ASSERT macros to not over-expand

### DIFF
--- a/include/spl/sys/debug.h
+++ b/include/spl/sys/debug.h
@@ -63,22 +63,59 @@ void spl_dumpstack(void);
 	    spl_panic(__FILE__, __FUNCTION__, __LINE__,			\
 	    "%s", "VERIFY(" #cond ") failed\n"))
 
-#define	VERIFY3_IMPL(LEFT, OP, RIGHT, TYPE, FMT, CAST)	do {		\
-		TYPE _verify3_left = (TYPE)(LEFT);				\
-		TYPE _verify3_right = (TYPE)(RIGHT);				\
+#define	VERIFY3B(LEFT, OP, RIGHT)	do {				\
+		boolean_t _verify3_left = (boolean_t)(LEFT);		\
+		boolean_t _verify3_right = (boolean_t)(RIGHT);		\
 		if (!(_verify3_left OP _verify3_right))			\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
-		    "VERIFY3(" #LEFT " " #OP " " #RIGHT ") "		\
-		    "failed (" FMT " " #OP " " FMT ")\n",		\
-		    CAST (_verify3_left), CAST (_verify3_right));	\
+		    "VERIFY3(" #LEFT  #OP  #RIGHT ") "			\
+		    "failed (%d " #OP " %d)\n",				\
+		    (boolean_t) (_verify3_left),			\
+                    (boolean_t) (_verify3_right));			\
 	} while (0)
 
-#define	VERIFY3B(x,y,z)	VERIFY3_IMPL(x, y, z, boolean_t, "%d", (boolean_t))
-#define	VERIFY3S(x,y,z)	VERIFY3_IMPL(x, y, z, int64_t, "%lld", (long long))
-#define	VERIFY3U(x,y,z)	VERIFY3_IMPL(x, y, z, uint64_t, "%llu",		\
-				    (unsigned long long))
-#define	VERIFY3P(x,y,z)	VERIFY3_IMPL(x, y, z, uintptr_t, "%p", (void *))
-#define	VERIFY0(x)	VERIFY3_IMPL(0, ==, x, int64_t, "%lld",	(long long))
+#define	VERIFY3S(LEFT, OP, RIGHT)	do {				\
+		int64_t _verify3_left = (int64_t)(LEFT);		\
+		int64_t _verify3_right = (int64_t)(RIGHT);		\
+		if (!(_verify3_left OP _verify3_right))			\
+		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
+		    "VERIFY3(" #LEFT  #OP  #RIGHT ") "			\
+		    "failed (%lld " #OP " %lld)\n",			\
+		    (long long) (_verify3_left),			\
+		    (long long) (_verify3_right));			\
+	} while (0)
+
+#define	VERIFY3U(LEFT, OP, RIGHT)	do {				\
+		uint64_t _verify3_left = (uint64_t)(LEFT);		\
+		uint64_t _verify3_right = (uint64_t)(RIGHT);		\
+		if (!(_verify3_left OP _verify3_right))			\
+		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
+		    "VERIFY3(" #LEFT  #OP  #RIGHT ") "			\
+		    "failed (%llu " #OP " %llu)\n",			\
+		    (unsigned long long) (_verify3_left),		\
+		    (unsigned long long) (_verify3_right));		\
+	} while (0)
+
+#define	VERIFY3P(LEFT, OP, RIGHT)	do {				\
+		uintptr_t _verify3_left = (uintptr_t)(LEFT);		\
+		uintptr_t _verify3_right = (uintptr_t)(RIGHT);		\
+		if (!(_verify3_left OP _verify3_right))			\
+		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
+		    "VERIFY3(" #LEFT  #OP  #RIGHT ") "			\
+		    "failed (%p " #OP " %p)\n",				\
+		    (void *) (_verify3_left),				\
+		    (void *) (_verify3_right));				\
+	} while (0)
+
+#define	VERIFY0(RIGHT)	do {				\
+		int64_t _verify3_left = (int64_t)(0);		\
+		int64_t _verify3_right = (int64_t)(RIGHT);		\
+		if (!(_verify3_left == _verify3_right))			\
+		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
+		    "VERIFY3(0 == " #RIGHT ") "				\
+		    "failed (0 == %lld)\n",				\
+		    (long long) (_verify3_right));			\
+	} while (0)
 
 #define	CTASSERT_GLOBAL(x)		_CTASSERT(x, __LINE__)
 #define	CTASSERT(x)			{ _CTASSERT(x, __LINE__); }
@@ -107,13 +144,13 @@ void spl_dumpstack(void);
  */
 #else
 
-#define	ASSERT(cond)		VERIFY(cond)
+#define	ASSERT3B	VERIFY3B
+#define	ASSERT3S	VERIFY3S
+#define	ASSERT3U	VERIFY3U
+#define	ASSERT3P	VERIFY3P
+#define	ASSERT0		VERIFY0
+#define	ASSERT		VERIFY
 #define	ASSERTV(x)		x
-#define	ASSERT3B(x,y,z)		VERIFY3B(x, y, z)
-#define	ASSERT3S(x,y,z)		VERIFY3S(x, y, z)
-#define	ASSERT3U(x,y,z)		VERIFY3U(x, y, z)
-#define	ASSERT3P(x,y,z)		VERIFY3P(x, y, z)
-#define	ASSERT0(x)		VERIFY0(x)
 #define	IMPLY(A, B) \
 	((void)(((!(A)) || (B)) || \
 	    spl_panic(__FILE__, __FUNCTION__, __LINE__, \

--- a/include/spl/sys/debug.h
+++ b/include/spl/sys/debug.h
@@ -68,10 +68,10 @@ void spl_dumpstack(void);
 		boolean_t _verify3_right = (boolean_t)(RIGHT);		\
 		if (!(_verify3_left OP _verify3_right))			\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
-		    "VERIFY3(" #LEFT  #OP  #RIGHT ") "			\
+		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%d " #OP " %d)\n",				\
 		    (boolean_t) (_verify3_left),			\
-                    (boolean_t) (_verify3_right));			\
+		    (boolean_t) (_verify3_right));			\
 	} while (0)
 
 #define	VERIFY3S(LEFT, OP, RIGHT)	do {				\
@@ -79,7 +79,7 @@ void spl_dumpstack(void);
 		int64_t _verify3_right = (int64_t)(RIGHT);		\
 		if (!(_verify3_left OP _verify3_right))			\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
-		    "VERIFY3(" #LEFT  #OP  #RIGHT ") "			\
+		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%lld " #OP " %lld)\n",			\
 		    (long long) (_verify3_left),			\
 		    (long long) (_verify3_right));			\
@@ -90,7 +90,7 @@ void spl_dumpstack(void);
 		uint64_t _verify3_right = (uint64_t)(RIGHT);		\
 		if (!(_verify3_left OP _verify3_right))			\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
-		    "VERIFY3(" #LEFT  #OP  #RIGHT ") "			\
+		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%llu " #OP " %llu)\n",			\
 		    (unsigned long long) (_verify3_left),		\
 		    (unsigned long long) (_verify3_right));		\
@@ -101,7 +101,7 @@ void spl_dumpstack(void);
 		uintptr_t _verify3_right = (uintptr_t)(RIGHT);		\
 		if (!(_verify3_left OP _verify3_right))			\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
-		    "VERIFY3(" #LEFT  #OP  #RIGHT ") "			\
+		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
 		    "failed (%p " #OP " %p)\n",				\
 		    (void *) (_verify3_left),				\
 		    (void *) (_verify3_right));				\

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -66,21 +66,54 @@ libspl_assertf(const char *file, const char *func, int line, char *format, ...)
 	(void) ((!(cond)) &&						\
 	    libspl_assert(#cond, __FILE__, __FUNCTION__, __LINE__))
 
-#define	VERIFY3_IMPL(LEFT, OP, RIGHT, TYPE)				\
+#define	VERIFY3B(LEFT, OP, RIGHT)					\
 do {									\
-	const TYPE __left = (TYPE)(LEFT);				\
-	const TYPE __right = (TYPE)(RIGHT);				\
+	const boolean_t __left = (boolean_t)(LEFT);			\
+	const boolean_t __right = (boolean_t)(RIGHT);			\
 	if (!(__left OP __right))					\
 		libspl_assertf(__FILE__, __FUNCTION__, __LINE__,	\
 		    "%s %s %s (0x%llx %s 0x%llx)", #LEFT, #OP, #RIGHT,	\
 		    (u_longlong_t)__left, #OP, (u_longlong_t)__right);	\
 } while (0)
 
-#define	VERIFY3B(x, y, z)	VERIFY3_IMPL(x, y, z, boolean_t)
-#define	VERIFY3S(x, y, z)	VERIFY3_IMPL(x, y, z, int64_t)
-#define	VERIFY3U(x, y, z)	VERIFY3_IMPL(x, y, z, uint64_t)
-#define	VERIFY3P(x, y, z)	VERIFY3_IMPL(x, y, z, uintptr_t)
-#define	VERIFY0(x)		VERIFY3_IMPL(x, ==, 0, uint64_t)
+#define	VERIFY3S(LEFT, OP, RIGHT)					\
+do {									\
+	const int64_t __left = (int64_t)(LEFT);				\
+	const int64_t __right = (int64_t)(RIGHT);			\
+	if (!(__left OP __right))					\
+		libspl_assertf(__FILE__, __FUNCTION__, __LINE__,	\
+		    "%s %s %s (0x%llx %s 0x%llx)", #LEFT, #OP, #RIGHT,	\
+		    (u_longlong_t)__left, #OP, (u_longlong_t)__right);	\
+} while (0)
+
+#define	VERIFY3U(LEFT, OP, RIGHT)					\
+do {									\
+	const uint64_t __left = (uint64_t)(LEFT);			\
+	const uint64_t __right = (uint64_t)(RIGHT);			\
+	if (!(__left OP __right))					\
+		libspl_assertf(__FILE__, __FUNCTION__, __LINE__,	\
+		    "%s %s %s (0x%llx %s 0x%llx)", #LEFT, #OP, #RIGHT,	\
+		    (u_longlong_t)__left, #OP, (u_longlong_t)__right);	\
+} while (0)
+
+#define	VERIFY3P(LEFT, OP, RIGHT)					\
+do {									\
+	const uintptr_t __left = (uintptr_t)(LEFT);			\
+	const uintptr_t __right = (uintptr_t)(RIGHT);			\
+	if (!(__left OP __right))					\
+		libspl_assertf(__FILE__, __FUNCTION__, __LINE__,	\
+		    "%s %s %s (0x%llx %s 0x%llx)", #LEFT, #OP, #RIGHT,	\
+		    (u_longlong_t)__left, #OP, (u_longlong_t)__right);	\
+} while (0)
+
+#define	VERIFY0(LEFT)							\
+do {									\
+	const uint64_t __left = (uint64_t)(LEFT);			\
+	if (!(__left == 0))						\
+		libspl_assertf(__FILE__, __FUNCTION__, __LINE__,	\
+		    "%s == 0 (0x%llx == 0)", #LEFT,			\
+		    (u_longlong_t)__left);				\
+} while (0)
 
 #ifdef assert
 #undef assert
@@ -106,13 +139,13 @@ do {									\
 #define	IMPLY(A, B)		((void)0)
 #define	EQUIV(A, B)		((void)0)
 #else
-#define	ASSERT3B(x, y, z)	VERIFY3B(x, y, z)
-#define	ASSERT3S(x, y, z)	VERIFY3S(x, y, z)
-#define	ASSERT3U(x, y, z)	VERIFY3U(x, y, z)
-#define	ASSERT3P(x, y, z)	VERIFY3P(x, y, z)
-#define	ASSERT0(x)		VERIFY0(x)
-#define	ASSERT(x)		VERIFY(x)
-#define	assert(x)		VERIFY(x)
+#define	ASSERT3B	VERIFY3B
+#define	ASSERT3S	VERIFY3S
+#define	ASSERT3U	VERIFY3U
+#define	ASSERT3P	VERIFY3P
+#define	ASSERT0		VERIFY0
+#define	ASSERT		VERIFY
+#define	assert		VERIFY
 #define	ASSERTV(x)		x
 #define	IMPLY(A, B) \
 	((void)(((!(A)) || (B)) || \


### PR DESCRIPTION
The ASSERT macros will over-expand because of the macro expansion rules in C. This will result in the macro-expanded version of the argument being displayed instead of the raw source code version, which can make debugging very difficult if macros like BP_IS_HOLE are used inside of an assert.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
To improve the debugging experience, the ZFS ASSERT and VERIFY macros display the text of the assertion that failed. This is supposed to be the raw version of the text as visible in the source code, which aids in debugging (though line numbers and file names also help).

### Description
The definition of VERIFY3* in terms of VERIFY3_IMPL results in the text being passed as an argument to it to be expanded before the arguments can be stringified. There is no way to prevent or change this behavior, so each of the macros has to be defined separately to provide the appropriate behavior.  This results in unfortunate code duplication, but it has very significant advantages that (in my opinion) make this worthwhile. ASSERT* can be #defined as the appropriate VERIFY macro directly, which avoids the problematic macro expansion.

### How Has This Been Tested?
This change has been tested by triggering several asserts with a variety of arguments (functions, macros, constants), and verifying that they displayed appropriately.

Code:
`ASSERT(BP_IS_HOLE(bp));`

Panic string before (the string is cut off at a maximum length, the actual line of preprocessed source goes on much longer):
`VERIFY((!((((bp)->blk_prop) >> (39)) & ((1ULL << (1)) - 1)) && ((((void) (__builtin_expect(!!(!(!((((bp)->blk_prop) >> (39)) & ((1ULL << (1)) - 1)))), 0) && spl_panic("/export/home/delphix/zfs/module/zfs/dmu_send.c", __FUNCTION__, 1151, "%s", "VERIFY(" "!`

Panic string after:
`ASSERT(BP_IS_HOLE(bp)) failed`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
