### PR TITLE
Fix filesystem_limit enforcement

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1149,6 +1149,14 @@ dmu_objset_create_check(void *arg, dmu_tx_t *tx)
 
 	dsl_dir_rele(pdd, FTAG);
 
+	/*
+	 * The user credential was verified and has the required access.
+	 * It must be converted to the kcred in order for this check to
+	 * pass again when run on the callers behalf in syncing context.
+	 */
+	if (error == 0 && doca->doca_cred == CRED())
+		doca->doca_cred = kcred;
+
 	return (error);
 }
 
@@ -1332,7 +1340,15 @@ dmu_objset_clone_check(void *arg, dmu_tx_t *tx)
 	dsl_dataset_rele(origin, FTAG);
 	dsl_dir_rele(pdd, FTAG);
 
-	return (0);
+	/*
+	 * The user credential was verified and has the required access.
+	 * It must be converted to the kcred in order for this check to
+	 * pass again when run on the callers behalf in syncing context.
+	 */
+	if (error == 0 && doca->doca_cred == CRED())
+		doca->doca_cred = kcred;
+
+	return (error);
 }
 
 static void

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -1566,6 +1566,14 @@ dsl_dataset_snapshot_check(void *arg, dmu_tx_t *tx)
 		}
 	}
 
+	/*
+	 * The user credential was verified and has the required access.
+	 * It must be converted to the kcred in order for this check to
+	 * pass again when run on the callers behalf in syncing context.
+	 */
+	if (rv == 0 && ddsa->ddsa_cr == CRED())
+		ddsa->ddsa_cr = kcred;
+
 	return (rv);
 }
 
@@ -3134,6 +3142,14 @@ dsl_dataset_promote_check(void *arg, dmu_tx_t *tx)
 	    0, ss_mv_cnt, ddpa->used, ddpa->cr);
 	if (err != 0)
 		goto out;
+
+	/*
+	 * The user credential was verified and has the required access.
+	 * It must be converted to the kcred in order for this check to
+	 * pass again when run on the callers behalf in syncing context.
+	 */
+	if (err == 0 && ddpa->cr == CRED())
+		ddpa->cr = kcred;
 
 	/*
 	 * Compute the amounts of space that will be used by snapshots


### PR DESCRIPTION
### Motivation and Context

Issue #8226.  Observed 'filesystem_limit' behavior differs from that
described in the man page and code.

TODO: Investigate adding test cases for the filesystem_limit feature.

### Description

As described in the zfs(8) man page the 'filesystem_limit' does not
apply to users who are allowed to change the property.

This was incorrectly failing because unlike all other operations
the credential was being checked again outside the user context in
the syncing context.   Checking the stored user credential in a
different context will always fail on Linux.  See the comment above
priv_policy_ns() for details.

The proposed solution is to convert the CRED() to a kcred after the
secpolicy_zfs() checks succeed in the calling context.  This allows
the check to be correctly performed a second time in the syncing
context.

To my surprise test cases were apparently never written for this
features.  If there had been some this may have been caught during
the initial port, and we some look in to adding some.  For the
moment this change was manually tested.

### How Has This Been Tested?

Locally built and manually tested the failure scenario.

```
[behlendo@centos7]$ sudo zfs create -o filesystem_limit=3 tank/limited
[behlendo@centos7]$ sudo zfs allow -u behlendo create,mount tank/limited
[behlendo@centos7]$ zfs create tank/limited/fs1
[behlendo@centos7]$ zfs create tank/limited/fs2
[behlendo@centos7]$ zfs create tank/limited/fs3
[behlendo@centos7]$ zfs create tank/limited/fs4
cannot create 'tank/limited/fs4': out of space
[behlendo@centos7]$ sudo zfs create tank/limited/fs4
[behlendo@centos7]$ sudo zfs create tank/limited/fs5
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
