### PR TITLE
Make zdb results for checkpoint tests consistent

### DIFF
--- a/tests/zfs-tests/tests/functional/pool_checkpoint/pool_checkpoint.kshlib
+++ b/tests/zfs-tests/tests/functional/pool_checkpoint/pool_checkpoint.kshlib
@@ -324,8 +324,19 @@ function fragment_after_checkpoint_and_verify
 	#
 	log_must zpool list -v
 
-	log_must zdb $NESTEDPOOL
-	log_must zdb -kc $NESTEDPOOL
+	#
+	# Typically we would just run zdb at this point and things
+	# would be fine. Unfortunately, if there is still any
+	# background I/O in the pool the zdb command can fail with
+	# checksum errors temporarily.
+	#
+	# Export the pool when running zdb so the pool is idle and
+	# the verification results are consistent.
+	#
+	log_must zpool export $NESTEDPOOL
+	log_must zdb -e -p $FILEDISKDIR $NESTEDPOOL
+	log_must zdb -e -p $FILEDISKDIR -kc $NESTEDPOOL
+	log_must zpool import -d $FILEDISKDIR $NESTEDPOOL
 }
 
 function wait_discard_finish


### PR DESCRIPTION
Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>

### Description

For the heavy checkpoint tests in ZTS we ran zdb after exposing the pool to different workloads and then ran zdb to ensure that the pool's state is consistent. The problem is that sometimes there is still so I/Os going on while zdb is running that rarely this can cause zdb to temporarily get checksum errors. This results in these tests failing once in a while.

This patch exports and re-imports the pool when these tests are analyzed with zdb to get consistent results.

### How Has This Been Tested?
- Compiled ZoL and ran the checkpoint tests successfully
- The change has been in DelphixOS for some time now (DLPX-51539)

Note: This is patch is part of a series of side-fixes and refactoring that will make the upstreaming of the Log Spacemap project easier.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
