### PR TITLE
Add NEWS file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ endif
 AUTOMAKE_OPTIONS = foreign
 EXTRA_DIST  = autogen.sh copy-builtin
 EXTRA_DIST += config/config.awk config/rpm.am config/deb.am config/tgz.am
-EXTRA_DIST += META AUTHORS COPYRIGHT LICENSE NOTICE README.md
+EXTRA_DIST += META AUTHORS COPYRIGHT LICENSE NEWS NOTICE README.md
 
 @CODE_COVERAGE_RULES@
 

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,3 @@
+Descriptions of all releases can be found on github:
+
+https://github.com/zfsonlinux/zfs/releases


### PR DESCRIPTION
I received a request for a NEWS file. That needs to be handled by Tony
and Brian, but for now, we can at least provide one that provides a link
to github so that users who expect NEWS files from their packages will
know where to go for release information.