### PR TITLE
ZTS: fix "not found" errors

### DIFF
--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_012_pos.ksh
@@ -24,7 +24,7 @@
 
 verify_runnable "global"
 
-claim= "Removing a special device from a pool succeeds."
+claim="Removing a special device from a pool succeeds."
 
 log_assert $claim
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_013_pos.ksh
@@ -24,7 +24,7 @@
 
 verify_runnable "global"
 
-claim= "Removing a dedup device from a pool succeeds."
+claim="Removing a dedup device from a pool succeeds."
 
 log_assert $claim
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/alloc_class/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/cleanup.ksh
@@ -21,7 +21,7 @@
 
 verify_runnable "global"
 
-pool_cleanup
+default_cleanup
 disk_cleanup
 
 log_pass

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.ksh
@@ -37,7 +37,7 @@ log_must_program $TESTPOOL $ZCP_ROOT/lua_core/tst.exists.zcp \
     $TESTPOOL $TESTPOOL/$TESTFS $TESTPOOL/$TESTFS@$TESTSNAP \
     $TESTPOOL/$TESTCLONE
 
-log_mustnot_checkerr_program "not in the target pool" \
+log_mustnot_checkerror_program "not in the target pool" \
     $TESTPOOL - <<-EOF
 	return zfs.exists('rpool')
 EOF

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.nvlist_to_lua.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.nvlist_to_lua.ksh
@@ -14,14 +14,14 @@
 # Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
-verify_runnable "global"
-
 . $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
 
 #
 # DESCRIPTION:
 #	run C program which tests passing different nvlists to lua
 #
+
+verify_runnable "global"
 
 log_assert "nvlist arguments can be passed to LUA."
 

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.return_nvlist_neg.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.return_nvlist_neg.ksh
@@ -14,8 +14,6 @@
 # Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
-verify_runnable "global"
-
 . $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
 
 #

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.return_nvlist_pos.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.return_nvlist_pos.ksh
@@ -14,8 +14,6 @@
 # Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
-verify_runnable "global"
-
 . $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
 
 #

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.return_recursive_table.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.return_recursive_table.ksh
@@ -14,8 +14,6 @@
 # Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
-verify_runnable "global"
-
 . $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
 
 #

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.timeout.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.timeout.ksh
@@ -14,8 +14,6 @@
 # Copyright (c) 2016, 2017 by Delphix. All rights reserved.
 #
 
-verify_runnable "global"
-
 . $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
 
 #

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_fs.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_fs.ksh
@@ -14,9 +14,9 @@
 # Copyright (c) 2016, 2017 by Delphix. All rights reserved.
 #
 
-verify_runnable "global"
-
 . $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
+
+verify_runnable "global"
 
 fs=$TESTPOOL/$TESTFS/testchild
 

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_snap.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_snap.ksh
@@ -14,9 +14,9 @@
 # Copyright (c) 2016, 2017 by Delphix. All rights reserved.
 #
 
-verify_runnable "global"
-
 . $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
+
+verify_runnable "global"
 
 snap=$TESTPOOL/$TESTFS@$TESTSNAP
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/import_cachefile_shared_device.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/import_cachefile_shared_device.ksh
@@ -90,7 +90,7 @@ function test_shared_device
 	typeset checksum2=$(dev_checksum $sharedvdev)
 
 	if [[ $checksum1 == $checksum2 ]]; then
-		log_pos "Device hasn't been modified by original pool"
+		log_pass "Device hasn't been modified by original pool"
 	else
 		log_fail "Device has been modified by original pool." \
 		    "Checksum mismatch: $checksum1 != $checksum2."

--- a/tests/zfs-tests/tests/functional/cli_user/misc/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/setup.ksh
@@ -55,7 +55,7 @@ default_setup_noexit "$DISK" "" "volume"
 log_must zfs snapshot $TESTPOOL/$TESTFS@snap
 log_must zfs clone $TESTPOOL/$TESTFS@snap $TESTPOOL/$TESTFS/clone
 # create a file in the filesystem that isn't in the above snapshot
-touch /$TESTDIR/file.txt
+touch $TESTDIR/file.txt
 
 
 # create a non-default property and a child we can use to test inherit
@@ -116,28 +116,28 @@ then
 
 	# Now create several virtual disks to test zpool with
 
