### PR TITLE
OpenZFS 9559 - zfs diff handles files on delete queue in fromsnap poorly

### DIFF
--- a/lib/libzfs/libzfs_diff.c
+++ b/lib/libzfs/libzfs_diff.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2015, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2015, 2018 by Delphix. All rights reserved.
  * Copyright 2016 Joyent, Inc.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  */
@@ -367,12 +367,12 @@ describe_free(FILE *fp, differ_info_t *di, uint64_t object, char *namebuf,
 
 	if (get_stats_for_obj(di, di->fromsnap, object, namebuf,
 	    maxlen, &sb) != 0) {
-		/* Let it slide, if in the delete queue on from side */
-		if (di->zerr == ENOENT && sb.zs_links == 0) {
-			di->zerr = 0;
-			return (0);
-		}
 		return (-1);
+	}
+	/* Don't print if in the delete queue on from side */
+	if (di->zerr == ESTALE) {
+		di->zerr = 0;
+		return (0);
 	}
 
 	print_file(fp, di, ZDIFF_REMOVED, namebuf, &sb);


### PR DESCRIPTION
### Motivation and Context

OpenZFS-issue: https://www.illumos.org/issues/9559
OpenZFS-commit: https://github.com/openzfs/openzfs/commit/d7e45412

### Description

Since the changes to zfs diff in 9421, there has been a bug in zfs diff. If a file is in the delete queue on the fromsnap, and it is deleted in the tosnap, we can print misleading messages in zfs diff's output, and hit an error case if no other files were deleted.

### How Has This Been Tested?

Locally built.  Pending CI results.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
