### PR TITLE
Limit spa_slop_shift tunable values

### DIFF
--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2553,6 +2553,26 @@ param_set_deadman_synctime(const char *val, zfs_kernel_param_t *kp)
 	return (0);
 }
 
+static int
+param_set_slop_shift(const char *buf, zfs_kernel_param_t *kp)
+{
+	unsigned long val;
+	int error;
+
+	error = kstrtoul(buf, 0, &val);
+	if (error)
+		return (SET_ERROR(error));
+
+	if (val < 1 || val > 31)
+		return (SET_ERROR(-EINVAL));
+
+	error = param_set_int(buf, kp);
+	if (error < 0)
+		return (SET_ERROR(error));
+
+	return (0);
+}
+
 /* Namespace manipulation */
 EXPORT_SYMBOL(spa_lookup);
 EXPORT_SYMBOL(spa_add);
@@ -2678,7 +2698,8 @@ module_param(spa_asize_inflation, int, 0644);
 MODULE_PARM_DESC(spa_asize_inflation,
 	"SPA size estimate multiplication factor");
 
-module_param(spa_slop_shift, int, 0644);
+module_param_call(spa_slop_shift, param_set_slop_shift, param_get_int,
+    &spa_slop_shift, 0644);
 MODULE_PARM_DESC(spa_slop_shift, "Reserved free space in pool");
 
 module_param(zfs_ddt_data_is_special, int, 0644);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7876 

### Description
<!--- Describe your changes in detail -->
This change limits `spa_slop_shift` possible values to avoid overflow conditions. Accepted values are 1 to 31 (inclusive).

NOTE: I don't know if this needs a new test case.

Limits were decided after the following observations (spa_slop_shift > 30 does not change slop space)

