### PR TITLE
Define timestruc_t for Lustre compatibility

### DIFF
--- a/include/spl/sys/time.h
+++ b/include/spl/sys/time.h
@@ -66,6 +66,9 @@ typedef struct timespec64	inode_timespec_t;
 typedef struct timespec		inode_timespec_t;
 #endif
 
+/* Include for Lustre compatibility */
+#define	timestruc_t	inode_timespec_t
+
 static inline void
 gethrestime(inode_timespec_t *ts)
 {


### PR DESCRIPTION
### Motivation and Context
Allow lustre to build against zfs

### Description
Lustre 2.8 (and possibly other versions) are still using `timestruc_t`, which was removed in `spl-0.7.10` in favour of `inode_timespec_t`.  Add in a backwards compatibility `#define` for `timestruc_t` so that Lustre builds.

Signed-off-by: Tony Hutter <hutter2@llnl.gov>

### How Has This Been Tested?
Verified lustre built.  This patch has been in the LLNL ZFS branch for the last three weeks (https://github.com/LLNL/zfs/releases/tag/zfs-0.7.11-2llnl).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
