### PR TITLE
ARC refcount fixes

### DIFF
--- a/include/sys/refcount.h
+++ b/include/sys/refcount.h
@@ -76,6 +76,8 @@ int64_t zfs_refcount_add_many(zfs_refcount_t *, uint64_t, void *);
 int64_t zfs_refcount_remove_many(zfs_refcount_t *, uint64_t, void *);
 void zfs_refcount_transfer(zfs_refcount_t *, zfs_refcount_t *);
 void zfs_refcount_transfer_ownership(zfs_refcount_t *, void *, void *);
+void zfs_refcount_transfer_ownership_many(zfs_refcount_t *, uint64_t,
+    void *, void *);
 boolean_t zfs_refcount_held(zfs_refcount_t *, void *);
 boolean_t zfs_refcount_not_held(zfs_refcount_t *, void *);
 
@@ -106,8 +108,9 @@ typedef struct refcount {
 	atomic_add_64(&(src)->rc_count, -__tmp); \
 	atomic_add_64(&(dst)->rc_count, __tmp); \
 }
-#define	zfs_refcount_transfer_ownership(rc, current_holder, new_holder)	(void)0
-#define	zfs_refcount_held(rc, holder)		((rc)->rc_count > 0)
+#define	zfs_refcount_transfer_ownership(rc, ch, nh)		((void)0)
+#define	zfs_refcount_transfer_ownership_many(rc, nr, ch, nh)	((void)0)
+#define	zfs_refcount_held(rc, holder)			((rc)->rc_count > 0)
 #define	zfs_refcount_not_held(rc, holder)		(B_TRUE)
 
 #define	zfs_refcount_init()

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6825,7 +6825,7 @@ arc_release(arc_buf_t *buf, void *tag)
 
 		mutex_exit(&buf->b_evict_lock);
 		(void) zfs_refcount_add_many(&arc_anon->arcs_size,
-		    HDR_GET_LSIZE(nhdr), buf);
+		    arc_buf_size(buf), buf);
 	} else {
 		mutex_exit(&buf->b_evict_lock);
 		ASSERT(zfs_refcount_count(&hdr->b_l1hdr.b_refcnt) == 1);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -3081,8 +3081,8 @@ arc_share_buf(arc_buf_hdr_t *hdr, arc_buf_t *buf)
 	 * refcount ownership to the hdr since it always owns
 	 * the refcount whenever an arc_buf_t is shared.
 	 */
-	zfs_refcount_transfer_ownership(&hdr->b_l1hdr.b_state->arcs_size,
-	    buf, hdr);
+	zfs_refcount_transfer_ownership_many(&hdr->b_l1hdr.b_state->arcs_size,
+	    arc_hdr_size(hdr), buf, hdr);
 	hdr->b_l1hdr.b_pabd = abd_get_from_buf(buf->b_data, arc_buf_size(buf));
 	abd_take_ownership_of_buf(hdr->b_l1hdr.b_pabd,
 	    HDR_ISTYPE_METADATA(hdr));
@@ -3110,8 +3110,8 @@ arc_unshare_buf(arc_buf_hdr_t *hdr, arc_buf_t *buf)
 	 * We are no longer sharing this buffer so we need
 	 * to transfer its ownership to the rightful owner.
 	 */
-	zfs_refcount_transfer_ownership(&hdr->b_l1hdr.b_state->arcs_size,
-	    hdr, buf);
+	zfs_refcount_transfer_ownership_many(&hdr->b_l1hdr.b_state->arcs_size,
+	    arc_hdr_size(hdr), hdr, buf);
 	arc_hdr_clear_flags(hdr, ARC_FLAG_SHARED_DATA);
 	abd_release_ownership_of_buf(hdr->b_l1hdr.b_pabd);
 	abd_put(hdr->b_l1hdr.b_pabd);

--- a/module/zfs/refcount.c
+++ b/module/zfs/refcount.c
@@ -234,8 +234,8 @@ zfs_refcount_transfer(zfs_refcount_t *dst, zfs_refcount_t *src)
 }
 
 void
-zfs_refcount_transfer_ownership(zfs_refcount_t *rc, void *current_holder,
-    void *new_holder)
+zfs_refcount_transfer_ownership_many(zfs_refcount_t *rc, uint64_t number,
+    void *current_holder, void *new_holder)
 {
 	reference_t *ref;
 	boolean_t found = B_FALSE;
@@ -248,7 +248,8 @@ zfs_refcount_transfer_ownership(zfs_refcount_t *rc, void *current_holder,
 
 	for (ref = list_head(&rc->rc_list); ref;
 	    ref = list_next(&rc->rc_list, ref)) {
-		if (ref->ref_holder == current_holder) {
+		if (ref->ref_holder == current_holder &&
+		    ref->ref_number == number) {
 			ref->ref_holder = new_holder;
 			found = B_TRUE;
 			break;
@@ -256,6 +257,14 @@ zfs_refcount_transfer_ownership(zfs_refcount_t *rc, void *current_holder,
 	}
 	ASSERT(found);
 	mutex_exit(&rc->rc_mtx);
+}
+
+void
+zfs_refcount_transfer_ownership(zfs_refcount_t *rc, void *current_holder,
+    void *new_holder)
+{
+	return (zfs_refcount_transfer_ownership_many(rc, 1, current_holder,
+	    new_holder));
 }
 
 /*


### PR DESCRIPTION
### Motivation and Context

Resolve #7219 which is occasionally encountered by `ztest` and was introduced by the encryption changes.

Additionally, resolve an unrelated reference count discrepancy accidentally introduced when porting compressed send/recv.  This may potentially explain #7820 though I was unable to reproduce the symptoms locally.

### Description

*  Fix arc_relase() refcount
    
    Update arc_release to use arc_buf_size().  This hunk was accidentally
    dropped when porting compressed send/recv, 2aa34383b.

* Add zfs_refcount_transfer_ownership_many()

    When debugging is enabled and a zfs_refcount_t contains multiple holders
    using the same key, but different ref_counts, the wrong reference_t may
    be transferred.  Add a zfs_refcount_transfer_ownership_many() function,
    like the existing zfs_refcount_*_many() functions, to match and transfer
    the correct refcount_t;
    
    This issue may occur when using encryption with refcount debugging
    enabled.  An arc_buf_hdr_t can have references for both the
    hdr->b_l1hdr.b_pabd and hdr->b_crypt_hdr.b_rabd which both use the
    hdr as the reference holder.  When unsharing the buffer the p_abd
    should be transferred.
    
    This issue does not impact production builds because refcount holders
    are not tracked.

### How Has This Been Tested?

Local `ztes`t runs.  Prior to this change I was able to reproduce the #7219 approximately once an hour using `ztest`.  With the fix applied I've thus far been unable to reproduce the issue.  I'm pushing this change to the CI for additional `ztest` coverage and will let my local `ztest` run overnight.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
