### PR TITLE
zfs receive and rollback can skew filesystem_count

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -289,6 +289,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/largest_pool/Makefile
 	tests/zfs-tests/tests/functional/link_count/Makefile
 	tests/zfs-tests/tests/functional/libzfs/Makefile
+	tests/zfs-tests/tests/functional/limits/Makefile
 	tests/zfs-tests/tests/functional/migration/Makefile
 	tests/zfs-tests/tests/functional/mmap/Makefile
 	tests/zfs-tests/tests/functional/mmp/Makefile

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -792,14 +792,8 @@ dsl_dir_destroy_sync(uint64_t ddobj, dmu_tx_t *tx)
 
 	ASSERT0(dsl_dir_phys(dd)->dd_head_dataset_obj);
 
-	/*
-	 * Decrement the filesystem count for all parent filesystems.
-	 *
-	 * When we receive an incremental stream into a filesystem that already
-	 * exists, a temporary clone is created.  We never count this temporary
-	 * clone, whose name begins with a '%'.
-	 */
-	if (dd->dd_myname[0] != '%' && dd->dd_parent != NULL)
+	/* Decrement the filesystem count for all parent filesystems. */
+	if (dd->dd_parent != NULL)
 		dsl_fs_ss_count_adjust(dd->dd_parent, -1,
 		    DD_FIELD_FILESYSTEM_COUNT, tx);
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -602,6 +602,11 @@ pre =
 post =
 tags = ['functional', 'largest_pool']
 
+[tests/functional/limits]
+tests = ['filesystem_count', 'filesystem_limit', 'snapshot_count',
+    'snapshot_limit']
+tags = ['functional', 'limits']
+
 [tests/functional/link_count]
 tests = ['link_count_001']
 tags = ['functional', 'link_count']

--- a/tests/zfs-tests/tests/functional/Makefile.am
+++ b/tests/zfs-tests/tests/functional/Makefile.am
@@ -32,6 +32,7 @@ SUBDIRS = \
 	large_files \
 	largest_pool \
 	libzfs \
+	limits \
 	pyzfs \
 	link_count \
 	migration \

--- a/tests/zfs-tests/tests/functional/limits/Makefile.am
+++ b/tests/zfs-tests/tests/functional/limits/Makefile.am
@@ -1,0 +1,9 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/limits
+dist_pkgdata_SCRIPTS = \
+	setup.ksh \
+	cleanup.ksh \
+	filesystem_count.ksh \
+	filesystem_limit.ksh \
+	snapshot_count.ksh \
+	snapshot_limit.ksh
+

