### PR TITLE
man/zfs.8: document  'received' property source

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -2951,8 +2951,8 @@ For each property, the following columns are displayed:
     name      Dataset name
     property  Property name
     value     Property value
-    source    Property source.  Can either be local, default,
-              temporary, inherited, or none (-).
+    source    Property source  \fBlocal\fP, \fBdefault\fP, \fBinherited\fP,
+              \fBtemporary\fP, \fBreceived\fP or none (\fB-\fP).
 .Ed
 .Pp
 All columns are displayed by default, though this can be controlled by using the
@@ -2997,6 +2997,7 @@ Each source must be one of the following:
 .Sy default ,
 .Sy inherited ,
 .Sy temporary ,
+.Sy received ,
 and
 .Sy none .
 The default value is all sources.


### PR DESCRIPTION
### Motivation and Context

* Stumbled over the `received` property source being not documented on ZoL
* It is documented on FreeBSD HEAD

### Description

One-liner.

### How Has This Been Tested?

Looked at it using `man`.

### Types of changes
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
