### PR TITLE
Do not enable stack tracer for ZFS performance test

### DIFF
--- a/scripts/zfs.sh
+++ b/scripts/zfs.sh
@@ -14,6 +14,7 @@ fi
 PROG=zfs.sh
 VERBOSE="no"
 UNLOAD="no"
+STACK_TRACER="no"
 
 ZED_PIDFILE=${ZED_PIDFILE:-/var/run/zed.pid}
 LDMOD=${LDMOD:-/sbin/modprobe}
@@ -33,7 +34,7 @@ KMOD_ZFS=${KMOD_ZFS:-zfs}
 usage() {
 cat << EOF
 USAGE:
-$0 [hvud] [module-options]
+$0 [hvudS] [module-options]
 
 DESCRIPTION:
 	Load/unload the ZFS module stack.
@@ -42,10 +43,11 @@ OPTIONS:
 	-h      Show this message
 	-v      Verbose
 	-u      Unload modules
+	-S      Enable kernel stack tracer
 EOF
 }
 
-while getopts 'hvu' OPTION; do
+while getopts 'hvuS' OPTION; do
 	case $OPTION in
 	h)
 		usage
@@ -56,6 +58,9 @@ while getopts 'hvu' OPTION; do
 		;;
 	u)
 		UNLOAD="yes"
+		;;
+	S)
+		STACK_TRACER="yes"
 		;;
 	?)
 		usage