```
root@linux:~# POOLNAME='testpool'
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR -o size=134217728G
root@linux:~# zpool destroy $POOLNAME
root@linux:~# rm -f $TMPDIR/disk
root@linux:~# truncate -s 128P /var/tmp/disk
root@linux:~# zpool create $POOLNAME $TMPDIR/disk
root@linux:~# 
root@linux:~# 
root@linux:~# cat > ./issue-7876.sh <<'EOF'
> #!/bin/bash
> for i in `seq 0 63`
> do
>    echo $i > /sys/module/zfs/parameters/spa_slop_shift
>    df /testpool > /dev/null
> done
> EOF
root@linux:~# chmod +x ./issue-7876.sh
root@linux:~# 
root@linux:~# 
root@linux:~# stap -d zfs -e '
> probe module("zfs").function("spa_get_slop_space").return
> {
>    printf("spa_slop_shift=%d, spa_get_slop_space=%lu\n", @entry($spa_slop_shift), ($return));
> }
> ' -c ./issue-7876.sh
spa_slop_shift=0, spa_get_slop_space=142989288169013248
spa_slop_shift=1, spa_get_slop_space=71494644084506624
spa_slop_shift=2, spa_get_slop_space=35747322042253312
spa_slop_shift=3, spa_get_slop_space=17873661021126656
spa_slop_shift=4, spa_get_slop_space=8936830510563328
spa_slop_shift=5, spa_get_slop_space=4468415255281664
spa_slop_shift=6, spa_get_slop_space=2234207627640832
spa_slop_shift=7, spa_get_slop_space=1117103813820416
spa_slop_shift=8, spa_get_slop_space=558551906910208
spa_slop_shift=9, spa_get_slop_space=279275953455104
spa_slop_shift=10, spa_get_slop_space=139637976727552
spa_slop_shift=11, spa_get_slop_space=69818988363776
spa_slop_shift=12, spa_get_slop_space=34909494181888
spa_slop_shift=13, spa_get_slop_space=17454747090944
spa_slop_shift=14, spa_get_slop_space=8727373545472
spa_slop_shift=15, spa_get_slop_space=4363686772736
spa_slop_shift=16, spa_get_slop_space=2181843386368
spa_slop_shift=17, spa_get_slop_space=1090921693184
spa_slop_shift=18, spa_get_slop_space=545460846592
spa_slop_shift=19, spa_get_slop_space=272730423296
spa_slop_shift=20, spa_get_slop_space=136365211648
spa_slop_shift=21, spa_get_slop_space=68182605824
spa_slop_shift=22, spa_get_slop_space=34091302912
spa_slop_shift=23, spa_get_slop_space=17045651456
spa_slop_shift=24, spa_get_slop_space=8522825728
spa_slop_shift=25, spa_get_slop_space=4261412864
spa_slop_shift=26, spa_get_slop_space=2130706432
spa_slop_shift=27, spa_get_slop_space=1065353216
spa_slop_shift=28, spa_get_slop_space=532676608
spa_slop_shift=29, spa_get_slop_space=266338304
spa_slop_shift=30, spa_get_slop_space=134217728
spa_slop_shift=31, spa_get_slop_space=134217728
spa_slop_shift=32, spa_get_slop_space=134217728
spa_slop_shift=33, spa_get_slop_space=134217728
spa_slop_shift=34, spa_get_slop_space=134217728
spa_slop_shift=35, spa_get_slop_space=134217728
spa_slop_shift=36, spa_get_slop_space=134217728
spa_slop_shift=37, spa_get_slop_space=134217728
spa_slop_shift=38, spa_get_slop_space=134217728
spa_slop_shift=39, spa_get_slop_space=134217728
spa_slop_shift=40, spa_get_slop_space=134217728
spa_slop_shift=41, spa_get_slop_space=134217728
spa_slop_shift=42, spa_get_slop_space=134217728
spa_slop_shift=43, spa_get_slop_space=134217728
spa_slop_shift=44, spa_get_slop_space=134217728
spa_slop_shift=45, spa_get_slop_space=134217728
spa_slop_shift=46, spa_get_slop_space=134217728
spa_slop_shift=47, spa_get_slop_space=134217728
spa_slop_shift=48, spa_get_slop_space=134217728
spa_slop_shift=49, spa_get_slop_space=134217728
spa_slop_shift=50, spa_get_slop_space=134217728
spa_slop_shift=51, spa_get_slop_space=134217728
spa_slop_shift=52, spa_get_slop_space=134217728
spa_slop_shift=53, spa_get_slop_space=134217728
spa_slop_shift=54, spa_get_slop_space=134217728
spa_slop_shift=55, spa_get_slop_space=134217728
spa_slop_shift=56, spa_get_slop_space=134217728
spa_slop_shift=57, spa_get_slop_space=134217728
spa_slop_shift=58, spa_get_slop_space=134217728
spa_slop_shift=59, spa_get_slop_space=134217728
spa_slop_shift=60, spa_get_slop_space=134217728
spa_slop_shift=61, spa_get_slop_space=134217728
spa_slop_shift=62, spa_get_slop_space=134217728
spa_slop_shift=63, spa_get_slop_space=134217728
root@linux:~# 
root@linux:~# df -h -t zfs
Filesystem      Size  Used Avail Use% Mounted on
testpool        127P     0  127P   0% /testpool
root@linux:~# 
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on local builder:

```
root@linux:~# modinfo -F version zfs
0.8.0-rc1
root@linux:~# echo 0 > /sys/module/zfs/parameters/spa_slop_shift
-bash: echo: write error: Invalid argument
root@linux:~# echo 1 > /sys/module/zfs/parameters/spa_slop_shift
root@linux:~# echo 2 > /sys/module/zfs/parameters/spa_slop_shift
root@linux:~# echo 3 > /sys/module/zfs/parameters/spa_slop_shift
root@linux:~# echo 31 > /sys/module/zfs/parameters/spa_slop_shift
root@linux:~# echo 32 > /sys/module/zfs/parameters/spa_slop_shift
-bash: echo: write error: Invalid argument
root@linux:~# echo 0xa > /sys/module/zfs/parameters/spa_slop_shift
root@linux:~# cat /sys/module/zfs/parameters/spa_slop_shift
10
root@linux:~# 
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
