### PR TITLE
Skip damaged logical block with size == 0

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6251,7 +6251,7 @@ top:
 
 		uint64_t bp_size = 0;
 		/*
-		 * the same size as in arc_hdr_size(arc_buf_hdr_t *hdr)
+		 * The same size as in arc_hdr_size(arc_buf_hdr_t *hdr)
 		 */
 		if (BP_GET_COMPRESS(bp) != ZIO_COMPRESS_OFF &&
 		    psize > 0) {

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6259,23 +6259,12 @@ top:
 		} else {
 				bp_size = lsize;
 		}
-		/*
-		 * Gracefully handle a damaged logical block size as a
-		 * checksum error.
-		 */
-		if(bp_size == 0){
-				(void) printk("arc_read: error wrong size  %llu\n",
-								(long long unsigned)bp_size);
-
-			rc = SET_ERROR(ECKSUM);
-			goto out;
-		}
 
 		/*
 		 * Gracefully handle a damaged logical block size as a
 		 * checksum error.
 		 */
-		if (lsize > spa_maxblocksize(spa)) {
+		if (lsize > spa_maxblocksize(spa) || bp_size == 0) {
 			rc = SET_ERROR(ECKSUM);
 			goto out;
 		}

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6249,12 +6249,12 @@ top:
 		uint64_t size;
 		abd_t *hdr_abd;
 
-		uint64_t bp_size=0;
+		uint64_t bp_size = 0;
 		/*
 		 * the same size as in arc_hdr_size(arc_buf_hdr_t *hdr)
 		 */
 		if (BP_GET_COMPRESS(bp) != ZIO_COMPRESS_OFF &&
-				psize > 0) {
+		    psize > 0) {
 				bp_size = psize;
 		} else {
 				bp_size = lsize;

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6254,10 +6254,10 @@ top:
 		 * the same size as in arc_hdr_size(arc_buf_hdr_t *hdr)
 		 */
 		if (BP_GET_COMPRESS(bp) != ZIO_COMPRESS_OFF &&
-				BP_GET_PSIZE(bp) > 0) {
-				bp_size = BP_GET_PSIZE(bp);
+				psize > 0) {
+				bp_size = psize;
 		} else {
-				bp_size = BP_GET_LSIZE(bp);
+				bp_size = lsize;
 		}
 		/*
 		 * Gracefully handle a damaged logical block size as a

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6249,6 +6249,28 @@ top:
 		uint64_t size;
 		abd_t *hdr_abd;
 
+		uint64_t bp_size=0;
+		/*
+		 * the same size as in arc_hdr_size(arc_buf_hdr_t *hdr)
+		 */
+		if (BP_GET_COMPRESS(bp) != ZIO_COMPRESS_OFF &&
+				BP_GET_PSIZE(bp) > 0) {
+				bp_size = BP_GET_PSIZE(bp);
+		} else {
+				bp_size = BP_GET_LSIZE(bp);
+		}
+		/*
+		 * Gracefully handle a damaged logical block size as a
+		 * checksum error.
+		 */
+		if(bp_size == 0){
+				(void) printk("arc_read: error wrong size  %llu\n",
+								(long long unsigned)bp_size);
+
+			rc = SET_ERROR(ECKSUM);
+			goto out;
+		}
+
 		/*
 		 * Gracefully handle a damaged logical block size as a
 		 * checksum error.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
Prevent kernel panic in recovery mode because of damaged file system.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
When file system damaged, logical block size  could be zero, in that case in recovery mode, with kernel module parameter zfs.zfs_recovery=3, kernel will `PANIC at zio.c:285:zio_data_buf_alloc()`, because of assertion  `VERIFY3(c < (1ULL << 24) >> 9) failed (36028797018963967 < 32768)`

This is happened because there is no check for zero size, so in zio_buf_alloc we have
```c++
void *
zio_data_buf_alloc(size_t size)
{
        //here the size == 0
	size_t c = (size - 1) >> SPA_MINBLOCKSHIFT;

	VERIFY3U(c, <, SPA_MAXBLOCKSIZE >> SPA_MINBLOCKSHIFT);

```
But the actual problem appeared much earlier, in arc_read.

These changes allow you to gracefully handle this error, it allows you to read all other non-broken blocks and restore data.

Full kernel log in [kernel_panic.txt](https://github.com/zfsonlinux/zfs/files/2552206/kernel_panic.txt)

In my case file system was damaged because of broken RAM.

One module without ECC at 16GB was faulty.

`zdb -AAA -e -F rpool` log before changes [zdb.log](https://github.com/zfsonlinux/zfs/files/2552332/zdb.log)

To successfully run zdb, a large paging file is needed, a 64Gb paging file was created, but the maximum usage was about 15 GB.



### How Has This Been Tested?
With this patch i successfully could dump disk image from damaged zfs.
Following steps was performed:
1. Patching the kernel module.
2. Load the patched zfs module with parameter zfs.zfs_recovery=3
3. Import zfs pool as follows `zpool import -f -o readonly=on -R /mnt rpool`
4. Make a data dump  (in my case virtual machine disk) as follows `dd if=/dev/zvol/rpool/data/vm-104-disk-1-part1 of=./vm-104-disk-1-part1.dump conv=sync,noerror`

Full dmesg [zfs_fixed_dmesg.txt](https://github.com/zfsonlinux/zfs/files/2552318/zfs_fixed_dmesg.txt) , 
`arc_read:  0` is the points where this patch was working.


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
