### PR TITLE
Document guidelines for usage of zfs_dbgmsg

### DIFF
--- a/include/sys/zfs_debug.h
+++ b/include/sys/zfs_debug.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_ZFS_DEBUG_H
@@ -58,6 +58,22 @@ extern int zfs_dbgmsg_enable;
 extern void __zfs_dbgmsg(char *buf);
 extern void __dprintf(boolean_t dprint, const char *file, const char *func,
     int line, const char *fmt, ...);
+
+/*
+ * Some general principles for using zfs_dbgmsg():
+ * 1. We don't want to pollute the log with typically-irrelevant messages,
+ *    so don't print too many messages in the "normal" code path - O(1)
+ *    per txg.
+ * 2. We want to know for sure what happened, so make the message specific
+ *    (e.g. *which* thing am I operating on).
+ * 3. Do print a message when something unusual or unexpected happens
+ *    (e.g. error cases).
+ * 4. Print a message when making user-initiated on-disk changes.
+ *
+ * Note that besides principle 1, another reason that we don't want to
+ * use zfs_dbgmsg in high-frequency routines is the potential impact
+ * that it can have on performance.
+ */
 #define	zfs_dbgmsg(...) \
 	if (zfs_dbgmsg_enable) \
 		__dprintf(B_FALSE, __FILE__, __func__, __LINE__, __VA_ARGS__)


### PR DESCRIPTION
Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>

Note: The actual contents of the comment were written by Matt Ahrens
on a chat log. The comment was introduced later in the Log Spacemap
commit on DelphixOS (see delphix/delphix-os@fe7bf6c).

### How Has This Been Tested?
- Compiled and ran checkstyle

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
