### PR TITLE
Fix allocation_classes GUID in zpool-features(5)

### DIFF
--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -766,7 +766,7 @@ for the filesystems containing a large number of files.
 .RS 4n
 .TS
 l l .
-GUID	com.intel:allocation_classes
+GUID	org.zfsonlinux:allocation_classes
 READ\-ONLY COMPATIBLE	yes
 DEPENDENCIES	none
 .TE


### PR DESCRIPTION
### Motivation and Context
<a href="https://github.com/zfsonlinux/zfs/blob/master/man/man5/zpool-features.5#L769">This</a> is <a href="https://github.com/zfsonlinux/zfs/blob/master/module/zcommon/zfeature_common.c#L429">wrong</a>.

### Description
Documentation fix

### How Has This Been Tested?
N/A

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
