### PR TITLE
Fix parsing of zpool status in checksum test

### DIFF
--- a/tests/zfs-tests/tests/functional/checksum/filetest_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/checksum/filetest_001_pos.ksh
@@ -20,6 +20,10 @@
 # CDDL HEADER END
 #
 
+#
+# Copyright (c) 2018 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/include/properties.shlib
 . $STF_SUITE/tests/functional/checksum/default.cfg
@@ -86,7 +90,7 @@ log_must zpool import $TESTPOOL
 log_must zpool scrub $TESTPOOL
 log_must wait_scrubbed $TESTPOOL
 
-zpool status -P -v $TESTPOOL | grep $firstvdev | read -r name state rd wr cksum
+cksum=$(zpool status -P -v $TESTPOOL | grep "$firstvdev" | awk '{print $5}')
 log_assert "Normal file write test saw $cksum checksum errors"
 log_must [ $cksum -eq 0 ]
 
@@ -111,8 +115,8 @@ while [[ $j -lt ${#CHECKSUM_TYPES[*]} ]]; do
 	log_must zpool scrub $TESTPOOL
 	log_must wait_scrubbed $TESTPOOL
 
-	zpool status -P -v $TESTPOOL | grep $firstvdev | \
-	    read -r name state rd wr cksum
+	cksum=$(zpool status -P -v $TESTPOOL | grep "$firstvdev" | \
+	    awk '{print $5}')
 
 	log_assert "Checksum '$type' caught $cksum checksum errors"
 	log_must [ $cksum -ne 0 ]


### PR DESCRIPTION
### Motivation and Context
The filetest_001_pos test can fail due to parsing errors if there are
enough checksum errors to degrade the vdev.

### Description
filetest_001_pos consumes zpool status output using read -r, assigning
each field to a variable. The problem comes when a vdev is marked
degraded, which appends extra fields to the line. This causes the trailing
text to be treated as part of the `cksum` variable. Using awk instead of
read -r allows us to extract the checksum error count from the output
whether the vdev is degraded or not.

### How Has This Been Tested?
Tested locally, both the test by itself as well as a complete functional run
on a VMWare VM.

### Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x ] All new and existing tests passed.
- [x ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
