### PR TITLE
OpenZFS 9677 - panic from zio_write_gang_block()

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2603,7 +2603,13 @@ zio_write_gang_member_ready(zio_t *zio)
 static void
 zio_write_gang_done(zio_t *zio)
 {
-	abd_put(zio->io_abd);
+	/*
+	 * The io_abd field will be NULL for a zio with no data.  The io_flags
+	 * will initially have the ZIO_FLAG_NODATA bit flag set, but we can't
+	 * check for it here as it is cleared in zio_ready.
+	 */
+	if (zio->io_abd != NULL)
+		abd_put(zio->io_abd);
 }
 
 static zio_t *
@@ -2624,6 +2630,7 @@ zio_write_gang_block(zio_t *pio)
 	int gbh_copies;
 	zio_prop_t zp;
 	int error;
+	boolean_t has_data = !(pio->io_flags & ZIO_FLAG_NODATA);
 
 	/*
 	 * encrypted blocks need DVA[2] free so encrypted gang headers can't
@@ -2636,7 +2643,7 @@ zio_write_gang_block(zio_t *pio)
 	int flags = METASLAB_HINTBP_FAVOR | METASLAB_GANG_HEADER;
 	if (pio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 		ASSERT(pio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
-		ASSERT(!(pio->io_flags & ZIO_FLAG_NODATA));
+		ASSERT(has_data);
 
 		flags |= METASLAB_ASYNC_ALLOC;
 		VERIFY(zfs_refcount_held(&mc->mc_alloc_slots[pio->io_allocator],
@@ -2660,7 +2667,7 @@ zio_write_gang_block(zio_t *pio)
 	if (error) {
 		if (pio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 			ASSERT(pio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
-			ASSERT(!(pio->io_flags & ZIO_FLAG_NODATA));
+			ASSERT(has_data);
 
 			/*
 			 * If we failed to allocate the gang block header then
@@ -2719,14 +2726,15 @@ zio_write_gang_block(zio_t *pio)
 		bzero(zp.zp_mac, ZIO_DATA_MAC_LEN);
 
 		zio_t *cio = zio_write(zio, spa, txg, &gbh->zg_blkptr[g],
-		    abd_get_offset(pio->io_abd, pio->io_size - resid), lsize,
-		    lsize, &zp, zio_write_gang_member_ready, NULL, NULL,
+		    has_data ? abd_get_offset(pio->io_abd, pio->io_size -
+		    resid) : NULL, lsize, lsize, &zp,
+		    zio_write_gang_member_ready, NULL, NULL,
 		    zio_write_gang_done, &gn->gn_child[g], pio->io_priority,
 		    ZIO_GANG_CHILD_FLAGS(pio), &pio->io_bookmark);
 
 		if (pio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 			ASSERT(pio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
-			ASSERT(!(pio->io_flags & ZIO_FLAG_NODATA));
+			ASSERT(has_data);
 
 			/*
 			 * Gang children won't throttle but we should


### PR DESCRIPTION
### Motivation and Context

OpenZFS-issue: https://illumos.org/issues/9677
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/7341a7d

### Description

When the amount of memory in the system changes, we automatically increase the size of the dump device. The dump device is allocated with ZIO_FLAG_NODATA, so that we just allocate the space and don't write to it (yet - we'll write when the system dumps). If the rpool is fragmented, then we may end up trying to create gang blocks for the dump device. What should happen is that we allocate the gang blocks, and then the zvol_dumpify() code will notice that there are gang blocks in the dump device, and fail to activate it for dump (since we don't have code to support this).

However, when we create the gang block for the dump device (with ZIO_FLAG_NODATA), we get a panic from zio_write_gang_block(), because pio->io_abd is NULL. It should be fine for this to be NULL, since we have ZIO_FLAG_NODATA we should not be touching it. However, with the ABD changes we are now doing "abd_get_offset(pio->io_abd, ...)" which will panic since the io_abd is NULL.

The solution is for zio_write_gang_block() to pass a NULL abd to zio_write() instead of calling abd_get_offset(pio->io_abd == NULL), when ZIO_FLAG_NODATA is set.

### How Has This Been Tested?

Locally built.  The specific scenario above can't be tested currently on Linux since the dump device logic was removed.  Regardless this is a fix we want for gang blocks in general.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
