### PR TITLE
ZTHR refactoring - eliminates multiple races

### DIFF
--- a/include/sys/spa_checkpoint.h
+++ b/include/sys/spa_checkpoint.h
@@ -20,7 +20,7 @@
  */
 
 /*
- * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2017, 2018 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_SPA_CHECKPOINT_H
@@ -37,7 +37,7 @@ int spa_checkpoint(const char *);
 int spa_checkpoint_discard(const char *);
 
 boolean_t spa_checkpoint_discard_thread_check(void *, zthr_t *);
-int spa_checkpoint_discard_thread(void *, zthr_t *);
+void spa_checkpoint_discard_thread(void *, zthr_t *);
 
 int spa_checkpoint_get_stats(spa_t *, pool_checkpoint_stat_t *);
 

--- a/include/sys/zthr.h
+++ b/include/sys/zthr.h
@@ -14,35 +14,22 @@
  */
 
 /*
- * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2017, 2018 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_ZTHR_H
 #define	_SYS_ZTHR_H
 
 typedef struct zthr zthr_t;
-typedef int (zthr_func_t)(void *, zthr_t *);
+typedef void (zthr_func_t)(void *, zthr_t *);
 typedef boolean_t (zthr_checkfunc_t)(void *, zthr_t *);
-
-struct zthr {
-	kthread_t	*zthr_thread;
-	kmutex_t	zthr_lock;
-	kcondvar_t	zthr_cv;
-	boolean_t	zthr_cancel;
-
-	zthr_checkfunc_t	*zthr_checkfunc;
-	zthr_func_t	*zthr_func;
-	void		*zthr_arg;
-	int		zthr_rc;
-};
 
 extern zthr_t *zthr_create(zthr_checkfunc_t checkfunc,
     zthr_func_t *func, void *arg);
-extern void zthr_exit(zthr_t *t, int rc);
 extern void zthr_destroy(zthr_t *t);
 
 extern void zthr_wakeup(zthr_t *t);
-extern int zthr_cancel(zthr_t *t);
+extern void zthr_cancel(zthr_t *t);
 extern void zthr_resume(zthr_t *t);
 
 extern boolean_t zthr_iscancelled(zthr_t *t);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
  * Copyright (c) 2018, Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
@@ -7047,12 +7047,12 @@ spa_async_suspend(spa_t *spa)
 	spa_vdev_remove_suspend(spa);
 
 	zthr_t *condense_thread = spa->spa_condense_zthr;
-	if (condense_thread != NULL && zthr_isrunning(condense_thread))
-		VERIFY0(zthr_cancel(condense_thread));
+	if (condense_thread != NULL)
+		zthr_cancel(condense_thread);
 
 	zthr_t *discard_thread = spa->spa_checkpoint_discard_zthr;
-	if (discard_thread != NULL && zthr_isrunning(discard_thread))
-		VERIFY0(zthr_cancel(discard_thread));
+	if (discard_thread != NULL)
+		zthr_cancel(discard_thread);
 }
 
 void
@@ -7065,11 +7065,11 @@ spa_async_resume(spa_t *spa)
 	spa_restart_removal(spa);
 
 	zthr_t *condense_thread = spa->spa_condense_zthr;
-	if (condense_thread != NULL && !zthr_isrunning(condense_thread))
+	if (condense_thread != NULL)
 		zthr_resume(condense_thread);
 
 	zthr_t *discard_thread = spa->spa_checkpoint_discard_zthr;
-	if (discard_thread != NULL && !zthr_isrunning(discard_thread))
+	if (discard_thread != NULL)
 		zthr_resume(discard_thread);
 }
 

--- a/module/zfs/spa_checkpoint.c
+++ b/module/zfs/spa_checkpoint.c
@@ -20,7 +20,7 @@
  */
 
 /*
- * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2017, 2018 by Delphix. All rights reserved.
  */
 
 /*
@@ -393,7 +393,7 @@ spa_checkpoint_discard_thread_check(void *arg, zthr_t *zthr)
 	return (B_TRUE);
 }
 
-int
+void
 spa_checkpoint_discard_thread(void *arg, zthr_t *zthr)
 {
 	spa_t *spa = arg;
@@ -408,7 +408,7 @@ spa_checkpoint_discard_thread(void *arg, zthr_t *zthr)
 			dmu_buf_t **dbp;
 
 			if (zthr_iscancelled(zthr))
-				return (0);
+				return;
 
 			ASSERT3P(vd->vdev_ops, !=, &vdev_indirect_ops);
 
@@ -445,8 +445,6 @@ spa_checkpoint_discard_thread(void *arg, zthr_t *zthr)
 	VERIFY0(dsl_sync_task(spa->spa_name, NULL,
 	    spa_checkpoint_discard_complete_sync, spa,
 	    0, ZFS_SPACE_CHECK_NONE));
-
-	return (0);
 }
 
 

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2014, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2018 by Delphix. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -647,7 +647,7 @@ spa_condense_indirect_thread_check(void *arg, zthr_t *zthr)
 }
 
 /* ARGSUSED */
