### PR TITLE
Allow copy-builtin to work with modified sources.

### DIFF
--- a/copy-builtin
+++ b/copy-builtin
@@ -30,7 +30,7 @@ then
 fi
 
 make clean || true
-scripts/make_gitrev.sh
+scripts/make_gitrev.sh || true
 
 rm -rf "$KERNEL_DIR/include/zfs" "$KERNEL_DIR/fs/zfs"
 cp --recursive include "$KERNEL_DIR/include/zfs"

--- a/scripts/make_gitrev.sh
+++ b/scripts/make_gitrev.sh
@@ -15,9 +15,8 @@
 # CDDL HEADER END
 #
 
-#
 # Copyright (c) 2018 by Delphix. All rights reserved.
-#
+# Copyright (c) 2018 by Matthew Thode. All rights reserved.
 
 #
 # Generate zfs_gitrev.h.  Note that we need to do this for every
@@ -26,29 +25,19 @@
 # `configure` is run.
 #
 
-BASE_DIR=$(dirname "$0")
+set -e -u
 
-file=${BASE_DIR}/../include/zfs_gitrev.h
+cleanup() {
+    ZFS_GIT_REV=${ZFS_GIT_REV:-"unknown"}
+    cat << EOF > "$(dirname "$0")"/../include/zfs_gitrev.h
+#define	ZFS_META_GITREV "${ZFS_GIT_REV}"
+EOF
+}
+trap cleanup EXIT
 
-#
-# Set default file contents in case we bail.
-#
-rm -f "$file"
-# shellcheck disable=SC2039
-/bin/echo -e "#define\tZFS_META_GITREV \"unknown\"" >>"$file"
-
-#
 # Check if git is installed and we are in a git repo.
-#
-git rev-parse --git-dir > /dev/null 2>&1 || exit
-
-#
+git rev-parse --git-dir > /dev/null 2>&1
 # Check if there are uncommitted changes
-#
-git diff-index --quiet HEAD || exit
-
-rev=$(git describe 2>/dev/null) || exit
-
-rm -f "$file"
-# shellcheck disable=SC2039
-/bin/echo -e "#define\tZFS_META_GITREV \"${rev}\"" >>"$file"
+git diff-index --quiet HEAD
+# Get the git current git revision
+ZFS_GIT_REV=$(git describe 2>/dev/null)


### PR DESCRIPTION
`scripts/make_gitrev.sh` had 'set -e' so if any command failed it would
fail and cause copy-builtin to fail (copy-builtin also has `set -e`.
This commit also simplifies scripts/make_gitrev.sh to always write a
file by using a cleanup function.  It also simplifies other areas of
the script as well (making it much shorter).

Closes: https://github.com/zfsonlinux/zfs/issues/8022

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