-	mkfile $MINVDEVSIZE /$TESTDIR/disk1.dat
-	mkfile $MINVDEVSIZE /$TESTDIR/disk2.dat
-	mkfile $MINVDEVSIZE /$TESTDIR/disk3.dat
-	mkfile $MINVDEVSIZE /$TESTDIR/disk-additional.dat
-	mkfile $MINVDEVSIZE /$TESTDIR/disk-export.dat
-	mkfile $MINVDEVSIZE /$TESTDIR/disk-offline.dat
-	mkfile $MINVDEVSIZE /$TESTDIR/disk-spare1.dat
-	mkfile $MINVDEVSIZE /$TESTDIR/disk-spare2.dat
+	mkfile $MINVDEVSIZE $TEST_BASE_DIR/disk1.dat
+	mkfile $MINVDEVSIZE $TEST_BASE_DIR/disk2.dat
+	mkfile $MINVDEVSIZE $TEST_BASE_DIR/disk3.dat
+	mkfile $MINVDEVSIZE $TEST_BASE_DIR/disk-additional.dat
+	mkfile $MINVDEVSIZE $TEST_BASE_DIR/disk-export.dat
+	mkfile $MINVDEVSIZE $TEST_BASE_DIR/disk-offline.dat
+	mkfile $MINVDEVSIZE $TEST_BASE_DIR/disk-spare1.dat
+	mkfile $MINVDEVSIZE $TEST_BASE_DIR/disk-spare2.dat
 
 	# and create a pool we can perform attach remove replace,
 	# etc. operations with
-	log_must zpool create $TESTPOOL.virt mirror /$TESTDIR/disk1.dat \
-	/$TESTDIR/disk2.dat /$TESTDIR/disk3.dat /$TESTDIR/disk-offline.dat \
-	spare /$TESTDIR/disk-spare1.dat
+	log_must zpool create $TESTPOOL.virt mirror $TEST_BASE_DIR/disk1.dat \
+	$TEST_BASE_DIR/disk2.dat $TEST_BASE_DIR/disk3.dat \
+	$TEST_BASE_DIR/disk-offline.dat spare $TEST_BASE_DIR/disk-spare1.dat
 
 
 	# Offline one of the disks to test online
-	log_must zpool offline $TESTPOOL.virt /$TESTDIR/disk-offline.dat
+	log_must zpool offline $TESTPOOL.virt $TEST_BASE_DIR/disk-offline.dat
 
 
 	# create an exported pool to test import
-	log_must zpool create $TESTPOOL.exported /$TESTDIR/disk-export.dat
+	log_must zpool create $TESTPOOL.exported $TEST_BASE_DIR/disk-export.dat
 	log_must zpool export $TESTPOOL.exported
 
 	set -A props $POOL_PROPS
@@ -154,8 +154,8 @@ then
 
 	# copy a v1 pool from cli_root
 	cp $STF_SUITE/tests/functional/cli_root/zpool_upgrade/blockfiles/zfs-pool-v1.dat.bz2 \
-	    /$TESTDIR
-	log_must bunzip2 /$TESTDIR/zfs-pool-v1.dat.bz2
-	log_must zpool import -d /$TESTDIR v1-pool
+	    $TEST_BASE_DIR/
+	log_must bunzip2 $TEST_BASE_DIR/zfs-pool-v1.dat.bz2
+	log_must zpool import -d $TEST_BASE_DIR/ v1-pool
 fi
 log_pass

--- a/tests/zfs-tests/tests/functional/cli_user/misc/zpool_upgrade_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/zpool_upgrade_001_neg.ksh
@@ -47,7 +47,6 @@ verify_runnable "global"
 
 log_assert "zpool upgrade returns an error when run as a user"
 
-log_onexit cleanup
 # zpool upgrade returns 0 when it can't do anything
 log_must zpool upgrade $TESTPOOL.virt
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ZTS Test Suite should run completely and without errors; some tests use undefined (or yet-to-be-defined) shell functions or contain syntax errors:

>Test: /usr/share/zfs/zfs-tests/tests/functional/alloc_class/alloc_class_013_pos (run as root) [00:16] [PASS]
>**10:37:36.31 /usr/share/zfs/zfs-tests/tests/functional/alloc_class/alloc_class_013_pos.ksh[27]: Removing a dedup device from a pool succeeds.: not found [No such file or directory]**
>10:37:36.31 ASSERTION:
>10:37:36.32 SUCCESS: disk_setup
>10:37:36.77 SUCCESS: zpool create testpool /mnt/device-0 /mnt/device-1 /mnt/device-2 dedup /mnt/device-3
>10:37:38.83 SUCCESS: display_status testpool

>Test: /usr/share/zfs/zfs-tests/tests/functional/alloc_class/cleanup (run as root) [00:00] [PASS]
>10:37:52.91 /usr/share/zfs/zfs-tests/tests/functional/alloc_class/cleanup.ksh[24]: **pool_cleanup: not found [No such file or directory]**
>Test: /usr/share/zfs/zfs-tests/tests/functional/arc/setup (run as root) [00:00] [PASS]

>10:43:12.18 NOTE: error:
>10:43:12.18 
>**10:43:12.19 /usr/share/zfs/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.ksh[40]: log_mustnot_checkerr_program: not found [No such file or directory]**
>10:43:12.19 zfs.exists() gives correct results

NOTE: OpenZFS has some of these same issues, too.

### Description
<!--- Describe your changes in detail -->
This commit fixes several "not found" errors caused by calling undefined or incorrect shell functions in the following ZFS Test Suite groups:

   * alloc_class
   * channel_program/lua_core
   * channel_program/synctask_core
   * cli_root/zpool_import
   * cli_user/misc

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
This was tested running the ZTS manually on a local Debian8 builder

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
