### PR TITLE
Fix libudev dependency in libzutil

### DIFF
--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -79,10 +79,16 @@ extern const char * const * zpool_default_search_paths(size_t *count);
 extern int zpool_read_label(int, nvlist_t **, int *);
 extern int zpool_label_disk_wait(const char *, int);
 
+#ifdef HAVE_LIBUDEV
 struct udev_device;
 
 extern int zfs_device_get_devid(struct udev_device *, char *, size_t);
 extern int zfs_device_get_physical(struct udev_device *, char *, size_t);
+#else
+#define	zfs_device_get_devid(dev, bufptr, buflen)	(ENODATA)
+#define	zfs_device_get_physical(dev, bufptr, buflen)	(ENODATA)
+#endif
+
 extern void update_vdev_config_dev_strs(nvlist_t *);
 
 /*
@@ -108,7 +114,7 @@ extern char *zfs_get_enclosure_sysfs_path(const char *);
 #ifdef HAVE_LIBUDEV
 extern boolean_t is_mpath_whole_disk(const char *);
 #else
-#define	is_mpath_whole_disk(path) (B_FALSE);
+#define	is_mpath_whole_disk(path) (B_FALSE)
 #endif
 
 /*

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -224,6 +224,7 @@ typedef struct vdev_dev_strs {
 	char	vds_devphys[128];
 } vdev_dev_strs_t;
 
+#ifdef HAVE_LIBUDEV
 /*
  * Obtain the persistent device id string (describes what)
  *
@@ -398,6 +399,7 @@ udev_device_is_ready(struct udev_device *dev)
 	return (udev_device_get_property_value(dev, "DEVLINKS") != NULL);
 #endif
 }
+#endif /* HAVE_LIBUDEV */
 
 /*
  * Wait up to timeout_ms for udev to set up the device node.  The device is


### PR DESCRIPTION
### Motivation and Context
ZFS should be able to build without `libudev` installed.  The recent change for `libzutil` inadvertently broke that.

### Description
Just make the `libudev` code conditional in `zutil_import.c`

### How Has This Been Tested?
Clean build of zfs with no `libudev` installed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
