### PR TITLE
Fix ASSERT in zfs_receive_one()

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -4240,10 +4240,21 @@ zfs_do_receive(int argc, char **argv)
 			}
 			break;
 		case 'd':
+			if (flags.istail) {
+				(void) fprintf(stderr, gettext("invalid option "
+				    "combination: -d and -e are mutually "
+				    "exclusive\n"));
+				usage(B_FALSE);
+			}
 			flags.isprefix = B_TRUE;
 			break;
 		case 'e':
-			flags.isprefix = B_TRUE;
+			if (flags.isprefix) {
+				(void) fprintf(stderr, gettext("invalid option "
+				    "combination: -d and -e are mutually "
+				    "exclusive\n"));
+				usage(B_FALSE);
+			}
 			flags.istail = B_TRUE;
 			break;
 		case 'n':
@@ -4278,6 +4289,10 @@ zfs_do_receive(int argc, char **argv)
 
 	argc -= optind;
 	argv += optind;
+
+	/* zfs recv -e (use "tail" name) implies -d (remove dataset "head") */
+	if (flags.istail)
+		flags.isprefix = B_TRUE;
 
 	/* check number of arguments */
 	if (argc < 1) {

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3801,8 +3801,9 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 	}
 
 	ASSERT(strstr(drrb->drr_toname, sendfs) == drrb->drr_toname);
-	ASSERT(chopprefix > drrb->drr_toname);
-	ASSERT(chopprefix <= drrb->drr_toname + strlen(drrb->drr_toname));
+	ASSERT(chopprefix > drrb->drr_toname || strchr(sendfs, '/') == NULL);
+	ASSERT(chopprefix <= drrb->drr_toname + strlen(drrb->drr_toname) ||
+	    strchr(sendfs, '/') == NULL);
 	ASSERT(chopprefix[0] == '/' || chopprefix[0] == '@' ||
 	    chopprefix[0] == '\0');
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -206,7 +206,7 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_013_pos', 'zfs_receive_014_pos', 'zfs_receive_015_pos',
     'receive-o-x_props_override', 'zfs_receive_from_encrypted',
     'zfs_receive_to_encrypted', 'zfs_receive_raw',
-    'zfs_receive_raw_incremental']
+    'zfs_receive_raw_incremental', 'zfs_receive_-e']
 tags = ['functional', 'cli_root', 'zfs_receive']
 
 [tests/functional/cli_root/zfs_remap]

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/Makefile.am
@@ -21,4 +21,5 @@ dist_pkgdata_SCRIPTS = \
 	zfs_receive_from_encrypted.ksh \
 	zfs_receive_to_encrypted.ksh \
 	zfs_receive_raw.ksh \
