### PR TITLE
More ztest fixes

### DIFF
--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -758,7 +758,7 @@ spa_keystore_load_wkey(const char *dsname, dsl_crypto_params_t *dcp,
 	dsl_crypto_key_t *dck = NULL;
 	dsl_wrapping_key_t *wkey = dcp->cp_wkey;
 	dsl_pool_t *dp = NULL;
-	uint64_t keyformat, salt, iters;
+	uint64_t rddobj, keyformat, salt, iters;
 
 	/*
 	 * We don't validate the wrapping key's keyformat, salt, or iters
@@ -783,6 +783,13 @@ spa_keystore_load_wkey(const char *dsname, dsl_crypto_params_t *dcp,
 	ret = dsl_dir_hold(dp, dsname, FTAG, &dd, NULL);
 	if (ret != 0) {
 		dd = NULL;
+		goto error;
+	}
+
+	/* confirm that dd is the encryption root */
+	ret = dsl_dir_get_encryption_root_ddobj(dd, &rddobj);
+	if (ret != 0 || rddobj != dd->dd_object) {
+		ret = (SET_ERROR(EINVAL));
 		goto error;
 	}
 

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -4598,7 +4598,14 @@ vdev_deadman(vdev_t *vd, char *tag)
 void
 vdev_set_deferred_resilver(spa_t *spa, vdev_t *vd)
 {
-	ASSERT(vd->vdev_ops->vdev_op_leaf);
+	for (uint64_t i = 0; i < vd->vdev_children; i++) {
+		vdev_set_deferred_resilver(spa, vd->vdev_child[i]);
+	}
+
+	if (!vd->vdev_ops->vdev_op_leaf || !vdev_writeable(vd) ||
+	    range_tree_is_empty(vd->vdev_dtl[DTL_MISSING]))
+		return;
+
 	vd->vdev_resilver_deferred = B_TRUE;
 	spa->spa_resilver_deferred = B_TRUE;
 }

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -2603,7 +2603,7 @@ vdev_dtl_reassess(vdev_t *vd, uint64_t txg, uint64_t scrub_txg, int scrub_done)
 		 * DTLs then reset its resilvering flag and dirty
 		 * the top level so that we persist the change.
 		 */
-		if (vd->vdev_resilver_txg != 0 &&
+		if (txg != 0 && vd->vdev_resilver_txg != 0 &&
 		    range_tree_is_empty(vd->vdev_dtl[DTL_MISSING]) &&
 		    range_tree_is_empty(vd->vdev_dtl[DTL_OUTAGE])) {
 			vd->vdev_resilver_txg = 0;

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -1115,19 +1115,16 @@ vdev_remove_replace_with_indirect(vdev_t *vd, uint64_t txg)
 
 	ASSERT(!list_link_active(&vd->vdev_state_dirty_node));
 
-	tx = dmu_tx_create_assigned(spa->spa_dsl_pool, txg);
-	dsl_sync_task_nowait(spa->spa_dsl_pool, vdev_remove_complete_sync, svr,
-	    0, ZFS_SPACE_CHECK_NONE, tx);
-	dmu_tx_commit(tx);
-
-	/*
-	 * Indicate that this thread has exited.
-	 * After this, we can not use svr.
-	 */
 	mutex_enter(&svr->svr_lock);
 	svr->svr_thread = NULL;
 	cv_broadcast(&svr->svr_cv);
 	mutex_exit(&svr->svr_lock);
+
+	/* After this, we can not use svr. */
+	tx = dmu_tx_create_assigned(spa->spa_dsl_pool, txg);
+	dsl_sync_task_nowait(spa->spa_dsl_pool, vdev_remove_complete_sync, svr,
+	    0, ZFS_SPACE_CHECK_NONE, tx);
+	dmu_tx_commit(tx);
 }
 
 /*

--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -217,8 +217,6 @@ maybe = {
     'cli_root/zdb/zdb_006_pos': ['FAIL', known_reason],
     'cli_root/zfs_get/zfs_get_004_pos': ['FAIL', known_reason],
     'cli_root/zfs_get/zfs_get_009_pos': ['SKIP', '5479'],
-    'cli_root/zfs_rename/zfs_rename_006_pos': ['FAIL', '5647'],
-    'cli_root/zfs_rename/zfs_rename_009_neg': ['FAIL', '5648'],
     'cli_root/zfs_rollback/zfs_rollback_001_pos': ['FAIL', '6415'],
     'cli_root/zfs_rollback/zfs_rollback_002_pos': ['FAIL', '6416'],
     'cli_root/zfs_share/setup': ['SKIP', share_reason],

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_006_pos.ksh
@@ -69,6 +69,7 @@ rename_dataset ${vol}-new $vol
 
 clone=$TESTPOOL/${snap}_clone
 create_clone $vol@$snap $clone
+block_device_wait
 
 #verify data integrity
 for input in $VOL_R_PATH $ZVOL_RDEVDIR/$clone; do

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_009_neg.ksh
@@ -33,13 +33,13 @@
 
 #
 # DESCRIPTION:
-#	A snapshot already exists with the new name, then none of the
-#	snapshots is renamed.
+#	When renaming a set of snapshots, if a snapshot already exists with
+#	the new name, then none of the snapshots is renamed.
 #
 # STRATEGY:
-#	1. Create snapshot for a set of datasets.
+#	1. Create a snapshot for a set of datasets.
 #	2. Create a new snapshot for one of datasets.
-#	3. Using rename -r command with exists snapshot name.
+#	3. Attempt to "zfs rename -r" with the second snapshot's name.
 #	4. Verify none of the snapshots is renamed.
 #
 
@@ -54,7 +54,7 @@ function cleanup
 	done
 }
 
-log_assert "zfs rename -r failed, when snapshot name is already existing."
+log_assert "Verify zfs rename -r failed when the snapshot name already exists."
 log_onexit cleanup
 
 set -A datasets $TESTPOOL		$TESTPOOL/$TESTCTR \
@@ -71,7 +71,7 @@ while ((i < ${#datasets[@]})); do
 	log_mustnot zfs rename -r ${TESTPOOL}@snap ${TESTPOOL}@snap2
 	log_must zfs destroy ${datasets[$i]}@snap2
 
-	# Check datasets, make sure none of them was renamed.
+	# Check datasets, make sure none of them have snap2.
 	typeset -i j=0
 	while ((j < ${#datasets[@]})); do
 		if datasetexists ${datasets[$j]}@snap2 ; then
@@ -83,4 +83,4 @@ while ((i < ${#datasets[@]})); do
 	((i += 1))
 done
 
-log_pass "zfs rename -r failed, when snapshot name is already existing passed."
+log_pass "zfs rename -r failed when the snapshot name already exists."


### PR DESCRIPTION
This PR is a follow-up to #8010 with more fixes for ztest.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### How Has This Been Tested?
All problems and fixes in this patch were discovered and verified with ztest (as much as ztest can verify anything).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
