### PR TITLE
Fix systemd generators macro

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -376,7 +376,7 @@ systemctl --system daemon-reload >/dev/null || true
 /usr/lib/modules-load.d/*
 %{_unitdir}/*
 %{_presetdir}/*
-%{_generatordir}/*
+%{_systemdgeneratordir}/*
 %else
 %config(noreplace) %{_sysconfdir}/init.d/*
 %config(noreplace) %{_initconfdir}/zfs


### PR DESCRIPTION
### Motivation and Context
Closes #7567



<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
This fixes an RPM build error:

`     File must begin with "/": %{_generatordir}/*`

Original-patch-by: Stewart Adam <s.adam@diffingo.com> (https://github.com/zfsonlinux/zfs/commit/26f2fb84e8fa5525c65c7a9f1b944a155dca3bc1)

### How Has This Been Tested?
Ran:

`./autogen.sh && ./configure && make -s -j$(nproc) && make srpm-utils && rpmbuild --rebuild zfs-0.8.0-rc1.fc29.src.rpm`

...and verified that the RPM build error went away on Fedora 29.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
