### PR TITLE
Fix and reenable zfs_rename tests

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -215,8 +215,6 @@ maybe = {
     'cli_root/zdb/zdb_006_pos': ['FAIL', known_reason],
     'cli_root/zfs_get/zfs_get_004_pos': ['FAIL', known_reason],
     'cli_root/zfs_get/zfs_get_009_pos': ['SKIP', '5479'],
-    'cli_root/zfs_rename/zfs_rename_006_pos': ['FAIL', '5647'],
-    'cli_root/zfs_rename/zfs_rename_009_neg': ['FAIL', '5648'],
     'cli_root/zfs_rollback/zfs_rollback_001_pos': ['FAIL', '6415'],
     'cli_root/zfs_rollback/zfs_rollback_002_pos': ['FAIL', '6416'],
     'cli_root/zfs_share/setup': ['SKIP', share_reason],

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_006_pos.ksh
@@ -69,6 +69,7 @@ rename_dataset ${vol}-new $vol
 
 clone=$TESTPOOL/${snap}_clone
 create_clone $vol@$snap $clone
+block_device_wait
 
 #verify data integrity
 for input in $VOL_R_PATH $ZVOL_RDEVDIR/$clone; do

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_009_neg.ksh
@@ -33,13 +33,13 @@
 
 #
 # DESCRIPTION:
-#	A snapshot already exists with the new name, then none of the
-#	snapshots is renamed.
+#	When renaming a set of snapshots, if a snapshot already exists with
+#	the new name, then none of the snapshots is renamed.
 #
 # STRATEGY:
-#	1. Create snapshot for a set of datasets.
+#	1. Create a snapshot for a set of datasets.
 #	2. Create a new snapshot for one of datasets.
-#	3. Using rename -r command with exists snapshot name.
+#	3. Attempt to "zfs rename -r" with the second snapshot's name.
 #	4. Verify none of the snapshots is renamed.
 #
 
@@ -54,7 +54,7 @@ function cleanup
 	done
 }
 
-log_assert "zfs rename -r failed, when snapshot name is already existing."
+log_assert "Verify zfs rename -r failed when the snapshot name already exists."
 log_onexit cleanup
 
 set -A datasets $TESTPOOL		$TESTPOOL/$TESTCTR \
@@ -71,7 +71,7 @@ while ((i < ${#datasets[@]})); do
 	log_mustnot zfs rename -r ${TESTPOOL}@snap ${TESTPOOL}@snap2
 	log_must zfs destroy ${datasets[$i]}@snap2
 
-	# Check datasets, make sure none of them was renamed.
+	# Check datasets, make sure none of them have snap2.
 	typeset -i j=0
 	while ((j < ${#datasets[@]})); do
 		if datasetexists ${datasets[$j]}@snap2 ; then
@@ -83,4 +83,4 @@ while ((i < ${#datasets[@]})); do
 	((i += 1))
 done
 
-log_pass "zfs rename -r failed, when snapshot name is already existing passed."
+log_pass "zfs rename -r failed when the snapshot name already exists."


### PR DESCRIPTION
zfs_rename_006_pos has been flaky in the past because it was
missing a call to block_device_wait to ensure the zvols it creates
are present before running dd. Whenever this this happened,
zfs_rename_009_neg would also fail because the first test would
leak a zvol clone that it did not know how to clean up. This patch
fixes the root cause and reenables the test. It also fixes some
minor grammar errors.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