--- a/tests/zfs-tests/tests/functional/limits/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/limits/cleanup.ksh
@@ -1,0 +1,19 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/limits/filesystem_count.ksh
+++ b/tests/zfs-tests/tests/functional/limits/filesystem_count.ksh
@@ -1,0 +1,123 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# ZFS 'filesystem_count' property is handled correctly by various actions
+#
+# STRATEGY:
+# 1. Verify 'zfs create' and 'zfs clone' increment 'filesystem_count' value
+# 2. Verify 'zfs destroy' decrements the value
+# 3. Verify 'zfs rename' updates counts across different hierarchies
+# 4. Verify 'zfs promote' preserves counts within different hierarchies
+# 5. Verify 'zfs receive' correct behaviour
+# 6. Verify 'zfs rollback' does not update 'filesystem_count' value
+# 7. Verify 'zfs diff' does not update 'filesystem_count' value
+#
+
+verify_runnable "both"
+
+function setup
+{
+	log_must zfs create "$DATASET_TEST"
+	log_must zfs create "$DATASET_UTIL"
+	# Set filesystem_limit just to activate the filesystem_count property
+	log_must zfs set filesystem_limit=100 "$DATASET_TEST"
+}
+
+function cleanup
+{
+	destroy_dataset "$DATASET_TEST" "-Rf"
+	destroy_dataset "$DATASET_UTIL" "-Rf"
+	rm -f $ZSTREAM
+}
+
+log_assert "Verify 'filesystem_count' is handled correctly by various actions"
+log_onexit cleanup
+
+DATASET_TEST="$TESTPOOL/$TESTFS/filesystem_count_test"
+DATASET_UTIL="$TESTPOOL/$TESTFS/filesystem_count_util"
+ZSTREAM="$TEST_BASE_DIR/filesystem_count.$$"
+
+# 1. Verify 'zfs create' and 'zfs clone' increment 'filesystem_count' value
+setup
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "0"
+log_must zfs create "$DATASET_TEST/create_clone"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "1"
+log_must zfs snapshot "$DATASET_TEST/create_clone@snap"
+log_must zfs clone "$DATASET_TEST/create_clone@snap" "$DATASET_TEST/clone"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "2"
+cleanup
+
+# 2. Verify 'zfs destroy' decrements the value
+setup
+log_must zfs create "$DATASET_TEST/destroy"
+log_must zfs destroy "$DATASET_TEST/destroy"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "0"
+cleanup
+
+# 3. Verify 'zfs rename' updates counts across different hierarchies
+setup
+log_must zfs create "$DATASET_TEST/rename"
+log_must zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "0"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_UTIL")" == "1"
+cleanup
+
+# 4. Verify 'zfs promote' preserves counts within different hierarchies
+setup
+log_must zfs create "$DATASET_UTIL/promote"
+log_must zfs snapshot "$DATASET_UTIL/promote@snap"
+log_must zfs clone "$DATASET_UTIL/promote@snap" "$DATASET_TEST/promoted"
+log_must zfs promote "$DATASET_TEST/promoted"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "1"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_UTIL")" == "1"
+cleanup
+
+# 5. Verify 'zfs receive' correct behaviour
+setup
+log_must zfs create "$DATASET_UTIL/send"
+log_must zfs snapshot "$DATASET_UTIL/send@snap1"
+log_must zfs snapshot "$DATASET_UTIL/send@snap2"
+log_must eval "zfs send $DATASET_UTIL/send@snap1 > $ZSTREAM"
+log_must eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "1"
+log_must eval "zfs send -i @snap1 $DATASET_UTIL/send@snap2 > $ZSTREAM"
+log_must eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "1"
+cleanup
+
+# 6. Verify 'zfs rollback' does not update 'filesystem_count' value
+setup
+log_must zfs create "$DATASET_TEST/rollback"
+log_must zfs snapshot "$DATASET_TEST/rollback@snap"
+log_must zfs rollback "$DATASET_TEST/rollback@snap"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "1"
+cleanup
+
+# 7. Verify 'zfs diff' does not update 'filesystem_count' value
+setup
+log_must zfs create "$DATASET_TEST/diff"
+log_must zfs snapshot "$DATASET_TEST/diff@snap1"
+log_must zfs snapshot "$DATASET_TEST/diff@snap2"
+log_must zfs diff "$DATASET_TEST/diff@snap1" "$DATASET_TEST/diff@snap2"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "1"
+log_must zfs diff "$DATASET_TEST/diff@snap2"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "1"
+
+log_pass "'filesystem_count' property is handled correctly"

