### PR TITLE
Fix reference to zpool-features(5)

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -2263,7 +2263,7 @@ Enables all supported features on the given pool.
 Once this is done, the pool will no longer be accessible on systems that do not
 support feature flags.
 See
-.Xr zfs-features 5
+.Xr zpool-features 5
 for details on compatibility with systems that support feature flags, but do not
 support all features enabled on the pool.
 .Bl -tag -width Ds


### PR DESCRIPTION
### Motivation and Context
Yet Moar man page errors

### Description
There is no zfs-features(5) and I'm pretty sure zpool-features was the intended reference

### How Has This Been Tested?
N/A

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
