### PR TITLE
[ZFS 0.7.x] Allow debuginfo option to be set in sysconfig file

### DIFF
--- a/scripts/dkms.mkconf
+++ b/scripts/dkms.mkconf
@@ -65,6 +65,10 @@ PRE_BUILD="configure
       then
         echo --enable-debug-dmu-tx
       fi
+      if [[ \${ZFS_DKMS_ENABLE_DEBUGINFO,,} == @(y|yes) ]]
+      then
+        echo --enable-debuginfo
+      fi
     }
   )
 "


### PR DESCRIPTION
### Motivation and Context
On some Linux distributions, the kernel module build will not
default to building with debuginfo symbols, which can make it
difficult for debugging and testing.

For this case, we provide a flag to override the build to force
debuginfo to be produced for the kernel module build.

This has already been fixed in master for zfs-0.8.0, this fixes it for zfs-0.7.x

### Description
* Cherry-pick e45c1734a665e571599781811a0cd3128a550226 into zfs-0.7-release.

### How Has This Been Tested?
I built the tree with this change and added the `ZFS_DKMS_ENABLE_DEBUGINFO=yes` flag to `/etc/sysconfig/zfs` and verified it forced debuginfo to be generated.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
