### PR TITLE
Introduce auxiliary metaslab histograms

### DIFF
--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -119,6 +119,7 @@ void metaslab_group_histogram_remove(metaslab_group_t *, metaslab_t *);
 void metaslab_group_alloc_decrement(spa_t *, uint64_t, void *, int, int,
     boolean_t);
 void metaslab_group_alloc_verify(spa_t *, const blkptr_t *, void *, int);
+void metaslab_recalculate_weight_and_sort(metaslab_t *);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/space_map.h
+++ b/include/sys/space_map.h
@@ -201,6 +201,7 @@ int space_map_iterate(space_map_t *sm, uint64_t length,
 int space_map_incremental_destroy(space_map_t *sm, sm_cb_t callback, void *arg,
     dmu_tx_t *tx);
 
+boolean_t space_map_histogram_verify(space_map_t *sm, range_tree_t *rt);
 void space_map_histogram_clear(space_map_t *sm);
 void space_map_histogram_add(space_map_t *sm, range_tree_t *rt,
     dmu_tx_t *tx);


### PR DESCRIPTION
    Introduce auxiliary metaslab histograms

    This patch introduces 3 new histograms per metaslab. These
    histograms track segments that have made it to the metaslab's
    space map histogram (and are part of the spacemap) but have
    not yet reached the ms_allocatable tree on loaded metaslab's
    because these metaslab's are currently syncing and haven't
    gone through metaslab_sync_done() yet.

    The histograms help when we decide whether to load an unloaded
    metaslab in-order to allocate from it. When calculating the
    weight of an unloaded metaslab traditionally, we look at the
    highest bucket of its spacemap's histogram.  The problem is
    that we are not guaranteed to be able to allocated that
    segment when we load the metaslab because it may still be at
    the freeing, freed, or defer trees. The new histograms are
    used when we try to calculate an unloaded metaslab's weight
    to deal with this issue by removing segments that have would
    not be in the allocatable tree at runtime. Note, that this
    method of dealing with this is not completely accurate as
    adjacent segments are not always consolidated in the space
    map histogram of a metaslab.

    In addition and to make things deterministic, we always reset
    the weight of unloaded metaslabs based on their space map
    weight (instead of doing that on a need basis). Thus, every
    time a metaslab is loaded and its weight is reset again (from
    the weight based on its space map to the one based on its
    allocatable range tree) we expect (and assert) that this
    change in weight can only get better if it doesn't stay the
    same.

Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>

### Side Note

This patch is part of a series of side-fixes and refactoring that are part of the Log Spacemap commit in DelphixOS (see delphix/delphix-os@fe7bf6c) and is separated from it to make upstreaming of the actual feature easier.

### How Has This Been Tested?
- Compiled in ZoL and ran ZTS internally
- Has been running in DelphixOS as part of the Log Spacemap commit for a while now

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
