### PR TITLE
Fix 'zfs receive -F' message when destination has snapshots

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3929,7 +3929,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "destination has snapshots (eg. %s)\n"
 				    "must destroy them to overwrite it"),
-				    name);
+				    zc.zc_name);
 				err = zfs_error(hdl, EZFS_EXISTS, errbuf);
 				goto out;
 			}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When receiving a send stream with forced rollback on a dataset with snapshots zfs suggests said snapshots must be removed to successfully receive the stream; however the message is misleading because it prints the dataset name instead of one of its snapshots.

>   $ sudo zfs snap pp/recvfs@snap-orig
>   $ sudo zfs recv -F pp/recvfs < sendstream
>   cannot receive new filesystem stream: destination has snapshots (eg. **pp/recvfs**)
>   must destroy them to overwrite it

### Description
<!--- Describe your changes in detail -->
This change simply restores the snapshot name in the error message, current master:

```
root@linux:~# POOLNAME='pp'
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:~# zpool destroy -f $POOLNAME
root@linux:~# rm -f $TMPDIR/zpool.dat
root@linux:~# truncate -s 128m $TMPDIR/zpool.dat
root@linux:~# zpool create -f -O mountpoint=none $POOLNAME $TMPDIR/zpool.dat
root@linux:~# 
root@linux:~# zfs create $POOLNAME/fs
root@linux:~# zfs create $POOLNAME/recvfs
root@linux:~# zfs snap $POOLNAME/fs@snap1
root@linux:~# zfs snap $POOLNAME/recvfs@snap-orig
root@linux:~# zfs send $POOLNAME/fs@snap1 | zfs recv -F $POOLNAME/recvfs
cannot receive new filesystem stream: destination has snapshots (eg. pp/recvfs)
must destroy them to overwrite it
root@linux:~# 
```

patched:

```
root@linux:~# POOLNAME='pp'
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:~# zpool destroy -f $POOLNAME
root@linux:~# rm -f $TMPDIR/zpool.dat
root@linux:~# truncate -s 128m $TMPDIR/zpool.dat
root@linux:~# zpool create -f -O mountpoint=none $POOLNAME $TMPDIR/zpool.dat
root@linux:~# 
root@linux:~# zfs create $POOLNAME/fs
root@linux:~# zfs create $POOLNAME/recvfs
root@linux:~# zfs snap $POOLNAME/fs@snap1
root@linux:~# zfs snap $POOLNAME/recvfs@snap-orig
root@linux:~# zfs send $POOLNAME/fs@snap1 | zfs recv -F $POOLNAME/recvfs
cannot receive new filesystem stream: destination has snapshots (eg. pp/recvfs@snap-orig)
must destroy them to overwrite it
root@linux:~# 
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Copy/pastable reproducer:

```shell
POOLNAME='pp'
TMPDIR='/var/tmp'
mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
zpool destroy -f $POOLNAME
rm -f $TMPDIR/zpool.dat
truncate -s 128m $TMPDIR/zpool.dat
zpool create -f -O mountpoint=none $POOLNAME $TMPDIR/zpool.dat

zfs create $POOLNAME/fs
zfs create $POOLNAME/recvfs
zfs snap $POOLNAME/fs@snap1
zfs snap $POOLNAME/recvfs@snap-orig
zfs send $POOLNAME/fs@snap1 | zfs recv -F $POOLNAME/recvfs
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
