### PR TITLE
Debug Fedora 29 group delete

### DIFF
--- a/TEST
+++ b/TEST
@@ -5,14 +5,14 @@
 #TEST_PREPARE_SHARES="yes"
 
 ### ztest
-#TEST_ZTEST_SKIP="yes"
+TEST_ZTEST_SKIP="yes"
 #TEST_ZTEST_TIMEOUT=1800
 #TEST_ZTEST_DIR="/var/tmp/"
 #TEST_ZTEST_OPTIONS="-V"
 #TEST_ZTEST_CORE_DIR="/mnt/zloop"
 
 ### zimport
-#TEST_ZIMPORT_SKIP="yes"
+TEST_ZIMPORT_SKIP="yes"
 #TEST_ZIMPORT_DIR="/var/tmp/zimport"
 #TEST_ZIMPORT_VERSIONS="master installed"
 #TEST_ZIMPORT_POOLS="zol-0.6.1 zol-0.6.2 master installed"
@@ -35,7 +35,7 @@
 #TEST_ZFSTESTS_ITERS="1"
 #TEST_ZFSTESTS_OPTIONS="-vx"
 #TEST_ZFSTESTS_RUNFILE="linux.run"
-#TEST_ZFSTESTS_TAGS="functional"
+TEST_ZFSTESTS_TAGS="acl"
 
 ### zfsstress
 #TEST_ZFSSTRESS_SKIP="yes"

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2422,7 +2422,7 @@ function del_group #<group_name>
 			# Group does not exist.
 			2) return 0 ;;
 			# Name already exists as a group name
-			0) log_must groupdel $grp ;;
+			0) log_must_retry "cannot remove" 5 groupdel $grp ;;
 			*) return 1 ;;
 		esac
 	else


### PR DESCRIPTION
### Motivation and Context

Debug the Fedora 29 failures which appear to only be reproducible
in the CI.  The groupdel failure was not reproducible for me in a local
Fedora 29 VM.  This change is being pushed to the bots where it is
reproducible for additional debugging.

### Description

Retry to see if the failure is transient.  The contents of this patch will
be updated as needed to diagnose the failure.

### How Has This Been Tested?

Locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
