### PR TITLE
Fix 'zpool list -v' alignment

### DIFF
--- a/module/zcommon/zprop_common.c
+++ b/module/zcommon/zprop_common.c
@@ -437,6 +437,12 @@ zprop_width(int prop, boolean_t *fixed, zfs_type_t type)
 		 */
 		if (prop == ZFS_PROP_CREATION)
 			*fixed = B_FALSE;
+		/*
+		 * 'health' is handled specially because it's a number
+		 * internally, but displayed as a fixed 8 character string.
+		 */
+		if (prop == ZPOOL_PROP_HEALTH)
+			ret = 8;
 		break;
 	case PROP_TYPE_INDEX:
 		idx = prop_tbl[prop].pd_table;


### PR DESCRIPTION
### Motivation and Context

Issue #7308.  The current output  of `zpool list -v` does a terrible
job properly aligning its output.  We want to correct that so it's
easy to read at a glance.  This change only tackles the major
cosmetic issues and intentionally avoids any extensive refactoring.
There's quite a bit more which could be improved.

### Description

The verbose output of 'zpool list' was not correctly aligned due
to differences in the vdev name lengths.  Minimally update the
code the correct the alignment using the same strategy employed
by 'zpool status'.

Missing dashes were added for the empty defaults columns, and
the vdev state is now printed for all vdevs.

The ALTROOT properly was removed from the default output to get
close to staying within an 80 character width.  At least for
short vdev names.

### How Has This Been Tested?

Manually inspected the output for a moderating interesting pool configuration.

BEFORE:
```
$ zpool list -v
NAME       SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
tank              7.50G   888K  7.50G        -         -     0%     0%  1.00x  DEGRADED  -
  mirror          7.50G   888K  7.50G        -         -     0%  0.01%
    vdb               -      -      -        -         -      -      -
    spare             -      -      -        -         -      -      -
      vdc             -      -      -        -         -      -      -
      vdd             -      -      -        -         -      -      -
cache                 -      -      -         -      -      -
  /var/tmp/cache  1020M  17.5K  1019M        -         -     0%  0.00%
spare                 -      -      -         -      -      -
  vdd   
```

AFTER:
```
$ zpool list -v
NAME               SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
tank              7.50G  1.63M  7.50G        -         -     0%     0%  1.00x  DEGRADED  -
  mirror          7.50G  1.63M  7.50G        -         -     0%  0.02%      -  DEGRADED
    vdb               -      -      -        -         -      -      -      -  ONLINE  
    spare             -      -      -        -         -      -      -      -  DEGRADED
      vdc             -      -      -        -         -      -      -      -  OFFLINE 
      vdd             -      -      -        -         -      -      -      -  ONLINE  
cache                 -      -      -        -         -      -      -      -  -
  /var/tmp/cache  1020M    34K  1019M        -         -     0%  0.00%      -  ONLINE  
spare                 -      -      -        -         -      -      -      -  -
  vdd                 -      -      -        -         -      -      -      -  INUSE 
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
