### PR TITLE
rename macro ZFS_MINOR due to lustre conflict

### DIFF
--- a/config/kernel-misc-minor.m4
+++ b/config/kernel-misc-minor.m4
@@ -11,15 +11,15 @@ AC_DEFUN([ZFS_AC_KERNEL_MISC_MINOR], [
 	for i in $(seq 249 -1 200); do
 		if ! grep -q "^#define\s\+.*_MINOR\s\+.*$i" \
 		    ${LINUX}/include/linux/miscdevice.h; then
-			ZFS_MINOR="$i"
-			AC_MSG_RESULT($ZFS_MINOR)
-			AC_DEFINE_UNQUOTED([ZFS_MINOR], [$ZFS_MINOR],
-			    [/dev/zfs minor])
+			ZFS_DEVICE_MINOR="$i"
+			AC_MSG_RESULT($ZFS_DEVICE_MINOR)
+			AC_DEFINE_UNQUOTED([ZFS_DEVICE_MINOR],
+			    [$ZFS_DEVICE_MINOR], [/dev/zfs minor])
 			break
 		fi
 	done
 
-	AS_IF([ test -z "$ZFS_MINOR"], [
+	AS_IF([ test -z "$ZFS_DEVICE_MINOR"], [
 		AC_MSG_ERROR([
 	*** No available misc minor numbers available for use.])
 	])

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7074,12 +7074,12 @@ static const struct file_operations zfsdev_fops = {
 };
 
 static struct miscdevice zfs_misc = {
-	.minor		= ZFS_MINOR,
+	.minor		= ZFS_DEVICE_MINOR,
 	.name		= ZFS_DRIVER,
 	.fops		= &zfsdev_fops,
 };
 
-MODULE_ALIAS_MISCDEV(ZFS_MINOR);
+MODULE_ALIAS_MISCDEV(ZFS_DEVICE_MINOR);
 MODULE_ALIAS("devname:zfs");
 
 static int
@@ -7100,7 +7100,7 @@ zfs_attach(void)
 		 */
 		printk(KERN_INFO "ZFS: misc_register() with static minor %d "
 		    "failed %d, retrying with MISC_DYNAMIC_MINOR\n",
-		    ZFS_MINOR, error);
+		    ZFS_DEVICE_MINOR, error);
 
 		zfs_misc.minor = MISC_DYNAMIC_MINOR;
 		error = misc_register(&zfs_misc);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Macro ZFS_MINOR, introduced in commit a6cc9756 to record the chosen
static minor number for /dev/zfs, conflicts with an existing macro
in Lustre.  The lustre macro (along with _MAJOR, _PATCH, _FIX) is
used to record the zfsonlinux version Lustre is being built against.

Since the Lustre macro came first, and is used in past versions of
lustre at least going back to 2.10, it makes sense to rename the
macro in ZFS instead of doing so in Lustre which would require
backporting the patch.

### Description
<!--- Describe your changes in detail -->
Rename ZFS_MINOR ZFS_DEVICE_MINOR.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Depending on automated testing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
