### PR TITLE
Fix filesystem_limit enforcement

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1144,8 +1144,14 @@ dmu_objset_create_check(void *arg, dmu_tx_t *tx)
 		return (error);
 	}
 
+	/*
+	 * The user credential can only be verified correctly in open context
+	 * because Linux provides and interface to check the *current* process
+	 * credentials; when in syncing context we use the kcred which allows
+	 * the same checks to pass successfully.
+	 */
 	error = dsl_fs_ss_limit_check(pdd, 1, ZFS_PROP_FILESYSTEM_LIMIT, NULL,
-	    doca->doca_cred);
+	    dmu_tx_is_syncing(tx) ? kcred : doca->doca_cred);
 
 	dsl_dir_rele(pdd, FTAG);
 

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -2005,8 +2005,16 @@ dsl_dir_rename_check(void *arg, dmu_tx_t *tx)
 			return (SET_ERROR(EINVAL));
 		}
 
+		/*
+		 * The user credential can only be verified correctly in open
+		 * context because Linux provides and interface to check the
+		 * *current* process credentials; when in syncing context we
+		 * use the kcred which allows the same checks to pass
+		 * successfully.
+		 */
 		error = dsl_dir_transfer_possible(dd->dd_parent,
-		    newparent, fs_cnt, ss_cnt, myspace, ddra->ddra_cred);
+		    newparent, fs_cnt, ss_cnt, myspace,
+		    dmu_tx_is_syncing(tx) ? kcred : ddra->ddra_cred);
 		if (error != 0) {
 			dsl_dir_rele(newparent, FTAG);
 			dsl_dir_rele(dd, FTAG);

--- a/tests/zfs-tests/tests/functional/limits/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/limits/cleanup.ksh
@@ -15,5 +15,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/delegate/delegate_common.kshlib
 
+cleanup_user_group
 default_cleanup

--- a/tests/zfs-tests/tests/functional/limits/filesystem_limit.ksh
+++ b/tests/zfs-tests/tests/functional/limits/filesystem_limit.ksh
@@ -15,10 +15,12 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/delegate/delegate_common.kshlib
 
 #
 # DESCRIPTION:
 # ZFS 'filesystem_limit' is enforced when executing various actions
+# NOTE: the limit should *not* be enforced if the user is allowed to change it.
 #
 # STRATEGY:
 # 1. Verify 'zfs create' and 'zfs clone' cannot exceed the filesystem_limit
@@ -30,8 +32,19 @@ verify_runnable "both"
 
 function setup
 {
-	log_must zfs create "$DATASET_TEST"
-	log_must zfs create "$DATASET_UTIL"
+	# We can't delegate 'mount' privs under Linux: to avoid issues with
+	# commands that may need to (re)mount datasets we set mountpoint=none
+	if is_linux; then
+		log_must zfs create -o mountpoint=none "$DATASET_TEST"
+		log_must zfs create -o mountpoint=none "$DATASET_UTIL"
+	else
+		log_must zfs create "$DATASET_TEST"
+		log_must zfs create "$DATASET_UTIL"
+	fi
+	log_must zfs allow -d -l $STAFF1 'create,mount,rename,clone,receive' \
+	    "$DATASET_TEST"
+	log_must zfs allow -d -l $STAFF1 'create,mount,rename,clone,receive' \
+	    "$DATASET_UTIL"
 }
 
 function cleanup
@@ -50,25 +63,39 @@ ZSTREAM="$TEST_BASE_DIR/filesystem_limit.$$"
 
 # 1. Verify 'zfs create' and 'zfs clone' cannot exceed the filesystem_limit
 setup
+# NOTE: we allow 'canmount' to the non-root user so we can use 'log_must' with
+# 'user_run zfs create -o canmount=off' successfully
+log_must zfs allow -d -l $STAFF1 'canmount' "$DATASET_TEST"
 log_must zfs set filesystem_limit=1 "$DATASET_TEST"
-log_must zfs create "$DATASET_TEST/create"
-log_mustnot zfs create "$DATASET_TEST/create_exceed"
+log_must user_run $STAFF1 zfs create -o canmount=off "$DATASET_TEST/create"
+log_mustnot user_run $STAFF1 zfs create -o canmount=off "$DATASET_TEST/create_exceed"
 log_mustnot datasetexists "$DATASET_TEST/create_exceed"
 log_must zfs set filesystem_limit=2 "$DATASET_TEST"
 log_must zfs snapshot "$DATASET_TEST/create@snap"
-log_must zfs clone "$DATASET_TEST/create@snap" "$DATASET_TEST/clone"
-log_mustnot zfs clone "$DATASET_TEST/create@snap" "$DATASET_TEST/clone_exceed"
+log_must user_run $STAFF1 zfs clone -o canmount=off "$DATASET_TEST/create@snap" "$DATASET_TEST/clone"
+log_mustnot user_run $STAFF1 zfs clone -o canmount=off "$DATASET_TEST/create@snap" "$DATASET_TEST/clone_exceed"
 log_mustnot datasetexists "$DATASET_TEST/clone_exceed"
 log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "2"
+# Verify filesystem_limit is *not* enforced for users allowed to change it
+log_must zfs create "$DATASET_TEST/create_notenforced_root"
+log_must zfs allow -l $STAFF1 'filesystem_limit' "$DATASET_TEST"
+log_must user_run $STAFF1 zfs create -o canmount=off "$DATASET_TEST/create_notenforced_user"
+log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "4"
 cleanup
 
 # 2. Verify 'zfs rename' cannot move filesystems exceeding the limit
 setup
 log_must zfs set filesystem_limit=0 "$DATASET_UTIL"
 log_must zfs create "$DATASET_TEST/rename"
-log_mustnot zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed"
+log_mustnot user_run $STAFF1 zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed"
 log_mustnot datasetexists "$DATASET_UTIL/renamed"
 log_must test "$(get_prop 'filesystem_count' "$DATASET_UTIL")" == "0"
+# Verify filesystem_limit is *not* enforced for users allowed to change it
+log_must zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed_notenforced_root"
+log_must zfs rename "$DATASET_UTIL/renamed_notenforced_root" "$DATASET_TEST/rename"
+log_must zfs allow -l $STAFF1 'filesystem_limit' "$DATASET_UTIL"
+log_must user_run $STAFF1 zfs rename "$DATASET_TEST/rename" "$DATASET_UTIL/renamed_notenforced_user"
+log_must datasetexists "$DATASET_UTIL/renamed_notenforced_user"
 cleanup
 
 # 3. Verify 'zfs receive' cannot exceed the limit
@@ -77,8 +104,14 @@ log_must zfs set filesystem_limit=0 "$DATASET_TEST"
 log_must zfs create "$DATASET_UTIL/send"
 log_must zfs snapshot "$DATASET_UTIL/send@snap1"
 log_must eval "zfs send $DATASET_UTIL/send@snap1 > $ZSTREAM"
-log_mustnot eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_mustnot user_run $STAFF1 eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
 log_mustnot datasetexists "$DATASET_TEST/received"
 log_must test "$(get_prop 'filesystem_count' "$DATASET_TEST")" == "0"
+# Verify filesystem_limit is *not* enforced for users allowed to change it
+log_must eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must zfs destroy -r "$DATASET_TEST/received"
+log_must zfs allow -l $STAFF1 'filesystem_limit' "$DATASET_TEST"
+log_must user_run $STAFF1 eval "zfs receive $DATASET_TEST/received < $ZSTREAM"
+log_must datasetexists "$DATASET_TEST/received"
 
 log_pass "'filesystem_limit' property is enforced"

--- a/tests/zfs-tests/tests/functional/limits/setup.ksh
+++ b/tests/zfs-tests/tests/functional/limits/setup.ksh
@@ -15,7 +15,14 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/delegate/delegate_common.kshlib
 
 DISK=${DISKS%% *}
+
+cleanup_user_group
+
+# Create staff group and user
+log_must add_group $STAFF_GROUP
+log_must add_user $STAFF_GROUP $STAFF1
 
 default_volume_setup $DISK


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #8226 
Alternative version #8228

`filesystem_limit` should not be enforced for users allowed to change it.

Current behaviour:
```
root@linux:~# # misc functions
root@linux:~# function is_linux() {
>    if [[ "$(uname)" == "Linux" ]]; then
>       return 0
>    else
>       return 1
>    fi
> }
root@linux:~# # setup
root@linux:~# POOLNAME='testpool'
root@linux:~# if is_linux; then
>    TMPDIR='/var/tmp'
>    mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/zpool_$POOLNAME.dat
>    truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> else
>    TMPDIR='/tmp'
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/zpool_$POOLNAME.dat
>    truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> fi
root@linux:~# useradd staff1
root@linux:~# sudo zfs create -o filesystem_limit=3 $POOLNAME/limited
root@linux:~# sudo zfs allow -u staff1 create,mount $POOLNAME/limited
root@linux:~# zfs create $POOLNAME/limited/fs1
root@linux:~# zfs create $POOLNAME/limited/fs2
root@linux:~# zfs create $POOLNAME/limited/fs3
root@linux:~# zfs create $POOLNAME/limited/fs4
cannot create 'testpool/limited/fs4': out of space
root@linux:~# zfs create $POOLNAME/limited/fs4
cannot create 'testpool/limited/fs4': out of space
root@linux:~# zfs create $POOLNAME/limited/fs5
cannot create 'testpool/limited/fs5': out of space
root@linux:~# 
```

Patch applied:
```
root@linux:~# modprobe zfs
root@linux:~# # misc functions
root@linux:~# function is_linux() {
>    if [[ "$(uname)" == "Linux" ]]; then
>       return 0
>    else
>       return 1
>    fi
> }
root@linux:~# # setup
root@linux:~# POOLNAME='testpool'
root@linux:~# if is_linux; then
>    TMPDIR='/var/tmp'
>    mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/zpool_$POOLNAME.dat
>    truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> else
>    TMPDIR='/tmp'
>    zpool destroy $POOLNAME
>    rm -f $TMPDIR/zpool_$POOLNAME.dat
>    truncate -s 128m $TMPDIR/zpool_$POOLNAME.dat
>    zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
> fi
cannot open 'testpool': no such pool
root@linux:~# useradd staff1
root@linux:~# sudo zfs create -o filesystem_limit=3 $POOLNAME/limited
root@linux:~# sudo zfs allow -u staff1 create,mount $POOLNAME/limited
root@linux:~# zfs create $POOLNAME/limited/fs1
root@linux:~# zfs create $POOLNAME/limited/fs2
root@linux:~# zfs create $POOLNAME/limited/fs3
root@linux:~# zfs create $POOLNAME/limited/fs4
root@linux:~# zfs create $POOLNAME/limited/fs4
cannot create 'testpool/limited/fs4': dataset already exists
root@linux:~# zfs create $POOLNAME/limited/fs5
```

### Description
<!--- Describe your changes in detail -->
The proposed solution is to verify the `CRED()` only in open context and then use the `kcred` for the same `secpolicy_zfs()` checks in syncing context: this allows the check to be correctly performed a second time while still verifying the caller credentials.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Update ZFS Test Suite

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