--- a/tests/zfs-tests/tests/functional/limits/filesystem_limit.ksh
+++ b/tests/zfs-tests/tests/functional/limits/filesystem_limit.ksh
@@ -1,0 +1,84 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# ZFS 'filesystem_limit' is enforced when executing various actions
+#
+# STRATEGY:
+# 1. Verify 'zfs create' and 'zfs clone' cannot exceed the filesystem_limit
+# 2. Verify 'zfs rename' cannot move filesystems exceeding the limit
+# 3. Verify 'zfs receive' cannot exceed the limit
+#
+
+verify_runnable "both"
+
+function setup
+{
+	log_must zfs create "$DATASET_TEST"
+	log_must zfs create "$DATASET_UTIL"
+}
+
+function cleanup
+{
+	destroy_dataset "$DATASET_TEST" "-Rf"
+	destroy_dataset "$DATASET_UTIL" "-Rf"
+	rm -f $ZSTREAM
+}
+
+log_assert "Verify 'filesystem_limit' is enforced executing various actions"
+log_onexit cleanup
+
+DATASET_TEST="$TESTPOOL/$TESTFS/filesystem_limit_test"
+DATASET_UTIL="$TESTPOOL/$TESTFS/filesystem_limit_util"
+ZSTREAM="$TEST_BASE_DIR/filesystem_limit.$$"
+
+# 1. Verify 'zfs create' and 'zfs clone' cannot exceed the filesystem_limit
+setup
+log_must zfs set filesystem_limit=1 "$DATASET_TEST"
+log_must zfs create "$DATASET_TEST/create"
+log_mustnot zfs create "$DATASET_TEST/create_exceed"
+log_mustnot datasetexists "$DATASET_TEST/create_exceed"
+log_must zfs set filesystem_limit=2 "$DATASET_TEST"
+log_must zfs snapshot "$DATASET_TEST/create@snap"
+log_must zfs clone "$DATASET_TEST/create@snap" "$DATASET_TEST/clone"
+log_mustnot zfs clone "$DATASET_TEST/create@snap" "$DATASET_TEST/clone_exceed"
+log_mustnot datasetexists "$DATASET_TEST/clone_exceed"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "2"
+cleanup
+
+# 2. Verify 'zfs rename' cannot move filesystems exceeding the limit
+setup
+log_must zfs set filesystem_limit=0 "$DATASET_UTIL"
+log_must zfs create "$DATASET_TEST/rename"
+log_mustnot zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed"
+log_mustnot datasetexists "$DATASET_UTIL/renamed"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_UTIL")" == "0"
+cleanup
+
+# 3. Verify 'zfs receive' cannot exceed the limit
+setup
+log_must zfs set filesystem_limit=0 "$DATASET_TEST"
+log_must zfs create "$DATASET_UTIL/send"
+log_must zfs snapshot "$DATASET_UTIL/send@snap1"
+log_must eval "zfs send $DATASET_UTIL/send@snap1 > $ZSTREAM"
+log_mustnot eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_mustnot datasetexists "$DATASET_TEST/received"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "0"
+
+log_pass "'filesystem_limit' property is enforced"

--- a/tests/zfs-tests/tests/functional/limits/setup.ksh
+++ b/tests/zfs-tests/tests/functional/limits/setup.ksh
@@ -1,0 +1,21 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+
+default_volume_setup $DISK

