### PR TITLE
zvol: allow rename of in use ZVOL dataset

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -2252,12 +2252,6 @@ zvol_rename_minors_impl(const char *oldname, const char *newname)
 
 		mutex_enter(&zv->zv_state_lock);
 
-		/* If in use, leave alone */
-		if (zv->zv_open_count > 0) {
-			mutex_exit(&zv->zv_state_lock);
-			continue;
-		}
-
 		if (strcmp(zv->zv_name, oldname) == 0) {
 			zvol_rename_minor(zv, newname);
 		} else if (strncmp(zv->zv_name, oldname, oldnamelen) == 0 &&

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -887,8 +887,8 @@ tags = ['functional', 'zvol', 'zvol_cli']
 [tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
     'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos',
-    'zvol_misc_hierarchy', 'zvol_misc_snapdev', 'zvol_misc_volmode',
-    'zvol_misc_zil']
+    'zvol_misc_hierarchy', 'zvol_misc_rename_inuse', 'zvol_misc_snapdev',
+    'zvol_misc_volmode', 'zvol_misc_zil']
 tags = ['functional', 'zvol', 'zvol_misc']
 
 [tests/functional/zvol/zvol_swap]

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/Makefile.am
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/Makefile.am
@@ -9,6 +9,7 @@ dist_pkgdata_SCRIPTS = \
 	zvol_misc_005_neg.ksh \
 	zvol_misc_006_pos.ksh \
 	zvol_misc_hierarchy.ksh \
+	zvol_misc_rename_inuse.ksh \
 	zvol_misc_snapdev.ksh \
 	zvol_misc_volmode.ksh \
 	zvol_misc_zil.ksh

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/cleanup.ksh
@@ -36,4 +36,6 @@ verify_runnable "global"
 
 default_zvol_cleanup
 
+[[ -d $TESTDIR ]] && rm -rf $TESTDIR
+
 log_pass

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/setup.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/setup.ksh
@@ -36,4 +36,6 @@ verify_runnable "global"
 
 default_zvol_setup $DISK $VOLSIZE
 
+log_must mkdir $TESTDIR
+
 log_pass

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
@@ -54,7 +54,6 @@ function cleanup
 	ismounted $TESTDIR $NEWFS_DEFAULT_FS
 	(( $? == 0 )) && log_must umount $TESTDIR
 
-	[[ -e $TESTDIR ]] && rm -rf $TESTDIR
 	zfs set volsize=$volsize $TESTPOOL/$TESTVOL
 }
 
@@ -70,7 +69,6 @@ log_must zfs set volsize=128m $TESTPOOL/$TESTVOL
 echo "y" | newfs -v ${ZVOL_RDEVDIR}/$TESTPOOL/$TESTVOL >/dev/null 2>&1
 (( $? != 0 )) && log_fail "Unable to newfs(1M) $TESTPOOL/$TESTVOL"
 