@@ -192,7 +197,7 @@ stack_clear() {
 	STACK_MAX_SIZE=/sys/kernel/debug/tracing/stack_max_size
 	STACK_TRACER_ENABLED=/proc/sys/kernel/stack_tracer_enabled
 
-	if [ -e "$STACK_MAX_SIZE" ]; then
+	if [ "$STACK_TRACER" = "yes" ] && [ -e "$STACK_MAX_SIZE" ]; then
 		echo 1 >"$STACK_TRACER_ENABLED"
 		echo 0 >"$STACK_MAX_SIZE"
 	fi


### PR DESCRIPTION
Linux ZFS test suite runs with /proc/sys/kernel/stack_tracer_enabled=1,
via zfs.sh script, which has negative performance impact, up to 40%.

Since large stack is a rare issue now, preferred behavior would be:
- making stack tracer an opt-in feature for zfs.sh
- zfs-test.sh enables stack tracer only when requested

Signed-off-by: Tony Nguyen <tony.nguyen@delphix.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Linux ZFS test suite runs with /proc/sys/kernel/stack_tracer_enabled=1,
via zfs.sh script, which has negative performance impact, up to 40%.

External-issue: LX-1603 perf tests should not enable stack tracer

### Description
<!--- Describe your changes in detail -->
A `-S` option is added to both zfs.sh and zfs-test.sh to enable stack tracer. New default behavior
is running without stack tracer.

Performance results with stack tracer enabled
```
delphix@appliance:/var/tmp/test_results/tracer.enabled/perf_data$ grep IOP *fio*
random_reads.ksh.fio.sync.8k-ios.16-threads.1-filesystems:   read: IOPS=42.6k, BW=333MiB/s (349MB/s)(39.0GiB/120001msec)
random_reads.ksh.fio.sync.8k-ios.32-threads.1-filesystems:   read: IOPS=57.9k, BW=452MiB/s (474MB/s)(52.0GiB/120002msec)
random_writes.ksh.fio.sync.8k-ios.128-threads.1-filesystems:  write: IOPS=20.3k, BW=159MiB/s (166MB/s)(18.6GiB/120004msec)
random_writes.ksh.fio.sync.8k-ios.32-threads.1-filesystems:  write: IOPS=18.7k, BW=146MiB/s (154MB/s)(17.2GiB/120001msec)
sequential_reads_arc_cached.ksh.fio.sync.128k-ios.128-threads.1-filesystems:   read: IOPS=25.4k, BW=3171MiB/s (3325MB/s)(372GiB/120059msec)
sequential_reads_arc_cached.ksh.fio.sync.128k-ios.64-threads.1-filesystems:   read: IOPS=25.5k, BW=3183MiB/s (3338MB/s)(373GiB/120007msec)
sequential_reads_arc_cached.ksh.fio.sync.1m-ios.128-threads.1-filesystems:   read: IOPS=2888, BW=2889MiB/s (3029MB/s)(339GiB/120061msec)
sequential_reads_arc_cached.ksh.fio.sync.1m-ios.64-threads.1-filesystems:   read: IOPS=2913, BW=2913MiB/s (3055MB/s)(341GiB/120020msec)
sequential_reads_dbuf_cached.ksh.fio.sync.64k-ios.64-threads.1-filesystems:   read: IOPS=150k, BW=9390MiB/s (9846MB/s)(1100GiB/120002msec)
sequential_reads.ksh.fio.sync.128k-ios.16-threads.1-filesystems:   read: IOPS=7690, BW=961MiB/s (1008MB/s)(113GiB/120004msec)
sequential_reads.ksh.fio.sync.128k-ios.8-threads.1-filesystems:   read: IOPS=7686, BW=961MiB/s (1008MB/s)(113GiB/120002msec)
sequential_reads.ksh.fio.sync.1m-ios.16-threads.1-filesystems:   read: IOPS=957, BW=958MiB/s (1004MB/s)(112GiB/120011msec)
sequential_reads.ksh.fio.sync.1m-ios.8-threads.1-filesystems:   read: IOPS=964, BW=965MiB/s (1012MB/s)(113GiB/120007msec)
sequential_writes.ksh.fio.sync.128k-ios.16-threads.1-filesystems:  write: IOPS=2140, BW=268MiB/s (281MB/s)(31.4GiB/120025msec)
sequential_writes.ksh.fio.sync.128k-ios.32-threads.1-filesystems:  write: IOPS=2033, BW=254MiB/s (267MB/s)(29.8GiB/120010msec)
sequential_writes.ksh.fio.sync.1m-ios.16-threads.1-filesystems:  write: IOPS=270, BW=270MiB/s (283MB/s)(31.7GiB/120060msec)
sequential_writes.ksh.fio.sync.1m-ios.32-threads.1-filesystems:  write: IOPS=255, BW=255MiB/s (268MB/s)(29.9GiB/120048msec)
sequential_writes.ksh.fio.sync.8k-ios.16-threads.1-filesystems:  write: IOPS=23.1k, BW=180MiB/s (189MB/s)(21.1GiB/120179msec)
sequential_writes.ksh.fio.sync.8k-ios.32-threads.1-filesystems:  write: IOPS=30.0k, BW=242MiB/s (254MB/s)(28.4GiB/120001msec)
delphix@appliance:/var/tmp/test_results/tracer.enabled/perf_data$
```

Performance results with stack tracer NOT enabled
```
delphix@appliance:/var/tmp/test_results/baseline.tracer_disabled/perf_data$ grep IOP *fio*
random_reads.ksh.fio.sync.8k-ios.16-threads.1-filesystems:   read: IOPS=48.8k, BW=382MiB/s (400MB/s)(67.1GiB/180001msec)
random_reads.ksh.fio.sync.8k-ios.32-threads.1-filesystems:   read: IOPS=70.3k, BW=549MiB/s (576MB/s)(96.5GiB/180002msec)
random_writes.ksh.fio.sync.8k-ios.128-threads.1-filesystems:  write: IOPS=21.0k, BW=172MiB/s (180MB/s)(30.2GiB/180061msec)
random_writes.ksh.fio.sync.8k-ios.32-threads.1-filesystems:  write: IOPS=19.5k, BW=152MiB/s (160MB/s)(26.8GiB/180001msec)
sequential_reads_arc_cached.ksh.fio.sync.128k-ios.128-threads.1-filesystems:   read: IOPS=40.6k, BW=5076MiB/s (5322MB/s)(892GiB/180022msec)
sequential_reads_arc_cached.ksh.fio.sync.128k-ios.64-threads.1-filesystems:   read: IOPS=40.6k, BW=5081MiB/s (5327MB/s)(893GiB/180005msec)
sequential_reads_arc_cached.ksh.fio.sync.1m-ios.128-threads.1-filesystems:   read: IOPS=4429, BW=4430MiB/s (4645MB/s)(779GiB/180065msec)
sequential_reads_arc_cached.ksh.fio.sync.1m-ios.64-threads.1-filesystems:   read: IOPS=4510, BW=4510MiB/s (4729MB/s)(793GiB/180014msec)
sequential_reads_dbuf_cached.ksh.fio.sync.64k-ios.64-threads.1-filesystems:   read: IOPS=199k, BW=12.1GiB/s (13.0GB/s)(2183GiB/180002msec)
sequential_reads.ksh.fio.sync.128k-ios.16-threads.1-filesystems:   read: IOPS=12.2k, BW=1525MiB/s (1600MB/s)(268GiB/180003msec)
sequential_reads.ksh.fio.sync.128k-ios.8-threads.1-filesystems:   read: IOPS=12.3k, BW=1539MiB/s (1614MB/s)(271GiB/180001msec)
sequential_reads.ksh.fio.sync.1m-ios.16-threads.1-filesystems:   read: IOPS=1523, BW=1524MiB/s (1598MB/s)(268GiB/180009msec)
sequential_reads.ksh.fio.sync.1m-ios.8-threads.1-filesystems:   read: IOPS=1534, BW=1534MiB/s (1609MB/s)(270GiB/180006msec)
sequential_writes.ksh.fio.sync.128k-ios.16-threads.1-filesystems:  write: IOPS=2062, BW=258MiB/s (270MB/s)(45.3GiB/180005msec)
sequential_writes.ksh.fio.sync.128k-ios.32-threads.1-filesystems:  write: IOPS=2074, BW=259MiB/s (272MB/s)(45.6GiB/180052msec)
sequential_writes.ksh.fio.sync.1m-ios.16-threads.1-filesystems:  write: IOPS=261, BW=262MiB/s (275MB/s)(46.1GiB/180022msec)
sequential_writes.ksh.fio.sync.1m-ios.32-threads.1-filesystems:  write: IOPS=258, BW=259MiB/s (271MB/s)(45.5GiB/180052msec)
sequential_writes.ksh.fio.sync.8k-ios.16-threads.1-filesystems:  write: IOPS=24.6k, BW=192MiB/s (201MB/s)(33.7GiB/180001msec)
sequential_writes.ksh.fio.sync.8k-ios.32-threads.1-filesystems:  write: IOPS=31.7k, BW=248MiB/s (260MB/s)(43.6GiB/180006msec)
delphix@appliance:/var/tmp/test_results/baseline.tracer_disabled/perf_data$
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Specific completed tests are:
- zfs.sh with and without `-S` option had correct behavior.
- ZFS performance tests with and without `-S` completed with correct behavior.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
