### PR TITLE
zfs-functions.in: Fix bug in is_mounted() where the return value is always 1

### DIFF
--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -423,9 +423,14 @@ is_mounted()
 	mount | \
 	    while read line; do
 		if echo "$line" | grep -q " on $mntpt "; then
-		    return 0
+		    # returns:
+		    #   0 on unsuccessful match
+		    #   1 on a successful match
+		    return 1
 		fi
 	    done
 
-	return 1
+	# The negation will flip the subshell return result where the default
+	# return value is 0 when a match is not found.
+	return $(( !$? ))
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
  The 'while read line; ...; done' loop is run in a piped subshell therefore the
  'return 0' would not cause a return from the is_mounted() function.  In all cases,
  this function will always return 1.

  The fix is to 'return 1' from the subshell on a successful match (no match == return 0),
  and then negating the final return value.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is a Gentoo server (OpenRC) running: sys-fs/zfs-0.7.11

It fixes an issue with zfs-mount trying to mount '/usr', which has already been done early via dracut +  usrmount module.
```filesystem 'rpool/TEST/usr' is already mounted```

It also fixes another issue where '/var' is being mounted by 'localmount' and zfs-mount is set to run after the localmounts have been completed.
```filesystem 'rpool/TEST/var' is already mounted```
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
By manually patching the code and ensuring the warning message has gone away.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
