### PR TITLE
Fix 0 byte memory leak in zfs receive

### DIFF
--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -1777,6 +1777,8 @@ receive_read_payload_and_next_header(struct receive_arg *ra, int len, void *buf)
 			ra->rrd->payload_size = len;
 			ra->rrd->bytes_read = ra->bytes_read;
 		}
+	} else {
+		ASSERT3P(buf, ==, NULL);
 	}
 
 	ra->prev_cksum = ra->cksum;
@@ -1928,8 +1930,11 @@ receive_read_record(struct receive_arg *ra)
 	{
 		struct drr_object *drro = &ra->rrd->header.drr_u.drr_object;
 		uint32_t size = DRR_OBJECT_PAYLOAD_SIZE(drro);
-		void *buf = kmem_zalloc(size, KM_SLEEP);
+		void *buf = NULL;
 		dmu_object_info_t doi;
+
+		if (size != 0)
+			buf = kmem_zalloc(size, KM_SLEEP);
 
 		err = receive_read_payload_and_next_header(ra, size, buf);
 		if (err != 0) {


### PR DESCRIPTION
Currently, when a DRR_OBJECT record is read into memory in
receive_read_record(), memory is allocated for the bonus buffer.
However, if the object doesnt have a bonus buffer the code will
still "allocate" the zero bytes, but the memory will not be passed
to the processing thread for cleanup later. This causes the spl
kmem trackking code to report a leak. This patch simply changes the
code so that it only allocates this memory if it has a non-zero
length.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### How Has This Been Tested?
On the current master (6955b40), this bug can be produced with the following script with spl kmem tracking enabled:

```
echo "password" | zfs create -o encryption=on -o keyformat=passphrase -V 1g pool/crypt
sleep 1
dd if=/dev/urandom of=/dev/zvol/pool/crypt bs=1M count=1 status=none
zfs snapshot pool/crypt@1
dd if=/dev/urandom of=/dev/zvol/pool/crypt bs=1M count=1 seek=1 status=none
zfs snapshot pool/crypt@2
dd if=/dev/urandom of=/dev/zvol/pool/crypt bs=1M count=1 seek=2 status=none
zfs snapshot pool/crypt@3
zfs send -w pool/crypt@1 | zfs recv pool/recv
echo "password" | zfs load-key pool/recv
zfs send -cI pool/crypt@1 pool/crypt@2 | zfs recv pool/recv
zfs send -wI pool/crypt@2 pool/crypt@3 | zfs recv pool/recv
dd if=/dev/zvol/pool/recv of=/dev/null bs=1M
zpool destroy -f pool
modprobe -r zfs
```

The leak can then be found in `dmesg`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
