### PR TITLE
ztest creates partially initialized root dataset

### DIFF
--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -457,6 +457,11 @@ dsl_pool_create(spa_t *spa, nvlist_t *zplprops, dsl_crypto_params_t *dcp,
 	int err;
 	dsl_pool_t *dp = dsl_pool_open_impl(spa, txg);
 	dmu_tx_t *tx = dmu_tx_create_assigned(dp, txg);
+#ifdef _KERNEL
+	objset_t *os;
+#else
+	objset_t *os __attribute__((unused));
+#endif
 	dsl_dataset_t *ds;
 	uint64_t obj;
 
@@ -520,15 +525,12 @@ dsl_pool_create(spa_t *spa, nvlist_t *zplprops, dsl_crypto_params_t *dcp,
 	/* create the root objset */
 	VERIFY0(dsl_dataset_hold_obj_flags(dp, obj,
 	    DS_HOLD_FLAG_DECRYPT, FTAG, &ds));
+	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
+	os = dmu_objset_create_impl(dp->dp_spa, ds,
+	    dsl_dataset_get_blkptr(ds), DMU_OST_ZFS, tx);
+	rrw_exit(&ds->ds_bp_rwlock, FTAG);
 #ifdef _KERNEL
-	{
-		objset_t *os;
-		rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
-		os = dmu_objset_create_impl(dp->dp_spa, ds,
-		    dsl_dataset_get_blkptr(ds), DMU_OST_ZFS, tx);
-		rrw_exit(&ds->ds_bp_rwlock, FTAG);
-		zfs_create_fs(os, kcred, zplprops, tx);
-	}
+	zfs_create_fs(os, kcred, zplprops, tx);
 #endif
 	dsl_dataset_rele_flags(ds, DS_HOLD_FLAG_DECRYPT, FTAG);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since d8fdfc2 was integrated `dsl_pool_create()` does not call `dmu_objset_create_impl()` for the root dataset when running in userland (`ztest`): this creates a pool with a partially initialized root dataset. Trying to import and use this pool results in both `zpool` and `zfs` executables dumping core.

```
root@linux:~# cat /proc/sys/kernel/spl/gitrev 
zfs-0.8.0-rc2-65-g6955b40
root@linux:~# ztest -p issue -T 10 -f /var/tmp/ -v 1 -s 128m -k 0 > /dev/null 2>&1
root@linux:~# echo $?
0
root@linux:~# zpool import -d /var/tmp/ issue
Aborted
root@linux:~# zfs list
Aborted
root@linux:~# ulimit -c unlimited 
root@linux:~# zfs list
Aborted (core dumped)
root@linux:~# gdb -q zfs core 
Reading symbols from zfs...done.
[New LWP 27733]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `zfs list'.
Program terminated with signal SIGABRT, Aborted.
#0  0x00007f01922c1067 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56	../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  0x00007f01922c1067 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007f01922c2448 in __GI_abort () at abort.c:89
#2  0x00007f01930a1ed6 in make_dataset_handle_common (zhp=0x253d480, zc=0x7ffc25c96ea0) at libzfs_dataset.c:450
#3  0x00007f01930a2075 in make_dataset_handle (hdl=0x2533060, path=0x2534d30 "issue") at libzfs_dataset.c:488
#4  0x00007f019309e024 in zfs_iter_root (hdl=0x2533060, func=0x405738 <zfs_callback>, data=0x7ffc25c9a4e0) at libzfs_config.c:449
#5  0x00000000004062db in zfs_for_each (argc=0, argv=0x2534cf0, flags=6, types=(ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT | ZFS_TYPE_VOLUME), sortcol=0x0, proplist=0x7ffc25c9a610, limit=0, callback=0x40c9ba <list_callback>, data=0x7ffc25c9a600) at zfs_iter.c:440
#6  0x000000000040cdbe in zfs_do_list (argc=0, argv=0x2534cf0) at zfs_main.c:3420
#7  0x00000000004163fa in main (argc=2, argv=0x7ffc25c9a788) at zfs_main.c:8042
(gdb) frame 2
#2  0x00007f01930a1ed6 in make_dataset_handle_common (zhp=0x253d480, zc=0x7ffc25c96ea0) at libzfs_dataset.c:450
450			abort();
(gdb) list
445		else if (zhp->zfs_dmustats.dds_type == DMU_OST_ZFS)
446			zhp->zfs_head_type = ZFS_TYPE_FILESYSTEM;
447		else if (zhp->zfs_dmustats.dds_type == DMU_OST_OTHER)
448			return (-1);
449		else
450			abort();
451	
452		if (zhp->zfs_dmustats.dds_is_snapshot)
453			zhp->zfs_type = ZFS_TYPE_SNAPSHOT;
454		else if (zhp->zfs_dmustats.dds_type == DMU_OST_ZVOL)
(gdb) p zhp->zfs_name 
$1 = "issue", '\000' <repeats 250 times>
(gdb) p zhp->zfs_dmustats.dds_type
$2 = DMU_OST_NONE
(gdb) 
```

This was discovered while testing #8181 (see buildbot ztest failures)

### Description
<!--- Describe your changes in detail -->
Fix this by adopting an alternative change suggested in OpenZFS 8607 code review (https://www.illumos.org/rb/r/666/#comment2909).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Run `ztest`, import "ztest" pool

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
