### PR TITLE
Bump commit subject length to 72 characters

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -164,7 +164,7 @@ coding convention.
 ### Commit Message Formats
 #### New Changes
 Commit messages for new changes must meet the following guidelines:
-* In 50 characters or less, provide a summary of the change as the
+* In 72 characters or less, provide a summary of the change as the
 first line in the commit message.
 * A body which provides a description of the change. If necessary,
 please summarize important information such as why the proposed

--- a/scripts/commitcheck.sh
+++ b/scripts/commitcheck.sh
@@ -69,10 +69,10 @@ function new_change_commit()
 {
     error=0
 
-    # subject is not longer than 50 characters
-    long_subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '.{51}')
+    # subject is not longer than 72 characters
+    long_subject=$(git log -n 1 --pretty=%s "$REF" | grep -E -m 1 '.{73}')
     if [ -n "$long_subject" ]; then
-        echo "error: commit subject over 50 characters"
+        echo "error: commit subject over 72 characters"
         error=1
     fi
 


### PR DESCRIPTION
### Motivation and Context
There's not really a reason to keep the subject length so short,
since the reason to make it this short was for making nice renders
of a summary list of the git log. With 72 characters, this still
works out fine, so let's just raise it to that so that it's easier
to give slightly more descriptive change summaries.

### Description
Raise the subject length allowed to 72 characters in git commits.

### How Has This Been Tested?
Ran the script the verify that the new length is permitted.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
