### PR TITLE
zpool: allow split of whole-disk devices

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -1286,7 +1286,7 @@ make_disks(zpool_handle_t *zhp, nvlist_t *nv)
 		 * symbolic link will be removed, partition table created,
 		 * and then block until udev creates the new link.
 		 */
-		if (!is_exclusive || !is_spare(NULL, udevpath)) {
+		if (!is_exclusive && !is_spare(NULL, udevpath)) {
 			char *devnode = strrchr(devpath, '/') + 1;
 
 			ret = strncmp(udevpath, UDISK_ROOT, strlen(UDISK_ROOT));

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -440,7 +440,7 @@ tags = ['functional', 'cli_root', 'zpool_set']
 [tests/functional/cli_root/zpool_split]
 tests = ['zpool_split_cliargs', 'zpool_split_devices',
     'zpool_split_encryption', 'zpool_split_props', 'zpool_split_vdevs',
-    'zpool_split_resilver']
+    'zpool_split_resilver', 'zpool_split_wholedisk']
 tags = ['functional', 'cli_root', 'zpool_split']
 
 [tests/functional/cli_root/zpool_status]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/Makefile.am
@@ -10,4 +10,8 @@ dist_pkgdata_SCRIPTS = \
 	zpool_split_encryption.ksh \
 	zpool_split_props.ksh \
 	zpool_split_vdevs.ksh \
-	zpool_split_resilver.ksh
+	zpool_split_resilver.ksh \
+	zpool_split_wholedisk.ksh
+
+dist_pkgdata_DATA = \
+	zpool_split.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split.cfg
@@ -1,0 +1,18 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+export DISKSARRAY=$DISKS
+export DISK_ARRAY_NUM=$(echo ${DISKS} | nawk '{print NF}')
+set_device_dir

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_cliargs.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_cliargs.ksh
@@ -15,6 +15,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_split/zpool_split.cfg
 
 #
 # DESCRIPTION:

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_devices.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_devices.ksh
@@ -15,6 +15,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_split/zpool_split.cfg
 
 #
 # DESCRIPTION:
@@ -91,7 +92,7 @@ do
 	# Verify "good" devices ended up in the new pool
 	log_must poolexists $TESTPOOL2
 	for filedev in ${gooddevs[$i]}; do
-		log_must check_vdev_state $TESTPOOL2 $filedev ""
+		log_must check_vdev_state $TESTPOOL2 $filedev "ONLINE"
 	done
 	cleanup
 	((i = i + 1))

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_encryption.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_encryption.ksh
@@ -15,6 +15,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_split/zpool_split.cfg
 
 #
 # DESCRIPTION:

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_props.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_props.ksh
@@ -15,6 +15,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_split/zpool_split.cfg
 . $STF_SUITE/tests/functional/mmp/mmp.kshlib
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_resilver.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_resilver.ksh
@@ -15,6 +15,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_split/zpool_split.cfg
 
 #
 # DESCRIPTION:

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_vdevs.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_vdevs.ksh
@@ -15,6 +15,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_split/zpool_split.cfg
 . $STF_SUITE/include/math.shlib
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_wholedisk.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_split/zpool_split_wholedisk.ksh
@@ -1,0 +1,84 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_split/zpool_split.cfg
+
+#
+# DESCRIPTION:
+# 'zpool split' should work with whole-disk devices.
+#
+# STRATEGY:
+# 1. Create a mirror with a whole-disk device
+# 2. Verify 'zpool split' works and successfully split the mirror
+# 3. Cleanup and create the same mirror
+# 4. Verify 'zpool split' using the other device
+#
+
+verify_runnable "both"
+
+if is_linux; then
+	# Add one 512b spare device (4Kn would generate IO errors on replace)
+	# NOTE: must be larger than other "file" vdevs and minimum SPA devsize:
+	# add 32m of fudge
+	load_scsi_debug $(($SPA_MINDEVSIZE/1024/1024+32)) 1 1 1 '512b'
+else
+	log_unsupported "scsi debug module unsupported"
+fi
+
+function cleanup
+{
+	destroy_pool $TESTPOOL
+	destroy_pool $TESTPOOL2
+	unload_scsi_debug
+	rm -f "$FILE_DEVICE"
+}
+
+function setup_mirror
+{
+	# NOTE: "-f" is required to create a mixed (file and disk device) mirror
+	log_must truncate -s $SPA_MINDEVSIZE $FILE_DEVICE
+	log_must zpool create -f $TESTPOOL mirror $FILE_DEVICE $DISK_DEVICE
+	# NOTE: verify disk is actually a "whole-disk" device
+	log_must test  "$(zdb -PC $TESTPOOL | grep -c 'whole_disk: 1')" == 1
+}
+
+log_assert "'zpool split' should work with whole-disk devices"
+log_onexit cleanup
+
+FILE_DEVICE="$TEST_BASE_DIR/file-device"
+DISK_DEVICE="$(get_debug_device)"
+ALTROOT="$TEST_BASE_DIR/altroot-$TESTPOOL2"
+
+# 1. Create a mirror with a whole-disk device
+setup_mirror
+
+# 2. Verify 'zpool split' works and successfully split the mirror
+log_must zpool split -R "$ALTROOT" $TESTPOOL $TESTPOOL2 $DISK_DEVICE
+log_must check_vdev_state $TESTPOOL $FILE_DEVICE "ONLINE"
+log_must check_vdev_state $TESTPOOL2 $DISK_DEVICE "ONLINE"
+
+# 3. Cleanup and create the same mirror
+destroy_pool $TESTPOOL
+destroy_pool $TESTPOOL2
+setup_mirror
+
+# 4. Verify 'zpool split' using the other device
+log_must zpool split -R "$ALTROOT" $TESTPOOL $TESTPOOL2 $FILE_DEVICE
+log_must check_vdev_state $TESTPOOL $DISK_DEVICE "ONLINE"
+log_must check_vdev_state $TESTPOOL2 $FILE_DEVICE "ONLINE"
+
+log_pass "'zpool split' works with whole-disk devices"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #6643 (Cannot split whole-disk mirror)

### Description
<!--- Describe your changes in detail -->
This change tries to fix the aforementioned issue. In `make_disks()` we can't label the input device if it is either open exclusively or is a spare; in case of a whole-disk split the former is true and the `zpool` command fails with EBUSY:

```
root@linux:~# POOLNAME='testpool'
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# #
root@linux:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:~# zpool destroy -f $POOLNAME
root@linux:~# modprobe -r scsi_debug
root@linux:~# #
root@linux:~# modprobe scsi_debug dev_size_mb=256 add_host=1 num_tgts=1 max_luns=1 sector_size=512 physblk_exp=0
root@linux:~# truncate -s 256m $TMPDIR/file-dev
root@linux:~# zpool create -f -O mountpoint=none $POOLNAME mirror $TMPDIR/file-dev sda
root@linux:~# 
root@linux:~# zdb -PC $POOLNAME | grep whole_disk
                    whole_disk: 1
root@linux:~# zpool split $POOLNAME $POOLNAME-new sda
cannot label 'sda': cannot label '/dev/sda': unable to open device: 16
root@linux:~# 
```

Debugging session shows we try to `zpool_label_disk()` a disk that is **not** as spare but **is** opened exclusively:

```
(gdb) bt
#0  zfs_verror (hdl=0x62b060, error=2044, fmt=0x7ffff779d09a "%s", ap=0x7fffffff5d08) at libzfs_util.c:311
#1  0x00007ffff777b162 in zfs_error_fmt (hdl=hdl@entry=0x62b060, error=error@entry=2044, fmt=fmt@entry=0x7ffff779d09a "%s") at libzfs_util.c:349
#2  0x00007ffff777b181 in zfs_error (hdl=hdl@entry=0x62b060, error=error@entry=2044, msg=msg@entry=0x7fffffff5e20 "cannot label 'sda'") at libzfs_util.c:338
#3  0x00007ffff77700ee in zpool_label_disk (hdl=0x62b060, zhp=zhp@entry=0x62cd40, name=name@entry=0x7fffffff8315 "sda") at libzfs_pool.c:4468
#4  0x0000000000417f8f in make_disks (zhp=zhp@entry=0x62cd40, nv=0x62d230) at zpool_vdev.c:1303
#5  0x00000000004180ba in make_disks (zhp=zhp@entry=0x62cd40, nv=nv@entry=0x62d100) at zpool_vdev.c:1341
#6  0x0000000000418e9b in split_mirror_vdev (zhp=zhp@entry=0x62cd40, newname=newname@entry=0x62caf0 "testpool-new", props=0x0, flags=..., flags@entry=..., argc=argc@entry=1, argv=argv@entry=0x62ccf0) at zpool_vdev.c:1781
#7  0x0000000000410563 in zpool_do_split (argc=1, argv=0x62ccf0) at zpool_main.c:5914
#8  0x0000000000405dcf in main (argc=5, argv=0x7fffffffec58) at zpool_main.c:8783
(gdb) p hdl->libzfs_desc
$2 = "cannot label '/dev/sda': unable to open device: 16", '\000' <repeats 973 times>
(gdb) p errno
$3 = 16
(gdb) frame 4
#4  0x0000000000417f8f in make_disks (zhp=zhp@entry=0x62cd40, nv=0x62d230) at zpool_vdev.c:1303
1303				if (zpool_label_disk(g_zfs, zhp, devnode) == -1)
(gdb) list zpool_vdev.c:1280
1275			} else {
1276				(void) close(fd);
1277			}
1278	
1279			/*
1280			 * If the partition exists, contains a valid spare label,
1281			 * and is opened exclusively there is no need to partition
1282			 * it.  Hot spares have already been partitioned and are
1283			 * held open exclusively by the kernel as a safety measure.
1284			 *
(gdb) 
1285			 * If the provided path is for a /dev/disk/ device its
1286			 * symbolic link will be removed, partition table created,
1287			 * and then block until udev creates the new link.
1288			 */
1289			if (!is_exclusive || !is_spare(NULL, udevpath)) {
1290				char *devnode = strrchr(devpath, '/') + 1;
1291	
1292				ret = strncmp(udevpath, UDISK_ROOT, strlen(UDISK_ROOT));
1293				if (ret == 0) {
1294					ret = lstat64(udevpath, &statbuf);
(gdb) p is_exclusive
$4 = 1
(gdb) p is_spare(0x0, udevpath)
$5 = B_FALSE
(gdb) p udevpath 
$6 = "/dev/sda1", '\000' <repeats 1551 times>...
(gdb) 
```

This PR updates the zpool_split test group and fixes "zpool_split/zpool_split_devices".

NOTE: Work in progress label because i'm not sure this is the best way to fix the issue, i'm hoping a full ZTS run can uncover possible problems, if any, with this approach.
EDIT: this does not seem to break anything, dropping WIP label.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Test added to the ZTS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
