### PR TITLE
zfs filesystem skipped by df -h

### DIFF
--- a/module/zfs/zfs_vfsops.c
+++ b/module/zfs/zfs_vfsops.c
@@ -1449,6 +1449,8 @@ zfs_statvfs(struct dentry *dentry, struct kstatfs *statp)
 	 * "preferred" size.
 	 */
 
+	/* Round up so we never have a filesytem using 0 blocks. */
+	refdbytes = P2ROUNDUP(refdbytes, statp->f_bsize);
 	statp->f_blocks = (refdbytes + availbytes) >> bshift;
 	statp->f_bfree = availbytes >> bshift;
 	statp->f_bavail = statp->f_bfree; /* no root reservation */

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -656,7 +656,8 @@ tests = ['nestedfs_001_pos']
 tags = ['functional', 'nestedfs']
 
 [tests/functional/no_space]
-tests = ['enospc_001_pos', 'enospc_002_pos', 'enospc_003_pos']
+tests = ['enospc_001_pos', 'enospc_002_pos', 'enospc_003_pos',
+    'enospc_df']
 tags = ['functional', 'no_space']
 
 [tests/functional/nopwrite]

--- a/tests/zfs-tests/tests/functional/no_space/Makefile.am
+++ b/tests/zfs-tests/tests/functional/no_space/Makefile.am
@@ -4,7 +4,8 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	enospc_001_pos.ksh \
 	enospc_002_pos.ksh \
-	enospc_003_pos.ksh
+	enospc_003_pos.ksh \
+	enospc_df.ksh
 
 dist_pkgdata_DATA = \
 	enospc.cfg

--- a/tests/zfs-tests/tests/functional/no_space/enospc_df.ksh
+++ b/tests/zfs-tests/tests/functional/no_space/enospc_df.ksh
@@ -1,0 +1,73 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2014, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2019 by Datto Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/no_space/enospc.cfg
+
+#
+# DESCRIPTION:
+# After filling a filesystem, the df command produces the
+# expected result against the pool root filesystem.
+#
+# STRATEGY:
+# 1. Write a file until the child file system is full.
+# 2. Ensure that ENOSPC is returned.
+# 3. Unmount the child file system.
+# 4. Issue df -h command.
+# 5. Ensure pool root filesystem is included (issue #8253).
+# 6. Issue df -h <filesystem>.
+# 7. Ensure size and used are non-zero.
+#
+
+verify_runnable "both"
+
+log_onexit default_cleanup_noexit
+
+log_assert "Correct df output is returned when file system is full."
+
+default_setup_noexit $DISK_SMALL
+log_must zfs set compression=off $TESTPOOL/$TESTFS
+
+log_note "Writing file: $TESTFILE0 until ENOSPC."
+file_write -o create -f $TESTDIR/$TESTFILE0 -b $BLOCKSZ \
+    -c $NUM_WRITES -d $DATA
+ret=$?
+
+(( $ret != $ENOSPC )) && \
+    log_fail "$TESTFILE0 returned: $ret rather than ENOSPC."
+
+log_must zfs umount $TESTPOOL/$TESTFS
+
+# Ensure the pool root filesystem shows in df output.
+# If the pool was full (available == 0) and the pool
+# root filesytem had very little in it (used < 1 block),
+# the size reported to df was zero (issue #8253) and
+# df skipped the filesystem in its output.
+log_must eval "df -h | grep $TESTPOOL"
+
+# Confirm df size and used are non-zero.
+size=$(df -h /$TESTPOOL | grep $TESTPOOL | awk '{print $2}')
+used=$(df -h /$TESTPOOL | grep $TESTPOOL | awk '{print $3}')
+if [[ "$size" = "0" ]] || [[ "$used" = "0" ]]
+then
+	log_fail "df failed with size $size and used $used."
+fi
+log_pass "df after ENOSPC works as expected."


### PR DESCRIPTION
On full pool when pool root filesystem references very few bytes,
the f_blocks returned to statvfs is 0 but should be at least 1.

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>
Fixes #8253 

In zfs_statvfs(), ensure that f_blocks is never less than one.

### Motivation and Context
Scripts using df -h and not finding the root pool filesystem in the output, fail.

### Description
In zfs_statvfs(), round up the dataset referenced bytes to dataset block size.

### How Has This Been Tested?
Used df -h against a few different filesystems, including some in a full pool.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).