### PR TITLE
Add pyzfs BuildRequires for mock(1)

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -79,18 +79,21 @@
 # is normally Python 3, but for RHEL <= 7 only Python 2 is provided.
 %if %{undefined __use_python}
 %if 0%{?rhel} && 0%{?rhel} <= 7
-%define __python              /usr/bin/python2
-%define __python_pkg_version  2
-%define __python_cffi_pkg     python-cffi
+%define __python                  /usr/bin/python2
+%define __python_pkg_version      2
+%define __python_cffi_pkg         python-cffi
+%define __python_setuptools_pkg   python-setuptools
 %else
-%define __python              /usr/bin/python3
-%define __python_pkg_version  3
-%define __python_cffi_pkg     python3-cffi
+%define __python                  /usr/bin/python3
+%define __python_pkg_version      3
+%define __python_cffi_pkg         python3-cffi
+%define __python_setuptools_pkg   python3-setuptools
 %endif
 %else
-%define __python              %{__use_python}
-%define __python_pkg_version  %{__use_python_pkg_version}
-%define __python_cffi_pkg     python%{__python_pkg_version}-cffi
+%define __python                  %{__use_python}
+%define __python_pkg_version      %{__use_python_pkg_version}
+%define __python_cffi_pkg         python%{__python_pkg_version}-cffi
+%define __python_setuptools_pkg   python%{__python_pkg_version}-setuptools
 %endif
 
 # By default python-pyzfs is enabled, with the exception of
@@ -270,6 +273,8 @@ Requires:       python%{__python_pkg_version}
 Requires:       %{__python_cffi_pkg}
 %if 0%{?rhel}%{?fedora}%{?suse_version}
 BuildRequires:  python%{__python_pkg_version}-devel
+BuildRequires:  %{__python_cffi_pkg}
+BuildRequires:  %{__python_setuptools_pkg}
 BuildRequires:  libffi-devel
 %endif
 


### PR DESCRIPTION
### Motivation and Context

Resolve build failure when building ZFS under `mock(1)`.

### Description

When building pyzfs under mock the python-cffi and python-setuptools
packages need to be installed and have been added to the BuildRequires.

### How Has This Been Tested?

Verified `mock --rebuild` is source rpm packages works on Fedora 27, 28, 29 and CentOS 6, and 7.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