-	zfs_receive_raw_incremental.ksh
+	zfs_receive_raw_incremental.ksh \
+	zfs_receive_-e.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_-e.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_-e.ksh
@@ -1,0 +1,106 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# ZFS receive '-e' option can be used to discard all but the last element of
+# the sent snapshot's file system name
+#
+# STRATEGY:
+# 1. Create a filesystem with children and snapshots
+# 2. Verify 'zfs receive -e' rejects invalid options
+# 3. Verify 'zfs receive -e' can receive the root dataset
+# 4. Verify 'zfs receive -e' can receive a replication stream
+# 5. Verify 'zfs receive -e' can receive an incremental replication stream
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	destroy_pool "$poolname"
+	log_must rm -f "$vdevfile"
+	log_must rm -f "$streamfile"
+}
+
+log_assert "ZFS receive '-e' option can be used to discard all but the last"\
+	"element of the sent snapshot's file system name"
+log_onexit cleanup
+
+poolname="$TESTPOOL-zfsrecv"
+recvfs="$poolname/recv"
+vdevfile="$TEST_BASE_DIR/vdevfile.$$"
+streamfile="$TEST_BASE_DIR/streamfile.$$"
+
+#
+# 1. Create a filesystem with children and snapshots
+# NOTE: set "mountpoint=none" just to speed up the test process
+#
+log_must truncate -s $MINVDEVSIZE "$vdevfile"
+log_must zpool create -O mountpoint=none "$poolname" "$vdevfile"
+log_must zfs create -p "$poolname/fs/a/b"
+log_must zfs create "$recvfs"
+log_must zfs snapshot -r "$poolname@full"
+log_must zfs snapshot -r "$poolname@incr"
+
+#
+# 2. Verify 'zfs receive -e' rejects invalid options
+#
+log_must eval "zfs send $poolname/fs@full > $streamfile"
+log_mustnot eval "zfs receive -e < $streamfile"
+log_mustnot eval "zfs receive -e $recvfs@snap < $streamfile"
+log_mustnot eval "zfs receive -e $recvfs/1/2/3 < $streamfile"
+log_mustnot eval "zfs receive -A -e $recvfs < $streamfile"
+log_mustnot eval "zfs receive -e -d $recvfs < $streamfile"
+
+#
+# 3. 'zfs receive -e' can receive the root dataset
+#
+recvfs_rootds="$recvfs/rootds"
+log_must zfs create "$recvfs_rootds"
+log_must eval "zfs send $poolname@full > $streamfile"
+log_must eval "zfs receive -e $recvfs_rootds < $streamfile"
+log_must datasetexists "$recvfs_rootds/$poolname"
+log_must snapexists "$recvfs_rootds/$poolname@full"
+
+#
+# 4. 'zfs receive -e' can receive a replication stream
+#
+recvfs_fs="$recvfs/fs"
+log_must zfs create "$recvfs_fs"
+log_must eval "zfs send -R $poolname/fs/a@full > $streamfile"
+log_must eval "zfs receive -e $recvfs_fs < $streamfile"
+log_must datasetexists "$recvfs_fs/a"
+log_must datasetexists "$recvfs_fs/a/b"
+log_must snapexists "$recvfs_fs/a@full"
+log_must snapexists "$recvfs_fs/a/b@full"
+
+#
+# 5. 'zfs receive -e' can receive an incremental replication stream
+#
+log_must eval "zfs send -R -i full $poolname/fs/a@incr > $streamfile"
+log_must eval "zfs receive -e $recvfs_fs < $streamfile"
+log_must snapexists "$recvfs_fs/a@incr"
+log_must snapexists "$recvfs_fs/a/b@incr"
+
+log_pass "ZFS receive '-e' discards all but the last element of the sent"\
+	"snapshot's file system name as expected"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On DEBUG builds a send stream from the root dataset cannot be received with the "-e" parameter:

