### PR TITLE
Fix test zfs_mount_006_pos

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -165,7 +165,6 @@ known = {
     'casenorm/mixed_formd_lookup': ['FAIL', '7633'],
     'casenorm/mixed_formd_lookup_ci': ['FAIL', '7633'],
     'casenorm/mixed_formd_delete': ['FAIL', '7633'],
-    'cli_root/zfs_mount/zfs_mount_006_pos': ['SKIP', '4990'],
     'cli_root/zfs_receive/zfs_receive_004_neg': ['FAIL', known_reason],
     'cli_root/zfs_unshare/zfs_unshare_002_pos': ['SKIP', na_reason],
     'cli_root/zfs_unshare/zfs_unshare_006_pos': ['SKIP', na_reason],


### PR DESCRIPTION
For Linux, place a file in the mount point folder so it will be
considered "busy".  Fix the while loop so it doesn't rm in
directories above the testdir.  Add Linux-specific code to test
overlay on|off.

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>
Fixes #4990

### Motivation and Context
The test is being skipped, therefore overlay on|off is not tested.

### Description
For Linux, place a file in the mount point folder so it will be
considered "busy".  Fix the while loop so it doesn't rm in
directories above the testdir.  Add Linux-specific code to test
overlay on|off.  Rewrite some of the comment sections and 
output.

### How Has This Been Tested?
Tested on Ubuntu 16.04

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
