### PR TITLE
Fix dnode_hold() freeing dnode behavior

### DIFF
--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1253,8 +1253,10 @@ dnode_buf_evict_async(void *dbu)
  * EINVAL - Invalid object number or flags.
  * ENOSPC - Hole too small to fulfill "slots" request (DNODE_MUST_BE_FREE)
  * EEXIST - Refers to an allocated dnode (DNODE_MUST_BE_FREE)
+ *        - Refers to a freeing dnode (DNODE_MUST_BE_FREE)
  *        - Refers to an interior dnode slot (DNODE_MUST_BE_ALLOCATED)
  * ENOENT - The requested dnode is not allocated (DNODE_MUST_BE_ALLOCATED)
+ *        - The requested dnode is being freed (DNODE_MUST_BE_ALLOCATED)
  * EIO    - I/O error when reading the meta dnode dbuf.
  *
  * succeeds even for free dnodes.
@@ -1443,7 +1445,7 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 		}
 
 		mutex_enter(&dn->dn_mtx);
-		if (dn->dn_type == DMU_OT_NONE) {
+		if (dn->dn_type == DMU_OT_NONE || dn->dn_free_txg != 0) {
 			DNODE_STAT_BUMP(dnode_hold_alloc_type_none);
 			mutex_exit(&dn->dn_mtx);
 			dnode_slots_rele(dnc, idx, slots);
@@ -1502,7 +1504,7 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 		}
 
 		mutex_enter(&dn->dn_mtx);
-		if (!zfs_refcount_is_zero(&dn->dn_holds)) {
+		if (!zfs_refcount_is_zero(&dn->dn_holds) || dn->dn_free_txg) {
 			DNODE_STAT_BUMP(dnode_hold_free_refcount);
 			mutex_exit(&dn->dn_mtx);
 			dnode_slots_rele(dnc, idx, slots);


### PR DESCRIPTION
### Motivation and Context

Observed during multi-day runs of `ztest(1)`.

```
#0  0x00007f7c7864f277 in raise () from /lib64/libc.so.6
#1  0x00007f7c78650968 in abort () from /lib64/libc.so.6
#2  0x00007f7c79c1e06d in libspl_assert (buf=buf@entry=0x7f7c79d9c420 "dn->dn_free_txg == 0 || dn->dn_free_txg >= txg",     file=file@entry=0x7f7c79d9b850 "../../module/zfs/dnode.c", 
#3  0x00007f7c79c2281d in dnode_setdirty (dn=dn@entry=0x14c0100, tx=tx@entry=0x7f7c48042010) at ../../module/zfs/dnode.c:1635
#4  0x00007f7c79bfc2f3 in dbuf_dirty (db=db@entry=0x7f7c482f4390, tx=tx@entry=0x7f7c48042010) at ../../module/zfs/dbuf.c:2161
#5  0x00007f7c79bfc2b0 in dbuf_dirty (db=db@entry=0x7f7c483fc010, tx=tx@entry=0x7f7c48042010) at ../../module/zfs/dbuf.c:2130
#6  0x00007f7c79bfc2b0 in dbuf_dirty (db=db@entry=0x7f7c482f16c0, tx=tx@entry=0x7f7c48042010) at ../../module/zfs/dbuf.c:2130
#7  0x00007f7c79c03c9b in dmu_object_remap_one_indirect (os=os@entry=0x16a0010, dn=<optimized out>, last_removal_txg=last_removal_txg@entry=143, offset=<optimized out>)    at ../../module/zfs/dmu.c:1105
#8  0x00007f7c79c06364 in dmu_object_remap_indirects (os=os@entry=0x16a0010, object=<optimized out>, last_removal_txg=last_removal_txg@entry=143)    at ../../module/zfs/dmu.c:1179
#9  0x00007f7c79c095a3 in dmu_objset_remap_indirects_impl (os=0x16a0010, last_removed_txg=last_removed_txg@entry=143) at ../../module/zfs/dmu_objset.c:1385
#10 0x00007f7c79c0cb0a in dmu_objset_remap_indirects (fsname=fsname@entry=0xcbada0 "ztest/ds_3") at ../../module/zfs/dmu_objset.c:1458
#11 0x000000000040a4f7 in ztest_remap_blocks (zd=0xcbad48, id=<optimized out>) at ztest.c:5544
#12 0x00000000004092bc in ztest_execute (test=<optimized out>, zi=0x61fe60 <ztest_info+992>, id=3) at ztest.c:6588
#13 0x000000000040b09b in ztest_thread (arg=0x3) at ztest.c:6635
#14 0x00007f7c789ede25 in start_thread () from /lib64/libpthread.so.0
#15 0x00007f7c78717bad in clone () from /lib64/libc.so.6
```

### Description

Commit 4c5b89f59 refactored dnode_hold() and in the process
accidentally introduced a slight change in behavior which was
not intended.  The required behavior is that once the ZPL,
or other consumer, declares its intent to free a dnode then
dnode_hold() should immediately start failing.  This updated
code wouldn't return the failure until after it was freed.

When DNODE_MUST_BE_ALLOCATED is set it must return ENOENT, and
when DNODE_MUST_BE_FREE is set it must return EEXIST;

This issue was uncovered by ztest_remap() which attempted
to remap a freeing object which should have been skipped as
described by the comment in dmu_objset_remap_indirects_impl().

### How Has This Been Tested?

Locally built and tested by running `ztest(8)` and a subset of the ZTS tests.
No issues we're observed so I'm opening this PR for feedback and
full run of the test suite by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
