### PR TITLE
Removed suggestion to use root dataset as bootfs

### DIFF
--- a/contrib/dracut/README.dracut.markdown
+++ b/contrib/dracut/README.dracut.markdown
@@ -11,12 +11,6 @@ the dataset mountpoint property to '/'.
     $ zpool set bootfs=pool/dataset pool
     $ zfs set mountpoint=/ pool/dataset
 
-It is also possible to set the bootfs property for an entire pool, just in
-case you are not using a dedicated dataset for '/'.
-
-    $ zpool set bootfs=pool pool
-    $ zfs set mountpoint=/ pool
-
 Alternately, legacy mountpoints can be used by setting the 'root=' option
 on the kernel line of your grub.conf/menu.lst configuration file.  Then
 set the dataset mountpoint property to 'legacy'.


### PR DESCRIPTION

### Motivation and Context
The dracut howto proposed to boot from the root dataset of a pool.

Apart from this giving problems when booting (as the code seems to expect a child dataset and creates an illegal dataset name when using the root dataset) the technical limitations of the root dataset (among others the inability to rename or destroy through the `zfs` subcommand) lead to the general consensus that it's best to only use it as a container for the datasets in the pool - not as a filesystem itself.

### Description
Removed the idea to boot from the root dataset from the dracut howto.

### How Has This Been Tested?
Documentation change.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
