### PR TITLE
Fix for current_kernel_time in 4.20 on 0.7.x

### DIFF
--- a/include/zpios-ctl.h
+++ b/include/zpios-ctl.h
@@ -181,9 +181,12 @@ zpios_timespec_t
 zpios_timespec_now(void)
 {
 	zpios_timespec_t zts_now;
-	struct timespec ts_now;
+	#if defined(HAVE_INODE_TIMESPEC64_TIMES)
+		inode_timespec_t ts_now = current_kernel_time64();
+	#else
+		inode_timespec_t ts_now = current_kernel_time();
+	#endif
 
-	ts_now = current_kernel_time();
 	zts_now.ts_sec  = ts_now.tv_sec;
 	zts_now.ts_nsec = ts_now.tv_nsec;
 


### PR DESCRIPTION
While https://github.com/zfsonlinux/spl/commit/cd1b28e0cfa923db988611df28958f7b84b53530 fixed the 4.20 current_kernel_time issues in the 0.7.x spl tree as per https://github.com/zfsonlinux/zfs/pull/8074 in 0.7.x, current_kernel_time is still being used inside zpios-ctl.h inside the 0.7.x zfs tree.

I believe this patch may fix this issue in 0.7.x to allow it to compile successfully for linux kernel 4.20.

Apologies if the coding style is inappropriate. The compiled module once so modified does work on my system, but I have not run tests on this.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

current_kernel_time needs to be updated for linux kernel 4.20 compatibility. While the 0.7.x spl's sys/include/time.h file was updated, in the 0.7.x zfs tree zpios-ctl.h also uses current_kernel_time.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixed compile for 4.20 on 0.7.x on my ubuntu system.

<!--- If it fixes an open issue, please link to the issue here. -->
The modifications as as per the issue referenced here: https://github.com/zfsonlinux/zfs/pull/8074 and also as applied in this commit: https://github.com/zfsonlinux/spl/commit/cd1b28e0cfa923db988611df28958f7b84b53530

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
(Note that this is for the 0.7.x branch and NOT for master.)
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