--- a/tests/zfs-tests/tests/functional/limits/snapshot_count.ksh
+++ b/tests/zfs-tests/tests/functional/limits/snapshot_count.ksh
@@ -1,0 +1,100 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# ZFS 'snapshot_count' property is handled correctly by various actions
+#
+# STRATEGY:
+# 1. Verify 'zfs snapshot' increments 'snapshot_count' value
+# 2. Verify 'zfs destroy' decrements the value
+# 3. Verify 'zfs rename' updates counts across different hierarchies
+# 4. Verify 'zfs promote' updates counts across different hierarchies
+# 5. Verify 'zfs receive' correct behaviour
+#
+
+verify_runnable "both"
+
+function setup
+{
+	log_must zfs create "$DATASET_TEST"
+	log_must zfs create "$DATASET_UTIL"
+	# Set snapshot_limit just to activate the snapshot_count property
+	log_must zfs set snapshot_limit=100 "$DATASET_TEST"
+}
+
+function cleanup
+{
+	destroy_dataset "$DATASET_TEST" "-Rf"
+	destroy_dataset "$DATASET_UTIL" "-Rf"
+	rm -f $ZSTREAM
+}
+
+log_assert "Verify 'snapshot_count' is handled correctly by various actions"
+log_onexit cleanup
+
+DATASET_TEST="$TESTPOOL/$TESTFS/snapshot_count_test"
+DATASET_UTIL="$TESTPOOL/$TESTFS/snapshot_count_util"
+ZSTREAM="$TEST_BASE_DIR/snapshot_count.$$"
+
+# 1. Verify 'zfs snapshot' increments 'snapshot_count' value
+setup
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "0"
+log_must zfs snapshot "$DATASET_TEST@snap"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "1"
+cleanup
+
+# 2. Verify 'zfs destroy' decrements the value
+setup
+log_must zfs snapshot "$DATASET_TEST@snap"
+log_must zfs destroy "$DATASET_TEST@snap"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "0"
+cleanup
+
+# 3. Verify 'zfs rename' updates counts across different hierarchies
+setup
+log_must zfs create "$DATASET_TEST/renamed"
+log_must zfs snapshot "$DATASET_TEST/renamed@snap"
+log_must zfs rename "$DATASET_TEST/renamed" "$DATASET_UTIL/renamed"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "0"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_UTIL")" == "1"
+cleanup
+
+# 4. Verify 'zfs promote' updates counts across different hierarchies
+setup
+log_must zfs create "$DATASET_UTIL/promote"
+log_must zfs snapshot "$DATASET_UTIL/promote@snap"
+log_must zfs clone "$DATASET_UTIL/promote@snap" "$DATASET_TEST/promoted"
+log_must zfs promote "$DATASET_TEST/promoted"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "1"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_UTIL")" == "0"
+cleanup
+
+# 5. Verify 'zfs receive' correct behaviour
+setup
+log_must zfs create "$DATASET_UTIL/send"
+log_must zfs snapshot "$DATASET_UTIL/send@snap1"
+log_must zfs snapshot "$DATASET_UTIL/send@snap2"
+log_must eval "zfs send $DATASET_UTIL/send@snap1 > $ZSTREAM"
+log_must eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "1"
+log_must eval "zfs send -i @snap1 $DATASET_UTIL/send@snap2 > $ZSTREAM"
+log_must eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "2"
+
+log_pass "'snapshot_count' property is handled correctly"

