### PR TITLE
changelist should be able to iter on mounts

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -26,8 +26,8 @@
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2016, Intel Corporation.
  * Copyright 2016 Nexenta Systems, Inc.
- * Copyright (c) 2017 Datto Inc.
  * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+ * Copyright (c) 2018 Datto Inc.
  */
 
 #ifndef	_LIBZFS_H
@@ -621,6 +621,7 @@ extern int zfs_iter_snapshots(zfs_handle_t *, boolean_t, zfs_iter_f, void *);
 extern int zfs_iter_snapshots_sorted(zfs_handle_t *, zfs_iter_f, void *);
 extern int zfs_iter_snapspec(zfs_handle_t *, const char *, zfs_iter_f, void *);
 extern int zfs_iter_bookmarks(zfs_handle_t *, zfs_iter_f, void *);
+extern int zfs_iter_mounted(zfs_handle_t *, zfs_iter_f, void *);
 
 typedef struct get_all_cb {
 	zfs_handle_t	**cb_handles;

--- a/lib/libzfs/libzfs_changelist.c
+++ b/lib/libzfs/libzfs_changelist.c
@@ -26,6 +26,7 @@
  * Portions Copyright 2007 Ramprakash Jelari
  * Copyright (c) 2014, 2015 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
+ * Copyright (c) 2018 Datto Inc.
  */
 
 #include <libintl.h>
@@ -68,22 +69,21 @@ typedef struct prop_changenode {
 	int			cn_mounted;
 	int			cn_zoned;
 	boolean_t		cn_needpost;	/* is postfix() needed? */
-	uu_list_node_t		cn_listnode;
+	uu_avl_node_t		cn_treenode;
 } prop_changenode_t;
 
 struct prop_changelist {
 	zfs_prop_t		cl_prop;
 	zfs_prop_t		cl_realprop;
 	zfs_prop_t		cl_shareprop;  /* used with sharenfs/sharesmb */
-	uu_list_pool_t		*cl_pool;
-	uu_list_t		*cl_list;
+	uu_avl_pool_t		*cl_pool;
+	uu_avl_t		*cl_tree;
 	boolean_t		cl_waslegacy;
 	boolean_t		cl_allchildren;
 	boolean_t		cl_alldependents;
 	int			cl_mflags;	/* Mount flags */
 	int			cl_gflags;	/* Gather request flags */
 	boolean_t		cl_haszonedchild;
-	boolean_t		cl_sorted;
 };
 
 /*
@@ -96,14 +96,17 @@ int
 changelist_prefix(prop_changelist_t *clp)
 {
 	prop_changenode_t *cn;
+	uu_avl_walk_t *walk;
 	int ret = 0;
 
 	if (clp->cl_prop != ZFS_PROP_MOUNTPOINT &&
 	    clp->cl_prop != ZFS_PROP_SHARESMB)
 		return (0);
 
-	for (cn = uu_list_first(clp->cl_list); cn != NULL;
-	    cn = uu_list_next(clp->cl_list, cn)) {
+	if ((walk = uu_avl_walk_start(clp->cl_tree, UU_WALK_ROBUST)) == NULL)
+		return (-1);
+
+	while ((cn = uu_avl_walk_next(walk)) != NULL) {
 
 		/* if a previous loop failed, set the remaining to false */
 		if (ret == -1) {
@@ -140,6 +143,8 @@ changelist_prefix(prop_changelist_t *clp)
 		}
 	}
 
+	uu_avl_walk_end(walk);
+
 	if (ret == -1)
 		(void) changelist_postfix(clp);
 
@@ -159,6 +164,7 @@ int
 changelist_postfix(prop_changelist_t *clp)
 {
 	prop_changenode_t *cn;
+	uu_avl_walk_t *walk;
 	char shareopts[ZFS_MAXPROPLEN];
 	int errors = 0;
 	libzfs_handle_t *hdl;
@@ -170,7 +176,7 @@ changelist_postfix(prop_changelist_t *clp)
 	 * location), or have explicit mountpoints set (in which case they won't
 	 * be in the changelist).
 	 */
