### PR TITLE
ZTS: fix wait_scrubbed()

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1029,7 +1029,7 @@ function get_endslice #<disk> <slice>
 
 		((endcyl = (endcyl + 1) / ratio))
 	fi
-	
+
 	echo $endcyl
 }
 
@@ -3209,15 +3209,10 @@ function wait_replacing #pool
 function wait_scrubbed
 {
 	typeset pool=${1:-$TESTPOOL}
-	typeset iter=${2:-10}
-	typeset -i i=0
-	for i in {1..$iter} ; do
-		if is_pool_scrubbed $pool ; then
-			return 0
-		fi
-		sleep 1
+	while true ; do
+		is_pool_scrubbed $pool && break
+		log_must sleep 1
 	done
-	return 1
 }
 
 # Backup the zed.rc in our test directory so that we can edit it for our test.

--- a/tests/zfs-tests/tests/functional/fault/scrub_after_resilver.ksh
+++ b/tests/zfs-tests/tests/functional/fault/scrub_after_resilver.ksh
@@ -60,5 +60,5 @@ log_must zpool replace $TESTPOOL $DISK1 $DISK3
 # Wait for the resilver to finish, and then the subsequent scrub to finish.
 # Waiting for the scrub has the effect of waiting for both.  Timeout after 10
 # seconds if nothing is happening.
-log_must wait_scrubbed $TESTPOOL 10
+log_must wait_scrubbed $TESTPOOL
 log_pass "Successfully ran the scrub after resilver zedlet"


### PR DESCRIPTION
Currently, wait_scrubbed() is the only function of its kind that
accepts a timeout, which is 10s by default. This timeout is pretty
short for a scrub and causes test failures if we run too long. This
patch remves the timeout, instead leaning on the global test suite
timeout to ensure the tests keep moving.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
