### PR TITLE
tests: change `$(cat)` to `$(<)` for speedup

### DIFF
--- a/tests/zfs-tests/callbacks/zfs_mmp.ksh
+++ b/tests/zfs-tests/callbacks/zfs_mmp.ksh
@@ -18,7 +18,7 @@
 
 # $1: number of lines to output (default: 40)
 typeset lines=${1:-40}
-typeset history=$(cat /sys/module/zfs/parameters/zfs_multihost_history)
+typeset history=$(</sys/module/zfs/parameters/zfs_multihost_history)
 
 if [ $history -eq 0 ]; then
 	exit

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3332,7 +3332,7 @@ function zed_stop
 
 	log_note "Stopping ZED"
 	if [[ -f ${ZEDLET_DIR}/zed.pid ]]; then
-		zedpid=$(cat ${ZEDLET_DIR}/zed.pid)
+		zedpid=$(<${ZEDLET_DIR}/zed.pid)
 		kill $zedpid
 		while ps -p $zedpid > /dev/null; do
 			sleep 1

--- a/tests/zfs-tests/tests/functional/channel_program/channel_common.kshlib
+++ b/tests/zfs-tests/tests/functional/channel_program/channel_common.kshlib
@@ -67,10 +67,10 @@ function log_program
 
 		outdiff=$(diff "$basename.out" "$tmpout")
 		if [[ $? -ne 0 ]]; then
-			output=$(cat $tmpout)
+			output=$(<$tmpout)
 			rm $tmpout $tmperr $tmpin
 			log_fail "Output mismatch. Expected:\n" \
-				"$(cat $basename.out)\nBut got:\n$output\n" \
+				"$(<$basename.out)\nBut got:\n$output\n" \
 				"Diff:\n$outdiff"
 		fi
 
@@ -78,10 +78,10 @@ function log_program
 
 		outdiff=$(diff "$basename.err" "$tmperr")
 		if [[ $? -ne 0 ]]; then
-			outputerror=$(cat $tmperr)
+			outputerror=$(<$tmperr)
 			rm $tmpout $tmperr $tmpin
 			log_fail "Error mismatch. Expected:\n" \
-				"$(cat $basename.err)\nBut got:\n$outputerror\n" \
+				"$(<$basename.err)\nBut got:\n$outputerror\n" \
 				"Diff:\n$outdiff"
 		fi
 
@@ -89,7 +89,7 @@ function log_program
 
 		grep -q "$expecterror" $tmperr
 		if [[ $? -ne 0 ]]; then
-			outputerror=$(cat $tmperr)
+			outputerror=$(<$tmperr)
 			rm $tmpout $tmperr $tmpin
 			log_fail "Error mismatch. Expected to contain:\n" \
 				"$expecterror\nBut got:\n$outputerror\n"
@@ -100,7 +100,7 @@ function log_program
 		# If there's no expected output, error reporting is allowed to
 		# vary, but ensure that we didn't fail silently.
 		#
-		if [[ -z "$(cat $tmperr)" ]]; then
+		if [[ -z "$(<$tmperr)" ]]; then
 			rm $tmpout $tmperr $tmpin
 			log_fail "error with no stderr output"
 		fi

