### PR TITLE
zfs_dbgmsg() is not safe from every context

### DIFF
--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -139,9 +139,16 @@ bdev_max_capacity(struct block_device *bdev, uint64_t wholedisk)
 static void
 vdev_disk_error(zio_t *zio)
 {
-	zfs_dbgmsg("zio error=%d type=%d offset=%llu size=%llu flags=%x\n",
-	    zio->io_error, zio->io_type, (u_longlong_t)zio->io_offset,
-	    (u_longlong_t)zio->io_size, zio->io_flags);
+	/*
+	 * This function can be called in interrupt context, for instance while
+	 * handling IRQs coming from a misbehaving disk device; use printk()
+	 * which is safe from any context.
+	 */
+	printk(KERN_WARNING "zio pool=%s vdev=%s error=%d type=%d "
+	    "offset=%llu size=%llu flags=%x\n", spa_name(zio->io_spa),
+	    zio->io_vd->vdev_path, zio->io_error, zio->io_type,
+	    (u_longlong_t)zio->io_offset, (u_longlong_t)zio->io_size,
+	    zio->io_flags);
 }
 
 /*


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/8137

### Description
<!--- Describe your changes in detail -->
This commit reverts to using `printk()` instead of `zfs_dbgmsg()` to log messages in `vdev_disk_error()`: this is necessary because the latter can be called from interrupt context where we are not allowed to sleep. Unfortunately `zfs_dbgmsg()` performs its allocations calling `kmalloc()` with the `KM_SLEEP` flag which may result in the following oops:

```
[17398.865377] BUG: scheduling while atomic: swapper/4/0/0x10000100
[17398.865416] Modules linked in: ip6t_rpfilter ipt_REJECT nf_reject_ipv4 ip6t_REJECT nf_reject_ipv6 xt_conntrack ip_set nfnetlink ebtable_nat ebtable_broute bridge stp llc ip6table_nat nf_conntrack_ipv6 nf_defrag_ipv6 nf_nat_ipv6 ip6table_mangle ip6table_security ip6table_raw iptable_nat nf_conntrack_ipv4 nf_defrag_ipv4 nf_nat_ipv4 nf_nat nf_conntrack iptable_mangle iptable_security iptable_raw ebtable_filter ebtables ip6table_filter ip6_tables iptable_filter zfs(POE) zunicode(POE) zlua(POE) intel_powerclamp coretemp kvm_intel ipmi_ssif kvm irqbypass crc32_pclmul ghash_clmulni_intel iTCO_wdt iTCO_vendor_support aesni_intel lrw gf128mul glue_helper ablk_helper zcommon(POE) cryptd znvpair(POE) zavl(POE) icp(POE) spl(OE) pcspkr joydev i2c_i801 lpc_ich ipmi_si sg ipmi_devintf ipmi_msghandler tpm_infineon
[17398.865478]  acpi_power_meter ioatdma i7core_edac shpchp acpi_cpufreq ip_tables xfs libcrc32c sd_mod crc_t10dif crct10dif_generic mgag200 drm_kms_helper qla2xxx syscopyarea sysfillrect ahci sysimgblt fb_sys_fops ttm libahci crct10dif_pclmul crct10dif_common drm crc32c_intel libata igb aacraid ptp pps_core dca i2c_algo_bit i2c_core scsi_transport_fc scsi_tgt dm_mirror dm_region_hash dm_log dm_mod
[17398.865514] CPU: 4 PID: 0 Comm: swapper/4 Kdump: loaded Tainted: P          IOE  ------------   3.10.0-862.14.4.el7.x86_64 #1
[17398.865517] Hardware name: FUJITSU                          PRIMERGY RX300 S6             /D2619, BIOS 6.00 Rev. 1.13.2619.N1           01/19/2012
[17398.865520] Call Trace:
[17398.865523]  <IRQ>  [<ffffffff9bb13754>] dump_stack+0x19/0x1b
[17398.865535]  [<ffffffff9bb0d862>] __schedule_bug+0x64/0x72
[17398.865540]  [<ffffffff9bb18eeb>] __schedule+0x9fb/0xa20
[17398.865546]  [<ffffffff9b7c6ffb>] ? fbcon_putcs+0x12b/0x160
[17398.865553]  [<ffffffff9b4ceb76>] __cond_resched+0x26/0x30
[17398.865557]  [<ffffffff9bb191da>] _cond_resched+0x3a/0x50
[17398.865562]  [<ffffffff9b5f92fc>] __kmalloc_node+0x5c/0x2b0
[17398.865575]  [<ffffffffc05644cf>] ? spl_kmem_alloc+0xdf/0x140 [spl]
[17398.865584]  [<ffffffffc05644cf>] spl_kmem_alloc+0xdf/0x140 [spl] <-- kmem_alloc(size, KM_SLEEP)
[17398.865656]  [<ffffffffc0cdb629>] __dprintf+0x69/0x150 [zfs]
[17398.865662]  [<ffffffff9b5fa282>] ? kmem_cache_free+0x1e2/0x200
[17398.865720]  [<ffffffffc0cb1abf>] vdev_disk_error.part.15+0x5f/0x70 [zfs]
[17398.865778]  [<ffffffffc0cb1b18>] vdev_disk_io_flush_completion+0x48/0x70 [zfs]
[17398.865783]  [<ffffffff9b65cbd7>] bio_endio+0x67/0xb0
[17398.865789]  [<ffffffff9b71f8e0>] blk_update_request+0x90/0x360
[17398.865793]  [<ffffffff9b71fbcc>] blk_update_bidi_request+0x1c/0x80
[17398.865797]  [<ffffffff9b720797>] __blk_end_bidi_request+0x17/0x40
[17398.865801]  [<ffffffff9b72089f>] __blk_end_request_all+0x1f/0x30
[17398.865805]  [<ffffffff9b722fe5>] blk_flush_complete_seq+0x345/0x360
[17398.865809]  [<ffffffff9b7233e0>] flush_end_io+0x1f0/0x2f0
[17398.865813]  [<ffffffff9b71fe43>] blk_finish_request+0x83/0x130
[17398.865819]  [<ffffffff9b8a99d6>] scsi_end_request+0x116/0x1e0
[17398.865823]  [<ffffffff9b8a9dd7>] scsi_io_completion+0x2d7/0x6a0
[17398.865827]  [<ffffffff9b89f14c>] scsi_finish_command+0xdc/0x140
[17398.865831]  [<ffffffff9b8a91b2>] scsi_softirq_done+0x132/0x160
[17398.865836]  [<ffffffff9b7272a6>] blk_done_softirq+0x96/0xc0
[17398.865841]  [<ffffffff9b49dba5>] __do_softirq+0xf5/0x280
[17398.865846]  [<ffffffff9bb28cec>] call_softirq+0x1c/0x30
[17398.865852]  [<ffffffff9b42e625>] do_softirq+0x65/0xa0
[17398.865855]  [<ffffffff9b49df25>] irq_exit+0x105/0x110
[17398.865859]  [<ffffffff9bb29fa6>] do_IRQ+0x56/0xf0
[17398.865863]  [<ffffffff9bb1c362>] common_interrupt+0x162/0x162
[17398.865865]  <EOI>  [<ffffffff9b96e704>] ? cpuidle_enter_state+0x54/0xd0
[17398.865873]  [<ffffffff9b96e85e>] cpuidle_idle_call+0xde/0x230
[17398.865877]  [<ffffffff9b4366ce>] arch_cpu_idle+0xe/0xb0
[17398.865882]  [<ffffffff9b4f5dea>] cpu_startup_entry+0x14a/0x1e0
[17398.865888]  [<ffffffff9b4571b7>] start_secondary+0x1f7/0x270
[17398.865893]  [<ffffffff9b4000d5>] start_cpu+0x5/0x14
```

NOTE: there are probably other ways to fix the issue:

 * make the `char* buf` a local variable in `__dprintf()` and avoid the `kmem_alloc(, KM_SLEEP)` altogether: this can probably hurt kernels where stack size is limited.

 * use `KM_NOSLEEP` in `__dprintf()` and call `printk()` if the allocation fails: under memory pressure we will not save messages to the dbgmsg log but would still be able to get them from the kernel ring buffer.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Unfortunately i am unable to reproduce https://github.com/zfsonlinux/zfs/issues/8137 on my hardware so i was not able to test this change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
