### PR TITLE
ZTS: Fix snapshot_009_pos, snapshot_010_pos

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -264,6 +264,8 @@ maybe = {
     'rsend/rsend_024_pos': ['FAIL', '5665'],
     'rsend/send-c_volume': ['FAIL', '6087'],
     'snapshot/clone_001_pos': ['FAIL', known_reason],
+    'snapshot/snapshot_009_pos': ['FAIL', '7961'],
+    'snapshot/snapshot_010_pos': ['FAIL', '7961'],
     'snapused/snapused_004_pos': ['FAIL', '5513'],
     'tmpfile/setup': ['SKIP', tmpfile_reason],
     'threadsappend/threadsappend_001_pos': ['FAIL', '6136'],

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -642,7 +642,7 @@ function destroy_snapshot
 	typeset snap=${1:-$TESTPOOL/$TESTFS@$TESTSNAP}
 
 	if ! snapexists $snap; then
-		log_fail "'$snap' does not existed."
+		log_fail "'$snap' does not exist."
 	fi
 
 	#

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_009_pos.ksh
@@ -52,18 +52,15 @@ function cleanup
 	typeset snap
 
 	for ds in $ctr/$TESTVOL1 $ctr/$TESTCLONE; do
-		datasetexists $ds && \
-			log_must zfs destroy -f $ds
+		destroy_dataset $ds "-rf"
 	done
 
 	for snap in $ctr/$TESTFS1@$TESTSNAP1 \
 		$snappool $snapvol $snapctr $snapctrvol \
 		$snapctrclone $snapctrfs
 	do
-		snapexists $snap && \
-			log_must zfs destroy -rf $snap
+		snapexists $snap && destroy_dataset $snap "-rf"
 	done
-
 }
 
 log_assert "Verify snapshot -r can correctly create a snapshot tree."
@@ -91,6 +88,7 @@ else
 fi
 
 log_must zfs snapshot -r $snappool
+log_must block_device_wait
 
 #verify the snapshot -r results
 for snap in $snappool $snapfs $snapvol $snapctr $snapctrvol \

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_010_pos.ksh
@@ -49,15 +49,13 @@ function cleanup
 {
 	typeset snap
 
-	datasetexists $ctrvol && \
-		log_must zfs destroy -f $ctrvol
+	destroy_dataset $ctrvol "-rf"
 
 	for snap in $ctrfs@$TESTSNAP1 \
 		$snappool $snapvol $snapctr $snapctrvol \
 		$snapctrclone $snapctrfs
 	do
-		snapexists $snap && \
-			log_must zfs destroy -rf $snap
+		snapexists $snap && destroy_dataset $snap "-rf"
 	done
 
 }
@@ -85,6 +83,7 @@ else
 fi
 
 log_must zfs snapshot -r $snappool
+log_must block_device_wait
 
 #select the $TESTCTR as destroy point, $TESTCTR is a child of $TESTPOOL
 log_must zfs destroy -r $snapctr


### PR DESCRIPTION
### Motivation and Context

Issue #7961.  

### Description

Mitigate the likelihood of the newly created volumes being busy
when the 'zfs destroy -r' is issued by waiting for udev to settle.
Since this is not a iron clad fix I've added the test case to
the known list of possible failures and referenced issue #7961.

Finally, in the case this test does fail fix the cleanup logic
so subsequent tests won't incorrectly fail.

### How Has This Been Tested?

Locally by running the `snapshot` test group in a loop.  I was unable
to cause the specific race to occur, but did manually verify the
updated cleanup logic does prevent subsequent tests from failing.

Since it's not clear that this will entirely resolve the issue for the CI
I've added the test to the exception list.  After this change has been
merged we'll be able to determine if this has resolved the failure.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
