### PR TITLE
zdb -k does not work on Linux when used with -e

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -6057,17 +6057,6 @@ main(int argc, char **argv)
 	error = 0;
 	target = argv[0];
 
-	char *checkpoint_pool = NULL;
-	char *checkpoint_target = NULL;
-	if (dump_opt['k']) {
-		checkpoint_pool = import_checkpointed_state(target, cfg,
-		    &checkpoint_target);
-
-		if (checkpoint_target != NULL)
-			target = checkpoint_target;
-
-	}
-
 	if (strpbrk(target, "/@") != NULL) {
 		size_t targetlen;
 
@@ -6111,6 +6100,24 @@ main(int argc, char **argv)
 			error = spa_import(target_pool, cfg, NULL,
 			    flags | ZFS_IMPORT_SKIP_MMP);
 		}
+	}
+
+	/*
+	 * import_checkpointed_state makes the assumption that the
+	 * target pool that we pass it is already part of the spa
+	 * namespace. Because of that we need to make sure to call
+	 * it always after the -e option has been processed, which
+	 * imports the pool to the namespace if it's not in the
+	 * cachefile.
+	 */
+	char *checkpoint_pool = NULL;
+	char *checkpoint_target = NULL;
+	if (dump_opt['k']) {
+		checkpoint_pool = import_checkpointed_state(target, cfg,
+		    &checkpoint_target);
+
+		if (checkpoint_target != NULL)
+			target = checkpoint_target;
 	}
 
 	if (target_pool != target)

--- a/tests/zfs-tests/tests/functional/pool_checkpoint/pool_checkpoint.kshlib
+++ b/tests/zfs-tests/tests/functional/pool_checkpoint/pool_checkpoint.kshlib
@@ -161,7 +161,16 @@ function cleanup_nested_pool
 function cleanup_test_pool
 {
 	log_must zpool destroy $TESTPOOL
-	zpool labelclear -f "$TESTDISK"
+
+	#
+	# We always clear the labels of all disks
+	# between tests so imports from zpool or
+	# or zdb do not get confused with leftover
+	# data from old pools.
+	#
+	for disk in $DISKS; do
+		zpool labelclear -f $disk
+	done
 }
 
 function cleanup_nested_pools


### PR DESCRIPTION
This minor bug was introduced with the port of the feature from
OpenZFS to ZoL. This patch fixes the issue that was caused by
a minor re-ordering from the original code.

Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>


### Description

One of my colleagues within Delphix hit this issue:
```
$ sudo zpool create testpool sdd
$ sudo zpool checkpoint testpool
$ sudo zdb -k -e testpool
zdb: Tried to read config of pool "testpool" but spa_get_stats() failed with error 2
```

We root-caused the issue to be a minor regression introduced by the ZoL
port of the checkpoint. The issue is that the `import_checkpointed_state()`
function assumes that the target pool is already in the spa namespace which
happens when we've called `spa_import()` at the target pool on zdb.
This was not the case in the zdb code when the -e option is specified (e.g.
the pool is exported and not in the cachefile), because we were first
processing the -k option which calls `import_checkpointed_state()` and
then -e which does the initial import of the current state of the pool.

This patch reverts that order to make this the same as it is in illumos.
A comment was added to warn future readers of that dependency.

### How Has This Been Tested?
Extended test from ZFS test-suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
