### PR TITLE
Fix systemd spec file macros

### DIFF
--- a/config/user-systemd.m4
+++ b/config/user-systemd.m4
@@ -18,7 +18,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_SYSTEMD], [
 	AC_ARG_WITH(systemdmodulesloaddir,
 		AC_HELP_STRING([--with-systemdmodulesloaddir=DIR],
 		[install systemd module load files into dir [[/usr/lib/modules-load.d]]]),
-		systemdmoduleloaddir=$withval,systemdmodulesloaddir=/usr/lib/modules-load.d)
+		systemdmodulesloaddir=$withval,systemdmodulesloaddir=/usr/lib/modules-load.d)
 
 	AC_ARG_WITH(systemdgeneratordir,
 		AC_HELP_STRING([--with-systemdgeneratordir=DIR],

--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -4,6 +4,9 @@
 %define not_rpm 1
 %endif
 
+# See comment in zfs.spec.in.
+%global __brp_mangle_shebangs_exclude_from arc_summary.py|arcstat.py|dbufstat.py|test-runner.py|zts-report.py
+
 %define module  @PACKAGE@
 %define mkconf  scripts/dkms.mkconf
 

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -1,5 +1,8 @@
 %define module  @PACKAGE@
 
+# See comment in zfs.spec.in.
+%global __brp_mangle_shebangs_exclude_from arc_summary.py|arcstat.py|dbufstat.py|test-runner.py|zts-report.py
+
 %if !%{defined ksrc}
 %if 0%{?rhel}%{?fedora}
 %define ksrc    ${kernel_version##*___}

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -28,9 +28,24 @@
 %endif
 %endif
 
-# Set the default _initconfdir when undefined.
 %if %{undefined _initconfdir}
 %global _initconfdir /etc/sysconfig
+%endif
+
+%if %{undefined _unitdir}
+%global _unitdir %{prefix}/lib/systemd/system
+%endif
+
+%if %{undefined _presetdir}
+%global _presetdir %{prefix}/lib/systemd/system-preset
+%endif
+
+%if %{undefined _modulesloaddir}
+%global _modulesloaddir %{prefix}/lib/modules-load.d
+%endif
+
+%if %{undefined _systemdgeneratordir}
+%global _systemdgeneratordir %{_prefix}/lib/systemd/system-generators
 %endif
 
 %bcond_with    debug
@@ -278,7 +293,7 @@ image which is ZFS aware.
 %endif
 
 %if 0%{?_systemd}
-    %define systemd --enable-systemd --with-systemdunitdir=%{_unitdir} --with-systemdpresetdir=%{_presetdir} --disable-sysvinit
+    %define systemd --enable-systemd --with-systemdunitdir=%{_unitdir} --with-systemdpresetdir=%{_presetdir} --with-systemdmodulesloaddir=%{_modulesloaddir} --with-systemdgeneratordir=%{_systemdgeneratordir} --disable-sysvinit
     %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target
 %else
     %define systemd --enable-sysvinit --disable-systemd
@@ -374,10 +389,10 @@ systemctl --system daemon-reload >/dev/null || true
 %{_udevdir}/zvol_id
 %{_udevdir}/rules.d/*
 %if 0%{?_systemd}
-/usr/lib/modules-load.d/*
 %{_unitdir}/*
 %{_presetdir}/*
-%{_generatordir}/*
+%{_modulesloaddir}/*
+%{_systemdgeneratordir}/*
 %else
 %config(noreplace) %{_sysconfdir}/init.d/*
 %config(noreplace) %{_initconfdir}/zfs

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -33,15 +33,15 @@
 %endif
 
 %if %{undefined _unitdir}
-%global _unitdir %{prefix}/lib/systemd/system
+%global _unitdir %{_prefix}/lib/systemd/system
 %endif
 
 %if %{undefined _presetdir}
-%global _presetdir %{prefix}/lib/systemd/system-preset
+%global _presetdir %{_prefix}/lib/systemd/system-preset
 %endif
 
 %if %{undefined _modulesloaddir}
-%global _modulesloaddir %{prefix}/lib/modules-load.d
+%global _modulesloaddir %{_prefix}/lib/modules-load.d
 %endif
 
 %if %{undefined _systemdgeneratordir}

--- a/rpm/redhat/zfs-kmod.spec.in
+++ b/rpm/redhat/zfs-kmod.spec.in
@@ -1,6 +1,9 @@
 %bcond_with     debug
 %bcond_with     debuginfo
 
+# See comment in zfs.spec.in.
+%global __brp_mangle_shebangs_exclude_from arc_summary.py|arcstat.py|dbufstat.py|test-runner.py|zts-report.py
+
 Name:           @PACKAGE@-kmod
 Version:        @VERSION@
 Release:        @RELEASE@%{?dist}


### PR DESCRIPTION
### Motivation and Context

Rebuilding the source rpm under mock uncovered several issues
with the packaging.  See #7567.

### Description

Ensure that the _unitdir, _presetdir, _modulesloaddir, and
_systemdgeneratordir macros are always defined.  If not set
them to the expected default values.  Pass all of these options
to ./configure and package the resulting files in those locations.

Additionally, set __brp_mangle_shebangs_exclude_from until the
conversion to Python 3 is complete so they may be built cleanly
under mock.

### How Has This Been Tested?

Cleanly builds on Fedora 29:

```
./configure --with-config-srpm
make srpm
mock --rebuild zfs-0.8.0-*.src.rpm
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
