### PR TITLE
Update zfs_admin_snapshot default value (disabled)

### DIFF
--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -29,6 +29,7 @@
  *   Brian Behlendorf <behlendorf1@llnl.gov>
  * Copyright (c) 2013 by Delphix. All rights reserved.
  * Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
+ * Copyright (c) 2018 George Melikov. All Rights Reserved.
  */
 
 /*
@@ -106,7 +107,7 @@ static krwlock_t zfs_snapshot_lock;
  * Control Directory Tunables (.zfs)
  */
 int zfs_expire_snapshot = ZFSCTL_EXPIRE_SNAPSHOT;
-int zfs_admin_snapshot = 1;
+int zfs_admin_snapshot = 0;
 
 typedef struct {
 	char		*se_name;	/* full snapshot name */

--- a/tests/zfs-tests/tests/functional/delegate/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/delegate/cleanup.ksh
@@ -27,6 +27,7 @@
 
 #
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2018 George Melikov. All Rights Reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -42,6 +43,8 @@ if ! is_linux; then
 	fi
 fi
 
-default_cleanup
+if is_linux; then
+	log_must set_tunable64 zfs_admin_snapshot 0
+fi
 
-log_pass
+default_cleanup

--- a/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
+++ b/tests/zfs-tests/tests/functional/delegate/delegate_common.kshlib
@@ -27,6 +27,7 @@
 #
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
 # Copyright 2016 Nexenta Systems, Inc.
+# Copyright (c) 2018 George Melikov. All Rights Reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -766,7 +767,7 @@ function verify_fs_clone
 	typeset fs=$3
 
 	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
-        typeset basefs=${fs%/*}
+	typeset basefs=${fs%/*}
 	typeset snap=$fs@snap.$stamp
 	typeset clone=$basefs/cfs.$stamp
 
@@ -811,7 +812,7 @@ function verify_fs_rename
 	typeset fs=$3
 
 	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
-        typeset basefs=${fs%/*}
+	typeset basefs=${fs%/*}
 	typeset snap=$fs@snap.$stamp
 	typeset renamefs=$basefs/nfs.$stamp
 
@@ -1001,7 +1002,7 @@ function verify_fs_promote
 	typeset fs=$3
 
 	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
-        typeset basefs=${fs%/*}
+	typeset basefs=${fs%/*}
 	typeset snap=$fs@snap.$stamp
 	typeset clone=$basefs/cfs.$stamp
 
@@ -1368,7 +1369,7 @@ function verify_vol_snapshot
 	typeset vol=$3
 
 	typeset stamp=${perm}.${user}.$(date +'%F-%T-%N')
-        typeset basevol=${vol%/*}
+	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 
 	user_run $user zfs snapshot $snap
@@ -1393,7 +1394,7 @@ function verify_vol_rollback
 	typeset vol=$3
 
 	typeset stamp=${perm}.${user}.$(date+'%F-%T-%N')
-        typeset basevol=${vol%/*}
+	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 
 	typeset oldval
@@ -1428,7 +1429,7 @@ function verify_vol_clone
 	typeset vol=$3
 
 	typeset stamp=${perm}.${user}.$(date+'%F-%T-%N')
-        typeset basevol=${vol%/*}
+	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 	typeset clone=$basevol/cvol.$stamp
 
@@ -1474,7 +1475,7 @@ function verify_vol_rename
 	typeset vol=$3
 
 	typeset stamp=${perm}.${user}.$(date+'%F-%T-%N')
-        typeset basevol=${vol%/*}
+	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 	typeset clone=$basevol/cvol.$stamp
 	typeset renamevol=$basevol/nvol.$stamp
@@ -1521,7 +1522,7 @@ function verify_vol_promote
 	typeset vol=$3
 
 	typeset stamp=${perm}.${user}.$(date+'%F-%T-%N')
-        typeset basevol=${vol%/*}
+	typeset basevol=${vol%/*}
 	typeset snap=$vol@snap.$stamp
 	typeset clone=$basevol/cvol.$stamp
 

--- a/tests/zfs-tests/tests/functional/delegate/setup.ksh
+++ b/tests/zfs-tests/tests/functional/delegate/setup.ksh
@@ -27,6 +27,7 @@
 
 #
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2018 George Melikov. All Rights Reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -68,7 +69,9 @@ if [ $? -ne 0 ]; then
 fi
 
 DISK=${DISKS%% *}
-default_volume_setup $DISK
-log_must chmod 777 $TESTDIR
 
-log_pass
+if is_linux; then
+	log_must set_tunable64 zfs_admin_snapshot 1
+fi
+
+default_volume_setup $DISK

--- a/tests/zfs-tests/tests/functional/snapshot/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/cleanup.ksh
@@ -31,4 +31,8 @@
 
 . $STF_SUITE/include/libtest.shlib
 
+if is_linux; then
+	log_must set_tunable64 zfs_admin_snapshot 0
+fi
+
 default_container_cleanup

--- a/tests/zfs-tests/tests/functional/snapshot/setup.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/setup.ksh
@@ -33,4 +33,8 @@
 
 DISK=${DISKS%% *}
 
+if is_linux; then
+	log_must set_tunable64 zfs_admin_snapshot 1
+fi
+
 default_container_volume_setup ${DISK}


### PR DESCRIPTION
It's a WIP PR to reflect buildbot on needed changes.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's disabled by default, update code to reflect
the documentation.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