-log_must mkdir $TESTDIR
 log_must mount ${ZVOL_DEVDIR}/$TESTPOOL/$TESTVOL $TESTDIR
 
 typeset -i fn=0

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_rename_inuse.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_rename_inuse.ksh
@@ -1,0 +1,71 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/zvol/zvol_common.shlib
+. $STF_SUITE/tests/functional/zvol/zvol_misc/zvol_misc_common.kshlib
+
+#
+# DESCRIPTION:
+# Verify 'zfs rename' works on a ZVOL already in use as block device
+#
+# STRATEGY:
+# 1. Create a ZVOL
+# 2. Create a filesystem on the ZVOL device and mount it
+# 3. Rename the ZVOL dataset
+# 4. Receive a send stream with the same name as the old ZVOL dataset and verify
+#    we don't trigger any issue like the one reported in #6263
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must umount "$MNTPFS"
+	log_must rmdir "$MNTPFS"
+	for ds in "$SENDFS" "$ZVOL" "$ZVOL-renamed"; do
+		destroy_dataset "$ds" '-rf'
+	done
+	udev_wait
+}
+
+log_assert "Verify 'zfs rename' works on a ZVOL already in use as block device"
+log_onexit cleanup
+
+ZVOL="$TESTPOOL/vol.$$"
+ZDEV="$ZVOL_DEVDIR/$ZVOL"
+MNTPFS="$TESTDIR/zvol_inuse_rename"
+SENDFS="$TESTPOOL/sendfs.$$"
+
+# 1. Create a ZVOL
+log_must zfs create -V $VOLSIZE "$ZVOL"
+
+# 2. Create a filesystem on the ZVOL device and mount it
+udev_wait
+log_must eval "echo y | newfs $ZDEV >/dev/null 2>&1"
+log_must mkdir "$MNTPFS"
+log_must mount "$ZDEV" "$MNTPFS"
+
+# 3. Rename the ZVOL dataset
+log_must zfs rename "$ZVOL" "$ZVOL-renamed"
+
+# 4. Receive a send stream with the same name as the old ZVOL dataset and verify
+#    we don't trigger any issue like the one reported in #6263
+log_must zfs create "$SENDFS"
+log_must zfs snap "$SENDFS@snap"
+log_must eval "zfs send $SENDFS@snap | zfs recv $ZVOL"
+
+log_pass "Renaming in use ZVOL works successfully"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #6263

### Description
<!--- Describe your changes in detail -->

NOTE: this is a tentative fix.

While ZFS allow renaming of in use ZVOLs at the DSL level without issues the ZVOL layer does not correctly update the renamed dataset if the device node is open (zv->zv_open_count > 0): trying to access the stale dataset name, for instance during a zfs receive, will cause the following failure:

```
VERIFY3(zv->zv_objset->os_dsl_dataset->ds_owner == zv) failed ((null) == ffff8800dbb6fc00)
PANIC at zvol.c:1255:zvol_resume()
Showing stack for process 1390
CPU: 0 PID: 1390 Comm: zfs Tainted: P           O  3.16.0-4-amd64 #1 Debian 3.16.51-3
Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
 0000000000000000 ffffffff8151ea00 ffffffffa0758a80 ffff88028aefba30
 ffffffffa0417219 ffff880037179220 ffffffff00000030 ffff88028aefba40
 ffff88028aefb9e0 2833594649524556 6f5f767a3e2d767a 6f3e2d7465736a62
Call Trace:
 [<0>] ? dump_stack+0x5d/0x78
 [<0>] ? spl_panic+0xc9/0x110 [spl]
 [<0>] ? mutex_lock+0xe/0x2a
 [<0>] ? zfs_refcount_remove_many+0x1ad/0x250 [zfs]
 [<0>] ? rrw_exit+0xc8/0x2e0 [zfs]
 [<0>] ? mutex_lock+0xe/0x2a
 [<0>] ? dmu_objset_from_ds+0x9a/0x250 [zfs]
 [<0>] ? dmu_objset_hold_flags+0x71/0xc0 [zfs]
 [<0>] ? zvol_resume+0x178/0x280 [zfs]
 [<0>] ? zfs_ioc_recv_impl+0x88b/0xf80 [zfs]
 [<0>] ? zfs_refcount_remove_many+0x1ad/0x250 [zfs]
 [<0>] ? zfs_ioc_recv+0x1c2/0x2a0 [zfs]
 [<0>] ? dmu_buf_get_user+0x13/0x20 [zfs]
 [<0>] ? __alloc_pages_nodemask+0x166/0xb50
 [<0>] ? zfsdev_ioctl+0x896/0x9c0 [zfs]
 [<0>] ? handle_mm_fault+0x464/0x1140
 [<0>] ? do_vfs_ioctl+0x2cf/0x4b0
 [<0>] ? __do_page_fault+0x177/0x410
 [<0>] ? SyS_ioctl+0x81/0xa0
 [<0>] ? async_page_fault+0x28/0x30
 [<0>] ? system_call_fast_compare_end+0x10/0x15
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested with reproducer added to the ZFS Test Suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
