### PR TITLE
Fix several ztest failures

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -225,6 +225,7 @@ dump_debug_buffer(void)
 {
 	if (dump_opt['G']) {
 		(void) printf("\n");
+		(void) fflush(stdout);
 		zfs_dbgmsg_print("zdb");
 	}
 }

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -3543,6 +3543,15 @@ ztest_device_removal(ztest_ds_t *zd, uint64_t id)
 	if (error == 0) {
 		mutex_exit(&ztest_vdev_lock);
 
+		/*
+		 * spa->spa_vdev_removal is created in a sync task that
+		 * is initiated via dsl_sync_task_nowait(). Since the
+		 * task may not run before spa_vdev_remove() returns, we
+		 * must wait at least 1 txg to ensure that the removal
+		 * struct has been created.
+		 */
+		txg_wait_synced(spa_get_dsl(spa), 0);
+
 		while (spa->spa_vdev_removal != NULL)
 			txg_wait_synced(spa_get_dsl(spa), 0);
 	} else {

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -7383,8 +7383,13 @@ main(int argc, char **argv)
 	 * Verify that even extensively damaged split blocks with many
 	 * segments can be reconstructed in a reasonable amount of time
 	 * when reconstruction is known to be possible.
+	 *
+	 * Note: the lower this value is, the more damage we inflict, and
+	 * the more time ztest spends in recovering that damage. We chose
+	 * to induce damage 1/100th of the time so recovery is tested but
+	 * not so frequently that ztest doesn't get to test other code paths.
 	 */
-	zfs_reconstruct_indirect_damage_fraction = 4;
+	zfs_reconstruct_indirect_damage_fraction = 100;
 
 	action.sa_handler = sig_handler;
 	sigemptyset(&action.sa_mask);

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -473,7 +473,7 @@ static spa_t *ztest_spa = NULL;
 static ztest_ds_t *ztest_ds;
 
 static kmutex_t ztest_vdev_lock;
-static boolean_t ztest_device_removal_active = B_FALSE;
+static kmutex_t ztest_removal_lock;
 static kmutex_t ztest_checkpoint_lock;
 
 /*
@@ -3332,6 +3332,15 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	if (ztest_opts.zo_mmp_test)
 		return;
 
+	/*
+	 * If a vdev is in the process of being removed, its removal may
+	 * finish while we are in progress, leading to an unexpected error
+	 * value.  Don't bother trying to attach while we are in the middle
+	 * of removal.
+	 */
+	if (!mutex_tryenter(&ztest_removal_lock))
+		return;
+
 	oldpath = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
 	newpath = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
 
@@ -3340,17 +3349,6 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 
 	spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
 
-	/*
-	 * If a vdev is in the process of being removed, its removal may
-	 * finish while we are in progress, leading to an unexpected error
-	 * value.  Don't bother trying to attach while we are in the middle
-	 * of removal.
-	 */
-	if (ztest_device_removal_active) {
-		spa_config_exit(spa, SCL_ALL, FTAG);
-		mutex_exit(&ztest_vdev_lock);
-		return;
-	}
 
 	/*
 	 * Decide whether to do an attach or a replace.
@@ -3515,6 +3513,7 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	}
 out:
 	mutex_exit(&ztest_vdev_lock);
+	mutex_exit(&ztest_removal_lock);
 
 	umem_free(oldpath, MAXPATHLEN);
 	umem_free(newpath, MAXPATHLEN);
@@ -3529,12 +3528,8 @@ ztest_device_removal(ztest_ds_t *zd, uint64_t id)
 	uint64_t guid;
 	int error;
 
+	mutex_enter(&ztest_removal_lock);
 	mutex_enter(&ztest_vdev_lock);
-
-	if (ztest_device_removal_active) {
-		mutex_exit(&ztest_vdev_lock);
-		return;
-	}
 
 	/*
 	 * Remove a random top-level vdev and wait for removal to finish.
@@ -3546,13 +3541,13 @@ ztest_device_removal(ztest_ds_t *zd, uint64_t id)
 
 	error = spa_vdev_remove(spa, guid, B_FALSE);
 	if (error == 0) {
-		ztest_device_removal_active = B_TRUE;
 		mutex_exit(&ztest_vdev_lock);
 
 		while (spa->spa_vdev_removal != NULL)
 			txg_wait_synced(spa_get_dsl(spa), 0);
 	} else {
 		mutex_exit(&ztest_vdev_lock);
+		mutex_exit(&ztest_removal_lock);
 		return;
 	}
 
@@ -3568,9 +3563,7 @@ ztest_device_removal(ztest_ds_t *zd, uint64_t id)
 			txg_wait_synced(spa_get_dsl(spa), 0);
 	}
 
-	mutex_enter(&ztest_vdev_lock);
-	ztest_device_removal_active = B_FALSE;
-	mutex_exit(&ztest_vdev_lock);
+	mutex_exit(&ztest_removal_lock);
 }
 
 /*
@@ -3700,22 +3693,18 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 	uint64_t top;
 	uint64_t old_class_space, new_class_space, old_ms_count, new_ms_count;
 
-	mutex_enter(&ztest_checkpoint_lock);
-	mutex_enter(&ztest_vdev_lock);
-	spa_config_enter(spa, SCL_STATE, spa, RW_READER);
-
 	/*
 	 * If there is a vdev removal in progress, it could complete while
 	 * we are running, in which case we would not be able to verify
 	 * that the metaslab_class space increased (because it decreases
 	 * when the device removal completes).
 	 */
-	if (ztest_device_removal_active) {
-		spa_config_exit(spa, SCL_STATE, spa);
-		mutex_exit(&ztest_vdev_lock);
-		mutex_exit(&ztest_checkpoint_lock);
+	if (!mutex_tryenter(&ztest_removal_lock))
 		return;
-	}
+
+	mutex_enter(&ztest_checkpoint_lock);
+	mutex_enter(&ztest_vdev_lock);
+	spa_config_enter(spa, SCL_STATE, spa, RW_READER);
 
 	top = ztest_random_vdev_top(spa, B_TRUE);
 
@@ -3744,6 +3733,7 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 		spa_config_exit(spa, SCL_STATE, spa);
 		mutex_exit(&ztest_vdev_lock);
 		mutex_exit(&ztest_checkpoint_lock);
+		mutex_exit(&ztest_removal_lock);
 		return;
 	}
 	ASSERT(psize > 0);