--- a/tests/zfs-tests/tests/functional/limits/snapshot_limit.ksh
+++ b/tests/zfs-tests/tests/functional/limits/snapshot_limit.ksh
@@ -1,0 +1,99 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# ZFS 'snapshot_limit' is enforced when executing various actions
+#
+# STRATEGY:
+# 1. Verify 'zfs snapshot' cannot exceed the snapshot_limit
+# 2. Verify 'zfs rename' cannot move snapshots exceeding the limit
+# 3. Verify 'zfs promote' cannot exceed the limit
+# 4. Verify 'zfs receive' cannot exceed the limit
+#
+
+verify_runnable "both"
+
+function setup
+{
+	log_must zfs create "$DATASET_TEST"
+	log_must zfs create "$DATASET_UTIL"
+}
+
+function cleanup
+{
+	destroy_dataset "$DATASET_TEST" "-Rf"
+	destroy_dataset "$DATASET_UTIL" "-Rf"
+	rm -f $ZSTREAM
+}
+
+log_assert "Verify 'snapshot_limit' is enforced when executing various actions"
+log_onexit cleanup
+
+DATASET_TEST="$TESTPOOL/$TESTFS/snapshot_limit_test"
+DATASET_UTIL="$TESTPOOL/$TESTFS/snapshot_limit_util"
+ZSTREAM="$TEST_BASE_DIR/snapshot_limit.$$"
+
+# 1. Verify 'zfs snapshot' cannot exceed the snapshot_limit
+setup
+log_must zfs set snapshot_limit=1 "$DATASET_TEST"
+log_must zfs snapshot "$DATASET_TEST@snap"
+log_mustnot zfs snapshot "$DATASET_TEST@snap_exceed"
+log_mustnot datasetexists "$DATASET_TEST@snap_exceed"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "1"
+cleanup
+
+# 2. Verify 'zfs rename' cannot move snapshots exceeding the limit
+setup
+log_must zfs set snapshot_limit=0 "$DATASET_UTIL"
+log_must zfs create "$DATASET_TEST/rename"
+log_must zfs snapshot "$DATASET_TEST/rename@snap"
+log_mustnot zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed"
+log_mustnot datasetexists "$DATASET_UTIL/renamed"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_UTIL")" == "0"
+cleanup
+
+# 3. Verify 'zfs promote' cannot exceed the limit
+setup
+log_must zfs set snapshot_limit=0 "$DATASET_UTIL"
+log_must zfs create "$DATASET_TEST/promote"
+log_must zfs snapshot "$DATASET_TEST/promote@snap"
+log_must zfs clone "$DATASET_TEST/promote@snap" "$DATASET_UTIL/promoted"
+log_mustnot zfs promote "$DATASET_UTIL/promoted"
+log_mustnot datasetexists "$DATASET_UTIL/promoted@snap"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_UTIL")" == "0"
+cleanup
+
+# 4. Verify 'zfs receive' cannot exceed the limit
+setup
+log_must zfs set snapshot_limit=0 "$DATASET_TEST"
+log_must zfs create "$DATASET_UTIL/send"
+log_must zfs snapshot "$DATASET_UTIL/send@snap1"
+log_must eval "zfs send $DATASET_UTIL/send@snap1 > $ZSTREAM"
+log_mustnot eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_mustnot datasetexists "$DATASET_TEST/received"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "0"
+log_must zfs set snapshot_limit=1 "$DATASET_TEST"
+log_must eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must zfs snapshot "$DATASET_UTIL/send@snap2"
+log_must eval "zfs send -i @snap1 $DATASET_UTIL/send@snap2 > $ZSTREAM"
+log_mustnot eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_mustnot datasetexists "$DATASET_TEST/received@snap2"
+log_must test "$(get_prop 'snapshot_count' "$DATASET_TEST")" == "1"
+
+log_pass "'snapshot_limit' property is enforced"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`zfs rollback` and incremental `zfs receive` incorrectly increment "filesystem_count":
```
root@linux:~# sudo zfs create $POOLNAME/fs
root@linux:~# sudo zfs set filesystem_limit=10 $POOLNAME/fs
root@linux:~# sudo zfs snap $POOLNAME/fs@snap
root@linux:~# sudo zfs get filesystem_count $POOLNAME/fs
NAME         PROPERTY          VALUE    SOURCE
testpool/fs  filesystem_count  0        local
root@linux:~# for i in {1..30}; do sudo zfs rollback $POOLNAME/fs@snap; done
root@linux:~# sudo zfs get filesystem_count $POOLNAME/fs
NAME         PROPERTY          VALUE    SOURCE
testpool/fs  filesystem_count  30       local
root@linux:~# sudo zfs list -t all -r $POOLNAME/fs
NAME               USED  AVAIL     REFER  MOUNTPOINT
testpool/fs         24K  55.1M       24K  /testpool/fs
testpool/fs@snap     0B      -       24K  -
root@linux:~# 
```

After 30 `zfs rollback`s filesystem_count is 30 without and sub-dataset. This can cause the count to rapidly hit the filesystem_limit on datasets seeing many rollback and/or receive operations.

Illumos seems to be affected too:

