### PR TITLE
Add `cut` binary to the initramfs

### DIFF
--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -59,6 +59,7 @@ install() {
 	dracut_install @udevdir@/vdev_id
 	dracut_install awk
 	dracut_install basename
+	dracut_install cut
 	dracut_install head
 	dracut_install @udevdir@/zvol_id
 	inst_hook cmdline 95 "${moddir}/parse-zfs.sh"

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -87,7 +87,7 @@ install() {
 	BB=`hostid | cut -b 3,4`
 	CC=`hostid | cut -b 5,6`
 	DD=`hostid | cut -b 7,8`
-	printf "\x${DD}\x${CC}\x${BB}\x${AA}" > "${initdir}/etc/hostid"
+	echo -ne "\\x${DD}\\x${CC}\\x${BB}\\x${AA}" > "${initdir}/etc/hostid"
 
 	if dracut_module_included "systemd"; then
 		mkdir -p "${initdir}/$systemdsystemunitdir/zfs-import.target.wants"

--- a/contrib/dracut/90zfs/parse-zfs.sh.in
+++ b/contrib/dracut/90zfs/parse-zfs.sh.in
@@ -10,7 +10,7 @@ if [ -n "${spl_hostid}" ] ; then
 	BB=$(echo "${spl_hostid}" | cut -b 3,4)
 	CC=$(echo "${spl_hostid}" | cut -b 5,6)
 	DD=$(echo "${spl_hostid}" | cut -b 7,8)
-	printf "\\x%s\\x%s\\x%s\\x%s" "${DD}" "${CC}" "${BB}" "${AA}" >/etc/hostid
+	echo -ne "\\x${DD}\\x${CC}\\x${BB}\\x${AA}" >/etc/hostid
 elif [ -f "/etc/hostid" ] ; then
 	info "ZFS: Using hostid from /etc/hostid: $(hostid)"
 else


### PR DESCRIPTION
### Motivation and Context

Since the `cut -b` command is used by `parse-zfs.sh`, ensure that it is copied to the initramfs.

I tried to set the `spl_hostid` kernel cmdline parameter, but the dracut module failed since `cut` was missing.

https://github.com/zfsonlinux/zfs/blob/900d09b285107e13fa0bdb8378274dff89347181/contrib/dracut/90zfs/parse-zfs.sh.in#L9

### Description
This commit adds `cut` to the list of binaries installed by the zfs module.

### How Has This Been Tested?

Running `dracut -f initramfs` with this patch and confirming that the `cut` binary is now present in the archive. (For me, it isn't there without this patch).
```
# lsinitrd initramfs | grep bin/cut
-rwxr-xr-x   1 root     root        43664 Jul 21 22:15 bin/cut
lrwxrwxrwx   1 root     root           13 Dec  9 15:41 usr/bin/cut -> ../../bin/cut
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
