### PR TITLE
Improve snapshot listing error message

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -178,7 +178,8 @@ zfs_validate_name(libzfs_handle_t *hdl, const char *path, int type,
 	if (type == ZFS_TYPE_SNAPSHOT && strchr(path, '@') == NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "missing '@' delimiter in snapshot name, did you mean to use -r?"));
+			    "missing '@' delimiter in snapshot name, "
+			    "did you mean to use -r?"));
 		return (0);
 	}
 
@@ -192,7 +193,8 @@ zfs_validate_name(libzfs_handle_t *hdl, const char *path, int type,
 	if (type == ZFS_TYPE_BOOKMARK && strchr(path, '#') == NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "missing '#' delimiter in bookmark name, did you mean to use -r?"));
+			    "missing '#' delimiter in bookmark name, "
+			    "did you mean to use -r?"));
 		return (0);
 	}
 

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -178,7 +178,7 @@ zfs_validate_name(libzfs_handle_t *hdl, const char *path, int type,
 	if (type == ZFS_TYPE_SNAPSHOT && strchr(path, '@') == NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "missing '@' delimiter in snapshot name"));
+			    "missing '@' delimiter in snapshot name, did you mean to use -r?"));
 		return (0);
 	}
 
@@ -192,7 +192,7 @@ zfs_validate_name(libzfs_handle_t *hdl, const char *path, int type,
 	if (type == ZFS_TYPE_BOOKMARK && strchr(path, '#') == NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "missing '#' delimiter in bookmark name"));
+			    "missing '#' delimiter in bookmark name, did you mean to use -r?"));
 		return (0);
 	}
 


### PR DESCRIPTION
### Motivation and Context
[#7056](https://github.com/zfsonlinux/zfs/issues/7056)

### Description
Provide a hint in the error message if listing snapshots for a single dataset fails.

Using -r is not needed to list all snapshots so requiring it when listing snapshots for a single dataset makes it confusing. This change will make the error message more clear.