```
loli@openindiana:~$ sudo zfs create $POOLNAME/fs
loli@openindiana:~$ sudo zfs set filesystem_limit=10 $POOLNAME/fs
loli@openindiana:~$ sudo zfs snap $POOLNAME/fs@snap
loli@openindiana:~$ sudo zfs get filesystem_count $POOLNAME/fs
NAME         PROPERTY          VALUE    SOURCE
testpool/fs  filesystem_count  0        local
loli@openindiana:~$ for i in {1..30}; do sudo zfs rollback $POOLNAME/fs@snap; done
loli@openindiana:~$ sudo zfs get filesystem_count $POOLNAME/fs
NAME         PROPERTY          VALUE    SOURCE
testpool/fs  filesystem_count  30       local
loli@openindiana:~$ sudo zfs list -t all -r $POOLNAME/fs
NAME               USED  AVAIL  REFER  MOUNTPOINT
testpool/fs         23K  55.1M    23K  /testpool/fs
testpool/fs@snap      0      -    23K  -
loli@openindiana:~$ uname -a
SunOS openindiana 5.11 master-0-g4c648f1475 i86pc i386 i86pc
loli@openindiana:~$ 
```

This change should probably fix https://www.illumos.org/issues/6254 too.

### Description
<!--- Describe your changes in detail -->

This change simply allow us to correctly decrement "filesystem_count" when destroying datasets whose name starts with the "%" character ("%recv" and "%rollback").

For instance when we perform an incremental receive the temporary dataset "%recv" is created under the existing destination:

```
root@linux:~# zfs create $POOLNAME/send
root@linux:~# zfs create $POOLNAME/recv
root@linux:~# zfs set filesystem_limit=10 $POOLNAME/recv
root@linux:~# zfs snapshot -r $POOLNAME/send@snap1
root@linux:~# zfs snapshot -r $POOLNAME/send@snap2
root@linux:~# zfs send $POOLNAME/send@snap1 | zfs recv -Fd $POOLNAME/recv
root@linux:~# zfs send -i $POOLNAME/send@snap1 $POOLNAME/send@snap2 | zfs recv -Fd $POOLNAME/recv
```

First the receive creates "$POOLNAME/recv/send/%recv" and increments filesystem_count on every parent dataset:

```
 dsl_dataset_create_sync -> dsl_dir_create_sync name="%recv"
 dsl_dir_create_sync -> dsl_fs_ss_count_adjust dd->dd_myname="send" delta=1 prop="com.joyent:filesystem_count"
 dsl_fs_ss_count_adjust -> dsl_fs_ss_count_adjust dd->dd_myname="recv" delta=1 prop="com.joyent:filesystem_count"
 dsl_fs_ss_count_adjust -> dsl_fs_ss_count_adjust dd->dd_myname="testpool" delta=1 prop="com.joyent:filesystem_count"
```

when we go to destroy the temporary "%recv" dataset, after the clone swap, we do not decrement filesystem_count because `dd->dd_myname == '%recv'`

```
 dmu_recv_end_sync -> dsl_dataset_clone_swap_sync_impl origin_head->ds_dir->dd_myname="send"
 dmu_recv_end_sync -> dsl_destroy_head_sync_impl ds->ds_dir->dd_myname="%recv"
 dsl_destroy_head_sync_impl -> dsl_dir_destroy_sync ddobj=96
*** no call to dsl_fs_ss_count_adjust() here ***
```

This skews the filesystem_count property.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Reproducer:

```
# misc functions
function is_linux() {
   if [[ "$(uname)" == "Linux" ]]; then
      return 0
   else
      return 1
   fi
}
# setup
POOLNAME='testpool'
if is_linux; then
   TMPDIR='/var/tmp'
   mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
   sudo zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
   sudo zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
else
   TMPDIR='/tmp'
   sudo zpool destroy $POOLNAME
   rm -f $TMPDIR/zpool_$POOLNAME.dat
   truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
   sudo zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
fi
sudo zfs create $POOLNAME/fs
sudo zfs set filesystem_limit=10 $POOLNAME/fs
sudo zfs snap $POOLNAME/fs@snap
sudo zfs get filesystem_count $POOLNAME/fs
for i in {1..30}; do sudo zfs rollback $POOLNAME/fs@snap; done
sudo zfs get filesystem_count $POOLNAME/fs
sudo zfs list -t all -r $POOLNAME/fs
```

Tests added to the ZFS Test Suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
