### PR TITLE
Add missing MMP status code to libzfs_status

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -303,6 +303,8 @@ typedef enum {
 	/*
 	 * The following correspond to faults as defined in the (fault.fs.zfs.*)
 	 * event namespace.  Each is associated with a corresponding message ID.
+	 * This must be kept in sync with the zfs_msgid_table in
+	 * lib/libzfs/libzfs_status.c.
 	 */
 	ZPOOL_STATUS_CORRUPT_CACHE,	/* corrupt /kernel/drv/zpool.cache */
 	ZPOOL_STATUS_MISSING_DEV_R,	/* missing device with replicas */

--- a/lib/libzfs/libzfs_status.c
+++ b/lib/libzfs/libzfs_status.c
@@ -51,27 +51,41 @@
 
 /*
  * Message ID table.  This must be kept in sync with the ZPOOL_STATUS_* defines
- * in libzfs.h.  Note that there are some status results which go past the end
- * of this table, and hence have no associated message ID.
+ * in include/libzfs.h.  Note that there are some status results which go past
+ * the end of this table, and hence have no associated message ID.
  */
 static char *zfs_msgid_table[] = {
-	"ZFS-8000-14",
-	"ZFS-8000-2Q",
-	"ZFS-8000-3C",
-	"ZFS-8000-4J",
-	"ZFS-8000-5E",
-	"ZFS-8000-6X",
-	"ZFS-8000-72",
-	"ZFS-8000-8A",
-	"ZFS-8000-9P",
-	"ZFS-8000-A5",
-	"ZFS-8000-EY",
-	"ZFS-8000-EY",
-	"ZFS-8000-EY",
-	"ZFS-8000-HC",
-	"ZFS-8000-JQ",
-	"ZFS-8000-K4",
-	"ZFS-8000-ER",
+	"ZFS-8000-14", /* ZPOOL_STATUS_CORRUPT_CACHE */
+	"ZFS-8000-2Q", /* ZPOOL_STATUS_MISSING_DEV_R */
+	"ZFS-8000-3C", /* ZPOOL_STATUS_MISSING_DEV_NR */
+	"ZFS-8000-4J", /* ZPOOL_STATUS_CORRUPT_LABEL_R */
+	"ZFS-8000-5E", /* ZPOOL_STATUS_CORRUPT_LABEL_NR */
+	"ZFS-8000-6X", /* ZPOOL_STATUS_BAD_GUID_SUM */
+	"ZFS-8000-72", /* ZPOOL_STATUS_CORRUPT_POOL */
+	"ZFS-8000-8A", /* ZPOOL_STATUS_CORRUPT_DATA */
+	"ZFS-8000-9P", /* ZPOOL_STATUS_FAILING_DEV */
+	"ZFS-8000-A5", /* ZPOOL_STATUS_VERSION_NEWER */
+	"ZFS-8000-EY", /* ZPOOL_STATUS_HOSTID_MISMATCH */
+	"ZFS-8000-EY", /* ZPOOL_STATUS_HOSTID_ACTIVE */
+	"ZFS-8000-EY", /* ZPOOL_STATUS_HOSTID_REQUIRED */
+	"ZFS-8000-HC", /* ZPOOL_STATUS_IO_FAILURE_WAIT */
+	"ZFS-8000-JQ", /* ZPOOL_STATUS_IO_FAILURE_CONTINUE */
+	"ZFS-8000-MM", /* ZPOOL_STATUS_IO_FAILURE_MMP */
+	"ZFS-8000-K4", /* ZPOOL_STATUS_BAD_LOG */
+	"ZFS-8000-ER", /* ZPOOL_STATUS_ERRATA */
+	/*
+	 * The following results have no message ID.
+	 *	ZPOOL_STATUS_UNSUP_FEAT_READ
+	 *	ZPOOL_STATUS_UNSUP_FEAT_WRITE
+	 *	ZPOOL_STATUS_FAULTED_DEV_R
+	 *	ZPOOL_STATUS_FAULTED_DEV_NR
+	 *	ZPOOL_STATUS_VERSION_OLDER
+	 *	ZPOOL_STATUS_FEAT_DISABLED
+	 *	ZPOOL_STATUS_RESILVERING
+	 *	ZPOOL_STATUS_OFFLINE_DEV
+	 *	ZPOOL_STATUS_REMOVED_DEV
+	 *	ZPOOL_STATUS_OK
+	 */
 };
 
 #define	NMSGID	(sizeof (zfs_msgid_table) / sizeof (zfs_msgid_table[0]))

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_errata3.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_errata3.ksh
@@ -62,7 +62,8 @@ log_assert "Verify that Errata 3 is properly handled"
 
 uncompress_pool
 log_must zpool import -d /$TESTPOOL/ $POOL_NAME
-log_must eval "zpool status | grep -q Errata"
+log_must eval "zpool status $POOL_NAME | grep -q Errata"
+log_must eval "zpool status $POOL_NAME | grep -q ZFS-8000-ER"
 log_must eval "echo 'password' | zfs load-key $POOL_NAME/testfs"
 log_must eval "echo 'password' | zfs load-key $POOL_NAME/testvol"
 
@@ -95,5 +96,6 @@ log_must zfs destroy -r $POOL_NAME/testvol
 
 log_must zpool export $POOL_NAME
 log_must zpool import -d /$TESTPOOL/ $POOL_NAME
-log_mustnot eval "zpool status | grep -q Errata"
+log_mustnot eval "zpool status $POOL_NAME | grep -q Errata"
+log_mustnot eval "zpool status $POOL_NAME | grep -q ZFS-8000-ER"
 log_pass "Errata 3 is properly handled"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue #8148

### Description
<!--- Describe your changes in detail -->
When MMP was merged the status codes in libzfs_status were not
updated to add the status code for ZPOOL_STATUS_IO_FAILURE_MMP.  This
commit corrects this and adds comments to help keep track of which
code is used for which status.

TODO: A page will need to be added to the website to describe the MMP error/status

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
