### PR TITLE
zstreamdump dumps core printing truncated nvlist

### DIFF
--- a/cmd/zstreamdump/zstreamdump.c
+++ b/cmd/zstreamdump/zstreamdump.c
@@ -384,10 +384,12 @@ main(int argc, char *argv[])
 				if (ferror(send_stream))
 					perror("fread");
 				err = nvlist_unpack(buf, sz, &nv, 0);
-				if (err)
+				if (err) {
 					perror(strerror(err));
-				nvlist_print(stdout, nv);
-				nvlist_free(nv);
+				} else {
+					nvlist_print(stdout, nv);
+					nvlist_free(nv);
+				}
 			}
 			break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While using `zstreamdump` to inspect a truncated send stream the binary dumped core.

Reproducer:

```
root@linux:~# POOLNAME='testpool'
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:~# zpool destroy -f $POOLNAME
root@linux:~# rm -f $TMPDIR/zpool.dat
root@linux:~# fallocate -l 128M $TMPDIR/zpool.dat
root@linux:~# zpool create -f -O mountpoint=none $POOLNAME $TMPDIR/zpool.dat
root@linux:~# zfs create -o mountpoint=/mnt testpool/fs
root@linux:~# dd if=/dev/urandom of=/mnt/file.bin bs=1M count=1 status=none
root@linux:~# zfs snap testpool/fs@snap1
root@linux:~# zfs send -p testpool/fs@snap1 | dd bs=512 count=1 status=none > $TMPDIR/trunc.zsnap
root@linux:~# gdb -q zstreamdump -ex "b nvlist_unpack" -ex "run -v < $TMPDIR/trunc.zsnap" 2>/dev/null 
Reading symbols from zstreamdump...done.
Breakpoint 1 at 0x400d20
Starting program: /usr/sbin/zstreamdump -v < /var/tmp/trunc.zsnap
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
BEGIN record
	hdrtype = 2
	features = 4
	magic = 2f5bacbac
	creation_time = 0
	type = 0
	flags = 0x0
	toguid = 0
	fromguid = 0
	toname = testpool/fs@snap1


Breakpoint 1, nvlist_unpack (buf=0x7ffff4b3d010 "\001\001", buflen=532, nvlp=0x7fffffffe938, kmflag=0) at ../../module/nvpair/nvpair.c:2700
2700	{
(gdb) bt
#0  nvlist_unpack (buf=0x7ffff4b3d010 "\001\001", buflen=532, nvlp=0x7fffffffe938, kmflag=0) at ../../module/nvpair/nvpair.c:2700
#1  0x0000000000401819 in main (argc=1, argv=0x214) at zstreamdump.c:386
(gdb) fin
Run till exit from #0  nvlist_unpack (buf=0x7ffff4b3d010 "\001\001", buflen=532, nvlp=0x7fffffffe938, kmflag=0) at ../../module/nvpair/nvpair.c:2700
main (argc=1, argv=0x214) at zstreamdump.c:387
387					if (err)
Value returned is $1 = 14
(gdb) list
382					}
383					(void) ssread(buf, sz, &zc);
384					if (ferror(send_stream))
385						perror("fread");
386					err = nvlist_unpack(buf, sz, &nv, 0);
387					if (err)
388						perror(strerror(err));
389					nvlist_print(stdout, nv);
390					nvlist_free(nv);
391				}
(gdb) p err
$2 = 14
(gdb) c
Continuing.
nvlist version: 1287685448

Program received signal SIGSEGV, Segmentation fault.
nvlist_next_nvpair (nvl=nvl@entry=0x7ffff7de558e, nvp=nvp@entry=0x0) at ../../module/nvpair/nvpair.c:1448
1448			curr = priv->nvp_list;
(gdb) bt
#0  nvlist_next_nvpair (nvl=nvl@entry=0x7ffff7de558e, nvp=nvp@entry=0x0) at ../../module/nvpair/nvpair.c:1448
#1  0x00007ffff7bcd481 in nvlist_print_with_indent (nvl=0x7ffff7de558e, pctl=pctl@entry=0x7fffffffe890) at libnvpair.c:579
#2  0x00007ffff7bce88f in nvlist_print (fp=<optimized out>, nvl=<optimized out>) at libnvpair.c:762
#3  0x0000000000401832 in main (argc=1, argv=0x214) at zstreamdump.c:389
```

We should not print the (invalid) nvlist data with a return code of 14 (`EFAULT`) from `nvlist_unpack()`.

### Description
<!--- Describe your changes in detail -->
This change prevents zstreamdump from crashing when trying to print invalid nvlist data (DRR_BEGIN record) from a truncated send stream.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on local builder, will add new ZTS test case if needed. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
