### PR TITLE
Fix zpool iostat -w queue names in man page

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -1767,10 +1767,10 @@ Display latency histograms:
 Total IO time (queuing + disk IO time).
 .Ar disk_wait :
 Disk IO time (time reading/writing the disk).
-.Ar syncq_wait :
+.Ar sync_queue :
 Amount of time IO spent in synchronous priority queues.  Does not include
 disk time.
-.Ar asyncq_wait :
+.Ar async_queue :
 Amount of time IO spent in asynchronous priority queues.  Does not include
 disk time.
 .Ar scrub :
@@ -1782,10 +1782,10 @@ Include average latency statistics:
 Average total IO time (queuing + disk IO time).
 .Ar disk_wait :
 Average disk IO time (time reading/writing the disk).
-.Ar syncq_wait :
+.Ar sync_queue :
 Average amount of time IO spent in synchronous priority queues. Does
 not include disk time.
-.Ar asyncq_wait :
+.Ar async_queue :
 Average amount of time IO spent in asynchronous priority queues.
 Does not include disk time.
 .Ar scrub :


### PR DESCRIPTION
### Motivation and Context
The `zpool` man page is wrong.

### Description
Update the `zpool` man page to use the correct `sync_queue` and `async_queue` column names instead of the incorrect `syncq_wait` and `asyncq_wait`.

```
tank         total_wait     disk_wait    sync_queue    async_queue
latency      read  write   read  write   read  write   read  write  scrub
----------  -----  -----  -----  -----  -----  -----  -----  -----  -----
1ns             0      0      0      0      0      0      0      0      0
3ns             0      0      0      0      0      0      0      0      0
```

### How Has This Been Tested?
Viewed man page

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
