### PR TITLE
Add removal_resume_export to zts-report.py

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -256,6 +256,7 @@ maybe = {
     'no_space/enospc_002_pos': ['FAIL', enospc_reason],
     'projectquota/setup': ['SKIP', exec_reason],
     'redundancy/redundancy_004_neg': ['FAIL', '7290'],
+    'removal/removal_resume_export': ['FAIL', '7894'],
     'reservation/reservation_008_pos': ['FAIL', '7741'],
     'reservation/reservation_018_pos': ['FAIL', '5642'],
     'rsend/rsend_019_pos': ['FAIL', '6086'],

--- a/tests/zfs-tests/tests/functional/removal/removal_resume_export.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_resume_export.ksh
@@ -53,7 +53,7 @@ function ensure_thread_running # spa_address
 	if is_linux; then
 		typeset TRIES=0
 		typeset THREAD_PID
-		while [[ $TRIES -lt 10 ]]; do
+		while [[ $TRIES -lt 50 ]]; do
 			THREAD_PID=$(pgrep spa_vdev_remove)
 			[[ "$THREAD_PID" ]] && break
 			sleep 0.1


### PR DESCRIPTION
### Motivation and Context

Properly annotate any ZTS false positives in the zts-results script until the test cases can be improved.
Issue #7894

### Description

Add the removal_resume_export test case to the possible failure section of the zts-report.py and reference the Github issue.  In the CI environment this test has proven to be unreliable due to
the way it detects the removal thread.  This is a flaw in the test and not device removal so update the result summary accordingly.

Additionally, increase the allowed timeout in an effort to reduce the observed rate of false positves.

### How Has This Been Tested?

Locally, pending additional result from the CI where the issue is more reproducible.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
