### PR TITLE
ZTS: "checksum" test group needs "lscpu"

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -68,6 +68,7 @@ export SYSTEM_FILES='arp
     ls
     lsattr
     lsblk
+    lscpu
     lsmod
     lsscsi
     md5sum


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The ZTS Test Suite cannot run the EdonR, Skein and SHA2 performance tests ("checksum" test group) because "lscpu" is not found in $PATH:

```
Test: /usr/share/zfs/zfs-tests/tests/functional/checksum/run_edonr_test (run as root) [00:02] [PASS]
22:43:00.88 ASSERTION: Run the tests for the EdonR hash algorithm.
22:43:00.88 /usr/share/zfs/zfs-tests/tests/functional/checksum/run_edonr_test.ksh[27]: get_cpu_freq: line 2990: lscpu: not found
22:43:03.55 Running algorithm correctness tests:
22:43:03.55 Edon-R-224   Message: test_msg0	Result: OK
22:43:03.55 Edon-R-224   Message: test_msg1	Result: OK
22:43:03.55 Edon-R-256   Message: test_msg0	Result: OK
22:43:03.55 Edon-R-256   Message: test_msg1	Result: OK
22:43:03.55 Edon-R-384   Message: test_msg0	Result: OK
22:43:03.55 Edon-R-384   Message: test_msg2	Result: OK
22:43:03.55 Edon-R-512   Message: test_msg0	Result: OK
22:43:03.55 Edon-R-512   Message: test_msg2	Result: OK
22:43:03.55 Running performance tests (hashing 1024 MiB of data):
22:43:03.55 Edon-R-256   1767399 us (0.00 CPB)
22:43:03.55 Edon-R-512   897509 us (0.00 CPB)
22:43:03.55 SUCCESS: /usr/share/zfs/zfs-tests/tests/functional/checksum/edonr_test
22:43:03.55 EdonR tests passed.
```

### Description
<!--- Describe your changes in detail -->
This change simply adds "lscpu" to the list of commands used by the ZFS Test Suite:

```
Test: /usr/share/zfs/zfs-tests/tests/functional/checksum/run_edonr_test (run as root) [00:05] [PASS]
12:09:29.54 ASSERTION: Run the tests for the EdonR hash algorithm.
12:09:34.95 Running algorithm correctness tests:
12:09:34.95 Edon-R-224   Message: test_msg0	Result: OK
12:09:34.95 Edon-R-224   Message: test_msg1	Result: OK
12:09:34.95 Edon-R-256   Message: test_msg0	Result: OK
12:09:34.95 Edon-R-256   Message: test_msg1	Result: OK
12:09:34.95 Edon-R-384   Message: test_msg0	Result: OK
12:09:34.95 Edon-R-384   Message: test_msg2	Result: OK
12:09:34.95 Edon-R-512   Message: test_msg0	Result: OK
12:09:34.95 Edon-R-512   Message: test_msg2	Result: OK
12:09:34.95 Running performance tests (hashing 1024 MiB of data):
12:09:34.95 Edon-R-256   3533334 us (11.16 CPB)
12:09:34.95 Edon-R-512   1821598 us (5.75 CPB)
12:09:34.95 SUCCESS: /usr/share/zfs/zfs-tests/tests/functional/checksum/edonr_test 3392.292
12:09:34.95 EdonR tests passed.
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
