### PR TITLE
ZTS: Fix removal_resume_export

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -256,7 +256,6 @@ maybe = {
     'no_space/enospc_002_pos': ['FAIL', enospc_reason],
     'projectquota/setup': ['SKIP', exec_reason],
     'redundancy/redundancy_004_neg': ['FAIL', '7290'],
-    'removal/removal_resume_export': ['FAIL', '7894'],
     'reservation/reservation_008_pos': ['FAIL', '7741'],
     'reservation/reservation_018_pos': ['FAIL', '5642'],
     'rsend/rsend_019_pos': ['FAIL', '6086'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7894 

>Test: /usr/share/zfs/zfs-tests/tests/functional/removal/removal_resume_export (run as root) [00:28] [FAIL]
>02:40:05.29 NOTE: begin default_setup_noexit
>02:40:05.39 SUCCESS: zpool create -f testpool loop0
>02:40:05.47 SUCCESS: zfs create testpool/testfs
>02:40:05.53 SUCCESS: zfs set mountpoint=/mnt/testdir testpool/testfs
>02:40:05.53 SUCCESS: default_setup_noexit loop0
>02:40:05.56 SUCCESS: zfs set compression=off testpool/testfs
>02:40:16.23 SUCCESS: dd if=/dev/urandom of=/mnt/testdir/testfile0 bs=64M count=32
>02:40:16.62 SUCCESS: zpool add -f testpool loop2
>02:40:18.16 SUCCESS: zpool remove testpool loop0
>02:40:18.17 Added handler 47 with the following properties:
>02:40:18.17   pool: testpool
>02:40:18.17   vdev: 429280afa785fd07
>02:40:18.18 SUCCESS: zinject -d loop0 -D 10:1 testpool
>02:40:18.22 SUCCESS: ensure_thread_running
>02:40:32.09 SUCCESS: zpool export testpool exited 1
>02:40:33.21 removal thread is not running TRIES=10 THREAD_PID=

Failure is caused by the fact we can't find the "spa_vdev_remove" thread running the second time we call `ensure_thread_running()`: this is because `zpool export` took too long to run which gave enough time to the removal process to complete.

### Description
<!--- Describe your changes in detail -->
We now umount all filesystems before starting the VDEV removal to minimize the time it takes to export the pool: this helps preventing race conditions in the test case.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
