### PR TITLE
vdev_disk_error() prints ASCII SOH to debug log

### DIFF
--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -139,10 +139,9 @@ bdev_max_capacity(struct block_device *bdev, uint64_t wholedisk)
 static void
 vdev_disk_error(zio_t *zio)
 {
-	zfs_dbgmsg(KERN_WARNING "zio error=%d type=%d offset=%llu size=%llu "
-	    "flags=%x\n", zio->io_error, zio->io_type,
-	    (u_longlong_t)zio->io_offset, (u_longlong_t)zio->io_size,
-	    zio->io_flags);
+	zfs_dbgmsg("zio error=%d type=%d offset=%llu size=%llu flags=%x\n",
+	    zio->io_error, zio->io_type, (u_longlong_t)zio->io_offset,
+	    (u_longlong_t)zio->io_size, zio->io_flags);
 }
 
 /*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently `vdev_disk_error()` prepends its messages sent to the internal ZFS debug log with KERN_WARNING, which is currently defined as follows:

```
   #define KERN_SOH      "\001"
   #define KERN_WARNING  KERN_SOH "4"
```

Since "\001" (ASCII Start Of Header) is not printable this results in weird characters displayed when inspecting the debug log:

```
[root@centos zfs]# grep vdev_disk_error /proc/spl/kstat/zfs/dbgmsg | head -n 1
1537466539   vdev_disk.c:145:vdev_disk_error(): 4zio error=5 type=2 offset=4197888 size=512 flags=808c0
[root@centos zfs]# grep vdev_disk_error /proc/spl/kstat/zfs/dbgmsg | head -n 1 | xxd
0000000: 3135 3337 3436 3635 3339 2020 2076 6465  1537466539   vde
0000010: 765f 6469 736b 2e63 3a31 3435 3a76 6465  v_disk.c:145:vde
0000020: 765f 6469 736b 5f65 7272 6f72 2829 3a20  v_disk_error(): 
0000030: 0134 7a69 6f20 6572 726f 723d 3520 7479  .4zio error=5 ty
0000040: 7065 3d32 206f 6666 7365 743d 3431 3937  pe=2 offset=4197
0000050: 3838 3820 7369 7a65 3d35 3132 2066 6c61  888 size=512 fla
0000060: 6773 3d38 3038 6330 0a                   gs=808c0.
[root@centos zfs]# 
```


### Description
<!--- Describe your changes in detail -->
This commit simply removes this superfluous prefix passed to `zfs_dbgmsg()`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Built on local CentOS7 builder

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
