### PR TITLE
ZTS: Update project quota tests

### DIFF
--- a/tests/zfs-tests/tests/functional/projectquota/projectid_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectid_001_pos.ksh
@@ -63,19 +63,19 @@ log_must touch $PRJFILE
 log_must mkdir $PRJDIR
 
 log_must chattr -p $PRJID1 $PRJFILE
-log_must eval "lsattr -p $PRJFILE | grep $PRJID1 | grep '\- '"
+log_must eval "lsattr -p $PRJFILE | grep $PRJID1 | grep -v '\-P[- ]* '"
 log_must chattr -p $PRJID1 $PRJDIR
-log_must eval "lsattr -pd $PRJDIR | grep $PRJID1 | grep '\- '"
+log_must eval "lsattr -pd $PRJDIR | grep $PRJID1 | grep -v '\-P[- ]* '"
 
 log_must chattr +P $PRJDIR
-log_must eval "lsattr -pd $PRJDIR | grep $PRJID1 | grep '\-P '"
+log_must eval "lsattr -pd $PRJDIR | grep $PRJID1 | grep '\-P[- ]* '"
 
 # "-1" is invalid project ID, should be denied
 log_mustnot chattr -p -1 $PRJFILE
-log_must eval "lsattr -p $PRJFILE | grep $PRJID1 | grep '\- '"
+log_must eval "lsattr -p $PRJFILE | grep $PRJID1 | grep -v '\-P[- ]* '"
 
 log_must mkdir $PRJDIR/dchild
-log_must eval "lsattr -pd $PRJDIR/dchild | grep $PRJID1 | grep '\-P '"
+log_must eval "lsattr -pd $PRJDIR/dchild | grep $PRJID1 | grep '\-P[- ]* '"
 log_must touch $PRJDIR/fchild
 log_must eval "lsattr -p $PRJDIR/fchild | grep $PRJID1"
 

--- a/tests/zfs-tests/tests/functional/projectquota/projecttree_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projecttree_001_pos.ksh
@@ -69,30 +69,30 @@ log_must chattr -p $PRJID1 $PRJDIR/a3
 log_must eval "zfs project $PRJDIR/a3 | grep '$PRJID1 \-'"
 
 log_must zfs project -p $PRJID2 $PRJDIR/a3
-log_must eval "lsattr -p $PRJDIR/a3 | grep $PRJID2 | grep '\- '"
+log_must eval "lsattr -p $PRJDIR/a3 | grep $PRJID2 | grep -v '\-P[- ]* '"
 
 log_must chattr -p $PRJID1 $PRJDIR/a1
 log_must eval "zfs project -d $PRJDIR/a1 | grep '$PRJID1 \-'"
 
 log_must zfs project -p $PRJID2 $PRJDIR/a1
-log_must eval "lsattr -pd $PRJDIR/a1 | grep $PRJID2 | grep '\- '"
+log_must eval "lsattr -pd $PRJDIR/a1 | grep $PRJID2 | grep -v '\-P[- ]* '"
 
 log_must chattr +P $PRJDIR/a2
 log_must eval "zfs project -d $PRJDIR/a2 | grep '0 P'"
 
 log_must zfs project -s $PRJDIR/a2
-log_must eval "lsattr -pd $PRJDIR/a2 | grep 0 | grep '\-P '"
+log_must eval "lsattr -pd $PRJDIR/a2 | grep 0 | grep '\-P[- ]* '"
 
 log_must chattr +P -p $PRJID1 $PRJDIR/a1
 log_must eval "zfs project -d $PRJDIR/a1 | grep '$PRJID1 P'"
 
 log_must zfs project -s -p $PRJID2 $PRJDIR/a2
-log_must eval "lsattr -pd $PRJDIR/a2 | grep $PRJID2 | grep '\-P '"
+log_must eval "lsattr -pd $PRJDIR/a2 | grep $PRJID2 | grep '\-P[- ]* '"
 
 log_must chattr -P $PRJDIR/a1
 log_must eval "zfs project -d $PRJDIR/a1 | grep '$PRJID1 \-'"
 
 log_must zfs project -C -k $PRJDIR/a2
-log_must eval "lsattr -pd $PRJDIR/a2 | grep $PRJID2 | grep '\- '"
+log_must eval "lsattr -pd $PRJDIR/a2 | grep $PRJID2 | grep -v '\-P[- ]* '"
 
 log_pass "Check 'zfs project' is compatible with chattr/lsattr"


### PR DESCRIPTION
### Motivation and Context

Resolve project quota failures observed in Fedora Rawhide.

### Description

http://build.zfsonlinux.org/builders/Fedora%20Rawhide%20x86_64%20%28TEST%29/builds/1525/steps/shell_9/logs/summary

e2fsprogs v1.44.1, which provides lsattr, added a new attibute for ext3 called "verity".  It is reported after the project quota flag as a 'V' character in the `lsattr` output.

Update projectid_001_pos.ksh and projecttree_001_pos.ksh to use a pattern which will match the expected output in both cases.

### How Has This Been Tested?

Manually tested with e2fsprogs v1.44.4-48-g29d78e01 and verified correct behavior.   Pending results from CI for testing on a wider range of `lsattr` versions.

NOTE: The e2fsprogs v1.44.4-1 package from Rawhide contains a bug which results in the `V` always being able when `P` is also set.  This was resolved in e2fsprogs but the updated version hasn't yet made it to Rawhide.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
