### PR TITLE
Add new fnvlist_lookup_* functions

### DIFF
--- a/include/sys/nvpair.h
+++ b/include/sys/nvpair.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2000, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  */
 
 #ifndef	_SYS_NVPAIR_H
@@ -313,20 +313,30 @@ void fnvlist_add_nvlist_array(nvlist_t *, const char *, nvlist_t **, uint_t);
 void fnvlist_remove(nvlist_t *, const char *);
 void fnvlist_remove_nvpair(nvlist_t *, nvpair_t *);
 
-nvpair_t *fnvlist_lookup_nvpair(nvlist_t *nvl, const char *name);
-boolean_t fnvlist_lookup_boolean(nvlist_t *nvl, const char *name);
-boolean_t fnvlist_lookup_boolean_value(nvlist_t *nvl, const char *name);
-uchar_t fnvlist_lookup_byte(nvlist_t *nvl, const char *name);
-int8_t fnvlist_lookup_int8(nvlist_t *nvl, const char *name);
-int16_t fnvlist_lookup_int16(nvlist_t *nvl, const char *name);
-int32_t fnvlist_lookup_int32(nvlist_t *nvl, const char *name);
-int64_t fnvlist_lookup_int64(nvlist_t *nvl, const char *name);
-uint8_t fnvlist_lookup_uint8(nvlist_t *nvl, const char *name);
-uint16_t fnvlist_lookup_uint16(nvlist_t *nvl, const char *name);
-uint32_t fnvlist_lookup_uint32(nvlist_t *nvl, const char *name);
-uint64_t fnvlist_lookup_uint64(nvlist_t *nvl, const char *name);
-char *fnvlist_lookup_string(nvlist_t *nvl, const char *name);
-nvlist_t *fnvlist_lookup_nvlist(nvlist_t *nvl, const char *name);
+nvpair_t *fnvlist_lookup_nvpair(nvlist_t *, const char *);
+boolean_t fnvlist_lookup_boolean(nvlist_t *, const char *);
+boolean_t fnvlist_lookup_boolean_value(nvlist_t *, const char *);
+uchar_t fnvlist_lookup_byte(nvlist_t *, const char *);
+int8_t fnvlist_lookup_int8(nvlist_t *, const char *);
+int16_t fnvlist_lookup_int16(nvlist_t *, const char *);
+int32_t fnvlist_lookup_int32(nvlist_t *, const char *);
+int64_t fnvlist_lookup_int64(nvlist_t *, const char *);
+uint8_t fnvlist_lookup_uint8(nvlist_t *, const char *);
+uint16_t fnvlist_lookup_uint16(nvlist_t *, const char *);
+uint32_t fnvlist_lookup_uint32(nvlist_t *, const char *);
+uint64_t fnvlist_lookup_uint64(nvlist_t *, const char *);
+char *fnvlist_lookup_string(nvlist_t *, const char *);
+nvlist_t *fnvlist_lookup_nvlist(nvlist_t *, const char *);
+boolean_t *fnvlist_lookup_boolean_array(nvlist_t *, const char *, uint_t *);
+uchar_t *fnvlist_lookup_byte_array(nvlist_t *, const char *, uint_t *);
+int8_t *fnvlist_lookup_int8_array(nvlist_t *, const char *, uint_t *);
+uint8_t *fnvlist_lookup_uint8_array(nvlist_t *, const char *, uint_t *);
+int16_t *fnvlist_lookup_int16_array(nvlist_t *, const char *, uint_t *);
+uint16_t *fnvlist_lookup_uint16_array(nvlist_t *, const char *, uint_t *);
+int32_t *fnvlist_lookup_int32_array(nvlist_t *, const char *, uint_t *);
+uint32_t *fnvlist_lookup_uint32_array(nvlist_t *, const char *, uint_t *);
+int64_t *fnvlist_lookup_int64_array(nvlist_t *, const char *, uint_t *);
+uint64_t *fnvlist_lookup_uint64_array(nvlist_t *, const char *, uint_t *);
 
 boolean_t fnvpair_value_boolean_value(nvpair_t *nvp);
 uchar_t fnvpair_value_byte(nvpair_t *nvp);

--- a/module/nvpair/fnvpair.c
+++ b/module/nvpair/fnvpair.c
@@ -20,7 +20,7 @@
  */
 
 /*
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  */
 
 #include <sys/nvpair.h>
@@ -409,6 +409,85 @@ fnvlist_lookup_nvlist(nvlist_t *nvl, const char *name)
 {
 	nvlist_t *rv;
 	VERIFY0(nvlist_lookup_nvlist(nvl, name, &rv));
+	return (rv);
+}
+boolean_t *
+fnvlist_lookup_boolean_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	boolean_t *rv;
+	VERIFY0(nvlist_lookup_boolean_array(nvl, name, &rv, n));
+	return (rv);
+}
+
+uchar_t *
+fnvlist_lookup_byte_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	uchar_t *rv;
+	VERIFY0(nvlist_lookup_byte_array(nvl, name, &rv, n));
+	return (rv);
+}
+
+int8_t *
+fnvlist_lookup_int8_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	int8_t *rv;
+	VERIFY0(nvlist_lookup_int8_array(nvl, name, &rv, n));
+	return (rv);
+}
+
+uint8_t *
+fnvlist_lookup_uint8_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	uint8_t *rv;
+	VERIFY0(nvlist_lookup_uint8_array(nvl, name, &rv, n));
+	return (rv);
+}
+
+int16_t *
+fnvlist_lookup_int16_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	int16_t *rv;
+	VERIFY0(nvlist_lookup_int16_array(nvl, name, &rv, n));
+	return (rv);
+}
+
+uint16_t *
+fnvlist_lookup_uint16_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	uint16_t *rv;
+	VERIFY0(nvlist_lookup_uint16_array(nvl, name, &rv, n));
+	return (rv);
+}
+
+int32_t *
+fnvlist_lookup_int32_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	int32_t *rv;
+	VERIFY0(nvlist_lookup_int32_array(nvl, name, &rv, n));
+	return (rv);
+}
+
+uint32_t *
+fnvlist_lookup_uint32_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	uint32_t *rv;
+	VERIFY0(nvlist_lookup_uint32_array(nvl, name, &rv, n));
+	return (rv);
+}
+
+int64_t *
+fnvlist_lookup_int64_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	int64_t *rv;
+	VERIFY0(nvlist_lookup_int64_array(nvl, name, &rv, n));
+	return (rv);
+}
+
+uint64_t *
+fnvlist_lookup_uint64_array(nvlist_t *nvl, const char *name, uint_t *n)
+{
+	uint64_t *rv;
+	VERIFY0(nvlist_lookup_uint64_array(nvl, name, &rv, n));
 	return (rv);
 }
 


### PR DESCRIPTION
This change adds new fnvlist functions for which there are already non-asserted equivalents, and cleans up part of the header files to match the style elsewhere in the codebase.

### Motivation and Context
This change is purely one of code cleanup, to grant the same guaranteed-success capabilities to all the different lookups nvlists can perform.

### Description
This change adds new fnvlist functions for which there are already non-asserted equivalents, and cleans up part of the header files to match the style elsewhere in the codebase.

### How Has This Been Tested?
This change has been confirmed to build and pass the code style requirements.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
