### PR TITLE
Make init scripts work properly for Debian+OpenRC setup.

### DIFF
--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -308,8 +308,7 @@ do_start()
 
 # ----------------------------------------------------
 
-if [ ! -e /sbin/openrc-run ]
-then
+if ! (echo @SHELL@ | grep openrc 1>/dev/null 2>/dev/null); then
 	case "$1" in
 		start)
 			do_start

--- a/etc/init.d/zfs-mount.in
+++ b/etc/init.d/zfs-mount.in
@@ -199,8 +199,7 @@ do_stop()
 
 # ----------------------------------------------------
 
-if [ ! -e /sbin/openrc-run ]
-then
+if ! (echo @SHELL@ | grep openrc 1>/dev/null 2>/dev/null); then
 	case "$1" in
 		start)
 			do_start

--- a/etc/init.d/zfs-share.in
+++ b/etc/init.d/zfs-share.in
@@ -58,7 +58,7 @@ do_stop()
 
 # ----------------------------------------------------
 
-if [ ! -e /sbin/openrc-run ]; then
+if ! (echo @SHELL@ | grep openrc 1>/dev/null 2>/dev/null); then
 	case "$1" in
 		start)
 			do_start

--- a/etc/init.d/zfs-zed.in
+++ b/etc/init.d/zfs-zed.in
@@ -98,7 +98,7 @@ do_reload()
 
 # ----------------------------------------------------
 
-if [ ! -e /sbin/openrc-run ]; then
+if ! (echo @SHELL@ | grep openrc 1>/dev/null 2>/dev/null); then
 	case "$1" in
 		start)
 			do_start


### PR DESCRIPTION


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required for the init scripts to correctly work for Debian + OpenRC setup.
It amends the problematic detection code for the init script executor.
<!--- If it fixes an open issue, please link to the issue here. -->
Closes: https://github.com/zfsonlinux/zfs/issues/8204

### Description
<!--- Describe your changes in detail -->
Previous version unconditionally do things in the way of openrc-run once `/sbin/openrc-run` is detected. However, on a Debian system with openrc installed, openrc-run is still not used as the default init script executor. The patched code determines the code branch to use during build time instead of runtime.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested the patch by running these init scripts in a virtual machine.
<!--- Include details of your testing environment, and the tests you ran to -->
Debian unstable + sysvinit-core: works
Debian unstable + openrc: works
<!--- see how your change affects other areas of the code, etc. -->
I don't think this change would affect any other code.
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
