### PR TITLE
ZTS: zpool_resilver_restart

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/zpool_resilver.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/zpool_resilver.cfg
@@ -27,4 +27,4 @@ export DISK1=$(echo $DISKS | nawk '{print $1}')
 export DISK2=$(echo $DISKS | nawk '{print $2}')
 export DISK3=$(echo $DISKS | nawk '{print $3}')
 
-export MAXTIMEOUT=80
+export MAXTIMEOUT=300

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/zpool_resilver_restart.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/zpool_resilver_restart.ksh
@@ -33,7 +33,7 @@
 #	"Verify 'zpool resilver' restarts in-progress resilvers"
 #
 # STRATEGY:
-#	1. Write some data and detatch the first drive so it has resilver
+#	1. Write some data and detach the first drive so it has resilver
 #	   work to do
 #	2. Repeat the process with a second disk
 #	3. Reattach the drives, causing the second drive's resilver to be
@@ -56,7 +56,7 @@ log_assert "Verify 'zpool resilver' restarts in-progress resilvers"
 
 mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
 
-# 1. Write some data and detatch the first drive so it has resilver work to do
+# 1. Write some data and detach the first drive so it has resilver work to do
 log_must file_write -b 524288 -c 1024 -o create -d 0 -f $mntpnt/biggerfile1
 log_must sync
 log_must zpool detach $TESTPOOL $DISK2


### PR DESCRIPTION
### Motivation and Context

Debug recent timeouts in this test case observed on the
coverage builder.

http://build.zfsonlinux.org/tgrid?length=100&branch=master&category=Tests&rev_order=desc

### Description

Since the vdev initialize feature was integrated the ZTS
`zpool_resilver_restart` test has been failing.  But only on the
coverage builder.  This test has always taken longer on this
builder so we're going to increase the timeout to prevent any
false positives.

~The vdev initialize functionally should not have slowed down
this case this.  This change is primary to debug the issue.~

### How Has This Been Tested?

```sh
$ ./scripts/zfs-tests.sh -T zpool_resilver
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/setup (run as root) [00:02] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/zpool_resilver_bad_args (run as root) [00:02] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/zpool_resilver_restart (run as root) [00:35] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/cli_root/zpool_resilver/cleanup (run as root) [00:00] [PASS]

Results Summary
PASS	   4
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
