### PR TITLE
Fix zfstest posix tests that should pass.

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -151,8 +151,6 @@ summary = {
 # reasons listed above can be used.
 #
 known = {
-    'acl/posix/posix_001_pos': ['FAIL', known_reason],
-    'acl/posix/posix_002_pos': ['FAIL', known_reason],
     'casenorm/sensitive_none_lookup': ['FAIL', '7633'],
     'casenorm/sensitive_none_delete': ['FAIL', '7633'],
     'casenorm/sensitive_formd_lookup': ['FAIL', '7633'],

--- a/tests/zfs-tests/tests/functional/acl/posix/posix_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/acl/posix/posix_001_pos.ksh
@@ -26,6 +26,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/acl/acl_common.kshlib
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
@@ -43,19 +44,47 @@
 #
 
 verify_runnable "both"
+
+function cleanup
+{
+	rmdir $TESTDIR/dir.0
+}
+
 log_assert "Verify acltype=posixacl works on file"
+log_onexit cleanup
 
 # Test access to FILE
 log_note "Testing access to FILE"
 log_must touch $TESTDIR/file.0
 log_must setfacl -m g:$ZFS_ACL_STAFF_GROUP:rw $TESTDIR/file.0
-getfacl $TESTDIR/file.0 2> /dev/null | egrep -q "^group:$ZFS_ACL_STAFF_GROUP:rw-$"
+getfacl $TESTDIR/file.0 2> /dev/null | egrep -q \
+    "^group:$ZFS_ACL_STAFF_GROUP:rw-$"
 if [ "$?" -eq "0" ]; then
 	# Should be able to write to file
-	log_must user_run $ZFS_ACL_STAFF1 "echo 'echo test > /dev/null' > $TESTDIR/file.0"
+	log_must user_run $ZFS_ACL_STAFF1 \
+	    "echo 'echo test > /dev/null' > $TESTDIR/file.0"
 
+	# Since $TESTDIR is 777, create a new dir with controlled permissions
+	# for testing that creating a new file is not allowed.
+	log_must mkdir $TESTDIR/dir.0
+	log_must chmod 700 $TESTDIR/dir.0
+	log_must setfacl -m g:$ZFS_ACL_STAFF_GROUP:rw $TESTDIR/dir.0
+	# Confirm permissions
+	ls -l $TESTDIR |grep "dir.0" |grep -q "drwxrw----+"
+	if [ "$?" -ne "0" ]; then
+		msk=$(ls -l $TESTDIR |grep "dir.0" | awk '{print $1}')
+		log_note "expected mask drwxrw----+ but found $msk"
+		log_fail "Expected permissions were not set."
+	fi
+	getfacl $TESTDIR/dir.0 2> /dev/null | egrep -q \
+	    "^group:$ZFS_ACL_STAFF_GROUP:rw-$"
+	if [ "$?" -ne "0" ]; then
+		acl=$(getfacl $TESTDIR/dir.0 2> /dev/null)
+		log_note $acl
+		log_fail "ACL group:$ZFS_ACL_STAFF_GROUP:rw- was not set."
+	fi
 	# Should NOT be able to create new file
-	log_mustnot user_run $ZFS_ACL_STAFF1 "touch $TESTDIR/file.1"
+	log_mustnot user_run $ZFS_ACL_STAFF1 "touch $TESTDIR/dir.0/file.1"
 
 	# Root should be able to run file, but not user
 	chmod +x $TESTDIR/file.0


### PR DESCRIPTION
Make sure tests have proper include files.  Make sure underlying "chmod" style permissions don't interfere with ACLs.

### Motivation and Context
These fixes are part of the push to get cleaner zfstest runs without so many expected failures.

### Description
Added an include file that was missing.  Lessened some permissions since the test starts in a folder with 777 permissions that interfere with testing the ACLs that are set during the tests.

### How Has This Been Tested?
Tested on Ubuntu 16.04.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).