### PR TITLE
Search and replace GUID in initramfs script

### DIFF
--- a/contrib/initramfs/scripts/zfs.in
+++ b/contrib/initramfs/scripts/zfs.in
@@ -878,7 +878,9 @@ mountroot()
 	pool="$("${ZPOOL}" get name,guid -o name,value -H | \
 	    awk -v pool="${ZFS_RPOOL}" '$2 == pool { print $1 }')"
 	if [ -n "$pool" ]; then
-		ZFS_BOOTFS="${pool}/${ZFS_BOOTFS#*/}"
+		# If $ZFS_BOOTFS contains guid, replace the guid portion with $pool
+		ZFS_BOOTFS=$(echo "$ZFS_BOOTFS" | \
+			sed -e "s/$("${ZPOOL}" get guid -o value "$pool" -H)/$pool/g")
 		ZFS_RPOOL="${pool}"
 	fi
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix a mailing list reported regression (http://list.zfsonlinux.org/pipermail/zfs-discuss/2019-January/033049.html) following #8052 for a user who kept root pool data in the root dataset.

### Description
<!--- Describe your changes in detail -->
After #8052, ZFS_BOOTFS and ZFS_RPOOL values are reconstructed following a sed command that ensures $pool is the pool name, not a GUID. This broke a user's root pool setup,  who used the zfs root dataset as their root.  After #8052, initramfs attempted to mount rpool/rpool, instead of just rpool.  This is corrected by doing a search and replace for only the GUID value within ZFS_BOOTFS and ZFS_RPOOL instead, leaving everything else alone.  As mailing responses indicate, this should not be considered a best practice for root pool layout, however it is valid and did work in the past.

### How Has This Been Tested?
Installed Ubuntu 18.04.1 to root of dataset
-- Note: Ubuntu's update-grub added a trailing "/" that needed to be manually removed from kernel line
System booted as expected.
Edited the grub.cfg and replaced kernel line pool name with pool GUID
System booted as expected.
Checked for regressions by moving data from root dataset to "rpool/ROOT/ubuntu" and set the kernel line appropriately.
System booted as expected.
Edited the grub.cfg kernel line to "\<GUID\>/ROOT/ubuntu"
System booted as expected.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
