### PR TITLE
Enable/disable pyzfs explicity in spec

### DIFF
--- a/config/always-pyzfs.m4
+++ b/config/always-pyzfs.m4
@@ -116,7 +116,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 	AC_SUBST([PYZFS_ENABLED], [$enable_pyzfs])
 
 	AS_IF([test "x$enable_pyzfs" = xyes], [
-		DEFINE_PYZFS='--define "_pyzfs 1"'
+		DEFINE_PYZFS='--with pyzfs'
 	],[
 		DEFINE_PYZFS=''
 	])

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -52,6 +52,7 @@
 %bcond_with    debuginfo
 %bcond_with    asan
 %bcond_with    systemd
+%bcond_with    pyzfs
 
 # Python permits the !/usr/bin/python shebang for scripts that are cross
 # compatible between python2 and python3, but Fedora 28 does not.  Fedora
@@ -240,7 +241,7 @@ Requires:       grep
 This package contains a dracut module used to construct an initramfs
 image which is ZFS aware.
 
-%if 0%{?_pyzfs}
+%if %{with pyzfs}
 %package -n pyzfs
 Summary:        Python wrapper for libzfs_core
 Group:          Development/Languages/Python
@@ -252,6 +253,7 @@ Requires:       libffi
 Requires:       python >= 2.7
 Requires:       python-cffi
 %if 0%{?rhel}%{?fedora}%{?suse_version}
+BuildRequires:  python-cffi
 BuildRequires:  python-devel
 BuildRequires:  libffi-devel
 %endif
@@ -292,6 +294,12 @@ image which is ZFS aware.
     %define asan --disable-asan
 %endif
 
+%if %{with pyzfs}
+    %define pyzfs --enable-pyzfs
+%else
+    %define pyzfs --disable-pyzfs
+%endif
+
 %if 0%{?_systemd}
     %define systemd --enable-systemd --with-systemdunitdir=%{_unitdir} --with-systemdpresetdir=%{_presetdir} --with-systemdmodulesloaddir=%{_modulesloaddir} --with-systemdgeneratordir=%{_systemdgeneratordir} --disable-sysvinit
     %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target
@@ -311,6 +319,7 @@ image which is ZFS aware.
     %{debug} \
     %{debuginfo} \
     %{asan} \
+    %{pyzfs} \
     %{systemd}
 make %{?_smp_mflags}
 
@@ -426,7 +435,7 @@ systemctl --system daemon-reload >/dev/null || true
 %doc contrib/dracut/README.dracut.markdown
 %{_dracutdir}/modules.d/*
 
-%if 0%{?_pyzfs}
+%if %{with pyzfs}
 %files -n pyzfs
 %doc contrib/pyzfs/README
 %doc contrib/pyzfs/LICENSE


### PR DESCRIPTION
Add --with/without pyzfs to rpm build

Explicitly enable or disable pyzfs during configure based on
what will be packaged.  Configuration test should not make
packaging fail if python-cffi is installed.

Partially Addresses Issue #7882 

Signed-off-by: Nathaniel Clark <nathaniel.clark@misrule.us>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
Explicitly enable or disable pyzfs during configure based on what will be packaged.  Configuration test should not make packaging fail if python-cffi is installed.

### Description
If building pyzfs package, enable pyzfs in configured, and disable if not building pyzfs.

### How Has This Been Tested?
Built locally on CentOS 7.4 with and without pyzfs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
