### PR TITLE
7947 - honour relatime / atime property values in dracut boot scripts

### DIFF
--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -74,14 +74,22 @@ import_pool() {
 # mount_dataset DATASET
 #   mounts the given zfs dataset.
 mount_dataset() {
-        dataset="${1}"
+    dataset="${1}"
     mountpoint="$(zfs get -H -o value mountpoint "${dataset}")"
-
+    mountopts="strictatime"
+    ATIME_OPTION=$(zfs get -H -o value -s default,local,inherited atime ${dataset})
+    if [ "${ATIME_OPTION}" = "off" ]; then
+        mountopts="noatime"
+    fi
+    RELATIME_OPTION=$(zfs get -H -o value -s default,local,inherited relatime ${dataset})
+    if [ "${RELATIME_OPTION}" = "on" ]; then
+        mountopts="relatime"
+    fi
     # We need zfsutil for non-legacy mounts and not for legacy mounts.
     if [ "${mountpoint}" = "legacy" ] ; then
-        mount -t zfs "${dataset}" "${NEWROOT}"
+        mount -t zfs -o ${mountopts} "${dataset}" "${NEWROOT}"
     else
-        mount -o zfsutil -t zfs "${dataset}" "${NEWROOT}"
+        mount -o zfsutil -t zfs -o ${mountopts} "${dataset}" "${NEWROOT}"
     fi
 
     return $?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context

Resolves #7947 by overriding the given property during mount.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
Looks at `relatime` and `atime` values from `local`, `default` and `inherited` sources.

`relatime=on` will override `atime=off`.
<!--- Describe your changes in detail -->

### How Has This Been Tested?

Boot a ZFS system from a dataset with various atime combinations.

Verify that relatime can be disabled:

```
% mount
[...]
newrpool/ocean/GENTOO/ROOT on / type zfs (rw,noatime,xattr,noacl)
[...]
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [x] Change has been approved by a ZFS on Linux member.
