### PR TITLE
Minor tweaks to zfs.8 man page for POSIX ACLs

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1105,7 +1105,7 @@ To obtain the best performance when setting
 users are strongly encouraged to set the
 .Sy xattr=sa
 property. This will result in the POSIX ACL being stored more efficiently on
-disk. But as a consequence of this all new extended attributes will only be
+disk. But as a consequence, all new extended attributes will only be
 accessible from OpenZFS implementations which support the
 .Sy xattr=sa
 property. See the

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1082,7 +1082,7 @@ accordance to the requested mode from the application.
 .Pp
 The
 .Sy aclinherit
-property does not apply to posix ACLs.
+property does not apply to POSIX ACLs.
 .It Sy acltype Ns = Ns Sy off Ns | Ns Sy noacl Ns | Ns Sy posixacl
 Controls whether ACLs are enabled and if so what type of ACL to use.
 .Bl -tag -width "posixacl"
@@ -1094,8 +1094,8 @@ property set to off then ACLs are disabled.
 an alias for
 .Sy off
 .It Sy posixacl
-indicates posix ACLs should be used. Posix ACLs are specific to Linux and are
-not functional on other platforms. Posix ACLs are stored as an extended
+indicates POSIX ACLs should be used. POSIX ACLs are specific to Linux and are
+not functional on other platforms. POSIX ACLs are stored as an extended
 attribute and therefore will not overwrite any existing NFSv4 ACLs which
 may be set.
 .El
@@ -1104,7 +1104,7 @@ To obtain the best performance when setting
 .Sy posixacl
 users are strongly encouraged to set the
 .Sy xattr=sa
-property. This will result in the posix ACL being stored more efficiently on
+property. This will result in the POSIX ACL being stored more efficiently on
 disk. But as a consequence of this all new extended attributes will only be
 accessible from OpenZFS implementations which support the
 .Sy xattr=sa
@@ -2161,7 +2161,7 @@ on platforms which do not support the
 feature.
 .Pp
 The use of system attribute based xattrs is strongly encouraged for users of
-SELinux or posix ACLs. Both of these features heavily rely of extended
+SELinux or POSIX ACLs. Both of these features heavily rely of extended
 attributes and benefit significantly from the reduced access time.
 .Pp
 The values


### PR DESCRIPTION
### Motivation and Context
POSIX should be in all caps.

### Description
I capitalized POSIX in POSIX ACL. This change makes the POSIX in POSIX ACLs all caps, which is both correct and consistent with the rest of the man page.

I also tweaked a sentence to add a missing comma, and as long as I was editing, removed a couple unnecessary words.

### How Has This Been Tested?
I ran `man man/man8/zfs.8` and looked at the changed section.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).