### PR TITLE
flake8 pass

### DIFF
--- a/tests/test-runner/bin/test-runner.py
+++ b/tests/test-runner/bin/test-runner.py
@@ -71,13 +71,13 @@ class Result(object):
         if killed:
             self.result = 'KILLED'
             Result.runresults['KILLED'] += 1
-        elif self.returncode is 0:
+        elif self.returncode == 0:
             self.result = 'PASS'
             Result.runresults['PASS'] += 1
-        elif self.returncode is 4:
+        elif self.returncode == 4:
             self.result = 'SKIP'
             Result.runresults['SKIP'] += 1
-        elif self.returncode is not 0:
+        elif self.returncode != 0:
             self.result = 'FAIL'
             Result.runresults['FAIL'] += 1
 
@@ -278,7 +278,7 @@ class Cmd(object):
         write_log(bytearray(result_line, encoding='utf-8'), LOG_FILE)
         if not options.quiet:
             write_log(result_line, LOG_OUT)
-        elif options.quiet and self.result.result is not 'PASS':
+        elif options.quiet and self.result.result != 'PASS':
             write_log(result_line, LOG_OUT)
 
         lines = sorted(self.result.stdout + self.result.stderr,
@@ -369,7 +369,7 @@ class Test(Cmd):
         cont = True
         if len(pretest.pathname):
             pretest.run(options)
-            cont = pretest.result.result is 'PASS'
+            cont = pretest.result.result == 'PASS'
             pretest.log(options)
 
         if cont:
@@ -448,7 +448,7 @@ class TestGroup(Test):
                           "because it failed verification.\n" %
                           (test, self.pathname), LOG_ERR)
 
-        return len(self.tests) is not 0
+        return len(self.tests) != 0
 
     def run(self, options):
         """
@@ -470,7 +470,7 @@ class TestGroup(Test):
         cont = True
         if len(pretest.pathname):
             pretest.run(options)
-            cont = pretest.result.result is 'PASS'
+            cont = pretest.result.result == 'PASS'
             pretest.log(options)
 
         for fname in self.tests:
@@ -586,7 +586,7 @@ class TestRun(object):
                 for prop in TestGroup.props:
                     for sect in ['DEFAULT', section]:
                         if config.has_option(sect, prop):
-                            if prop is "tags":
+                            if prop == "tags":
                                 setattr(testgroup, prop,
                                         eval(config.get(sect, prop)))
                             else:
@@ -676,7 +676,7 @@ class TestRun(object):
             return
 
         global LOG_FILE_OBJ
-        if options.cmd is not 'wrconfig':
+        if options.cmd != 'wrconfig':
             try:
                 old = os.umask(0)
                 os.makedirs(self.outputdir, mode=0o777)
@@ -712,12 +712,12 @@ class TestRun(object):
             iteration += 1
 
     def summary(self):
-        if Result.total is 0:
+        if Result.total == 0:
             return 2
 
         print('\nResults Summary')
         for key in list(Result.runresults.keys()):
-            if Result.runresults[key] is not 0:
+            if Result.runresults[key] != 0:
                 print('%s\t% 4d' % (key, Result.runresults[key]))
 
         m, s = divmod(time() - self.starttime, 60)
@@ -787,7 +787,7 @@ def verify_user(user):
 
     p = Popen(testcmd)
     p.wait()
-    if p.returncode is not 0:
+    if p.returncode != 0:
         write_log("Warning: user '%s' cannot use passwordless sudo.\n" % user,
                   LOG_ERR)
         return False
@@ -824,18 +824,18 @@ def fail(retstr, ret=1):
 def options_cb(option, opt_str, value, parser):
     path_options = ['runfile', 'outputdir', 'template', 'testdir']
 
-    if option.dest is 'runfile' and '-w' in parser.rargs or \
-            option.dest is 'template' and '-c' in parser.rargs:
+    if option.dest == 'runfile' and '-w' in parser.rargs or \
+            option.dest == 'template' and '-c' in parser.rargs:
         fail('-c and -w are mutually exclusive.')
 
     if opt_str in parser.rargs:
         fail('%s may only be specified once.' % opt_str)
 
-    if option.dest is 'runfile':
+    if option.dest == 'runfile':
         parser.values.cmd = 'rdconfig'
-    if option.dest is 'template':
+    if option.dest == 'template':
         parser.values.cmd = 'wrconfig'
-    if option.dest is 'tags':
+    if option.dest == 'tags':
         value = [x.strip() for x in value.split(',')]
 
     setattr(parser.values, option.dest, value)
@@ -904,11 +904,11 @@ def main():
     options = parse_args()
     testrun = TestRun(options)
 
-    if options.cmd is 'runtests':
+    if options.cmd == 'runtests':
         find_tests(testrun, options)
-    elif options.cmd is 'rdconfig':
+    elif options.cmd == 'rdconfig':
         testrun.read(options)
-    elif options.cmd is 'wrconfig':
+    elif options.cmd == 'wrconfig':
         find_tests(testrun, options)
         testrun.write(options)
         exit(0)

--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -312,7 +312,7 @@ def process_results(pathname):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) is not 2:
+    if len(sys.argv) != 2:
         usage('usage: %s <pathname>' % sys.argv[0])
     results = process_results(sys.argv[1])
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
testing fix for #8365

### Description
<!--- Describe your changes in detail -->
F632 use ==/!= to compare str, bytes, and int literals

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
`make flake8` locally tested on gentoo with flake8 3.6.0 python 3.6.5, could not reproduce but fixing to see if style bot is happy

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
