### PR TITLE
Pool allocation classes misplacing small file blocks

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1521,9 +1521,11 @@ This feature must be enabled to be used
 .Pc .
 .It Sy special_small_blocks Ns = Ns Em size
 This value represents the threshold block size for including small file
-blocks into the special allocation class. Valid values are zero or a
-power of two from 512B up to 128K. The default size is 0 which means no
-small file blocks will be allocated in the special class.
+blocks into the special allocation class. Blocks smaller than or equal to this
+value will be assigned to the special allocation class while greater blocks
+will be assigned to the regular class. Valid values are zero or a power of two
+from 512B up to 128K. The default size is 0 which means no small file blocks
+will be allocated in the special class.
 .Pp
 Before setting this property, a special class vdev must be added to the
 pool. See

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1851,7 +1851,7 @@ spa_preferred_class(spa_t *spa, uint64_t size, dmu_object_type_t objtype,
 	 * zfs_special_class_metadata_reserve_pct exclusively for metadata.
 	 */
 	if (DMU_OT_IS_FILE(objtype) &&
-	    has_special_class && size < special_smallblk) {
+	    has_special_class && size <= special_smallblk) {
 		metaslab_class_t *special = spa_special_class(spa);
 		uint64_t alloc = metaslab_class_get_alloc(special);
 		uint64_t space = metaslab_class_get_space(special);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #8351 

NOTE: i am not sure this fix is correct, maybe the way it is currently implemented is already "working as intended" and we just need to update the man page, but the "alloc_class_012_pos" test case seems to suggest that setting `recordsize == special_small_blocks` should force allocations on the special vdev (which is *almost* not happening):

```
Test: /usr/share/zfs/zfs-tests/tests/functional/alloc_class/alloc_class_012_pos (run as root) [00:19] [PASS]
06:26:25.65 ASSERTION: Removing a special device from a pool succeeds.
06:26:25.65 SUCCESS: disk_setup
06:26:25.80 SUCCESS: zpool create testpool /mnt/device-0 /mnt/device-1 /mnt/device-2 special /mnt/device-3 special /mnt/device-4
06:26:27.83 SUCCESS: display_status testpool
06:26:27.86 SUCCESS: zfs create -o special_small_blocks=32K -o recordsize=32K testpool/testfs
06:26:28.01 SUCCESS: dd if=/dev/urandom of=/testpool/testfs/testfile.1 bs=1M count=25
06:26:28.31 SUCCESS: dd if=/dev/urandom of=/testpool/testfs/testfile.2 bs=1M count=50
06:26:29.45 SUCCESS: dd if=/dev/urandom of=/testpool/testfs/testfile.3 bs=1M count=75
06:26:30.68 SUCCESS: dd if=/dev/urandom of=/testpool/testfs/testfile.4 bs=1M count=100
06:26:30.89 SUCCESS: zpool sync testpool
06:26:30.89 SUCCESS: sync_pool testpool
06:26:30.89 NAME              SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
06:26:30.89 testpool         3.75G   251M  3.50G        -         -     0%     6%  1.00x    ONLINE  -
06:26:30.89   /mnt/device-0   960M  85.2M   875M        -         -     0%  8.88%      -  ONLINE  
06:26:30.89   /mnt/device-1   960M  79.1M   881M        -         -     0%  8.23%      -  ONLINE  
06:26:30.89   /mnt/device-2   960M  85.7M   874M        -         -     0%  8.92%      -  ONLINE  
06:26:30.89 special              -      -      -        -         -      -      -      -  -
06:26:30.89   /mnt/device-3   480M   426K   480M        -         -     0%  0.08%      -  ONLINE  
06:26:30.89   /mnt/device-4   480M   428K   480M        -         -     0%  0.08%      -  ONLINE  
06:26:30.90 SUCCESS: zpool list -v testpool
```

### Description
<!--- Describe your changes in detail -->
Due to an off-by-one condition in `spa_preferred_class()` we are picking the "normal" allocation class instead of the "special" one for file blocks with size equal to the special_small_blocks property value.

This change fix the small code issue, update the ZFS Test Suite and the zfs(8) man page.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

When `recordsize == special_small_blocks` file blocks are placed in the special vdev:

```
root@linux:~# POOLNAME='testpool'
root@linux:~# TMPDIR='/var/tmp'
root@linux:~# mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
root@linux:~# zpool destroy $POOLNAME
cannot open 'testpool': no such pool
root@linux:~# rm -f $TMPDIR/zpool_$POOLNAME.*.dat
root@linux:~# truncate -s 128m $TMPDIR/zpool_$POOLNAME.normal.dat
root@linux:~# truncate -s 128m $TMPDIR/zpool_$POOLNAME.special.dat
root@linux:~# zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.normal.dat special $TMPDIR/zpool_$POOLNAME.special.dat
root@linux:~# zfs create -o mountpoint=/mnt/specialfs -o recordsize=32K -o special_small_blocks=32K $POOLNAME/specialfs
root@linux:~# dd if=/dev/zero of=/mnt/specialfs/zero bs=1M count=10
10+0 records in
10+0 records out
10485760 bytes (10 MB) copied, 0.046305 s, 226 MB/s
root@linux:~# zpool list -v
NAME                                    SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
testpool                                224M  9.96M   214M        -         -     0%     4%  1.00x    ONLINE  -
  /var/tmp/zpool_testpool.normal.dat    112M      0   112M        -         -     0%  0.00%      -  ONLINE  
special                                    -      -      -        -         -      -      -      -  -
  /var/tmp/zpool_testpool.special.dat   112M  9.96M   102M        -         -     3%  8.89%      -  ONLINE  
root@linux:~# 
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
