### PR TITLE
Fix coverity defects: CID 184285

### DIFF
--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -228,8 +228,6 @@ vdev_config_generate_stats(vdev_t *vd, nvlist_t *nv)
 	fnvlist_add_uint64_array(nv, ZPOOL_CONFIG_VDEV_STATS,
 	    (uint64_t *)vs, sizeof (*vs) / sizeof (uint64_t));
 
-	kmem_free(vs, sizeof (*vs));
-
 	/*
 	 * Add extended stats into a special extended stats nvlist.  This keeps
 	 * all the extended stats nicely grouped together.  The extended stats
@@ -354,6 +352,7 @@ vdev_config_generate_stats(vdev_t *vd, nvlist_t *nv)
 	fnvlist_add_nvlist(nv, ZPOOL_CONFIG_VDEV_STATS_EX, nvx);
 
 	fnvlist_free(nvx);
+	kmem_free(vs, sizeof (*vs));
 	kmem_free(vsx, sizeof (*vsx));
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This patch fixes an use-after-free in `vdev_config_generate_stats()` detected by Coverity (CID 184285: Read from pointer after free) and KASAN.

### Description
<!--- Describe your changes in detail -->
Move the `kmem_free()` call at the end of `vdev_config_generate_stats()`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on Kernel with KASAN enabled. Before patch, running `zpool status -s`

```
[ 1765.734066] ==================================================================
[ 1765.735349] BUG: KASAN: use-after-free in vdev_config_generate_stats+0x3a6/0x3f0 [zfs] at addr ffff880059c67e28
[ 1765.736654] Read of size 8 by task zpool/24939
[ 1765.737229] CPU: 4 PID: 24939 Comm: zpool Tainted: P    B      OE   4.9.67 #2
[ 1765.737230] Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
[ 1765.737232]  ffff880063957a80 ffffffff8bae5a78 ffff88006cc00500 ffff880059c67d40
[ 1765.737235]  ffff880063957aa8 ffffffff8b6d5041 ffffed000b38cfc5 ffff880059c67d40
[ 1765.737238]  ffffed000b38cfc5 ffff880063957b30 ffffffff8b6d53b1 ffff880000000000
[ 1765.737241] Call Trace:
[ 1765.737247]  [<ffffffff8bae5a78>] dump_stack+0x63/0x8b
[ 1765.737251]  [<ffffffff8b6d5041>] kasan_object_err+0x21/0x80
[ 1765.737254]  [<ffffffff8b6d53b1>] kasan_report+0x231/0x510
[ 1765.737388]  [<ffffffffc0676546>] ? vdev_config_generate_stats+0x3a6/0x3f0 [zfs]
[ 1765.737391]  [<ffffffff8b6d412e>] __asan_load8+0x5e/0x70
[ 1765.737546]  [<ffffffffc0676546>] vdev_config_generate_stats+0x3a6/0x3f0 [zfs]
[ 1765.737680]  [<ffffffffc0676cd9>] vdev_config_generate+0x749/0xe50 [zfs]
[ 1765.737812]  [<ffffffffc067751e>] ? vdev_top_config_generate+0x13e/0x1f0 [zfs]
[ 1765.737943]  [<ffffffffc0644233>] spa_config_generate+0x2c3/0x590 [zfs]
[ 1765.738074]  [<ffffffffc063b5f0>] spa_open_common+0x110/0x660 [zfs]
[ 1765.738077]  [<ffffffff8b6f6713>] ? create_object+0x343/0x410
[ 1765.738215]  [<ffffffffc063bbd2>] spa_get_stats+0x62/0x6e0 [zfs]
[ 1765.738219]  [<ffffffff8b6d4653>] ? kasan_kmalloc+0x93/0xc0
[ 1765.738221]  [<ffffffff8b6d0c43>] ? __kmalloc+0x133/0x5c0
[ 1765.738355]  [<ffffffffc06bd039>] zfs_ioc_pool_stats+0x39/0xa0 [zfs]
[ 1765.738511]  [<ffffffffc06c7089>] zfsdev_ioctl+0xbe9/0xd50 [zfs]
[ 1765.738515]  [<ffffffff8b71c8b8>] do_vfs_ioctl+0xc8/0x7f0
[ 1765.738519]  [<ffffffff8b495ae9>] ? __do_page_fault+0x4d9/0x690
[ 1765.738522]  [<ffffffff8b71d059>] SyS_ioctl+0x79/0x90
[ 1765.738525]  [<ffffffff8c091afb>] entry_SYSCALL_64_fastpath+0x1e/0xad
[ 1765.738528] Object at ffff880059c67d40, in cache kmalloc-256 size: 256
[ 1765.739392] Allocated:
[ 1765.739720] PID = 24939
[ 1765.740041]  save_stack_trace+0x1b/0x20
[ 1765.740043]  save_stack+0x46/0xd0
[ 1765.740045]  kasan_kmalloc+0x93/0xc0
[ 1765.740047]  __kmalloc_node+0x4a/0x60
[ 1765.740061]  spl_kmem_alloc+0xe6/0x170 [spl]
[ 1765.740202]  vdev_config_generate_stats+0x2e/0x3f0 [zfs]
[ 1765.740334]  vdev_config_generate+0x749/0xe50 [zfs]
[ 1765.740486]  spa_config_generate+0x2c3/0x590 [zfs]
[ 1765.740617]  spa_open_common+0x110/0x660 [zfs]
[ 1765.740747]  spa_get_stats+0x62/0x6e0 [zfs]
[ 1765.740880]  zfs_ioc_pool_stats+0x39/0xa0 [zfs]
[ 1765.741014]  zfsdev_ioctl+0xbe9/0xd50 [zfs]
[ 1765.741016]  do_vfs_ioctl+0xc8/0x7f0
[ 1765.741018]  SyS_ioctl+0x79/0x90
[ 1765.741020]  entry_SYSCALL_64_fastpath+0x1e/0xad
[ 1765.741020] Freed:
[ 1765.741332] PID = 24939
[ 1765.741672]  save_stack_trace+0x1b/0x20
[ 1765.741674]  save_stack+0x46/0xd0
[ 1765.741676]  kasan_slab_free+0x7d/0xc0
[ 1765.741678]  kfree+0x7b/0x100
[ 1765.741690]  spl_kmem_free+0x3f/0x50 [spl]
[ 1765.741823]  vdev_config_generate_stats+0x7e/0x3f0 [zfs]
[ 1765.741955]  vdev_config_generate+0x749/0xe50 [zfs]
[ 1765.742085]  spa_config_generate+0x2c3/0x590 [zfs]
[ 1765.742222]  spa_open_common+0x110/0x660 [zfs]
[ 1765.742370]  spa_get_stats+0x62/0x6e0 [zfs]
[ 1765.742504]  zfs_ioc_pool_stats+0x39/0xa0 [zfs]
[ 1765.742651]  zfsdev_ioctl+0xbe9/0xd50 [zfs]
[ 1765.742653]  do_vfs_ioctl+0xc8/0x7f0
[ 1765.742655]  SyS_ioctl+0x79/0x90
[ 1765.742657]  entry_SYSCALL_64_fastpath+0x1e/0xad
[ 1765.742658] Memory state around the buggy address:
[ 1765.743286]  ffff880059c67d00: fc fc fc fc fc fc fc fc fb fb fb fb fb fb fb fb
[ 1765.744221]  ffff880059c67d80: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
[ 1765.745158] >ffff880059c67e00: fb fb fb fb fb fb fb fb fc fc fc fc fc fc fc fc
[ 1765.746091]                                   ^
[ 1765.746701]  ffff880059c67e80: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
[ 1765.747634]  ffff880059c67f00: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
[ 1765.748565] ==================================================================
[ 1765.751762] ==================================================================
```

After patch KASAN does not detect the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