```
root@linux:~# # misc functions
root@linux:~# function is_linux() {
>    if [[ "$(uname)" == "Linux" ]]; then
>       return 0
>    else
>       return 1
>    fi
> }
root@linux:~# # setup
root@linux:~# POOLNAME='testpool'
root@linux:~# if is_linux; then
>    TMPDIR='/var/tmp'
>    mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/zpool_$POOLNAME.dat
>    truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> else
>    TMPDIR='/tmp'
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/zpool_$POOLNAME.dat
>    truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> fi
root@linux:~# #
root@linux:~# zfs create -o mountpoint=none $POOLNAME/recvfs
root@linux:~# zfs snap -r $POOLNAME@snap
root@linux:~# zfs send $POOLNAME@snap | zfs recv -ve $POOLNAME/recvfs
chopprefix > drrb->drr_toname
ASSERT at libzfs_sendrecv.c:3804:zfs_receive_one()Aborted (core dumped)
root@linux:~# gdb -q zfs /var/crash/zfs.16562 
Reading symbols from zfs...done.
[New LWP 16562]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `zfs recv -ve testpool/recvfs'.
Program terminated with signal SIGABRT, Aborted.
#0  0x00007fcd58941067 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56	../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  0x00007fcd58941067 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007fcd58942448 in __GI_abort () at abort.c:89
#2  0x00007fcd5973590d in libspl_assert (buf=buf@entry=0x7fcd597652dd "chopprefix > drrb->drr_toname", file=file@entry=0x7fcd59762e30 "libzfs_sendrecv.c", func=func@entry=0x7fcd59765b00 <__FUNCTION__.19826> "zfs_receive_one", line=line@entry=3804) at ../../lib/libspl/include/assert.h:41
#3  0x00007fcd5973c585 in zfs_receive_one (hdl=0x15f8060, infd=0, tosnap=0x15f9af0 "testpool/recvfs", originsnap=0x0, flags=0x7fff0f199390, drr=0x7fff0f198640, drr_noswap=0x7fff0f198780, sendfs=0x7fff0f198e00 "testpool", stream_nv=0x0, stream_avl=0x0, top_zfs=0x7fff0f199290, cleanup_fd=6, action_handlep=0x7fff0f199298, finalsnap=0x0, cmdprops=0x15f9a80) at libzfs_sendrecv.c:3804
#4  0x00007fcd5973eb4e in zfs_receive_impl (hdl=0x15f8060, tosnap=0x40b2 <error: Cannot access memory at address 0x40b2>, tosnap@entry=0x15f9af0 "testpool/recvfs", originsnap=0x6 <error: Cannot access memory at address 0x6>, flags=0x7fcd58941067 <__GI_raise+55>, flags@entry=0x7fff0f199390, infd=1509619584, infd@entry=0, sendfs=0x7fcd5895799a <_IO_vfprintf_internal+22490> "\200\275(\373\377\377", sendfs@entry=0x0, stream_nv=0x0, stream_avl=0x0, top_zfs=0x7fff0f199290, cleanup_fd=6, action_handlep=0x7fff0f199298, finalsnap=0x0, cmdprops=0x15f9a80) at libzfs_sendrecv.c:4546
#5  0x00007fcd5973f505 in zfs_receive (hdl=0x15f8060, tosnap=0x15f9af0 "testpool/recvfs", props=0x15f9a80, flags=0x7fff0f199390, infd=0, stream_avl=0x0) at libzfs_sendrecv.c:4625
#6  0x000000000040d81c in zfs_do_receive (argc=1, argv=0x15f9d28) at zfs_main.c:4344
#7  0x0000000000405576 in main (argc=4, argv=0x7fff0f199618) at zfs_main.c:7984
(gdb) frame 3
#3  0x00007fcd5973c585 in zfs_receive_one (hdl=0x15f8060, infd=0, tosnap=0x15f9af0 "testpool/recvfs", originsnap=0x0, flags=0x7fff0f199390, drr=0x7fff0f198640, drr_noswap=0x7fff0f198780, sendfs=0x7fff0f198e00 "testpool", stream_nv=0x0, stream_avl=0x0, top_zfs=0x7fff0f199290, cleanup_fd=6, action_handlep=0x7fff0f199298, finalsnap=0x0, cmdprops=0x15f9a80) at libzfs_sendrecv.c:3804
3804		ASSERT(chopprefix > drrb->drr_toname);
(gdb) p chopprefix
$1 = 0x15f9c20 "/testpool@snap"
(gdb) p drrb->drr_toname
$2 = "testpool@snap", '\000' <repeats 242 times>
(gdb)
```

This bug has likely existed forever and can probably be reproduced on other OpenZFS implementations.

### Description
<!--- Describe your changes in detail -->
This change simply corrects the ASSERT: if we `malloc()`'d the `chopprefix` local variable it is unlikey to live inside `drrb->drr_toname` memory boundaries.

NOTE: Work in progress label because we probably will need a new test case in the ZTS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Copy/pastable reproducer (need assertions enabled):
```shell
# misc functions
function is_linux() {
   if [[ "$(uname)" == "Linux" ]]; then
      return 0
   else
      return 1
   fi
}
# setup
POOLNAME='testpool'
if is_linux; then
   TMPDIR='/var/tmp'
   mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
else
   TMPDIR='/tmp'
   zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
   zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
fi
#
zfs create -o mountpoint=none $POOLNAME/recvfs
zfs snap -r $POOLNAME@snap
zfs send $POOLNAME@snap | zfs recv -ve $POOLNAME/recvfs
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