--- a/tests/zfs-tests/tests/functional/pool_checkpoint/pool_checkpoint.kshlib
+++ b/tests/zfs-tests/tests/functional/pool_checkpoint/pool_checkpoint.kshlib
@@ -211,8 +211,8 @@ function test_verify_pre_checkpoint_state
 {
 	log_must zfs list $FS0
 	log_must zfs list $FS1
-	log_must [ "$(cat $FS0FILE)" = "$FILECONTENTS0" ]
-	log_must [ "$(cat $FS1FILE)" = "$FILECONTENTS1" ]
+	log_must [ "$(<$FS0FILE)" = "$FILECONTENTS0" ]
+	log_must [ "$(<$FS1FILE)" = "$FILECONTENTS1" ]
 
 	#
 	# If we've opened the checkpointed state of the
@@ -227,15 +227,15 @@ function test_verify_pre_checkpoint_state
 	# Ensure post-checkpoint state is not present
 	#
 	log_mustnot zfs list $FS2
-	log_mustnot [ "$(cat $FS0FILE)" = "$NEWFILECONTENTS0" ]
+	log_mustnot [ "$(<$FS0FILE)" = "$NEWFILECONTENTS0" ]
 }
 
 function nested_verify_pre_checkpoint_state
 {
 	log_must zfs list $NESTEDFS0
 	log_must zfs list $NESTEDFS1
-	log_must [ "$(cat $NESTEDFS0FILE)" = "$FILECONTENTS0" ]
-	log_must [ "$(cat $NESTEDFS1FILE)" = "$FILECONTENTS1" ]
+	log_must [ "$(<$NESTEDFS0FILE)" = "$FILECONTENTS0" ]
+	log_must [ "$(<$NESTEDFS1FILE)" = "$FILECONTENTS1" ]
 
 	#
 	# If we've opened the checkpointed state of the
@@ -250,7 +250,7 @@ function nested_verify_pre_checkpoint_state
 	# Ensure post-checkpoint state is not present
 	#
 	log_mustnot zfs list $NESTEDFS2
-	log_mustnot [ "$(cat $NESTEDFS0FILE)" = "$NEWFILECONTENTS0" ]
+	log_mustnot [ "$(<$NESTEDFS0FILE)" = "$NEWFILECONTENTS0" ]
 }
 
 function test_change_state_after_checkpoint
@@ -275,8 +275,8 @@ function test_verify_post_checkpoint_state
 {
 	log_must zfs list $FS0
 	log_must zfs list $FS2
-	log_must [ "$(cat $FS0FILE)" = "$NEWFILECONTENTS0" ]
-	log_must [ "$(cat $FS2FILE)" = "$NEWFILECONTENTS2" ]
+	log_must [ "$(<$FS0FILE)" = "$NEWFILECONTENTS0" ]
+	log_must [ "$(<$FS2FILE)" = "$NEWFILECONTENTS2" ]
 
 	log_must zdb $TESTPOOL
 
@@ -285,7 +285,7 @@ function test_verify_post_checkpoint_state
 	# is not present
 	#
 	log_mustnot zfs list $FS1
-	log_mustnot [ "$(cat $FS0FILE)" = "$FILECONTENTS0" ]
+	log_mustnot [ "$(<$FS0FILE)" = "$FILECONTENTS0" ]
 }
 
 function fragment_before_checkpoint

--- a/tests/zfs-tests/tests/functional/privilege/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/cleanup.ksh
@@ -37,10 +37,10 @@ fi
 
 verify_runnable "global"
 
-ZFS_USER=$(cat $TEST_BASE_DIR/zfs-privs-test-user.txt)
+ZFS_USER=$(<$TEST_BASE_DIR/zfs-privs-test-user.txt)
 [[ -z $ZFS_USER ]] && log_fail "no ZFS_USER found"
 
-USES_NIS=$(cat $TEST_BASE_DIR/zfs-privs-test-nis.txt)
+USES_NIS=$(<$TEST_BASE_DIR/zfs-privs-test-nis.txt)
 
 if [ "${USES_NIS}" == "true" ]
 then

--- a/tests/zfs-tests/tests/functional/privilege/privilege_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/privilege_001_pos.ksh
@@ -63,7 +63,7 @@ fi
 
 log_assert "The RBAC profile \"ZFS Storage Management\" works"
 
-ZFS_USER=$(cat $TEST_BASE_DIR/zfs-privs-test-user.txt)
+ZFS_USER=$(<$TEST_BASE_DIR/zfs-privs-test-user.txt)
 
 # the user shouldn't be able to do anything initially
 log_mustnot user_run $ZFS_USER "zpool create $TESTPOOL $DISKS"

--- a/tests/zfs-tests/tests/functional/privilege/privilege_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/privilege_002_pos.ksh
@@ -66,7 +66,7 @@ fi
 
 log_assert "The RBAC profile \"ZFS File System Management\" works"
 
-ZFS_USER=$(cat $TEST_BASE_DIR/zfs-privs-test-user.txt)
+ZFS_USER=$(<$TEST_BASE_DIR/zfs-privs-test-user.txt)
 
 # Set a $DATASET where we can create child files systems
 if is_global_zone; then

