### PR TITLE
Update vdev_is_spacemap_addressable() for new spacemap encoding

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3804,13 +3804,17 @@ vdev_get_child_stat_ex(vdev_t *cvd, vdev_stat_ex_t *vsx, vdev_stat_ex_t *cvsx)
 boolean_t
 vdev_is_spacemap_addressable(vdev_t *vd)
 {
+	if (spa_feature_is_active(vd->vdev_spa, SPA_FEATURE_SPACEMAP_V2))
+		return (B_TRUE);
+
 	/*
-	 * Assuming 47 bits of the space map entry dedicated for the entry's
-	 * offset (see description in space_map.h), we calculate the maximum
-	 * address that can be described by a space map entry for the given
-	 * device.
+	 * If double-word space map entries are not enabled we assume
+	 * 47 bits of the space map entry are dedicated to the entry's
+	 * offset (see SM_OFFSET_BITS in space_map.h). We then use that
+	 * to calculate the maximum address that can be described by a
+	 * space map entry for the given device.
 	 */
-	uint64_t shift = vd->vdev_ashift + 47;
+	uint64_t shift = vd->vdev_ashift + SM_OFFSET_BITS;
 
 	if (shift >= 63) /* detect potential overflow */
 		return (B_TRUE);

--- a/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_sm_scale.ksh
+++ b/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_sm_scale.ksh
@@ -12,21 +12,21 @@
 #
 
 #
-# Copyright (c) 2017 by Delphix. All rights reserved.
+# Copyright (c) 2017, 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/pool_checkpoint/pool_checkpoint.kshlib
 
 #
 # DESCRIPTION:
-#	The maximum address that can be described by the current space
-#	map design (assuming the minimum 512-byte addressable storage)
-#	limits the maximum allocatable space of any top-level vdev to
-#	64PB whenever a vdev-wide space map is used.
+#	The maximum address that can be described by a single-word
+#	space map entry limits the maximum allocatable space of any
+#	top-level vdev to 64PB whenever a vdev-wide space map is used.
 #
 #	Since a vdev-wide space map is introduced for the checkpoint
-#	we want to ensure that we cannot checkpoint a pool that has a
-#	top-level vdev with more than 64PB of allocatable space.
+#	we want to ensure that we cannot checkpoint a pool that does
+#	not use the new space map encoding (V2) and has a top-level
+#	vdev with more than 64PB of allocatable space.
 #
 #	Note: Since this is a pool created from file-based vdevs we
 #	      are guaranteed that vdev_ashift  is SPA_MINBLOCKSHIFT
@@ -35,11 +35,24 @@
 #
 # STRATEGY:
 #	1. Create pool with a disk of exactly 64PB
-#	   (so ~63.5PB of allocatable space)
+#	   (so ~63.5PB of allocatable space) and
+#	   ensure that has the checkpoint feature
+#	   enabled but not space map V2
 #	2. Ensure that you can checkpoint it
 #	3. Create pool with a disk of exactly 65PB
-#	   (so ~64.5PB of allocatable space)
+#	   (so ~64.5PB of allocatable space) with
+#	   the same setup
 #	4. Ensure we fail trying to checkpoint it
+#
+# Note:
+# This test used to create the two pools and attempt to checkpoint
+# them at the same time, then destroy them. We later had to change
+# this to test one pool at a time as the metaslabs (even though empty)
+# consumed a lot of memory, especially on a machine that has been
+# running with debug enabled. To give an example, each metaslab
+# structure is ~1712 bytes (at the time of this writing), and each
+# vdev has 128K metaslabs, which means that just the structures
+# consume 131071 * 1712 = ~224M.
 #
 
 verify_runnable "global"
@@ -65,10 +78,15 @@ log_must zfs create $DISKFS
 log_must mkfile -n $((64 * 1024 * 1024))g $DISK64PB
 log_must mkfile -n $((65 * 1024 * 1024))g $DISK65PB
 
-log_must zpool create $TESTPOOL1 $DISK64PB
-log_must zpool create $TESTPOOL2 $DISK65PB
-
+log_must zpool create -d $TESTPOOL1 $DISK64PB
+log_must zpool set feature@zpool_checkpoint=enabled $TESTPOOL1
 log_must zpool checkpoint $TESTPOOL1
-log_mustnot zpool checkpoint $TESTPOOL2
+destroy_pool $TESTPOOL1
 
-log_pass "Attempting to checkpoint a pool with a vdev that's more than 64PB."
+log_must zpool create -d $TESTPOOL2 $DISK65PB
+log_must zpool set feature@zpool_checkpoint=enabled $TESTPOOL2
+log_mustnot zpool checkpoint $TESTPOOL2
+destroy_pool $TESTPOOL2
+
+log_pass "Fail to checkpoint pool with old spacemap encoding" \
+    " and a vdev that's more than 64PB."


### PR DESCRIPTION
Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>

### Motivation and Context
The Storage Pool Checkpoint feature was limited due to the old spacemap encoding and could not be used with pools that have a vdev that is more than 64PB. There is also a test case in ZTS that tests the aforementioned functionality.

### Description
Since the new spacemap encoding was ported to ZoL that's no longer a limitation. This patch updates `vdev_is_spacemap_addressable()` that was performing that check.

It also updates the appropriate test to ensure that the same functionality is tested.
The test does so by creating pools that don't have the new spacemap encoding enabled - just the checkpoint feature. This patch also reorganizes that same tests in order to cut in half its memory consumption.

Note: This is patch is part of a series of side-fixes and refactoring that will make the upstreaming of the Log Spacemap project easier.

### How Has This Been Tested?
- Compiled the patch and then run the test case in Linux
- Code has been in DelphixOS and running in production for a while now. It was introduced as part of the Log Spacemap project.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
