### PR TITLE
ztest: ENOSPC in ztest_objset_destroy_cb()

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -3980,9 +3980,13 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 		VERIFY0(dsl_destroy_snapshot(name, B_TRUE));
 	} else {
 		error = dsl_destroy_head(name);
-		/* There could be a hold on this dataset */
-		if (error != EBUSY)
+		if (error == ENOSPC) {
+			/* There could be checkpoint or insufficient slop */
+			ztest_record_enospc(FTAG);
+		} else if (error != EBUSY) {
+			/* There could be a hold on this dataset */
 			ASSERT0(error);
+		}
 	}
 	return (0);
 }


### PR DESCRIPTION
### Motivation and Context

Observed while running ztest.

```
error == 0 (0x1c == 0)
ASSERT at ztest.c:3995:ztest_objset_destroy_cb()error == 0 (0x1c == 0)
```

```
#0  0x00007f8ed2569207 in raise () from /lib64/libc.so.6
#1  0x00007f8ed256a8f8 in abort () from /lib64/libc.so.6
#2  0x000000000040a9b1 in libspl_assertf (file=0x419424 "ztest.c", func=func@entry=0x41aea0 <__FUNCTION__.21479> "ztest_objset_destroy_cb", line=line@entry=3995, format=format@entry=0x41951b "%s == 0 (0x%llx == 0)", file=0x419424 "ztest.c") at ../../lib/libspl/include/assert.h:55
#3  0x000000000040b38e in ztest_objset_destroy_cb (name=name@entry=0x7f8e46595d00 "ztest/temp_17", arg=arg@entry=0x0) at ztest.c:3995
#4  0x00007f8ed3b0fbc0 in dmu_objset_find_impl (spa=<optimized out>, name=name@entry=0x7f8e46595d00 "ztest/temp_17", func=func@entry=0x40b2a0 <ztest_objset_destroy_cb>, arg=arg@entry=0x0, flags=flags@entry=3) at ../../module/zfs/dmu_objset.c:2916
#5  0x00007f8ed3b141f1 in dmu_objset_find (name=name@entry=0x7f8e46595d00 "ztest/temp_17", func=func@entry=0x40b2a0 <ztest_objset_destroy_cb>, arg=arg@entry=0x0, flags=flags@entry=3) at ../../module/zfs/dmu_objset.c:2932
#6  0x0000000000413fc0 in ztest_dmu_objset_create_destroy (zd=<optimized out>, id=17) at ztest.c:4073
#7  0x000000000040d607 in ztest_execute (id=17, zi=<optimized out>, test=<optimized out>) at ztest.c:6659
#8  ztest_thread (arg=0x11) at ztest.c:6706
#9  0x00007f8ed2907dd5 in start_thread () from /lib64/libpthread.so.0
#10 0x00007f8ed2630ead in clone () from /lib64/libc.so.6
```

### Description

While unlikely it is possible for dsl_destroy_head() to return
ENOSPC in the ztest_objset_destroy_cb().  This can occur even
when ZFS_SPACE_CHECK_DESTROY is used with the dsl_sync_task().
Both the existance of a checkpoint and pending defered frees
can cause this.

### How Has This Been Tested?

Locally built, and verified with `ztest`.  Pending CI results.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