-static int
+static void
 spa_condense_indirect_thread(void *arg, zthr_t *zthr)
 {
 	spa_t *spa = arg;
@@ -744,13 +744,11 @@ spa_condense_indirect_thread(void *arg, zthr_t *zthr)
 	 * shutting down.
 	 */
 	if (zthr_iscancelled(zthr))
-		return (0);
+		return;
 
 	VERIFY0(dsl_sync_task(spa_name(spa), NULL,
 	    spa_condense_indirect_complete_sync, sci, 0,
 	    ZFS_SPACE_CHECK_EXTRA_RESERVED));
-
-	return (0);
 }
 
 /*


### PR DESCRIPTION
### Motivation and Context

This fixes issue: https://github.com/zfsonlinux/zfs/issues/7744
It also fixes a bunch of other related and non-related races mentioned below

### Description

There are a couple of similar race conditions with code
as it is right now:

1] Race Condition 1

As we are running the zthr_func(), zthr_cancel() raises
the cancel flag and blocks until zthr_thread is NULL,
dropping the lock in the meantime. If`zthr_resume() is
called at that point, it grabs the lock and it assumes
that the cancel flag is not raised, failing the assertion.
In reality, this doesn't usually happen because the
spa_export() code always checks if zthr_isrunning()
before calling zthr_resume(), but still there is a small
window where zthr_isrunning() drops the lock and
zthr_resume() has to grab it again. With multiple threads
there could be scenarios where the same assertion fails.
This race condition also sets up the basis for race
condition 2.

This patch:
Puts the check of zthr_isrunning() inside zthr_resume().
This takes care of aforementioned window between
zthr_isrunning() and zthr_cancel().

2] Race Condition 2
zthr_cancel() was called while the zthr_func was running
and the cancel flag was raised. zthr_cancel() waits for
zthr_thread to be set to NULL. This doesn't happen until
zthr_procedure calls zthr_exit() which sets zthr_thread
to NULL and drops the zthr_lock. Then, ideally, the
zthr_cancel() thread would wake up and set the cancel
flag 0. Unfortunately, if a zthr_resume() is called at
that point `zthr_thread` is NULL but the cancel flag is
still raised, thus we can fail the assertion again.

This patch:
Ensures that the zthr is the one reseting the cancel flag
to 0. This is nice for 2 reasons:
(1) Any flag raised from other threads requesting
cancellation, resumption, or waiting on the zthr, are reset
from the zthr itself. This is makes reasoning easier.
(current flags: zthr_cancel, zthr_initializing)
(2) The zthr_procedure() sets zthr_thread to NULL, resets
the cancel flag and then drops the lock. So even if a
zthr_resume()` comes up and sees that zthr_thread is NULL
it won't fail the assertion because the cancel flag has
been reset.

Withe the above change though another problem comes up. If
a zthr_cancel() raises the cancel flag and waits for
zthr_thread to be set to NULL. The zthr gets cancelled,
resets the flag and sets zthr_thread to NULL. Then, before
the zthr_cancel() wakes up again, a zthr_resume() comes up
and spawns a new thread, essentially repopulating zthr_thread.
As a result, zthr_cancel() hangs forever waiting for
zthr_thread to be NULL.

The way this patch deals with the above, is by introducing
the zthr_cancellation_stamp which is basically a logical
timestamp for each cancellation. The timestamp is incremented
every time the zthr gets cancelled. The idea is that before
dropping the lock, zthr_cancel() looks at the value of the
current at the time timestamp. This way, even if the above
scenario happens when zthr_thread has been repopulated
the cancellation timestamp of the zthr would have changed
and the zthr_cancel() thread will detect that and go on with
its flow instead of going to sleep again.

Other Side-changes:

* Ripped out zthr_rc (zthr return code) and change the
signature of zthr_func_t to return void. This code was never
really needed.
* Ripped out zthr_exit(). It wasn't really used anywhere
outside the ZTHR code (e.g. zthr_procedure()) and even there
we were dropping and grabbing the zthr lock for no reason.
* Introduced zthr_initializing variables. Basically the flag
answers the question "Are we initializing the zthr now?".
This deals with any race conditions that can take place
while the zthr is initializing (this is critical especially
for later when the fast clone deletion feature will add the
zthr_wait() changes).

### How Has This Been Tested?

Running ztest for a while in Linux (at the time of this writing for ~2 hours).
In illumos I had this patch running for around week with `ztest_spa_create_destroy` having a frequency of always.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