--- a/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
@@ -86,7 +86,7 @@ function check_all
 
 	state1=$(zpool status $pool | awk '/state: /{print $2}');
 	state2=$(zpool list -H -o health $pool)
-	state3=$(cat /proc/spl/kstat/zfs/$pool/state)
+	state3=$(</proc/spl/kstat/zfs/$pool/state)
 	log_note "Checking $expected = $state1 = $state2 = $state3"
 	if [[ "$expected" == "$state1" &&  "$expected" == "$state2" && \
 	    "$expected" == "$state3" ]] ; then

--- a/tests/zfs-tests/tests/functional/procfs/procfs_list_stale_read.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/procfs_list_stale_read.ksh
@@ -86,7 +86,7 @@ typeset default_max_entries
 
 log_onexit cleanup
 
-default_max_entries=$(cat $MAX_ENTRIES_PARAM) || log_fail
+default_max_entries=$(<$MAX_ENTRIES_PARAM) || log_fail
 echo 50 >$MAX_ENTRIES_PARAM || log_fail
 
 # Clear all of the existing entries.

--- a/tests/zfs-tests/tests/functional/removal/removal_multiple_indirection.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_multiple_indirection.ksh
@@ -67,8 +67,8 @@ log_onexit cleanup
 log_must set_tunable32 zfs_remove_max_segment 32768
 
 log_must dd if=/dev/urandom of=$TESTDIR/$TESTFILE0 bs=128k count=1
-FILE_CONTENTS=`cat $TESTDIR/$TESTFILE0`
-log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+FILE_CONTENTS=$(<$TESTDIR/$TESTFILE0)
+log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 
 for i in {1..10}; do
 	log_must zpool remove $TESTPOOL $TMPDIR/dsk1
@@ -78,7 +78,7 @@ for i in {1..10}; do
 
 	log_must zinject -a
 	log_must dd if=$TESTDIR/$TESTFILE0 of=/dev/null
-	log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+	log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 
 	log_must zpool remove $TESTPOOL $TMPDIR/dsk2
 	log_must wait_for_removal $TESTPOOL
@@ -87,7 +87,7 @@ for i in {1..10}; do
 
 	log_must zinject -a
 	log_must dd if=$TESTDIR/$TESTFILE0 of=/dev/null
-	log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+	log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 done
 
 log_pass "File contents transferred completely from one disk to another."

--- a/tests/zfs-tests/tests/functional/removal/removal_sanity.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_sanity.ksh
@@ -27,13 +27,13 @@ log_onexit default_cleanup_noexit
 FILE_CONTENTS="Leeloo Dallas mul-ti-pass."
 
 echo $FILE_CONTENTS  >$TESTDIR/$TESTFILE0
-log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 
 log_must zpool remove $TESTPOOL $REMOVEDISK
 log_must wait_for_removal $TESTPOOL
 log_mustnot vdevs_in_pool $TESTPOOL $REMOVEDISK
 
 log_must dd if=/$TESTDIR/$TESTFILE0 of=/dev/null
-log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 
 log_pass "Removed device not in use after removal."

--- a/tests/zfs-tests/tests/functional/removal/removal_with_dedup.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_dedup.ksh
@@ -31,9 +31,9 @@ FILE_CONTENTS="Leeloo Dallas mul-ti-pass."
 echo $FILE_CONTENTS  >$TESTDIR/$TESTFILE0
 echo $FILE_CONTENTS  >$TESTDIR/$TESTFILE1
 echo $FILE_CONTENTS  >$TESTDIR/$TESTFILE2
-log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
-log_must [ "x$(cat $TESTDIR/$TESTFILE1)" = "x$FILE_CONTENTS" ]
-log_must [ "x$(cat $TESTDIR/$TESTFILE2)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE1)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE2)" = "x$FILE_CONTENTS" ]
 
 log_must zpool remove $TESTPOOL $REMOVEDISK
 log_must wait_for_removal $TESTPOOL
@@ -42,8 +42,8 @@ log_mustnot vdevs_in_pool $TESTPOOL $REMOVEDISK
 log_must dd if=/$TESTDIR/$TESTFILE0 of=/dev/null
 log_must dd if=/$TESTDIR/$TESTFILE1 of=/dev/null
 log_must dd if=/$TESTDIR/$TESTFILE2 of=/dev/null
