### PR TITLE
zed: detect and offline physically removed devices

### DIFF
--- a/cmd/zed/agents/zfs_mod.c
+++ b/cmd/zed/agents/zfs_mod.c
@@ -475,7 +475,20 @@ zfs_iter_vdev(zpool_handle_t *zhp, nvlist_t *nvl, void *data)
 	    &child, &children) == 0) {
 		for (c = 0; c < children; c++)
 			zfs_iter_vdev(zhp, child[c], data);
-		return;
+	}
+
+	/*
+	 * Iterate over any spares and cache devices
+	 */
+	if (nvlist_lookup_nvlist_array(nvl, ZPOOL_CONFIG_SPARES,
+	    &child, &children) == 0) {
+		for (c = 0; c < children; c++)
+			zfs_iter_vdev(zhp, child[c], data);
+	}
+	if (nvlist_lookup_nvlist_array(nvl, ZPOOL_CONFIG_L2CACHE,
+	    &child, &children) == 0) {
+		for (c = 0; c < children; c++)
+			zfs_iter_vdev(zhp, child[c], data);
 	}
 
 	/* once a vdev was matched and processed there is nothing left to do */

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -717,6 +717,7 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_MMP_HOSTNAME	"mmp_hostname"	/* not stored on disk */
 #define	ZPOOL_CONFIG_MMP_HOSTID		"mmp_hostid"	/* not stored on disk */
 #define	ZPOOL_CONFIG_ALLOCATION_BIAS	"alloc_bias"	/* not stored on disk */
+#define	ZPOOL_CONFIG_EXPANSION_TIME	"expansion_time"	/* not stored */
 
 /*
  * The persistent vdev state is stored as separate values rather than a single

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -344,6 +344,7 @@ struct vdev {
 	uint64_t	vdev_leaf_zap;
 	hrtime_t	vdev_mmp_pending; /* 0 if write finished	*/
 	uint64_t	vdev_mmp_kstat_id;	/* to find kstat entry */
