### PR TITLE
Issue 8131: Seeing negative values for wlentime

### DIFF
--- a/module/spl/spl-kstat.c
+++ b/module/spl/spl-kstat.c
@@ -261,9 +261,10 @@ kstat_seq_show_intr(struct seq_file *f, kstat_intr_t *kip)
 static int
 kstat_seq_show_io(struct seq_file *f, kstat_io_t *kip)
 {
+	/* though wlentime & friends are signed, they will never be negative */
 	seq_printf(f,
-	    "%-8llu %-8llu %-8u %-8u %-8lld %-8lld "
-	    "%-8lld %-8lld %-8lld %-8lld %-8u %-8u\n",
+	    "%-8llu %-8llu %-8u %-8u %-8llu %-8llu "
+	    "%-8llu %-8llu %-8llu %-8llu %-8u %-8u\n",
 	    kip->nread, kip->nwritten,
 	    kip->reads, kip->writes,
 	    kip->wtime, kip->wlentime, kip->wlastupdate,
@@ -277,7 +278,7 @@ static int
 kstat_seq_show_timer(struct seq_file *f, kstat_timer_t *ktp)
 {
 	seq_printf(f,
-	    "%-31s %-8llu %-8lld %-8lld %-8lld %-8lld %-8lld\n",
+	    "%-31s %-8llu %-8llu %-8llu %-8llu %-8llu %-8llu\n",
 	    ktp->name, ktp->num_events, ktp->elapsed_time,
 	    ktp->min_time, ktp->max_time,
 	    ktp->start_time, ktp->stop_time);


### PR DESCRIPTION
Linux kstat IO and TIMER printed values as signed. However the counters
only increment. Thus humans looking at the data can be confused when
the counters roll over.

Note: The recommended use of these values is to monitor the derivative,
which don't really care about the sign. See explanations related to
non-negative derivatives in the various time-series databases.

Signed-off-by: Richard Elling <Richard.Elling@RichardElling.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
