### PR TITLE
deadlock between mm_sem and tx assign in zfs_write() and page fault

### DIFF
--- a/include/spl/sys/uio.h
+++ b/include/spl/sys/uio.h
@@ -53,6 +53,7 @@ typedef struct uio {
 	int		uio_iovcnt;
 	offset_t	uio_loffset;
 	uio_seg_t	uio_segflg;
+	boolean_t	uio_fault_disable;
 	uint16_t	uio_fmode;
 	uint16_t	uio_extflg;
 	offset_t	uio_limit;

--- a/include/sys/uio_impl.h
+++ b/include/sys/uio_impl.h
@@ -42,7 +42,7 @@
 #include <sys/uio.h>
 
 extern int uiomove(void *, size_t, enum uio_rw, uio_t *);
-extern void uio_prefaultpages(ssize_t, uio_t *);
+extern int uio_prefaultpages(ssize_t, uio_t *);
 extern int uiocopy(void *, size_t, enum uio_rw, uio_t *, size_t *);
 extern void uioskip(uio_t *, size_t);
 

--- a/module/zcommon/zfs_uio.c
+++ b/module/zcommon/zfs_uio.c
@@ -52,6 +52,7 @@
 #include <sys/sysmacros.h>
 #include <sys/strings.h>
 #include <linux/kmap_compat.h>
+#include <linux/uaccess.h>
 
 /*
  * Move "n" bytes at byte address "p"; "rw" indicates the direction
@@ -79,8 +80,24 @@ uiomove_iov(void *p, size_t n, enum uio_rw rw, struct uio *uio)
 				if (copy_to_user(iov->iov_base+skip, p, cnt))
 					return (EFAULT);
 			} else {
-				if (copy_from_user(p, iov->iov_base+skip, cnt))
-					return (EFAULT);
+				if (uio->uio_fault_disable) {
+					if (!access_ok(VERIFY_READ,
+					    (iov->iov_base + skip), cnt)) {
+						return (EFAULT);
+					}
+
+					pagefault_disable();
+					if (__copy_from_user_inatomic(p,
+					    (iov->iov_base + skip), cnt)) {
+						pagefault_enable();
+						return (EFAULT);
+					}
+					pagefault_enable();
+				} else {
+					if (copy_from_user(p,
+					    (iov->iov_base + skip), cnt))
+						return (EFAULT);
+				}
 			}
 			break;
 		case UIO_SYSSPACE:

--- a/module/zcommon/zfs_uio.c
+++ b/module/zcommon/zfs_uio.c
@@ -175,7 +175,7 @@ EXPORT_SYMBOL(uiomove);
  * error will terminate the process as this is only a best attempt to get
  * the pages resident.
  */
-void
+int
 uio_prefaultpages(ssize_t n, struct uio *uio)
 {
 	const struct iovec *iov;
@@ -189,7 +189,7 @@ uio_prefaultpages(ssize_t n, struct uio *uio)
 	switch (uio->uio_segflg) {
 		case UIO_SYSSPACE:
 		case UIO_BVEC:
-			return;
+			return (0);
 		case UIO_USERSPACE:
 		case UIO_USERISPACE:
 			break;
@@ -213,7 +213,7 @@ uio_prefaultpages(ssize_t n, struct uio *uio)
 		p = iov->iov_base + skip;
 		while (cnt) {
 			if (fuword8((uint8_t *)p, &tmp))
-				return;
+				return (EFAULT);
 			incr = MIN(cnt, PAGESIZE);
 			p += incr;
 			cnt -= incr;
@@ -223,8 +223,10 @@ uio_prefaultpages(ssize_t n, struct uio *uio)
 		 */
 		p--;
 		if (fuword8((uint8_t *)p, &tmp))
-			return;
+			return (EFAULT);
 	}
+
+	return (0);
 }
 EXPORT_SYMBOL(uio_prefaultpages);
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -822,7 +822,7 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 				}
 				continue;
 			} else if (error != 0) {
-				dmu_tx_abort(tx);
+				dmu_tx_commit(tx);
 				break;
 			}
 			tx_bytes -= uio->uio_resid;

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -651,6 +651,7 @@ zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr)
 	else
 #endif
 		if (uio_prefaultpages(MIN(n, max_blksz), uio)) {
+			ZFS_EXIT(zfsvfs);
 			return (SET_ERROR(EFAULT));
 		}
 

--- a/tests/zfs-tests/tests/functional/mmap/mmap_write_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/mmap/mmap_write_001_pos.ksh
@@ -53,12 +53,14 @@ if ! is_mp; then
 fi
 
 log_must chmod 777 $TESTDIR
-mmapwrite $TESTDIR/test-write-file &
+mmapwrite $TESTDIR/normal_write_file $TESTDIR/map_write_file &
 PID_MMAPWRITE=$!
-log_note "mmapwrite $TESTDIR/test-write-file pid: $PID_MMAPWRITE"
+log_note "mmapwrite $TESTDIR/normal_write_file $TESTDIR/map_write_file"\
+	 "pid: $PID_MMAPWRITE"
 log_must sleep 30
 
 log_must kill -9 $PID_MMAPWRITE