+	uint64_t	vdev_expansion_time;	/* vdev's last expansion time */
 
 	/*
 	 * For DTrace to work in userland (libzpool) context, these fields must

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3421,6 +3421,7 @@ vdev_online(spa_t *spa, uint64_t guid, uint64_t flags, vdev_state_t *newstate)
 		for (pvd = vd; pvd != rvd; pvd = pvd->vdev_parent)
 			pvd->vdev_expanding = !!((flags & ZFS_ONLINE_EXPAND) ||
 			    spa->spa_autoexpand);
+		vd->vdev_expansion_time = gethrestime_sec();
 	}
 
 	vdev_reopen(tvd);

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -512,6 +512,10 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 	if (vd->vdev_crtxg)
 		fnvlist_add_uint64(nv, ZPOOL_CONFIG_CREATE_TXG, vd->vdev_crtxg);
 
+	if (vd->vdev_expansion_time)
+		fnvlist_add_uint64(nv, ZPOOL_CONFIG_EXPANSION_TIME,
+		    vd->vdev_expansion_time);
+
 	if (flags & VDEV_CONFIG_MOS) {
 		if (vd->vdev_leaf_zap != 0) {
 			ASSERT(vd->vdev_ops->vdev_op_leaf);

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -543,10 +543,10 @@ tests = ['exec_001_pos', 'exec_002_neg']
 tags = ['functional', 'exec']
 
 [tests/functional/fault]
-tests = ['auto_online_001_pos', 'auto_replace_001_pos', 'auto_spare_001_pos',
-    'auto_spare_002_pos', 'auto_spare_ashift', 'auto_spare_multiple',
-    'auto_spare_shared', 'scrub_after_resilver', 'decrypt_fault',
-    'decompress_fault']
+tests = ['auto_offline_001_pos', 'auto_online_001_pos', 'auto_replace_001_pos',
+    'auto_spare_001_pos', 'auto_spare_002_pos', 'auto_spare_ashift',
+    'auto_spare_multiple', 'auto_spare_shared', 'scrub_after_resilver',
+    'decrypt_fault', 'decompress_fault']
 tags = ['functional', 'fault']
 
 [tests/functional/features/async_destroy]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_001_pos.ksh
@@ -96,8 +96,7 @@ for type in " " mirror raidz raidz2; do
 	fi
 
 	typeset prev_size=$(get_pool_prop size $TESTPOOL1)
-	typeset zfs_prev_size=$(zfs get -p avail $TESTPOOL1 | tail -1 | \
-	    awk '{print $3}')
+	typeset zfs_prev_size=$(get_prop avail $TESTPOOL1)
 
 	# Expand each device as appropriate being careful to add an artificial
 	# delay to ensure we get a single history entry for each.  This makes
@@ -117,8 +116,7 @@ for type in " " mirror raidz raidz2; do
 	log_must zpool online -e $TESTPOOL1 $FILE_RAW
 
 	typeset expand_size=$(get_pool_prop size $TESTPOOL1)
-	typeset zfs_expand_size=$(zfs get -p avail $TESTPOOL1 | tail -1 | \
-	    awk '{print $3}')
+	typeset zfs_expand_size=$(get_prop avail $TESTPOOL1)
 
 	log_note "$TESTPOOL1 $type has previous size: $prev_size and " \
 	    "expanded size: $expand_size"

--- a/tests/zfs-tests/tests/functional/fault/Makefile.am
+++ b/tests/zfs-tests/tests/functional/fault/Makefile.am
@@ -2,6 +2,7 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/fault
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
+	auto_offline_001_pos.ksh \
 	auto_online_001_pos.ksh \
 	auto_replace_001_pos.ksh \
 	auto_spare_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/fault/auto_offline_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fault/auto_offline_001_pos.ksh
@@ -1,0 +1,177 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/events/events_common.kshlib
+. $STF_SUITE/tests/functional/fault/fault.cfg
+
+#
+# DESCRIPTION:
+# Testing Fault Management Agent ZED Logic - Physically removed device is
+# offlined and onlined when reattached
+#
+# STRATEGY:
+# 1. Create a pool
+# 2. Simulate physical removal of one device
+# 3. Verify the device is offlined
+# 4. Reattach the device
+# 5. Verify the device is onlined
+# 6. Repeat the same tests with a spare device: zed will use the spare to handle
+#    the removed data device
+# 7. Repeat the same tests again with a faulted spare device: zed should offline
+#    the removed data device if no spare is available
+#
+# NOTE: the use of 'block_device_wait' throughout the test helps avoid race
+# conditions caused by mixing creation/removal events from partitioning the
+# disk (zpool create) and events from physically removing it (remove_disk).
+#
+verify_runnable "both"
+
+if is_linux; then
+	# Add one 512b scsi_debug device (4Kn would generate IO errors)
+	# NOTE: must be larger than other "file" vdevs and minimum SPA devsize:
+	# add 32m of fudge
+	load_scsi_debug $(($SPA_MINDEVSIZE/1024/1024+32)) 1 1 1 '512b'
+else
+	log_unsupported "scsi debug module unsupported"
+fi
+
+function cleanup
+{
+	destroy_pool $TESTPOOL
+	rm -f $filedev1
+	rm -f $filedev2
+	rm -f $filedev3
+	rm -f $sparedev
+	unload_scsi_debug
+}
+
+log_assert "ZED detects physically removed devices"
+
+log_onexit cleanup
+
+filedev1="$TEST_BASE_DIR/file-vdev-1"
+filedev2="$TEST_BASE_DIR/file-vdev-2"
+filedev3="$TEST_BASE_DIR/file-vdev-3"
+sparedev="$TEST_BASE_DIR/file-vdev-spare"
+removedev=$(get_debug_device)
+
+typeset poolconfs=("mirror $filedev1 $removedev"
+    "raidz $filedev1 $removedev"
+    "raidz2 $filedev1 $filedev2 $removedev"
+    "raidz3 $filedev1 $filedev2 $filedev3 $removedev"
+    "$filedev1 cache $removedev"
+    "mirror $filedev1 $filedev2 cache $removedev"
+    "raidz $filedev1 $filedev2 $filedev3 cache $removedev"
+)
+
+log_must truncate -s $SPA_MINDEVSIZE $filedev1
+log_must truncate -s $SPA_MINDEVSIZE $filedev2
+log_must truncate -s $SPA_MINDEVSIZE $filedev3
+log_must truncate -s $SPA_MINDEVSIZE $sparedev
+
+for conf in "${poolconfs[@]}"
+do
+	# 1. Create a pool
+	log_must zpool create -f $TESTPOOL $conf
+	block_device_wait
+
+	# 2. Simulate physical removal of one device
+	remove_disk $removedev
+
+	# 3. Verify the device is offlined
+	log_must wait_vdev_state $TESTPOOL $removedev "OFFLINE"
+
+	# 4. Reattach the device
+	insert_disk $removedev
+
+	# 5. Verify the device is onlined
+	log_must wait_vdev_state $TESTPOOL $removedev "ONLINE"
+
+	# cleanup
+	destroy_pool $TESTPOOL
+	log_must parted "/dev/${removedev}" -s -- mklabel msdos
+	block_device_wait
+done
+
+# 6. Repeat the same tests with a spare device: zed will use the spare to handle
+#    the removed data device
+for conf in "${poolconfs[@]}"
+do
+	# 1. Create a pool with a spare
+	log_must zpool create -f $TESTPOOL $conf
+	block_device_wait
+	log_must zpool add $TESTPOOL spare $sparedev
+
+	# 3. Simulate physical removal of one device
+	remove_disk $removedev
+
+	# 4. Verify the device is handled by the spare unless is a l2arc disk
+	# which can only be offlined
+	if [[ $(echo "$conf" | grep -c 'cache') -eq 0 ]]; then
+		log_must wait_hotspare_state $TESTPOOL $sparedev "INUSE"
+	else
+		log_must wait_vdev_state $TESTPOOL $removedev "OFFLINE"
+	fi
+
+	# 5. Reattach the device
+	insert_disk $removedev
+
+	# 6. Verify the device is onlined
+	log_must wait_vdev_state $TESTPOOL $removedev "ONLINE"
+
+	# cleanup
+	destroy_pool $TESTPOOL
+	log_must parted "/dev/${removedev}" -s -- mklabel msdos
+	block_device_wait
+done
+
+# 7. Repeat the same tests again with a faulted spare device: zed should offline
+#    the removed data device if no spare is available
+for conf in "${poolconfs[@]}"
+do
+	# 1. Create a pool with a spare
+	log_must zpool create -f $TESTPOOL $conf
+	block_device_wait
+	log_must zpool add $TESTPOOL spare $sparedev
+
+	# 2. Fault the spare device making it unavailable
+	log_must zpool offline -f $TESTPOOL $sparedev
+	log_must wait_hotspare_state $TESTPOOL $sparedev "FAULTED"
+
+	# 3. Simulate physical removal of one device
+	remove_disk $removedev
+
+	# 4. Verify the device is offlined
+	log_must wait_vdev_state $TESTPOOL $removedev "OFFLINE"
+
+	# 5. Reattach the device
+	insert_disk $removedev
+
+	# 6. Verify the device is onlined
+	log_must wait_vdev_state $TESTPOOL $removedev "ONLINE"
+
+	# cleanup
+	destroy_pool $TESTPOOL
+	log_must parted "/dev/${removedev}" -s -- mklabel msdos
+	block_device_wait
+done
+
+log_pass "ZED detects physically removed devices"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Close #1537 

### Description
<!--- Describe your changes in detail -->
~~This commit adds a new test case to the ZFS Test Suite to verify ZED can detect when a cache device is physically removed from a running system.~~ ~~The underlying issue has been (probably) fixed for quite some time: this change, if anything, can only help prevent regression in functionality.~~

EDIT: The existing functionality is not reliable on some kernels (https://github.com/zfsonlinux/zfs/pull/7926#issuecomment-423657451), additional code has been added to implement this in userland (using events coming from the existing libudev monitor thread). ZED will now offline devices (data and l2arc, but not spares[1]) when they cannot be handled by a spare in the pool.

NOTE 1: we cannot offline a spare device.

NOTE 2: a modified "TEST" file will be pushed initially to "stress test" this change and avoid flaky scripts in the ZTS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Testing done in https://github.com/zfsonlinux/zfs/issues/1537#issuecomment-422262928
Test added to the ZFS Test Suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
