### PR TITLE
Linux does not HAVE_DNLC

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -117,7 +117,7 @@ cppcheck:
 		cppcheck --quiet --force --error-exitcode=2 --inline-suppr \
 			--suppressions-list=.github/suppressions.txt \
 			-UHAVE_SSE2 -UHAVE_AVX512F -UHAVE_UIO_ZEROCOPY \
-			-UHAVE_DNLC ${top_srcdir}; \
+			${top_srcdir}; \
 	else \
 		echo "skipping cppcheck because cppcheck is not installed"; \
 	fi

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -1208,27 +1208,6 @@ zfs_lookup(struct inode *dip, char *nm, struct inode **ipp, int flags,
 				return (0);
 			}
 			return (error);
-#ifdef HAVE_DNLC
-		} else if (!zdp->z_zfsvfs->z_norm &&
-		    (zdp->z_zfsvfs->z_case == ZFS_CASE_SENSITIVE)) {
-
-			vnode_t *tvp = dnlc_lookup(dvp, nm);
-
-			if (tvp) {
-				error = zfs_fastaccesschk_execute(zdp, cr);
-				if (error) {
-					iput(tvp);
-					return (error);
-				}
-				if (tvp == DNLC_NO_VNODE) {
-					iput(tvp);
-					return (SET_ERROR(ENOENT));
-				} else {
-					*vpp = tvp;
-					return (specvp_check(vpp, cr));
-				}
-			}
-#endif /* HAVE_DNLC */
 		}
 	}
 
@@ -1764,13 +1743,6 @@ top:
 		error = SET_ERROR(EPERM);
 		goto out;
 	}
-
-#ifdef HAVE_DNLC
-	if (realnmp)
-		dnlc_remove(dvp, realnmp->pn_buf);
-	else
-		dnlc_remove(dvp, name);
-#endif /* HAVE_DNLC */
 
 	mutex_enter(&zp->z_lock);
 	may_delete_now = atomic_read(&ip->i_count) == 1 && !(zp->z_is_mapped);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since Linux does not have the Directory Name Lookup Cache, we don't need
the code to manage it.  The HAVE_DNLC CPP macro is never defined.

Note that if upstream (illumos) changes are made relating to the DNLC, we will have merge conflicts.  But that was probably the case already, and having merge conflicts in areas where the functionality differs is a good thing because it brings our attention to changes that require more thought.  

Carrying this dead code has more cost than benefit, and if we ever decide we need it, we can revive it by reverting this commit.

### Description
<!--- Describe your changes in detail -->

Remove code that's under HAVE_DNLC.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
build.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
