### PR TITLE
port async unlinked drain from illumos-nexenta

### DIFF
--- a/include/sys/dataset_kstats.h
+++ b/include/sys/dataset_kstats.h
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2018 Datto Inc.
  */
 
 #ifndef _SYS_DATASET_KSTATS_H
@@ -35,6 +36,8 @@ typedef struct dataset_aggsum_stats_t {
 	aggsum_t das_nwritten;
 	aggsum_t das_reads;
 	aggsum_t das_nread;
+	aggsum_t das_nunlinks;
+	aggsum_t das_nunlinked;
 } dataset_aggsum_stats_t;
 
 typedef struct dataset_kstat_values {
@@ -43,6 +46,16 @@ typedef struct dataset_kstat_values {
 	kstat_named_t dkv_nwritten;
 	kstat_named_t dkv_reads;
 	kstat_named_t dkv_nread;
+	/*
+	 * nunlinks is initialized to the unlinked set size on mount and
+	 * is incremented whenever a new entry is added to the unlinked set
+	 */
+	kstat_named_t dkv_nunlinks;
+	/*
+	 * nunlinked is initialized to zero on mount and is incremented when an
+	 * entry is removed from the unlinked set
+	 */
+	kstat_named_t dkv_nunlinked;
 } dataset_kstat_values_t;
 
 typedef struct dataset_kstats {
@@ -55,5 +68,8 @@ void dataset_kstats_destroy(dataset_kstats_t *);
 
 void dataset_kstats_update_write_kstats(dataset_kstats_t *, int64_t);
 void dataset_kstats_update_read_kstats(dataset_kstats_t *, int64_t);
+
+void dataset_kstats_update_nunlinks_kstat(dataset_kstats_t *, int64_t);
+void dataset_kstats_update_nunlinked_kstat(dataset_kstats_t *, int64_t);
 
 #endif /* _SYS_DATASET_KSTATS_H */

--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -96,6 +96,7 @@ typedef struct dsl_pool {
 	struct dsl_dataset *dp_origin_snap;
 	uint64_t dp_root_dir_obj;
 	struct taskq *dp_iput_taskq;
+	struct taskq *dp_unlinked_drain_taskq;
 
 	/* No lock needed - sync context only */
 	blkptr_t dp_meta_rootbp;
@@ -176,6 +177,7 @@ boolean_t dsl_pool_config_held(dsl_pool_t *dp);
 boolean_t dsl_pool_config_held_writer(dsl_pool_t *dp);
 
 taskq_t *dsl_pool_iput_taskq(dsl_pool_t *dp);
+taskq_t *dsl_pool_unlinked_drain_taskq(dsl_pool_t *dp);
 
 int dsl_pool_user_hold(dsl_pool_t *dp, uint64_t dsobj,
     const char *tag, uint64_t now, dmu_tx_t *tx);

--- a/include/sys/zfs_dir.h
+++ b/include/sys/zfs_dir.h
@@ -64,6 +64,7 @@ extern void zfs_dl_name_switch(zfs_dirlock_t *dl, char *new, char **old);
 extern boolean_t zfs_dirempty(znode_t *);
 extern void zfs_unlinked_add(znode_t *, dmu_tx_t *);
 extern void zfs_unlinked_drain(zfsvfs_t *zfsvfs);
+extern void zfs_unlinked_drain_stop_wait(zfsvfs_t *zfsvfs);
 extern int zfs_sticky_remove_access(znode_t *, znode_t *, cred_t *cr);
 extern int zfs_get_xattrdir(znode_t *, struct inode **, cred_t *, int);
 extern int zfs_make_xattrdir(znode_t *, vattr_t *, struct inode **, cred_t *);

--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -117,6 +117,8 @@ struct zfsvfs {
 	boolean_t	z_replay;	/* set during ZIL replay */
 	boolean_t	z_use_sa;	/* version allow system attributes */
 	boolean_t	z_xattr_sa;	/* allow xattrs to be stores as SA */
+	boolean_t	z_draining;	/* is true when drain is active */
+	boolean_t	z_drain_cancel; /* signal the unlinked drain to stop */
 	uint64_t	z_version;	/* ZPL version */
 	uint64_t	z_shares_dir;	/* hidden shares dir */
 	dataset_kstats_t	z_kstat;	/* fs kstats */
@@ -132,6 +134,7 @@ struct zfsvfs {
 	uint64_t	z_hold_size;	/* znode hold array size */
 	avl_tree_t	*z_hold_trees;	/* znode hold trees */
 	kmutex_t	*z_hold_locks;	/* znode hold locks */
+	taskqid_t	z_drain_task;	/* task id for the unlink drain task */
 };
 
 #define	ZSB_XATTR	0x0001		/* Enable user xattrs */

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1152,6 +1152,21 @@ Default value: 20
 .sp
 .ne 2
 .na
+\fBzfs_unlink_suspend_progress\fR (uint)
+.ad
+.RS 12n
+When enabled, files will not be asynchronously removed from the list of pending
+unlinks and the space they consume will be leaked. Once this option has been
+disabled and the dataset is remounted, the pending unlinks will be processed
+and the freed space returned to the pool.
+This option is used by the test suite to facilitate testing.
+.sp
+Uses \fB0\fR (default) to allow progress and \fB1\fR to pause progress.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_delete_blocks\fR (ulong)
 .ad
 .RS 12n

--- a/module/zfs/dataset_kstats.c
+++ b/module/zfs/dataset_kstats.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2018 Datto Inc.
  */
 
 #include <sys/dataset_kstats.h>
@@ -34,6 +35,8 @@ static dataset_kstat_values_t empty_dataset_kstats = {
 	{ "nwritten",	KSTAT_DATA_UINT64 },
 	{ "reads",	KSTAT_DATA_UINT64 },
 	{ "nread",	KSTAT_DATA_UINT64 },
+	{ "nunlinks",	KSTAT_DATA_UINT64 },
+	{ "nunlinked",	KSTAT_DATA_UINT64 },
 };
 
 static int
@@ -54,6 +57,10 @@ dataset_kstats_update(kstat_t *ksp, int rw)
 	    aggsum_value(&dk->dk_aggsums.das_reads);
 	dkv->dkv_nread.value.ui64 =
 	    aggsum_value(&dk->dk_aggsums.das_nread);
+	dkv->dkv_nunlinks.value.ui64 =
+	    aggsum_value(&dk->dk_aggsums.das_nunlinks);
+	dkv->dkv_nunlinked.value.ui64 =
+	    aggsum_value(&dk->dk_aggsums.das_nunlinked);
 
 	return (0);
 }
@@ -136,6 +143,8 @@ dataset_kstats_create(dataset_kstats_t *dk, objset_t *objset)
 	aggsum_init(&dk->dk_aggsums.das_nwritten, 0);
 	aggsum_init(&dk->dk_aggsums.das_reads, 0);
 	aggsum_init(&dk->dk_aggsums.das_nread, 0);
+	aggsum_init(&dk->dk_aggsums.das_nunlinks, 0);
+	aggsum_init(&dk->dk_aggsums.das_nunlinked, 0);
 }
 
 void
@@ -156,6 +165,8 @@ dataset_kstats_destroy(dataset_kstats_t *dk)
 	aggsum_fini(&dk->dk_aggsums.das_nwritten);
 	aggsum_fini(&dk->dk_aggsums.das_reads);
 	aggsum_fini(&dk->dk_aggsums.das_nread);
+	aggsum_fini(&dk->dk_aggsums.das_nunlinks);
+	aggsum_fini(&dk->dk_aggsums.das_nunlinked);
 }
 
 void
@@ -182,4 +193,22 @@ dataset_kstats_update_read_kstats(dataset_kstats_t *dk,
 
 	aggsum_add(&dk->dk_aggsums.das_reads, 1);
 	aggsum_add(&dk->dk_aggsums.das_nread, nread);
+}
+
+void
+dataset_kstats_update_nunlinks_kstat(dataset_kstats_t *dk, int64_t delta)
+{
+	if (dk->dk_kstats == NULL)
+		return;
+
+	aggsum_add(&dk->dk_aggsums.das_nunlinks, delta);
+}
+
+void
+dataset_kstats_update_nunlinked_kstat(dataset_kstats_t *dk, int64_t delta)
+{
+	if (dk->dk_kstats == NULL)
+		return;
+
+	aggsum_add(&dk->dk_aggsums.das_nunlinked, delta);
 }

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -644,7 +644,7 @@ tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
 tags = ['functional', 'mmp']
 
 [tests/functional/mount]
-tests = ['umount_001', 'umountall_001']
+tests = ['umount_001', 'umount_unlinked_drain', 'umountall_001']
 tags = ['functional', 'mount']
 
 [tests/functional/mv_files]

--- a/tests/zfs-tests/tests/functional/mount/Makefile.am
+++ b/tests/zfs-tests/tests/functional/mount/Makefile.am
@@ -3,4 +3,5 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
 	umount_001.ksh \
+	umount_unlinked_drain.ksh \
 	umountall_001.ksh

--- a/tests/zfs-tests/tests/functional/mount/umount_unlinked_drain.ksh
+++ b/tests/zfs-tests/tests/functional/mount/umount_unlinked_drain.ksh
@@ -1,0 +1,119 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Test async unlinked drain to ensure mounting is not held up when there are
+# entries in the unlinked set. We also try to test that the list is able to be
+# filled up and drained at the same time.
+#
+# STRATEGY:
+# 1. Use zfs_unlink_suspend_progress tunable to disable freeing to build up
+#    the unlinked set
+# 2. Make sure mount happens even when there are entries in the unlinked set
+# 3. Drain and build up the unlinked list at the same time to test for races
+#
+
+function cleanup
+{
+	log_must set_tunable32 zfs_unlink_suspend_progress $default_unlink_sp
+	for fs in $(seq 1 3); do
+		mounted $TESTDIR.$fs || zfs mount $TESTPOOL/$TESTFS.$fs
+		rm -f $TESTDIR.$fs/file-*
+		zfs set xattr=on $TESTPOOL/$TESTFS.$fs
+	done
+}
+
+function unlinked_size_is
+{
+	MAX_ITERS=5 # iteration to do before we consider reported number stable
+	iters=0
+	last_usize=0
+	while [[ $iters -le $MAX_ITERS ]]; do
+		kstat_file=$(grep -nrwl /proc/spl/kstat/zfs/$2/objset-0x* -e $3)
+		nunlinks=`cat $kstat_file | grep nunlinks | awk '{print $3}'`
+		nunlinked=`cat $kstat_file | grep nunlinked | awk '{print $3}'`
+		usize=$(($nunlinks - $nunlinked))
+		if [[ $iters == $MAX_ITERS && $usize == $1 ]]; then
+			return 0
+		fi
+		if [[ $usize == $last_usize ]]; then
+			(( iters++ ))
+		else
+			iters=0
+		fi
+		last_usize=$usize
+	done
+
+	log_note "Unexpected unlinked set size: $last_usize, expected $1"
+	return 1
+}
+
+
+UNLINK_SP_PARAM=/sys/module/zfs/parameters/zfs_unlink_suspend_progress
+default_unlink_sp=$(get_tunable zfs_unlink_suspend_progress)
+
+log_onexit cleanup
+
+log_assert "Unlinked list drain does not hold up mounting of fs"
+
+for fs in 1 2 3; do
+	set -A xattrs on sa off
+	for xa in ${xattrs[@]}; do
+		# setup fs and ensure all deleted files got into unliked set
+		log_must mounted $TESTDIR.$fs
+
+		log_must zfs set xattr=$xa $TESTPOOL/$TESTFS.$fs
+
+		if [[ $xa == off ]]; then
+			for fn in $(seq 1 175); do
+				log_must mkfile 128k $TESTDIR.$fs/file-$fn
+			done
+		else
+			log_must xattrtest -f 175 -x 3 -r -k -p $TESTDIR.$fs
+		fi
+
+		log_must set_tunable32 zfs_unlink_suspend_progress 1
+		log_must unlinked_size_is 0 $TESTPOOL $TESTPOOL/$TESTFS.$fs
+
+		# build up unlinked set
+		for fn in $(seq 1 100); do
+			log_must eval "rm $TESTDIR.$fs/file-$fn &"
+		done
+		log_must unlinked_size_is 100 $TESTPOOL $TESTPOOL/$TESTFS.$fs
+
+		# test that we can mount fs without emptying the unlinked list
+		log_must zfs umount $TESTPOOL/$TESTFS.$fs
+		log_must unmounted $TESTDIR.$fs
+		log_must zfs mount $TESTPOOL/$TESTFS.$fs
+		log_must mounted $TESTDIR.$fs
+		log_must unlinked_size_is 100 $TESTPOOL $TESTPOOL/$TESTFS.$fs
+
+		# confirm we can drain and add to unlinked set at the same time
+		log_must set_tunable32 zfs_unlink_suspend_progress 0
+		log_must zfs umount $TESTPOOL/$TESTFS.$fs
+		log_must zfs mount $TESTPOOL/$TESTFS.$fs
+		for fn in $(seq 101 175); do
+			log_must eval "rm $TESTDIR.$fs/file-$fn &"
+		done
+		log_must unlinked_size_is 0 $TESTPOOL $TESTPOOL/$TESTFS.$fs
+	done
+done
+
+log_pass "Confirmed unlinked list drain does not hold up mounting of fs"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This patch is an async implementation of the existing sync `zfs_unlinked_drain()` function. This function is called at mount time and is responsible for freeing znodes that we didn't get to freeing before.
We don't have to hold mounting of the dataset until the unlinked list is fully drained as is done now. Since we can process the unlinked set asynchronously this results in a better user experience when mounting a dataset with entries in the unlinked set.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The problem this patch is attempting to solve is long mount times when the dataset being mounted has a long list of znodes in the unlinked set.
Originally this issue came to us @datto as a request to investigate why a particular snapshot took a lot longer to create a clone from than the other snapshots. Looking at what the "stuck" clone was doing we saw variations of:
```
[<ffffffffc05a5b63>] cv_wait_common+0xb3/0x130 [spl]
[<ffffffffc05a5c38>] __cv_wait_io+0x18/0x20 [spl]
[<ffffffffc10f2463>] zio_wait+0x103/0x1e0 [zfs]
[<ffffffffc1066e5f>] dmu_tx_hold_free+0x1ff/0x900 [zfs]
[<ffffffffc1056d42>] dmu_free_long_range+0x192/0x270 [zfs]
[<ffffffffc10c878a>] zfs_rmnode+0x28a/0x350 [zfs]
[<ffffffffc10e944b>] zfs_zinactive+0xbb/0xd0 [zfs]
[<ffffffffc10e29c1>] zfs_inactive+0x61/0x250 [zfs]
[<ffffffffc10f9933>] zpl_evict_inode+0x43/0x60 [zfs]
[<ffffffff812314c1>] evict+0xc1/0x190
[<ffffffff812317a7>] iput+0x1c7/0x250
[<ffffffffc10c78f4>] zfs_unlinked_drain+0xb4/0xe0 [zfs]
[<ffffffffc10dabad>] zfs_sb_setup+0xed/0x160 [zfs]
[<ffffffffc10dc00f>] zfs_domount+0x29f/0x330 [zfs]
[<ffffffffc10f9a7c>] zpl_fill_super+0x2c/0x40 [zfs]
[<ffffffff81218a4f>] mount_nodev+0x4f/0xa0
[<ffffffffc10f9eef>] zpl_mount+0x4f/0x80 [zfs]
[<ffffffff8121974d>] mount_fs+0x3d/0x170
[<ffffffff81236187>] vfs_kern_mount+0x67/0x110
[<ffffffff8123882f>] do_mount+0x25f/0xd90
[<ffffffff8123969f>] SyS_mount+0x9f/0x100
[<ffffffff8185328e>] entry_SYSCALL_64_fastpath+0x22/0xc1
[<ffffffffffffffff>] 0xffffffffffffffff
```

<!-- If it fixes an open issue, please link to the issue here. -->

### Description
As can be seen above the reason that the `zfs_unlinked_drain()` call can take so long is that it eventually calls `iput()` which destroys/frees the corresponding inode and could sleep:
```
Puts an inode, dropping its usage count. If the inode use count hits zero, the inode is then freed and may also be destroyed.
Consequently, iput can sleep.
```
If there are other entires in the unlinked set this will loop untill all the znodes are freed synchronously continuing to hold up mount in the process.

To solve this problems and facilitate async unlinked list drain we added a pool-wide taskq for processing unlinked drain asyncronsoly. This patch tracks the state of the unlinked drain per `zfsvfs` and is able to stop async processing of the unlinked set if we need to unmount or suspend the filesystem.


This patch was inspired by work done @nexenta mostly by @skiselkov and @Ramzec.
The general approach is simular to a mix of code from the following patches https://github.com/Nexenta/illumos-nexenta/commit/ea0ae4efc65a839131 and https://github.com/Nexenta/illumos-nexenta/commit/5d09257a00d903.


<!-- Describe your changes in detail -->

### How Has This Been Tested?
I unit tested this by comparing clone times on a snapshot that was created immediately after several large files (~250GB) were deleted. The difference between the two mount times was ~8x. I expect the difference will be bigger for non-SSD systems.

The zfs-test looked good on my workstation as well.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
