### PR TITLE
zfs.8 uses wrong snapshot names in Example 15

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -30,7 +30,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2018 Joyent, Inc.
 .\"
-.Dd July 13, 2018
+.Dd Jan 05, 2019
 .Dt ZFS 8 SMM
 .Os Linux
 .Sh NAME
@@ -4811,9 +4811,9 @@ renames the remaining snapshots, and then creates a new snapshot, as follows:
 # zfs destroy -r pool/users@7daysago
 # zfs rename -r pool/users@6daysago @7daysago
 # zfs rename -r pool/users@5daysago @6daysago
-# zfs rename -r pool/users@yesterday @5daysago
-# zfs rename -r pool/users@yesterday @4daysago
-# zfs rename -r pool/users@yesterday @3daysago
+# zfs rename -r pool/users@4daysago @5daysago
+# zfs rename -r pool/users@3daysago @4daysago
+# zfs rename -r pool/users@2daysago @3daysago
 # zfs rename -r pool/users@yesterday @2daysago
 # zfs rename -r pool/users@today @yesterday
 # zfs snapshot -r pool/users@today


### PR DESCRIPTION
### Motivation and Context
in Example 15 of zfs.8 manual the snapshot names are wrong:

```
     Example 15 Performing a Rolling Snapshot
       The following example shows how to maintain a history of snapshots with a consistent naming
       scheme.  To keep a week's worth of snapshots, the user destroys the oldest snapshot, renames
       the remaining snapshots, and then creates a new snapshot, as follows:

       # zfs destroy -r pool/users@7daysago
       # zfs rename -r pool/users@6daysago @7daysago
       # zfs rename -r pool/users@5daysago @6daysago
       # zfs rename -r pool/users@yesterday @5daysago    <<<<
       # zfs rename -r pool/users@yesterday @4daysago    <<<<
       # zfs rename -r pool/users@yesterday @3daysago    <<<<
       # zfs rename -r pool/users@yesterday @2daysago
       # zfs rename -r pool/users@today @yesterday
       # zfs snapshot -r pool/users@today
```

### Description
It should be

```
       # zfs rename -r pool/users@4daysago @5daysago
       # zfs rename -r pool/users@3daysago @4daysago
       # zfs rename -r pool/users@2daysago @3daysago
```

It's already fixed on FreeBSD: https://svnweb.freebsd.org/base/head/cddl/contrib/opensolaris/cmd/zfs/zfs.8?r1=239217&r2=239216&pathrev=239217
and a similar fix has been proposed to illumos https://www.illumos.org/issues/9623.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
