### PR TITLE
Check for strlcat and strlcpy

### DIFF
--- a/config/user.m4
+++ b/config/user.m4
@@ -21,7 +21,7 @@ AC_DEFUN([ZFS_AC_CONFIG_USER], [
 
 	ZFS_AC_TEST_FRAMEWORK
 
-	AC_CHECK_FUNCS([mlockall])
+	AC_CHECK_FUNCS([mlockall strlcat strlcpy])
 ])
 
 dnl #

--- a/lib/libspl/Makefile.am
+++ b/lib/libspl/Makefile.am
@@ -22,6 +22,8 @@ USER_C = \
 	list.c \
 	mkdirp.c \
 	page.c \
+	strlcat.c \
+	strlcpy.c \
 	timestamp.c \
 	zone.c \
 	include/sys/list.h \

--- a/lib/libspl/strlcat.c
+++ b/lib/libspl/strlcat.c
@@ -1,0 +1,60 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+#ifndef HAVE_STRLCAT
+
+#include <string.h>
+#include <sys/types.h>
+
+/*
+ * Appends src to the dstsize buffer at dst. The append will never
+ * overflow the destination buffer and the buffer will always be null
+ * terminated. Never reference beyond &dst[dstsize-1] when computing
+ * the length of the pre-existing string.
+ */
+
+size_t
+strlcat(char *dst, const char *src, size_t dstsize)
+{
+	char *df = dst;
+	size_t left = dstsize;
+	size_t l1;
+	size_t l2 = strlen(src);
+	size_t copied;
+
+	while (left-- != 0 && *df != '\0')
+		df++;
+	l1 = df - dst;
+	if (dstsize == l1)
+		return (l1 + l2);
+
+	copied = l1 + l2 >= dstsize ? dstsize - l1 - 1 : l2;
+	(void) memcpy(dst + l1, src, copied);
+	dst[l1+copied] = '\0';
+
+	return (l1 + l2);
+}
+
+#endif

--- a/lib/libspl/strlcpy.c
+++ b/lib/libspl/strlcpy.c
@@ -2,9 +2,8 @@
  * CDDL HEADER START
  *
  * The contents of this file are subject to the terms of the
- * Common Development and Distribution License, Version 1.0 only
- * (the "License").  You may not use this file except in compliance
- * with the License.
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
  *
  * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
  * or http://www.opensolaris.org/os/licensing.
@@ -19,22 +18,39 @@
  *
  * CDDL HEADER END
  */
+
 /*
- * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
+ * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
 
-#ifndef _LIBSPL_STRING_H
-#define	_LIBSPL_STRING_H
-
-#include_next <string.h>
-
-#ifndef HAVE_STRLCAT
-extern size_t strlcat(char *dst, const char *src, size_t dstsize);
-#endif
-
 #ifndef HAVE_STRLCPY
-extern size_t strlcpy(char *dst, const char *src, size_t len);
-#endif
 
-#endif
+#include <string.h>
+#include <sys/types.h>
+
+/*
+ * Copies src to the dstsize buffer at dst. The copy will never
+ * overflow the destination buffer and the buffer will always be null
+ * terminated.
+ */
+
+size_t
+strlcpy(char *dst, const char *src, size_t len)
+{
+	size_t slen = strlen(src);
+	size_t copied;
+
+	if (len == 0)
+		return (slen);
+
+	if (slen >= len)
+		copied = len - 1;
+	else
+		copied = slen;
+	(void) memcpy(dst, src, copied);
+	dst[copied] = '\0';
+	return (slen);
+}
+
+#endif /* HAVE_STRLCPY */

--- a/tests/zfs-tests/cmd/libzfs_input_check/Makefile.am
+++ b/tests/zfs-tests/cmd/libzfs_input_check/Makefile.am
@@ -10,5 +10,6 @@ pkgexec_PROGRAMS = libzfs_input_check
 
 libzfs_input_check_SOURCES = libzfs_input_check.c
 libzfs_input_check_LDADD = \
+	$(top_builddir)/lib/libspl/libspl.la \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la


### PR DESCRIPTION
### Motivation and Context

Resolve the build issues introduced by 8005ca4f7.  See the full conversation in the https://github.com/zfsonlinux/zfs/commit/8005ca4f749f71397197292452ca539a25286b89 commit comments.

### Description

This partially reverts commit 8005ca4f7 by moving the strlcat()
and strlcpy() compatibility impementations back to their original
location.

In addition, these two functions were added to the AC_CHECK_FUNCS
macro.  When these functions are available from the C library,
HAVE_STRLCAT and HAVE_STRLCPY will be defined and library version
used.  Otherwise the compatibility version is built.

### How Has This Been Tested?

Locally built on Fedora 29, pending full build results from the CI.

@BrainSlayer additional verification on the other platforms (musl) with would be welcome.  As far as I could tell in spite of [years of debate](https://lwn.net/Articles/612244/), glibc still has not yet added these functions.  So the compatibility code is needed.  There is an optional library called `libbsd` available but for the moment I'd prefer to avoid a new external dependency solely for this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
