### PR TITLE
Remove ztest dependency on libzfs

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -5823,7 +5823,8 @@ main(int argc, char **argv)
 	}
 
 	if (dump_opt['e']) {
-		cfg = lzp_find_pool_config(target_pool, nsearch, searchdirs);
+		cfg = lzp_find_pool_config(target_pool, nsearch, searchdirs,
+		    B_TRUE);
 
 		if (cfg != NULL) {
 			if (nvlist_add_nvlist(cfg,

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -141,7 +141,6 @@ usage(void)
 	    "\t%s -l [-Aqu] <device>\n"
 	    "\t%s -m [-AFLPX] [-e [-V] [-p <path> ...]] [-t <txg>] "
 	    "[-U <cache>]\n\t\t<poolname> [<vdev> [<metaslab> ...]]\n"
-	    "\t%s -N <file-path> -e [-p <path>] <poolname>\n"
 	    "\t%s -O <dataset> <path>\n"
 	    "\t%s -R [-A] [-e [-V] [-p <path> ...]] [-U <cache>]\n"
 	    "\t\t<poolname> <vdev>:<offset>:<size>[:<flags>]\n"
@@ -149,7 +148,7 @@ usage(void)
 	    "\t%s -S [-AP] [-e [-V] [-p <path> ...]] [-U <cache>] "
 	    "<poolname>\n\n",
 	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname, cmdname,
-	    cmdname, cmdname, cmdname);
+	    cmdname, cmdname);
 
 	(void) fprintf(stderr, "    Dataset name must include at least one "
 	    "separator character '/' or '@'\n");
@@ -175,8 +174,6 @@ usage(void)
 	    "load spacemaps)\n");
 	(void) fprintf(stderr, "        -m metaslabs\n");
 	(void) fprintf(stderr, "        -M metaslab groups\n");
-	(void) fprintf(stderr, "        -N <file-path> write the pool's config "
-	    "nvlist to file\n");
 	(void) fprintf(stderr, "        -O perform object lookups by path\n");
 	(void) fprintf(stderr, "        -R read and display block from a "
 	    "device\n");
@@ -5595,7 +5592,6 @@ main(int argc, char **argv)
 	int flags = ZFS_IMPORT_MISSING_LOG;
 	int rewind = ZPOOL_NEVER_REWIND;
 	char *spa_config_path_env;
-	const char *nvlist_config_file = NULL;
 	boolean_t target_is_spa = B_TRUE;
 	nvlist_t *cfg = NULL;
 
@@ -5614,7 +5610,7 @@ main(int argc, char **argv)
 		spa_config_path = spa_config_path_env;
 
 	while ((c = getopt(argc, argv,
-	    "AbcCdDeEFGhiI:klLmMN:o:Op:PqRsSt:uU:vVx:X")) != -1) {
+	    "AbcCdDeEFGhiI:klLmMo:Op:PqRsSt:uU:vVx:X")) != -1) {
 		switch (c) {
 		case 'b':
 		case 'c':
@@ -5647,15 +5643,6 @@ main(int argc, char **argv)
 			dump_opt[c]++;
 			break;
 		/* NB: Sort single match options below. */
-		case 'N':
-			nvlist_config_file = optarg;
-			if (nvlist_config_file[0] != '/') {
-				(void) fprintf(stderr, "N: must be an absolute "
-				    "path (i.e. start with a slash)\n");
-				usage();
-			}
-			dump_all = 0;
-			break;
 		case 'I':
 			max_inflight = strtoull(optarg, NULL, 0);
 			if (max_inflight == 0) {
@@ -5719,11 +5706,6 @@ main(int argc, char **argv)
 
 	if (!dump_opt['e'] && searchdirs != NULL) {
 		(void) fprintf(stderr, "-p option requires use of -e\n");
-		usage();
-	}
-
-	if (!dump_opt['e'] && nvlist_config_file != NULL) {
-		(void) fprintf(stderr, "-N option requires use of -e\n");
 		usage();
 	}
 
@@ -5849,32 +5831,8 @@ main(int argc, char **argv)
 
 		error = zpool_tryimport(g_zfs, target_pool, &cfg, &args);
 
-		/*
-		 * '-N' writes the XDR encoded pool config nvlist
-		 */
-		if (error == 0 && nvlist_config_file != NULL) {
-			size_t nvsize, residual;
-			char *packed;
-			int fd;
-
-			fd = open(nvlist_config_file,
-			    O_RDWR | O_CREAT | O_TRUNC, 0644);
-			if (fd < 0) {
-				fatal("can't open '%s': %s", nvlist_config_file,
-				    strerror(errno));
-			}
-			packed = fnvlist_pack(cfg, &nvsize);
-			residual = nvsize;
-			while (residual > 0) {
-				ssize_t bytes = write(fd, packed, residual);
-				ASSERT(bytes >= 0);
-				residual -= bytes;
-			}
-			(void) close(fd);
-			fnvlist_pack_free(packed, nvsize);
-		}
-
 		if (error == 0) {
+
 			if (nvlist_add_nvlist(cfg,
 			    ZPOOL_LOAD_POLICY, policy) != 0) {
 				fatal("can't open '%s': %s",

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -141,6 +141,7 @@ usage(void)
 	    "\t%s -l [-Aqu] <device>\n"
 	    "\t%s -m [-AFLPX] [-e [-V] [-p <path> ...]] [-t <txg>] "
 	    "[-U <cache>]\n\t\t<poolname> [<vdev> [<metaslab> ...]]\n"
+	    "\t%s -N <file-path> -e [-p <path>] <poolname>\n"
 	    "\t%s -O <dataset> <path>\n"
 	    "\t%s -R [-A] [-e [-V] [-p <path> ...]] [-U <cache>]\n"
 	    "\t\t<poolname> <vdev>:<offset>:<size>[:<flags>]\n"
@@ -148,7 +149,7 @@ usage(void)
 	    "\t%s -S [-AP] [-e [-V] [-p <path> ...]] [-U <cache>] "
 	    "<poolname>\n\n",
 	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname, cmdname,
-	    cmdname, cmdname);
+	    cmdname, cmdname, cmdname);
 
 	(void) fprintf(stderr, "    Dataset name must include at least one "
 	    "separator character '/' or '@'\n");
@@ -174,6 +175,8 @@ usage(void)
 	    "load spacemaps)\n");
 	(void) fprintf(stderr, "        -m metaslabs\n");
 	(void) fprintf(stderr, "        -M metaslab groups\n");
+	(void) fprintf(stderr, "        -N <file-path> write the pool's config "
+	    "nvlist to file\n");
 	(void) fprintf(stderr, "        -O perform object lookups by path\n");
 	(void) fprintf(stderr, "        -R read and display block from a "
 	    "device\n");
@@ -5592,6 +5595,7 @@ main(int argc, char **argv)
 	int flags = ZFS_IMPORT_MISSING_LOG;
 	int rewind = ZPOOL_NEVER_REWIND;
 	char *spa_config_path_env;
+	const char *nvlist_config_file = NULL;
 	boolean_t target_is_spa = B_TRUE;
 	nvlist_t *cfg = NULL;
 
@@ -5610,7 +5614,7 @@ main(int argc, char **argv)
 		spa_config_path = spa_config_path_env;
 
 	while ((c = getopt(argc, argv,
-	    "AbcCdDeEFGhiI:klLmMo:Op:PqRsSt:uU:vVx:X")) != -1) {
+	    "AbcCdDeEFGhiI:klLmMN:o:Op:PqRsSt:uU:vVx:X")) != -1) {
 		switch (c) {
 		case 'b':
 		case 'c':
@@ -5643,6 +5647,15 @@ main(int argc, char **argv)
 			dump_opt[c]++;
 			break;
 		/* NB: Sort single match options below. */
+		case 'N':
+			nvlist_config_file = optarg;
+			if (nvlist_config_file[0] != '/') {
+				(void) fprintf(stderr, "N: must be an absolute "
+				    "path (i.e. start with a slash)\n");
+				usage();
+			}
+			dump_all = 0;
+			break;
 		case 'I':
 			max_inflight = strtoull(optarg, NULL, 0);
 			if (max_inflight == 0) {
@@ -5706,6 +5719,11 @@ main(int argc, char **argv)
 
 	if (!dump_opt['e'] && searchdirs != NULL) {
 		(void) fprintf(stderr, "-p option requires use of -e\n");
+		usage();
+	}
+
+	if (!dump_opt['e'] && nvlist_config_file != NULL) {
+		(void) fprintf(stderr, "-N option requires use of -e\n");
 		usage();
 	}
 
@@ -5831,8 +5849,32 @@ main(int argc, char **argv)
 
 		error = zpool_tryimport(g_zfs, target_pool, &cfg, &args);
 
-		if (error == 0) {
+		/*
+		 * '-N' writes the XDR encoded pool config nvlist
+		 */
+		if (error == 0 && nvlist_config_file != NULL) {
+			size_t nvsize, residual;
+			char *packed;
+			int fd;
 
+			fd = open(nvlist_config_file,
+			    O_RDWR | O_CREAT | O_TRUNC, 0644);
+			if (fd < 0) {
+				fatal("can't open '%s': %s", nvlist_config_file,
+				    strerror(errno));
+			}
+			packed = fnvlist_pack(cfg, &nvsize);
+			residual = nvsize;
+			while (residual > 0) {
+				ssize_t bytes = write(fd, packed, residual);
+				ASSERT(bytes >= 0);
+				residual -= bytes;
+			}
+			(void) close(fd);
+			fnvlist_pack_free(packed, nvsize);
+		}
+
+		if (error == 0) {
 			if (nvlist_add_nvlist(cfg,
 			    ZPOOL_LOAD_POLICY, policy) != 0) {
 				fatal("can't open '%s': %s",

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -5823,16 +5823,9 @@ main(int argc, char **argv)
 	}
 
 	if (dump_opt['e']) {
-		importargs_t args = { 0 };
+		cfg = lzp_find_pool_config(target_pool, nsearch, searchdirs);
 
-		args.paths = nsearch;
-		args.path = searchdirs;
-		args.can_be_active = B_TRUE;
-
-		error = zpool_tryimport(g_zfs, target_pool, &cfg, &args);
-
-		if (error == 0) {
-
+		if (cfg != NULL) {
 			if (nvlist_add_nvlist(cfg,
 			    ZPOOL_LOAD_POLICY, policy) != 0) {
 				fatal("can't open '%s': %s",

--- a/cmd/zhack/Makefile.am
+++ b/cmd/zhack/Makefile.am
@@ -11,5 +11,4 @@ zhack_SOURCES = \
 
 zhack_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
-	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzpool/libzpool.la

--- a/cmd/ztest/Makefile.am
+++ b/cmd/ztest/Makefile.am
@@ -20,7 +20,6 @@ ztest_SOURCES = \
 
 ztest_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
-	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzpool/libzpool.la
 
 ztest_LDADD += -lm

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -7196,7 +7196,7 @@ ztest_import(ztest_shared_t *zs)
 
 	searchdirs[0] = ztest_opts.zo_dir;
 
-	cfg = lzp_find_pool_config(name, 1, searchdirs);
+	cfg = lzp_find_pool_config(name, 1, searchdirs, B_FALSE);
 	if (cfg == NULL)
 		(void) fatal(0, "No pools found\n");
 
@@ -7205,6 +7205,7 @@ ztest_import(ztest_shared_t *zs)
 	zs->zs_metaslab_sz =
 	    1ULL << spa->spa_root_vdev->vdev_child[0]->vdev_ms_shift;
 	spa_close(spa, FTAG);
+	nvlist_free(cfg);
 
 	kernel_fini();
 

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -409,6 +409,13 @@ extern void zpool_print_unsup_feat(nvlist_t *config);
 
 /*
  * Search for pools to import
+ *
+ * Note:
+ * . returned config will contain runtime stats (unless 'can_be_active' is set)
+ * . 'paths' and 'cachefile' are mutually exclusive operations
+ * . 'can_be_active' (aka zdb mode) also avoids refeshing the config via ioctl
+ * . 'cachefile' mode precludes 'can_be_active'
+ * . 'unique' is for reporting uniqueness (no enforcement)
  */
 
 typedef struct importargs {
@@ -417,7 +424,7 @@ typedef struct importargs {
 	char *poolname;		/* name of a pool to find		*/
 	uint64_t guid;		/* guid of a pool to find		*/
 	char *cachefile;	/* cachefile to use for import		*/
-	int can_be_active : 1;	/* can the pool be active?		*/
+	int can_be_active : 1;	/* can the pool be active? for "zdb -e"	*/
 	int unique : 1;		/* does 'poolname' already exist?	*/
 	int exists : 1;		/* set on return if pool already exists	*/
 	int scan : 1;		/* prefer scanning to libblkid cache    */

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -666,7 +666,9 @@ struct spa;
 extern void nicenum(uint64_t num, char *buf, size_t);
 extern void show_pool_stats(struct spa *);
 extern int set_global_var(char *arg);
-extern nvlist_t *lzp_find_pool_config(const char *, int, char *searchdirs[]);
+extern nvlist_t *lzp_find_pool_config(const char *, int, char *searchdirs[],
+    boolean_t);
+extern nvlist_t *lzp_find_import_cached(const char *, const char *, boolean_t);
 
 typedef struct callb_cpr {
 	kmutex_t	*cc_lockp;

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
- * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
  */
 
@@ -666,6 +666,7 @@ struct spa;
 extern void nicenum(uint64_t num, char *buf, size_t);
 extern void show_pool_stats(struct spa *);
 extern int set_global_var(char *arg);
+extern nvlist_t *lzp_find_pool_config(const char *, int, char *searchdirs[]);
 
 typedef struct callb_cpr {
 	kmutex_t	*cc_lockp;

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1245,7 +1245,8 @@ get_configs(libzfs_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 
 		/*
 		 * zdb uses this path to report on active pools that were
-		 * imported or created using -R.
+		 * imported or created using -R. It also avoids the refresh
+		 * step (i.e. a trip to kernel).
 		 */
 		if (active_ok)
 			goto add_pool;

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -1275,6 +1275,7 @@ get_configs(libzfs_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 				goto nomem;
 		}
 
+		/* Use ZFS_IOC_POOL_TRYIMPORT ioctl to update config */
 		if ((nvl = refresh_config(hdl, config)) == NULL) {
 			nvlist_free(config);
 			config = NULL;
@@ -2232,6 +2233,7 @@ zpool_find_import_cached(libzfs_handle_t *hdl, const char *cachefile,
 
 	elem = NULL;
 	while ((elem = nvlist_next_nvpair(raw, elem)) != NULL) {
+		VERIFY3U(nvpair_type(elem), ==, DATA_TYPE_NVLIST);
 		src = fnvpair_value_nvlist(elem);
 
 		name = fnvlist_lookup_string(src, ZPOOL_CONFIG_POOL_NAME);
@@ -2259,6 +2261,7 @@ zpool_find_import_cached(libzfs_handle_t *hdl, const char *cachefile,
 			return (NULL);
 		}
 
+		/* Use ZFS_IOC_POOL_TRYIMPORT ioctl to update config */
 		if ((dst = refresh_config(hdl, src)) == NULL) {
 			nvlist_free(raw);
 			nvlist_free(pools);

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -10,7 +10,7 @@
 .\"
 .\"
 .\" Copyright 2012, Richard Lowe.
-.\" Copyright (c) 2012, 2017 by Delphix. All rights reserved.
+.\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Lawrence Livermore National Security, LLC.
 .\" Copyright (c) 2017 Intel Corporation.
@@ -70,6 +70,12 @@
 .Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar poolname
+.Nm
+.Fl N Ar file-path
+.Fl e
+.Op Fl p Ar path
+.Ar poolname
+
 .Sh DESCRIPTION
 The
 .Nm
@@ -215,6 +221,11 @@ Also display information about the maximum contiguous free space and the
 percentage of free space in each space map.
 .It Fl MMM
 Display every spacemap record.
+.It Fl N Ar file-path
+Write a pool's config nvlist to a file. Requires
+.Fl e
+option and a
+.Ar poolname .
 .It Fl O Ar dataset path
 Look up the specified
 .Ar path

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -10,7 +10,7 @@
 .\"
 .\"
 .\" Copyright 2012, Richard Lowe.
-.\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
+.\" Copyright (c) 2012, 2017 by Delphix. All rights reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Lawrence Livermore National Security, LLC.
 .\" Copyright (c) 2017 Intel Corporation.
@@ -70,12 +70,6 @@
 .Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar poolname
-.Nm
-.Fl N Ar file-path
-.Fl e
-.Op Fl p Ar path
-.Ar poolname
-
 .Sh DESCRIPTION
 The
 .Nm
@@ -221,11 +215,6 @@ Also display information about the maximum contiguous free space and the
 percentage of free space in each space map.
 .It Fl MMM
 Display every spacemap record.
-.It Fl N Ar file-path
-Write a pool's config nvlist to a file. Requires
-.Fl e
-option and a
-.Ar poolname .
 .It Fl O Ar dataset path
 Look up the specified
 .Ar path

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -115,6 +115,11 @@
 .Ar pool Ns | Ns Ar id
 .Op Ar newpool Oo Fl t Oc
 .Nm
+.Cm import
+.Fl C Ar configfile
+.Op Fl d Ar dir
+.Ar pool Ns | Ns Ar id
+.Nm
 .Cm iostat
 .Op Oo Oo Fl c Ar SCRIPT Oc Oo Fl lq Oc Oc Ns | Ns Fl rw
 .Op Fl T Sy u Ns | Ns Sy d
@@ -1591,6 +1596,26 @@ is temporary. Temporary pool names last until export. Ensures that
 the original pool name will be used in all label updates and therefore
 is retained upon export.
 Will also set -o cachefile=none when not explicitly specified.
+.El
+.It Xo
+.Nm
+.Cm import
+.Fl C Ar configfile
+.Op Fl d Ar dir
+.Ar pool Ns | Ns Ar id
+.Xc
+Writes the given pool's configuration to a file. A pool can be
+identified by its name or the numeric identifier.
+.Bl -tag -width Ds
+.It Fl C Ar configfile
+Writes the configuration to the specified
+.Ar configfile .
+.It Fl d Ar dir
+Searches for devices in
+.Ar dir .
+The
+.Fl d
+option can be specified multiple times.
 .El
 .It Xo
 .Nm

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -116,7 +116,7 @@
 .Op Ar newpool Oo Fl t Oc
 .Nm
 .Cm import
-.Fl C Ar configfile
+.Fl C Ar cachefile
 .Op Fl d Ar dir
 .Ar pool Ns | Ns Ar id
 .Nm
@@ -1600,16 +1600,16 @@ Will also set -o cachefile=none when not explicitly specified.
 .It Xo
 .Nm
 .Cm import
-.Fl C Ar configfile
+.Fl C Ar cachefile
 .Op Fl d Ar dir
 .Ar pool Ns | Ns Ar id
 .Xc
 Writes the given pool's configuration to a file. A pool can be
 identified by its name or the numeric identifier.
 .Bl -tag -width Ds
-.It Fl C Ar configfile
+.It Fl C Ar cachefile
 Writes the configuration to the specified
-.Ar configfile .
+.Ar cachefile .
 .It Fl d Ar dir
 Searches for devices in
 .Ar dir .


### PR DESCRIPTION
### Motivation and Context
The `ztest(8)` binary uses `libzpool`, which is comprised of the zfs module sources, to exercise the zfs module implementation.  On the other hand, the `zfs(8)` and `zpool(8)` CLI use `libzfs` to interact with the running zfs kernel module.

The property tables in the `libzpool` instance are initialized via `kernel_init()` --> `spa_init()` -> `zpool_prop_init()`. `ztest(8)` can also call the property functions, like `zpool_prop_to_name()` directly and assumes that they were properly initialized as described above.  We have encountered cases where these direct calls fail since there are identical symbols for these property functions inside `libzfs`. `ztest(8)` currently links against `libzfs` but doesn't call `libzfs_init()` in the normal code paths (only for the '-E' option).

### Description
It should also be noted that the `libzfs` version of the property functions have an additional step that will check if the running kernel supports a property. We don't want any runtime dependencies like this from within a `ztest(8)` context, so initializing `libzfs` to work around this identical symbol issue is not really an option.

The only use of `libzfs` in `ztest(8)` is for the '-E' option (use existing pool) which requires `zpool_tryimport()` from `libzfs`. We can get this functionality from `zpool(8)`.  We only need a mechanism to write the config nvlist results, for which a new 'import -C' option was added to `zpool(8)`.

### How Has This Been Tested?
Manually tested the `ztest -E` option with existing pools
Manually tested the new `zpool -C` option to confirm proper function
Ran `ztest` and `zloop`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
