### PR TITLE
Fixes to compile in Fedora 28

### DIFF
--- a/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
+++ b/tests/zfs-tests/cmd/libzfs_input_check/libzfs_input_check.c
@@ -147,7 +147,7 @@ lzc_ioctl_run(zfs_ioc_t ioc, const char *name, nvlist_t *innvl, int expected)
 	}
 
 	packed = fnvlist_pack(innvl, &size);
-	(void) strncpy(zc.zc_name, name, sizeof (zc.zc_name));
+	(void) strncpy(zc.zc_name, name, sizeof (zc.zc_name)-1);
 	zc.zc_name[sizeof (zc.zc_name) - 1] = '\0';
 	zc.zc_nvlist_src = (uint64_t)(uintptr_t)packed;
 	zc.zc_nvlist_src_size = size;
@@ -234,7 +234,7 @@ lzc_ioctl_test(zfs_ioc_t ioc, const char *name, nvlist_t *required,
 			char pname[MAXNAMELEN];
 			data_type_t ptype;
 
-			strncpy(pname, nvpair_name(pair), sizeof (pname));
+			strncpy(pname, nvpair_name(pair), sizeof (pname)-1);
 			pname[sizeof (pname) - 1] = '\0';
 			ptype = nvpair_type(pair);
 			fnvlist_remove_nvpair(input, pair);
@@ -648,7 +648,7 @@ zfs_destroy(const char *dataset)
 	zfs_cmd_t zc = {"\0"};
 	int err;
 
-	(void) strncpy(zc.zc_name, dataset, sizeof (zc.zc_name));
+	(void) strncpy(zc.zc_name, dataset, sizeof (zc.zc_name)-1);
 	zc.zc_name[sizeof (zc.zc_name) - 1] = '\0';
 	zc.zc_objset_type = DMU_OST_ZFS;
 	err = ioctl(zfs_fd, ZFS_IOC_DESTROY, &zc);
@@ -760,7 +760,7 @@ zfs_ioc_input_tests(const char *pool)
 		ioc_tested[ioc_skip[i] - ZFS_IOC_FIRST] = B_TRUE;
 	}
 
-	(void) strncpy(zc.zc_name, pool, sizeof (zc.zc_name));
+	(void) strncpy(zc.zc_name, pool, sizeof (zc.zc_name)-1);
 	zc.zc_name[sizeof (zc.zc_name) - 1] = '\0';
 
 	for (unsigned ioc = ZFS_IOC_FIRST; ioc < ZFS_IOC_LAST; ioc++) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes to compile on Fedora 28

### Description
<!--- Describe your changes in detail -->
Some strncpy were out of bound, and Fedora's compiler rejected them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Just compiled.  No more tests done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
