### PR TITLE
Merge the Pull Requests #5824 to branch 0.6.5.11

### DIFF
--- a/include/linux/blkdev_compat.h
+++ b/include/linux/blkdev_compat.h
@@ -145,6 +145,7 @@ get_disk_ro(struct gendisk *disk)
 #define	BIO_BI_SECTOR(bio)	(bio)->bi_iter.bi_sector
 #define	BIO_BI_SIZE(bio)	(bio)->bi_iter.bi_size
 #define	BIO_BI_IDX(bio)		(bio)->bi_iter.bi_idx
+#define	BIO_BI_SKIP(bio)	(bio)->bi_iter.bi_bvec_done
 #define	bio_for_each_segment4(bv, bvp, b, i)	\
 	bio_for_each_segment((bv), (b), (i))
 typedef struct bvec_iter bvec_iterator_t;
@@ -152,6 +153,7 @@ typedef struct bvec_iter bvec_iterator_t;
 #define	BIO_BI_SECTOR(bio)	(bio)->bi_sector
 #define	BIO_BI_SIZE(bio)	(bio)->bi_size
 #define	BIO_BI_IDX(bio)		(bio)->bi_idx
+#define	BIO_BI_SKIP(bio)	(0)
 #define	bio_for_each_segment4(bv, bvp, b, i)	\
 	bio_for_each_segment((bvp), (b), (i))
 typedef int bvec_iterator_t;
@@ -501,8 +503,14 @@ blk_queue_discard_granularity(struct request_queue *q, unsigned int dg)
 #define	VDEV_HOLDER			((void *)0x2401de7)
 
 #ifndef HAVE_GENERIC_IO_ACCT
-#define	generic_start_io_acct(rw, slen, part)		((void)0)
-#define	generic_end_io_acct(rw, part, start_jiffies)	((void)0)
+static inline void
+generic_start_io_acct(int rw, unsigned long sectors, struct hd_struct *part)
+{
+}
+static inline void
+generic_end_io_acct(int rw, struct hd_struct *part, unsigned long start_time)
+{
+}
 #endif
 
 #endif /* _ZFS_BLKDEV_H */


### PR DESCRIPTION
Merge the Pull Requests #5824 (Reinstate zvol_taskq to fix aio on zvol) from branch 0.7.* to 0.6.5.11.


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Obviously PR #5824 fixed the AIO on zvol. We want to merge the PR to 0.6.5, thus we can get better performance on zvol with the randread IO mode.
reference:
https://github.com/zfsonlinux/zfs/pull/5824
https://github.com/zfsonlinux/zfs/commit/692e55b8fea00a0d0bd46188d68031292f04e4a8?diff=unified

### Description
<!--- Describe your changes in detail -->
1. Reinstate the zvol_taskq to support concurrent IO operations
2. We delete the codes about `zv_suspend_lock`, because this code is added on the commit 040dab993936d832df4c7624bbcdb71c3fb9b34b


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