@@ -3770,6 +3760,7 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 		spa_config_exit(spa, SCL_STATE, spa);
 		mutex_exit(&ztest_vdev_lock);
 		mutex_exit(&ztest_checkpoint_lock);
+		mutex_exit(&ztest_removal_lock);
 		return;
 	}
 
@@ -3805,6 +3796,7 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 		spa_config_exit(spa, SCL_STATE, spa);
 		mutex_exit(&ztest_vdev_lock);
 		mutex_exit(&ztest_checkpoint_lock);
+		mutex_exit(&ztest_removal_lock);
 		return;
 	}
 
@@ -3836,6 +3828,7 @@ ztest_vdev_LUN_growth(ztest_ds_t *zd, uint64_t id)
 	spa_config_exit(spa, SCL_STATE, spa);
 	mutex_exit(&ztest_vdev_lock);
 	mutex_exit(&ztest_checkpoint_lock);
+	mutex_exit(&ztest_removal_lock);
 }
 
 /*
@@ -5715,18 +5708,15 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 	path0 = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
 	pathrand = umem_alloc(MAXPATHLEN, UMEM_NOFAIL);
 
-	mutex_enter(&ztest_vdev_lock);
-
 	/*
-	 * Device removal is in progress, fault injection must be disabled
-	 * until it completes and the pool is scrubbed.  The fault injection
-	 * strategy for damaging blocks does not take in to account evacuated
-	 * blocks which may have already been damaged.
+	 * The fault injection strategy for damaging blocks does not take
+	 * in to account evacuated blocks which may have already been damaged.
+	 * It must not run concurrently with device removal.
 	 */
