### PR TITLE
kernel_fpu fixes

### DIFF
--- a/config/kernel-fpu.m4
+++ b/config/kernel-fpu.m4
@@ -12,25 +12,49 @@ dnl # Pre-4.2:	Use kernel_fpu_{begin,end}()
 dnl #		HAVE_KERNEL_FPU & KERNEL_EXPORTS_X86_FPU
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_FPU], [
-	AC_MSG_CHECKING([which kernel_fpu function to use])
+	AC_MSG_CHECKING([which kernel_fpu header to use])
 	ZFS_LINUX_TRY_COMPILE([
+		#include <linux/module.h>
+		#include <asm/fpu/api.h>
+	],[
+	],[
+		AC_DEFINE(HAVE_KERNEL_FPU_API_HEADER, 1, [kernel has asm/fpu/api.h])
+		AC_MSG_RESULT(asm/fpu/api.h)
+	],[
+		AC_MSG_RESULT(i387.h & xcr.h)
+	])
+
+	AC_MSG_CHECKING([which kernel_fpu function to use])
+	ZFS_LINUX_TRY_COMPILE_SYMBOL([
+		#include <linux/module.h>
+		#ifdef HAVE_KERNEL_FPU_API_HEADER
+		#include <asm/fpu/api.h>
+		#else
 		#include <asm/i387.h>
 		#include <asm/xcr.h>
+		#endif
+		MODULE_LICENSE("$ZFS_META_LICENSE");
 	],[
 		kernel_fpu_begin();
 		kernel_fpu_end();
-	],[
+	], [kernel_fpu_begin], [arch/x86/kernel/fpu/core.c], [
 		AC_MSG_RESULT(kernel_fpu_*)
 		AC_DEFINE(HAVE_KERNEL_FPU, 1, [kernel has kernel_fpu_* functions])
 		AC_DEFINE(KERNEL_EXPORTS_X86_FPU, 1, [kernel exports FPU functions])
 	],[
-		ZFS_LINUX_TRY_COMPILE([
-			#include <linux/kernel.h>
+		ZFS_LINUX_TRY_COMPILE_SYMBOL([
+			#include <linux/module.h>
+			#ifdef HAVE_KERNEL_FPU_API_HEADER
 			#include <asm/fpu/api.h>
+			#else
+			#include <asm/i387.h>
+			#include <asm/xcr.h>
+			#endif
+			MODULE_LICENSE("$ZFS_META_LICENSE");
 		],[
 			__kernel_fpu_begin();
 			__kernel_fpu_end();
-		],[
+		], [__kernel_fpu_begin], [arch/x86/kernel/fpu/core.c arch/x86/kernel/i387.c], [
 			AC_MSG_RESULT(__kernel_fpu_*)
 			AC_DEFINE(HAVE_UNDERSCORE_KERNEL_FPU, 1, [kernel has __kernel_fpu_* functions])
 			AC_DEFINE(KERNEL_EXPORTS_X86_FPU, 1, [kernel exports FPU functions])

--- a/include/linux/simd_x86.h
+++ b/include/linux/simd_x86.h
@@ -81,9 +81,16 @@
 #endif
 
 #if defined(_KERNEL)
-#if defined(HAVE_UNDERSCORE_KERNEL_FPU)
+
+#if defined(HAVE_KERNEL_FPU_API_HEADER)
 #include <asm/fpu/api.h>
 #include <asm/fpu/internal.h>
+#else
+#include <asm/i387.h>
+#include <asm/xcr.h>
+#endif
+
+#if defined(HAVE_UNDERSCORE_KERNEL_FPU)
 #define	kfpu_begin()		\
 {							\
 	preempt_disable();		\
@@ -95,8 +102,6 @@
 	preempt_enable();		\
 }
 #elif defined(HAVE_KERNEL_FPU)
-#include <asm/i387.h>
-#include <asm/xcr.h>
 #define	kfpu_begin()	kernel_fpu_begin()
 #define	kfpu_end()		kernel_fpu_end()
 #else


### PR DESCRIPTION
### Motivation and Context
This patch fixes a few issues when detecting which kernel_fpu functions are available.

### Description
- Use `kernel_fpu_begin()` if it's exported on newer kernels.

- Use `ZFS_LINUX_TRY_COMPILE_SYMBOL()` to choose the right kernel_fpu  function when using `--enable-linux-builtin`.

Signed-off-by: Tony Hutter <hutter2@llnl.gov>
Closes: #8259

### How Has This Been Tested?
I verified the correct kernel_fpu functions were used in a number of test configurations:

Fedora 30 (rawhide):  Tested a normal build, a build with kernel_fpu_begin() GPL-exported, and a build with --enable-linux-builtin.  
Fedora 28: Tested a normal build.
Centos 6.8: Tested a normal build.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