-log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
-log_must [ "x$(cat $TESTDIR/$TESTFILE1)" = "x$FILE_CONTENTS" ]
-log_must [ "x$(cat $TESTDIR/$TESTFILE2)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE1)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE2)" = "x$FILE_CONTENTS" ]
 
 log_pass "Removed device not in use after removal."

--- a/tests/zfs-tests/tests/functional/removal/removal_with_ganging.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_with_ganging.ksh
@@ -34,7 +34,7 @@ log_onexit cleanup
 FILE_CONTENTS="Leeloo Dallas mul-ti-pass."
 
 echo $FILE_CONTENTS  >$TESTDIR/$TESTFILE0
-log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 log_must file_write -o create -f $TESTDIR/$TESTFILE1 -b $((2**20)) -c $((2**7))
 
 log_must zpool remove $TESTPOOL $REMOVEDISK
@@ -42,6 +42,6 @@ log_must wait_for_removal $TESTPOOL
 log_mustnot vdevs_in_pool $TESTPOOL $REMOVEDISK
 
 log_must dd if=/$TESTDIR/$TESTFILE0 of=/dev/null
-log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 
 log_pass "Removed device not in use after removal."

--- a/tests/zfs-tests/tests/functional/removal/remove_mirror_sanity.ksh
+++ b/tests/zfs-tests/tests/functional/removal/remove_mirror_sanity.ksh
@@ -39,7 +39,7 @@ elif [[ -f $WORDS_FILE2 ]]; then
     log_must cp $WORDS_FILE2 $TESTDIR
 else
     echo $FILE_CONTENTS  >$TESTDIR/$TESTFILE0
-    log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+    log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 fi
 
 log_must zpool remove $TESTPOOL mirror-1
@@ -52,7 +52,7 @@ elif [[ -f $WORDS_FILE2 ]]; then
     log_must diff $WORDS_FILE2 $TESTDIR/words
 else
     log_must dd if=/$TESTDIR/$TESTFILE0 of=/dev/null
-    log_must [ "x$(cat $TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
+    log_must [ "x$(<$TESTDIR/$TESTFILE0)" = "x$FILE_CONTENTS" ]
 fi
 
 log_pass "Removed top-level mirror device not in use after removal."

--- a/tests/zfs-tests/tests/perf/perf.shlib
+++ b/tests/zfs-tests/tests/perf/perf.shlib
@@ -416,7 +416,7 @@ function get_system_config
 			then
 				printf ",\n" >>$config
 			fi
-			printf  "    \"$tunable\": \"$(cat $zfs_tunables/$tunable)\"" \
+			printf  "    \"$tunable\": \"$(<$zfs_tunables/$tunable)\"" \
 			    >>$config
 		done
 		printf "\n  }\n" >>$config


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's better to use ksh/bash built in methods,
rather than spawn new processes every time.

Just because we can.

Signed-off-by: George Melikov <mail@gmelikov.ru>

### Description
<!--- Describe your changes in detail -->
change `$(cat)` to `$(<)` for speedup, we can get file content via ksh itself.

Benchmark:
```
gmelikov@gmpc:/tmp$ cat ./cat.sh 
i=1
while [ $i -le 1000 ]
do
	i=$((i+1))
	test=$(cat /tmp/test)
	#test=$(</tmp/test)
done

gmelikov@gmpc:/tmp$ cat ./test
1

gmelikov@gmpc:/tmp$ time ksh ./cat.sh 
real	0m0.572s
user	0m0.428s
sys	0m0.180s

gmelikov@gmpc:/tmp$ time ksh ./builtin.sh 
real	0m0.016s
user	0m0.008s
sys	0m0.008s
```

Bash one (not so interested):
```
gmelikov@gmpc:/tmp$ time bash ./cat.sh 
real	0m0.625s
user	0m0.472s
sys	0m0.179s

gmelikov@gmpc:/tmp$ time bash ./builtin.sh 
real	0m0.329s
user	0m0.251s
sys	0m0.102s
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Waiting for buildbots.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