-	if (ztest_device_removal_active) {
-		mutex_exit(&ztest_vdev_lock);
-		goto out;
-	}
+	if (!mutex_tryenter(&ztest_removal_lock))
+		return;
+
+	mutex_enter(&ztest_vdev_lock);
 
 	maxfaults = MAXFAULTS(zs);
 	leaves = MAX(zs->zs_mirrors, 1) * ztest_opts.zo_raidz;
@@ -5957,6 +5947,8 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 
 	(void) close(fd);
 out:
+	mutex_exit(&ztest_removal_lock);
+
 	umem_free(path0, MAXPATHLEN);
 	umem_free(pathrand, MAXPATHLEN);
 }
@@ -6086,12 +6078,14 @@ ztest_scrub(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * Scrub in progress by device removal.
 	 */
-	if (ztest_device_removal_active)
+	if (!mutex_tryenter(&ztest_removal_lock))
 		return;
 
 	(void) spa_scan(spa, POOL_SCAN_SCRUB);
 	(void) poll(NULL, 0, 100); /* wait a moment, then force a restart */
 	(void) spa_scan(spa, POOL_SCAN_SCRUB);
+
+	mutex_exit(&ztest_removal_lock);
 }
 
 /*
@@ -6755,7 +6749,9 @@ ztest_run(ztest_shared_t *zs)
 	 * Initialize parent/child shared state.
 	 */
 	mutex_init(&ztest_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&ztest_removal_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&ztest_checkpoint_lock, NULL, MUTEX_DEFAULT, NULL);
+
 	VERIFY0(pthread_rwlock_init(&ztest_name_lock, NULL));
 
 	zs->zs_thread_start = gethrtime();
@@ -6916,6 +6912,7 @@ ztest_run(ztest_shared_t *zs)
 	mutex_destroy(&zcl.zcl_callbacks_lock);
 	(void) pthread_rwlock_destroy(&ztest_name_lock);
 	mutex_destroy(&ztest_vdev_lock);
+	mutex_destroy(&ztest_removal_lock);
 	mutex_destroy(&ztest_checkpoint_lock);
 }
 

--- a/include/sys/zfs_debug.h
+++ b/include/sys/zfs_debug.h
@@ -55,11 +55,12 @@ extern int zfs_dbgmsg_enable;
 #define	ZFS_DEBUG_SET_ERROR		(1 << 9)
 #define	ZFS_DEBUG_INDIRECT_REMAP	(1 << 10)
 
