### PR TITLE
zstreamdump: -d option is not documented in manpage

### DIFF
--- a/man/man8/zstreamdump.8
+++ b/man/man8/zstreamdump.8
@@ -9,7 +9,7 @@ zstreamdump \- filter data in zfs send stream
 .SH SYNOPSIS
 .LP
 .nf
-\fBzstreamdump\fR [\fB-C\fR] [\fB-v\fR]
+\fBzstreamdump\fR [\fB-C\fR] [\fB-v\fR] [\fB-d\fR]
 .fi
 
 .SH DESCRIPTION
@@ -17,7 +17,7 @@ zstreamdump \- filter data in zfs send stream
 .LP
 The \fBzstreamdump\fR utility reads from the output of the \fBzfs send\fR
 command, then displays headers and some statistics from that output.  See
-\fBzfs\fR(1M).
+\fBzfs\fR(8).
 .SH OPTIONS
 .sp
 .LP
@@ -40,6 +40,16 @@ Suppress the validation of checksums.
 .sp .6
 .RS 4n
 Verbose. Dump all headers, not only begin and end headers.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-d\fR\fR
+.ad
+.sp .6
+.RS 4n
+Dump contents of blocks modified. Implies verbose.
 .RE
 
 .SH SEE ALSO


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. Decide to investigate pool allocation classes handling of spill blocks
2. Read some docs on spill blocks
3. Find http://open-zfs.org/wiki/Documentation/ZfsSend, realize `zstreamdump` has a `-d` option
4. Never heard of `zstreamdump -d`, decide to read the manpage
5. Discover `zstreamdump -d` is not documented in the manpage

### Description
<!--- Describe your changes in detail -->

This change simply documents the missing -d (dump contents) option in zstreamdump(8).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Executed `man man/man8/zstreamdump.8` on the updated manpage.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