-	if ((cn = uu_list_last(clp->cl_list)) == NULL)
+	if ((cn = uu_avl_last(clp->cl_tree)) == NULL)
 		return (0);
 
 	if (clp->cl_prop == ZFS_PROP_MOUNTPOINT)
@@ -193,8 +199,11 @@ changelist_postfix(prop_changelist_t *clp)
 	 * datasets before mounting the children.  We walk all datasets even if
 	 * there are errors.
 	 */
-	for (cn = uu_list_last(clp->cl_list); cn != NULL;
-	    cn = uu_list_prev(clp->cl_list, cn)) {
+	if ((walk = uu_avl_walk_start(clp->cl_tree,
+	    UU_WALK_REVERSE | UU_WALK_ROBUST)) == NULL)
+		return (-1);
+
+	while ((cn = uu_avl_walk_next(walk)) != NULL) {
 
 		boolean_t sharenfs;
 		boolean_t sharesmb;
@@ -261,6 +270,8 @@ changelist_postfix(prop_changelist_t *clp)
 			errors += zfs_unshare_smb(cn->cn_handle, NULL);
 	}
 
+	uu_avl_walk_end(walk);
+
 	return (errors ? -1 : 0);
 }
 
@@ -294,10 +305,13 @@ void
 changelist_rename(prop_changelist_t *clp, const char *src, const char *dst)
 {
 	prop_changenode_t *cn;
+	uu_avl_walk_t *walk;
 	char newname[ZFS_MAX_DATASET_NAME_LEN];
 
-	for (cn = uu_list_first(clp->cl_list); cn != NULL;
-	    cn = uu_list_next(clp->cl_list, cn)) {
+	if ((walk = uu_avl_walk_start(clp->cl_tree, UU_WALK_ROBUST)) == NULL)
+		return;
+
+	while ((cn = uu_avl_walk_next(walk)) != NULL) {
 		/*
 		 * Do not rename a clone that's not in the source hierarchy.
 		 */
@@ -316,6 +330,8 @@ changelist_rename(prop_changelist_t *clp, const char *src, const char *dst)
 		(void) strlcpy(cn->cn_handle->zfs_name, newname,
 		    sizeof (cn->cn_handle->zfs_name));
 	}
+
+	uu_avl_walk_end(walk);
 }
 
 /*
@@ -326,17 +342,22 @@ int
 changelist_unshare(prop_changelist_t *clp, zfs_share_proto_t *proto)
 {
 	prop_changenode_t *cn;
+	uu_avl_walk_t *walk;
 	int ret = 0;
 
 	if (clp->cl_prop != ZFS_PROP_SHARENFS &&
 	    clp->cl_prop != ZFS_PROP_SHARESMB)
 		return (0);
 
-	for (cn = uu_list_first(clp->cl_list); cn != NULL;
-	    cn = uu_list_next(clp->cl_list, cn)) {
+	if ((walk = uu_avl_walk_start(clp->cl_tree, UU_WALK_ROBUST)) == NULL)
+		return (-1);
+
+	while ((cn = uu_avl_walk_next(walk)) != NULL) {
 		if (zfs_unshare_proto(cn->cn_handle, NULL, proto) != 0)
 			ret = -1;
 	}
+
+	uu_avl_walk_end(walk);
 
 	return (ret);
 }
@@ -359,17 +380,22 @@ void
 changelist_remove(prop_changelist_t *clp, const char *name)
 {
 	prop_changenode_t *cn;
+	uu_avl_walk_t *walk;
 
-	for (cn = uu_list_first(clp->cl_list); cn != NULL;
-	    cn = uu_list_next(clp->cl_list, cn)) {
+	if ((walk = uu_avl_walk_start(clp->cl_tree, UU_WALK_ROBUST)) == NULL)
+		return;
 
+	while ((cn = uu_avl_walk_next(walk)) != NULL) {
 		if (strcmp(cn->cn_handle->zfs_name, name) == 0) {
-			uu_list_remove(clp->cl_list, cn);
+			uu_avl_remove(clp->cl_tree, cn);
 			zfs_close(cn->cn_handle);
 			free(cn);
+			uu_avl_walk_end(walk);
 			return;
 		}
 	}
+
+	uu_avl_walk_end(walk);
 }
 
 /*
@@ -379,21 +405,68 @@ void
 changelist_free(prop_changelist_t *clp)
 {
 	prop_changenode_t *cn;
-	void *cookie;
 
-	if (clp->cl_list) {
-		cookie = NULL;
-		while ((cn = uu_list_teardown(clp->cl_list, &cookie)) != NULL) {
+	if (clp->cl_tree) {
+		uu_avl_walk_t *walk;
+
+		if ((walk = uu_avl_walk_start(clp->cl_tree,
+		    UU_WALK_ROBUST)) == NULL)
+			return;
+
+		while ((cn = uu_avl_walk_next(walk)) != NULL) {
+			uu_avl_remove(clp->cl_tree, cn);
 			zfs_close(cn->cn_handle);
 			free(cn);
 		}
 
-		uu_list_destroy(clp->cl_list);
+		uu_avl_walk_end(walk);
+		uu_avl_destroy(clp->cl_tree);
 	}
 	if (clp->cl_pool)
-		uu_list_pool_destroy(clp->cl_pool);
+		uu_avl_pool_destroy(clp->cl_pool);
 
 	free(clp);
+}
+
+/*
+ * Add one dataset to changelist
+ */
+static int
+changelist_add_mounted(zfs_handle_t *zhp, void *data)
+{
+	prop_changelist_t *clp = data;
+	prop_changenode_t *cn;
+	uu_avl_index_t idx;
+
+	ASSERT3U(clp->cl_prop, ==, ZFS_PROP_MOUNTPOINT);
+
+	if ((cn = zfs_alloc(zfs_get_handle(zhp),
+	    sizeof (prop_changenode_t))) == NULL) {
+		zfs_close(zhp);
+		return (ENOMEM);
+	}
+
+	cn->cn_handle = zhp;
+	cn->cn_mounted = zfs_is_mounted(zhp, NULL);
+	ASSERT3U(cn->cn_mounted, ==, B_TRUE);
+	cn->cn_shared = zfs_is_shared(zhp);
+	cn->cn_zoned = zfs_prop_get_int(zhp, ZFS_PROP_ZONED);
+	cn->cn_needpost = B_TRUE;
+
+	/* Indicate if any child is exported to a local zone. */
+	if (getzoneid() == GLOBAL_ZONEID && cn->cn_zoned)
+		clp->cl_haszonedchild = B_TRUE;
+
+	uu_avl_node_init(cn, &cn->cn_treenode, clp->cl_pool);
+
+	if (uu_avl_find(clp->cl_tree, cn, NULL, &idx) == NULL) {
+		uu_avl_insert(clp->cl_tree, cn, idx);
+	} else {
+		free(cn);
+		zfs_close(zhp);
+	}
+
+	return (0);
 }
 
 static int
@@ -460,26 +533,15 @@ change_one(zfs_handle_t *zhp, void *data)
 		if (getzoneid() == GLOBAL_ZONEID && cn->cn_zoned)
 			clp->cl_haszonedchild = B_TRUE;
 
-		uu_list_node_init(cn, &cn->cn_listnode, clp->cl_pool);
+		uu_avl_node_init(cn, &cn->cn_treenode, clp->cl_pool);
 
-		if (clp->cl_sorted) {
-			uu_list_index_t idx;
+		uu_avl_index_t idx;
 
-			(void) uu_list_find(clp->cl_list, cn, NULL,
-			    &idx);
-			uu_list_insert(clp->cl_list, cn, idx);
+		if (uu_avl_find(clp->cl_tree, cn, NULL, &idx) == NULL) {
+			uu_avl_insert(clp->cl_tree, cn, idx);
 		} else {
-			/*
-			 * Add this child to beginning of the list. Children
-			 * below this one in the hierarchy will get added above
-			 * this one in the list. This produces a list in
-			 * reverse dataset name order.
-			 * This is necessary when the original mountpoint
-			 * is legacy or none.
-			 */
-			ASSERT(!clp->cl_alldependents);
-			verify(uu_list_insert_before(clp->cl_list,
-			    uu_list_first(clp->cl_list), cn) == 0);
+			free(cn);
+			zfs_close(zhp);
 		}
 
 		if (!clp->cl_alldependents)
@@ -542,7 +604,6 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	prop_changenode_t *cn;
 	zfs_handle_t *temp;
 	char property[ZFS_MAXPROPLEN];
-	uu_compare_fn_t *compare = NULL;
 	boolean_t legacy = B_FALSE;
 
 	if ((clp = zfs_alloc(zhp->zfs_hdl, sizeof (prop_changelist_t))) == NULL)
@@ -562,19 +623,14 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 		    NULL, NULL, 0, B_FALSE) == 0 &&
 		    (strcmp(property, "legacy") == 0 ||
 		    strcmp(property, "none") == 0)) {
-
 			legacy = B_TRUE;
-		}
-		if (!legacy) {
-			compare = compare_mountpoints;
-			clp->cl_sorted = B_TRUE;
 		}
 	}
 