-log_must ls -l $TESTDIR/test-write-file
+log_must ls -l $TESTDIR/normal_write_file
+log_must ls -l $TESTDIR/map_write_file
 
 log_pass "write(2) a mmap(2)'ing file succeeded."


### PR DESCRIPTION
The bug time sequence:
1. context #1, `zfs_write` assign a txg "n".
2. In the same process, context #2, mmap page fault (which means the `mm_sem`
   is hold) occurred, `zfs_dirty_inode` open a txg failed, and wait previous
   txg "n" completed.
3. context #1 call `uiomove` to write, however page fault is occurred in
   `uiomove`, which means it need `mm_sem`, but `mm_sem` is hold by
   context #2, so it stuck and can't complete,  then txg "n" will not complete.

So context #1 and context #2 trap into the "dead lock".

Signed-off-by: Grady Wong <grady.w@xtaotech.com>

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/zfsonlinux/zfs/issues/7512
### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Test being done based on zfs-0.7.9:
Regression testing: fstress, ztest
Unit testing program: Limit system memory to 1.5GB and try to simulate race condition of file write and mmap access in one process. One thread keep writing file A's 1 byte of each page, the other thread keep modifying 10 byte of mmaped one page of file B. The method increases the page fault rate inside `uiomove() `.
The unit test program is attached below. 
```c
#include <fcntl.h>
#include <stdio.h>
#include <unistd.h>
#include <sys/mman.h>
#include <err.h>
#include <errno.h>
#include <string.h>
#include <stdlib.h>
#include <time.h>
#include <pthread.h>


#define BUF_SIZE (128 * 1024)
#define MAP_THREAD 1

long get_tick()
{
	struct timespec now;
	if (clock_gettime(CLOCK_MONOTONIC, &now))
		return 0;
	return now.tv_sec + now.tv_nsec;
}


static char *rand_string(char *str, size_t size)
{
	const char charset[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJK...";
	size_t n = 0;

	if (size) {
		srand(get_tick());
		--size;
		for (n = 0; n < size; n++) {
			int key = rand() % (int) (sizeof charset - 1);
			str[n] = charset[key];
		}
		str[size] = '\0';
	}
	return str;
}

void *write_map_file_thread(void *data)
{
	int fd = -1;
	int ret = 0;
	char *buf = NULL;
	int page_size = getpagesize();
	int op_errno = 0;
	char *path = data;
	char map_write_file[4] = {0, };
	char file_path[255] = {0, };

	rand_string(map_write_file, 4);
	sprintf(file_path, "%s/%s", path, map_write_file);
	while (1) {
		ret = access(file_path, F_OK);
		if (ret) {
			op_errno = errno;
			if (op_errno == ENOENT) {
				fd = open(file_path, O_RDWR | O_CREAT, 0777);
				if (fd == -1) {
					err(1, "open file failed");
				}

				ret = ftruncate(fd, page_size);
				if (ret == -1) {
					err(1, "truncate file failed");
				}
			} else {
				err(1, "access file failed!");
			}
		} else {
			fd = open(file_path, O_RDWR, 0777);
			if (fd == -1) {
				err(1, "open file failed");
			}
		}

		buf = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
		if (buf == MAP_FAILED) {
			err(1, "map file failed");
		}
		printf("map file %s\n", file_path);

		if (fd != -1)
			close(fd);

	        char s[10];
		memcpy(buf, s, 10);
		printf("write %s to mapfile %s\n", s, file_path);
		ret = munmap(buf, page_size);
		if (ret != 0) {
			err(1, "unmap file failed");
		}
		printf("unmap file %s\n", file_path);
	}
}

void *write_file_thread(void *data)
{
	char *path = data;
	char file_name[4] = {0, };
	char file_path[255] = {0, };
	int fd = -1;
	ssize_t write_num = 0;
	int page_size = getpagesize();
	off_t offset = 0;

	rand_string(file_name, 4);
	sprintf(file_path, "%s/%s", path, file_name);

	fd = open(file_path, O_RDWR | O_CREAT, 0777);
	if (fd == -1) {
		err(1, "failed to open %s", file_path);
	}

	char *buf = malloc(1);
	while (1) {
		write_num = write(fd, buf, 1);
		if (write_num == 0) {
			err(1, "write failed!");
			break;
		}
		offset = lseek(fd, page_size, SEEK_CUR);
	}
}

int main(int argc, char *argv[])
{
	int ret = 0;
	pthread_t write_file_th;
	pthread_t write_file_th2;
	int sleep_time = 0;
	int i = 0;
	pthread_t map_file_th[MAP_THREAD];
	pthread_t eat_mem_th;
	pthread_t more_pg_th;

	if (argc != 2) {
		err(1, "invalid argument");
	}

	pthread_create(&write_file_th, NULL, write_file_thread, argv[1]);
	pthread_create(&write_file_th2, NULL, write_file_thread, argv[1]);


	for (i = 0; i < MAP_THREAD; i++) {
		pthread_create(&map_file_th[i], NULL, write_map_file_thread, argv[1]);
	}

	pthread_join(write_file_th, NULL);
	pthread_join(write_file_th2, NULL);
}
```

I didn't find a easy way to reproduce the problem constantly. But I no longer suffer the problem during the tests so far with my fixing. If  you guys have any good idea to reproduce the problem, please shed me a light.
 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