-extern void __dprintf(const char *file, const char *func,
+extern void __zfs_dbgmsg(char *buf);
+extern void __dprintf(boolean_t dprint, const char *file, const char *func,
     int line, const char *fmt, ...);
 #define	zfs_dbgmsg(...) \
 	if (zfs_dbgmsg_enable) \
-		__dprintf(__FILE__, __func__, __LINE__, __VA_ARGS__)
+		__dprintf(B_FALSE, __FILE__, __func__, __LINE__, __VA_ARGS__)
 
 #ifdef ZFS_DEBUG
 /*
@@ -69,7 +70,7 @@ extern void __dprintf(const char *file, const char *func,
  */
 #define	dprintf(...) \
 	if (zfs_flags & ZFS_DEBUG_DPRINTF) \
-		__dprintf(__FILE__, __func__, __LINE__, __VA_ARGS__)
+		__dprintf(B_TRUE, __FILE__, __func__, __LINE__, __VA_ARGS__)
 #else
 #define	dprintf(...) ((void)0)
 #endif /* ZFS_DEBUG */

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -312,7 +312,7 @@ unsigned long zfs_deadman_ziotime_ms = 300000ULL;
  * Check time in milliseconds. This defines the frequency at which we check
  * for hung I/O.
  */
-unsigned long  zfs_deadman_checktime_ms = 60000ULL;
+unsigned long zfs_deadman_checktime_ms = 60000ULL;
 
 /*
  * By default the deadman is enabled.

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -562,22 +562,22 @@ txg_sync_thread(void *arg)
 		tx->tx_quiesced_txg = 0;
 		tx->tx_syncing_txg = txg;
 		DTRACE_PROBE2(txg__syncing, dsl_pool_t *, dp, uint64_t, txg);
-		txg_stat_t *ts = spa_txg_history_init_io(spa, txg, dp);
 		cv_broadcast(&tx->tx_quiesce_more_cv);
 
 		dprintf("txg=%llu quiesce_txg=%llu sync_txg=%llu\n",
 		    txg, tx->tx_quiesce_txg_waiting, tx->tx_sync_txg_waiting);
 		mutex_exit(&tx->tx_sync_lock);
 
+		txg_stat_t *ts = spa_txg_history_init_io(spa, txg, dp);
 		start = ddi_get_lbolt();
 		spa_sync(spa, txg);
 		delta = ddi_get_lbolt() - start;
+		spa_txg_history_fini_io(spa, ts);
 
 		mutex_enter(&tx->tx_sync_lock);
 		tx->tx_synced_txg = txg;
 		tx->tx_syncing_txg = 0;
 		DTRACE_PROBE2(txg__synced, dsl_pool_t *, dp, uint64_t, txg);
-		spa_txg_history_fini_io(spa, ts);
 		cv_broadcast(&tx->tx_sync_done_cv);
 
 		/*

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -1614,7 +1614,7 @@ vdev_indirect_splits_damage(indirect_vsd_t *iv, zio_t *zio)
 	 * result in two or less unique copies per indirect_child_t.
 	 * Both may need to be checked in order to reconstruct the block.
 	 * Set iv->iv_attempts_max such that all unique combinations will
-	 * enumerated, but limit the damage to at most 16 indirect splits.
+	 * enumerated, but limit the damage to at most 12 indirect splits.
 	 */
 	iv->iv_attempts_max = 1;
 
@@ -1632,7 +1632,7 @@ vdev_indirect_splits_damage(indirect_vsd_t *iv, zio_t *zio)
 		}
 
 		iv->iv_attempts_max *= 2;
-		if (iv->iv_attempts_max > (1ULL << 16)) {
+		if (iv->iv_attempts_max >= (1ULL << 12)) {
 			iv->iv_attempts_max = UINT64_MAX;
 			break;
 		}
@@ -1718,7 +1718,7 @@ vdev_indirect_reconstruct_io_done(zio_t *zio)
 	/*
 	 * If nonzero, every 1/x blocks will be damaged, in order to validate
 	 * reconstruction when there are split segments with damaged copies.
-	 * Known_good will TRUE when reconstruction is known to be possible.
+	 * Known_good will be TRUE when reconstruction is known to be possible.
 	 */
 	if (zfs_reconstruct_indirect_damage_fraction != 0 &&
 	    spa_get_random(zfs_reconstruct_indirect_damage_fraction) == 0)

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -720,7 +720,8 @@ zil_create(zilog_t *zilog)
 		txg_wait_synced(zilog->zl_dmu_pool, txg);
 	}
 
-	ASSERT(bcmp(&blk, &zh->zh_log, sizeof (blk)) == 0);
+	ASSERT(error != 0 || bcmp(&blk, &zh->zh_log, sizeof (blk)) == 0);
+	IMPLY(error == 0, lwb != NULL);
 
 	return (lwb);
 }


### PR DESCRIPTION
This PR contains several patches which fix several common failures that buildbot is currently hitting when running `zloop.sh`. This patch also fixes a few long-standing bugs that prevented various debug output from being printed during ztest execution.

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