-	clp->cl_pool = uu_list_pool_create("changelist_pool",
+	clp->cl_pool = uu_avl_pool_create("changelist_pool",
 	    sizeof (prop_changenode_t),
-	    offsetof(prop_changenode_t, cn_listnode),
-	    compare, 0);
+	    offsetof(prop_changenode_t, cn_treenode),
+	    compare_mountpoints, 0);
 	if (clp->cl_pool == NULL) {
 		assert(uu_error() == UU_ERROR_NO_MEMORY);
 		(void) zfs_error(zhp->zfs_hdl, EZFS_NOMEM, "internal error");
@@ -582,12 +638,11 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 		return (NULL);
 	}
 
-	clp->cl_list = uu_list_create(clp->cl_pool, NULL,
-	    clp->cl_sorted ? UU_LIST_SORTED : 0);
+	clp->cl_tree = uu_avl_create(clp->cl_pool, NULL, UU_DEFAULT);
 	clp->cl_gflags = gather_flags;
 	clp->cl_mflags = mnt_flags;
 
-	if (clp->cl_list == NULL) {
+	if (clp->cl_tree == NULL) {
 		assert(uu_error() == UU_ERROR_NO_MEMORY);
 		(void) zfs_error(zhp->zfs_hdl, EZFS_NOMEM, "internal error");
 		changelist_free(clp);
@@ -631,7 +686,17 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	else if (clp->cl_prop == ZFS_PROP_SHARESMB)
 		clp->cl_shareprop = ZFS_PROP_SHARENFS;
 
-	if (clp->cl_alldependents) {
+	if (clp->cl_prop == ZFS_PROP_MOUNTPOINT &&
+	    (clp->cl_gflags & CL_GATHER_MOUNT_ALWAYS) == 0) {
+		/*
+		 * Instead of iterating through all of the dataset children we
+		 * gather mounted dataset children from MNTTAB
+		 */
+		if (zfs_iter_mounted(zhp, changelist_add_mounted, clp) != 0) {
+			changelist_free(clp);
+			return (NULL);
+		}
+	} else if (clp->cl_alldependents) {
 		if (zfs_iter_dependents(zhp, B_TRUE, change_one, clp) != 0) {
 			changelist_free(clp);
 			return (NULL);
@@ -669,20 +734,13 @@ changelist_gather(zfs_handle_t *zhp, zfs_prop_t prop, int gather_flags,
 	cn->cn_zoned = zfs_prop_get_int(zhp, ZFS_PROP_ZONED);
 	cn->cn_needpost = B_TRUE;
 
-	uu_list_node_init(cn, &cn->cn_listnode, clp->cl_pool);
-	if (clp->cl_sorted) {
-		uu_list_index_t idx;
-		(void) uu_list_find(clp->cl_list, cn, NULL, &idx);
-		uu_list_insert(clp->cl_list, cn, idx);
+	uu_avl_node_init(cn, &cn->cn_treenode, clp->cl_pool);
+	uu_avl_index_t idx;
+	if (uu_avl_find(clp->cl_tree, cn, NULL, &idx) == NULL) {
+		uu_avl_insert(clp->cl_tree, cn, idx);
 	} else {
-		/*
-		 * Add the target dataset to the end of the list.
-		 * The list is not really unsorted. The list will be
-		 * in reverse dataset name order. This is necessary
-		 * when the original mountpoint is legacy or none.
-		 */
-		verify(uu_list_insert_after(clp->cl_list,
-		    uu_list_last(clp->cl_list), cn) == 0);
+		free(cn);
+		zfs_close(temp);
 	}
 
 	/*

--- a/lib/libzfs/libzfs_iter.c
+++ b/lib/libzfs/libzfs_iter.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, 2015 by Delphix. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018 Datto Inc.
  */
 
 #include <stdio.h>
@@ -32,6 +33,7 @@
 #include <stddef.h>
 #include <libintl.h>
 #include <libzfs.h>
+#include <sys/mntent.h>
 
 #include "libzfs_impl.h"
 
@@ -521,4 +523,51 @@ zfs_iter_dependents(zfs_handle_t *zhp, boolean_t allowrecursion,
 	ida.data = data;
 	ida.first = B_TRUE;
 	return (iter_dependents_cb(zfs_handle_dup(zhp), &ida));
+}
+
+/*
+ * Iterate over mounted children of the specified dataset
+ */
+int
+zfs_iter_mounted(zfs_handle_t *zhp, zfs_iter_f func, void *data)
+{
+	char mnt_prop[ZFS_MAXPROPLEN];
+	struct mnttab entry;
+	zfs_handle_t *mtab_zhp;
+	size_t namelen = strlen(zhp->zfs_name);
+	FILE *mnttab;
+	int err = 0;
+
+	if ((mnttab = fopen(MNTTAB, "r")) == NULL)
+		return (ENOENT);
+
+	while (err == 0 && getmntent(mnttab, &entry) == 0) {
+		/* Ignore non-ZFS entries */
+		if (strcmp(entry.mnt_fstype, MNTTYPE_ZFS) != 0)
+			continue;
+
+		/* Ignore datasets not within the provided dataset */
+		if (strncmp(entry.mnt_special, zhp->zfs_name, namelen) != 0 ||
+		    (entry.mnt_special[namelen] != '/' &&
+		    entry.mnt_special[namelen] != '@'))
+			continue;
+
+		if ((mtab_zhp = zfs_open(zhp->zfs_hdl, entry.mnt_special,
+		    ZFS_TYPE_FILESYSTEM)) == NULL)
+			continue;
+
+		/* Ignore legacy mounts as they are user managed */
+		verify(zfs_prop_get(mtab_zhp, ZFS_PROP_MOUNTPOINT, mnt_prop,
+		    sizeof (mnt_prop), NULL, NULL, 0, B_FALSE) == 0);
+		if (strcmp(mnt_prop, "legacy") == 0) {
+			zfs_close(mtab_zhp);
+			continue;
+		}
+
+		err = func(mtab_zhp, data);
+	}
+
+	fclose(mnttab);
+
+	return (err);
 }

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -277,7 +277,7 @@ tags = ['functional', 'cli_root', 'zfs_unload-key']
 tests = ['zfs_unmount_001_pos', 'zfs_unmount_002_pos', 'zfs_unmount_003_pos',
     'zfs_unmount_004_pos', 'zfs_unmount_005_pos', 'zfs_unmount_006_pos',
     'zfs_unmount_007_neg', 'zfs_unmount_008_neg', 'zfs_unmount_009_pos',
-    'zfs_unmount_all_001_pos']
+    'zfs_unmount_all_001_pos', 'zfs_unmount_nested']
 tags = ['functional', 'cli_root', 'zfs_unmount']
 
 [tests/functional/cli_root/zfs_unshare]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/Makefile.am
@@ -11,7 +11,8 @@ dist_pkgdata_SCRIPTS = \
 	zfs_unmount_007_neg.ksh \
 	zfs_unmount_008_neg.ksh \
 	zfs_unmount_009_pos.ksh \
-	zfs_unmount_all_001_pos.ksh
+	zfs_unmount_all_001_pos.ksh \
+	zfs_unmount_nested.ksh
 
 dist_pkgdata_DATA = \
 	zfs_unmount.cfg \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_nested.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_nested.ksh
@@ -1,0 +1,189 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy is of the CDDL is also available via the Internet
+# at http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2018 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#	zfs unmount should work on nested datasets
+#
+# STRATEGY:
+#	1. Create a set of nested datasets
+#	2. Unmount a nested dataset and make sure it is unmounted
+#	3. Ensure the dataset deeper than the one above is also unmounted
+#	4. Ensure the datasets shallower than the unmounted one is still mounted
+#	5. Repeat from step 2 with other mountpoint values and shallower nesting
+#
+
+verify_runnable "both"
+
+function nesting_cleanup
+{
+	log_must zfs destroy -fR $TESTPOOL/a
+	log_must zfs destroy -fR $TESTPOOL/b
+	log_must zfs destroy -fR $TESTPOOL/c
+	log_must zfs destroy -fR $TESTPOOL/d
+}
+
+log_onexit nesting_cleanup
+
+set -A test_depths 30 16 3
+
+dsA32=$(printf 'a/%.0s' {1..32})"a"
+log_must zfs create -p $TESTPOOL/$dsA32
+
+dsB32=$(printf 'b/%.0s' {1..32})"b"
+log_must zfs create -o mountpoint=none -p $TESTPOOL/$dsB32
+log_mustnot mount -t zfs $TESTPOOL/$dsB32 /mnt
+
+dsC32=$(printf 'c/%.0s' {1..32})"c"
+log_must zfs create -o mountpoint=legacy -p $TESTPOOL/$dsC32
+log_must mount -t zfs $TESTPOOL/$dsC32 /mnt
+
+dsD32=$(printf 'd/%.0s' {1..32})"d"
+log_must zfs create -o mountpoint=/$TESTPOOL/mnt -p $TESTPOOL/$dsD32
+
+
+for d in ${test_depths[@]}; do
+	# default mountpoint
+	ds_pre=$(printf 'a/%.0s' {1..$(($d-2))})"a"
+	ds=$(printf 'a/%.0s' {1..$(($d-1))})"a"
+	ds_post=$(printf 'a/%.0s' {1..$(($d))})"a"
+	if ! ismounted $TESTPOOL/$ds_pre; then
+		log_fail "$TESTPOOL/$ds_pre (pre) not initially mounted"
+	fi
+	if ! ismounted $TESTPOOL/$ds; then
+		log_fail "$TESTPOOL/$ds not initially mounted"
+	fi
+	if ! ismounted $TESTPOOL/$ds_post; then
+		log_fail "$TESTPOOL/$ds_post (post) not initially mounted"
+	fi
+
+	log_must zfs snapshot $TESTPOOL/$ds@snap
+	# force snapshot mount in .zfs
+	log_must ls /$TESTPOOL/$ds/.zfs/snapshot/snap
+	log_must zfs unmount $TESTPOOL/$ds
+
+	if ! ismounted $TESTPOOL/$ds_pre; then
+		log_fail "$ds_pre is not mounted"
+	fi
+	if ismounted $TESTPOOL/$ds; then
+		log_fail "$ds is mounted"
+	fi
+	if ismounted $TESTPOOL/$ds_post; then
+		log_fail "$ds_post (post) is mounted"
+	fi
+
+
+	# mountpoint=none
+	ds_pre=$(printf 'b/%.0s' {1..$(($d-2))})"b"
+	ds=$(printf 'b/%.0s' {1..$(($d-1))})"b"
+	ds_post=$(printf 'b/%.0s' {1..$(($d))})"b"
+	if ! ismounted $TESTPOOL/$ds_pre; then
+		log_fail "$TESTPOOL/$ds_pre (pre) not initially mounted"
+	fi
+	if ! ismounted $TESTPOOL/$ds; then
+		log_fail "$TESTPOOL/$ds not initially mounted"
+	fi
+	if ! ismounted $TESTPOOL/$ds_post; then
+		log_fail "$TESTPOOL/$ds_post (post) not initially mounted"
+	fi
+
+	log_must zfs snapshot $TESTPOOL/$ds@snap
+	# force snapshot mount in .zfs
+	log_must ls /$TESTPOOL/$ds/.zfs/snapshot/snap
+	log_must zfs unmount $TESTPOOL/$ds
+
+	if ! ismounted $TESTPOOL/$ds_pre; then
+		log_fail "$TESTPOOL/$ds_pre (pre) not mounted"
+	fi
+	if ismounted $TESTPOOL/$ds; then
+		log_fail "$TESTPOOL/$ds is mounted"
+	fi
+	if ismounted $TESTPOOL/$ds_post; then
+		log_fail "$TESTPOOL/$ds_post (post) is mounted"
+	fi
+
+
+	# mountpoint=legacy
+	ds_pre=$(printf 'c/%.0s' {1..$(($d-2))})"c"
+	ds=$(printf 'c/%.0s' {1..$(($d-1))})"c"
+	ds_post=$(printf 'c/%.0s' {1..$(($d))})"c"
+	if ! ismounted $TESTPOOL/$ds_pre; then
+		log_fail "$TESTPOOL/$ds_pre (pre) not initially mounted"
+	fi
+	if ! ismounted $TESTPOOL/$ds; then
+		log_fail "$TESTPOOL/$ds not initially mounted"
+	fi
+	if ! ismounted $TESTPOOL/$ds_post; then
+		log_fail "$TESTPOOL/$ds_post (post) not initially mounted"
+	fi
+
+	log_must zfs snapshot $TESTPOOL/$ds@snap
+	# force snapshot mount in .zfs
+	log_must ls /$TESTPOOL/$ds/.zfs/snapshot/snap
+	log_must zfs unmount $TESTPOOL/$ds
+
+	if ! ismounted $TESTPOOL/$ds_pre; then
+		log_fail "$TESTPOOL/$ds_pre (pre) not mounted"
+	fi
+	if ismounted $TESTPOOL/$ds; then
+		log_fail "$TESTPOOL/$ds is mounted"
+	fi
+	if ismounted $TESTPOOL/$ds_post; then
+		log_fail "$TESTPOOL/$ds_post (post) is mounted"
+	fi
+
+
+	# mountpoint=testpool/mnt
+	ds_pre=$(printf 'd/%.0s' {1..$(($d-2))})"d"
+	ds=$(printf 'd/%.0s' {1..$(($d-1))})"d"
+	ds_post=$(printf 'd/%.0s' {1..$(($d))})"d"
+	if ! ismounted $TESTPOOL/$ds_pre; then
+		log_fail "$TESTPOOL/$ds_pre (pre) not initially mounted"
+	fi
+	if ! ismounted $TESTPOOL/$ds; then
+		log_fail "$TESTPOOL/$ds not initially mounted"
+	fi
+	if ! ismounted $TESTPOOL/$ds_post; then
+		log_fail "$TESTPOOL/$ds_post (post) not initially mounted"
+	fi
+
+	log_must zfs snapshot $TESTPOOL/$ds@snap
+	# force snapshot mount in .zfs
+	log_must ls /$TESTPOOL/$ds/.zfs/snapshot/snap
+	log_must zfs unmount $TESTPOOL/$ds
+
+	if ! ismounted $TESTPOOL/$ds_pre; then
+		log_fail "$ds_pre is not mounted"
+	fi
+	if ismounted $TESTPOOL/$ds; then
+		log_fail "$ds is mounted"
+	fi
+	if ismounted $TESTPOOL/$ds_post; then
+		log_fail "$ds_post (post) is mounted"
+	fi
+done
+
+log_must zpool export $TESTPOOL
+log_must rmdir /testpool/mnt # remove the mountpoint we created
+log_must zpool import $TESTPOOL
+
+log_pass "Verified nested dataset are unmounted."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modified `changelist_gather()`ing for the `mountpoint` property. Now instead of iterating on all dataset descendants, we read `/proc/self/mounts` and iterate on the mounted descendant datasets only.

Switched changelist implementation from a `uu_list_*` to `uu_avl_*` in order to reduce changlist code-path's worst case time complexity.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was initially internally brought up @datto as an observation that certain `zfs rename` and `zfs unmount` operations were much slower than others.

### Description
<!--- Describe your changes in detail -->
Upon investigation of the slow unmount process we could see the unmount was doing something simular to
```
➜ zfs-datto git:(mounted_iter) ✗ cat /proc/27757/stack
[<ffffffffc05ce735>] __cv_timedwait_common+0x195/0x310 [spl]
[<ffffffffc05ce8e9>] __cv_timedwait_io+0x19/0x20 [spl]
[<ffffffffc0b6ae49>] zio_wait+0x1e9/0x4d0 [zfs]
[<ffffffffc0a44d45>] dbuf_read+0x905/0x1170 [zfs]
[<ffffffffc0a48f2a>] dbuf_hold_impl_arg+0x9ea/0xb20 [zfs]
[<ffffffffc0a490fa>] dbuf_hold_impl+0x9a/0xc0 [zfs]
[<ffffffffc0a491b6>] dbuf_hold+0x36/0x60 [zfs]
[<ffffffffc0a75cdc>] dnode_hold_impl+0x15c/0x1050 [zfs]
[<ffffffffc0a76beb>] dnode_hold+0x1b/0x20 [zfs]
[<ffffffffc0a58be4>] dmu_bonus_hold_impl+0x54/0x250 [zfs]
[<ffffffffc0a58df6>] dmu_bonus_hold+0x16/0x20 [zfs]
[<ffffffffc0a81ad6>] dsl_dataset_hold_obj_flags+0x56/0xcb0 [zfs]
[<ffffffffc0a82746>] dsl_dataset_hold_obj+0x16/0x20 [zfs]
[<ffffffffc0b33c35>] zfs_ioc_snapshot_list_next+0x165/0x220 [zfs]
[<ffffffffc0b395d2>] zfsdev_ioctl+0x8b2/0x9a0 [zfs]
[<ffffffff81222faf>] do_vfs_ioctl+0x29f/0x490
[<ffffffff81223219>] SyS_ioctl+0x79/0x90
[<ffffffff81840b72>] entry_SYSCALL_64_fastpath+0x16/0x71
[<ffffffffffffffff>] 0xffffffffffffffff

➜ zfs-datto git:(mounted_iter) ✗ cat /proc/27757/stack
[<ffffffffc05ce735>] __cv_timedwait_common+0x195/0x310 [spl]
[<ffffffffc05ce8e9>] __cv_timedwait_io+0x19/0x20 [spl]
[<ffffffffc0b6ae49>] zio_wait+0x1e9/0x4d0 [zfs]
[<ffffffffc0a3353a>] arc_read+0xeea/0x1e50 [zfs]
[<ffffffffc0a5e1ff>] dmu_objset_open_impl+0xff/0xca0 [zfs]
[<ffffffffc0a5eee5>] dmu_objset_from_ds+0x145/0x280 [zfs]
[<ffffffffc0b33c48>] zfs_ioc_snapshot_list_next+0x178/0x220 [zfs]
[<ffffffffc0b395d2>] zfsdev_ioctl+0x8b2/0x9a0 [zfs]
[<ffffffff81222faf>] do_vfs_ioctl+0x29f/0x490
[<ffffffff81223219>] SyS_ioctl+0x79/0x90
[<ffffffff81840b72>] entry_SYSCALL_64_fastpath+0x16/0x71
[<ffffffffffffffff>] 0xffffffffffffffff
```
The calls to `zfs_ioc_snapshot_list_next()` reflect that we are iterating snapshots during this unmount which could be slow since we may need to read from disk for every snapshot.

The issue turned out to be that the current `changelist_gather()` path for dataset properties could in turn iterate on child snapshots/descendants datasets. This means that the execution of  `changelist_gather()`  and therefore `zfs unmount/rename` was dependent on the number of snapshots the datasets being unmounted/renamed has. This patch removes this dependency in most cases (see `CL_GATHER_MOUNT_ALWAYS`) and only for `changelist_gather()`ing of the `mountpoint` property.

As a side note - we would also benefit if something simular was done for the `sharesmb` and `sharenfs` properties.

### How Has This Been Tested?
This change is somewhat invasive so I've added a new test to do some nested unmounting.
Nested rename seemed to be covered by existing test `zfs_rename_014_neg.ksh`.
This change also affect `zfs recv`.  All the `zfs recv` tests and the rest of the zfs-tests are passing on my dev machine but let's see what buildbot thinks.

Also tested the patch on a system with 35k snapshots and the execution time for `zfs rename/unmount` went from minute(s) to fractions of a second.
 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
