### PR TITLE
Prevent user accounting on readonly pool

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -2433,7 +2433,8 @@ dmu_objset_userobjspace_upgradable(objset_t *os)
 	return (dmu_objset_type(os) == DMU_OST_ZFS &&
 	    !dmu_objset_is_snapshot(os) &&
 	    dmu_objset_userobjused_enabled(os) &&
-	    !dmu_objset_userobjspace_present(os));
+	    !dmu_objset_userobjspace_present(os) &&
+	    spa_writeable(dmu_objset_spa(os)));
 }
 
 boolean_t
@@ -2442,7 +2443,8 @@ dmu_objset_projectquota_upgradable(objset_t *os)
 	return (dmu_objset_type(os) == DMU_OST_ZFS &&
 	    !dmu_objset_is_snapshot(os) &&
 	    dmu_objset_projectquota_enabled(os) &&
-	    !dmu_objset_projectquota_present(os));
+	    !dmu_objset_projectquota_present(os) &&
+	    spa_writeable(dmu_objset_spa(os)));
 }
 
 void

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -841,7 +841,8 @@ tests = ['truncate_001_pos', 'truncate_002_pos', 'truncate_timestamps']
 tags = ['functional', 'truncate']
 
 [tests/functional/upgrade]
-tests = ['upgrade_userobj_001_pos', 'upgrade_projectquota_001_pos']
+tests = ['upgrade_userobj_001_pos', 'upgrade_projectquota_001_pos',
+    'upgrade_readonly_pool']
 tags = ['functional', 'upgrade']
 
 [tests/functional/user_namespace]

--- a/tests/zfs-tests/tests/functional/upgrade/Makefile.am
+++ b/tests/zfs-tests/tests/functional/upgrade/Makefile.am
@@ -3,7 +3,8 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
 	upgrade_userobj_001_pos.ksh \
-	upgrade_projectquota_001_pos.ksh
+	upgrade_projectquota_001_pos.ksh \
+	upgrade_readonly_pool.ksh
 
 dist_pkgdata_DATA = \
 	upgrade_common.kshlib

--- a/tests/zfs-tests/tests/functional/upgrade/upgrade_readonly_pool.ksh
+++ b/tests/zfs-tests/tests/functional/upgrade/upgrade_readonly_pool.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/upgrade/upgrade_common.kshlib
+
+#
+# DESCRIPTION:
+# User accounting upgrade should not be executed on readonly pool
+#
+# STRATEGY:
+# 1. Create a pool with the feature@userobj_accounting disabled to simulate
+#    a legacy pool from a previous ZFS version.
+# 2. Create a file on the "legecy" dataset and store its checksum
+# 3. Enable feature@userobj_accounting on the pool and verify it is only
+#    "enabled" and not "active": upgrading starts when the filesystem is mounted
+# 4. Export the pool and re-import is readonly, without mounting any filesystem
+# 5. Try to mount the root dataset manually without the "ro" option, then verify
+#    filesystem status and the pool feature status (not "active") to ensure the
+#    pool "readonly" status is enforced.
+#
+
+verify_runnable "global"
+
+TESTFILE="$TESTDIR/file.bin"
+
+log_assert "User accounting upgrade should not be executed on readonly pool"
+log_onexit cleanup_upgrade
+
+# 1. Create a pool with the feature@userobj_accounting disabled to simulate
+#    a legacy pool from a previous ZFS version.
+log_must zpool create -d -m $TESTDIR $TESTPOOL $TMPDEV
+
+# 2. Create a file on the "legecy" dataset
+log_must touch $TESTDIR/file.bin
+
+# 3. Enable feature@userobj_accounting on the pool and verify it is only
+#    "enabled" and not "active": upgrading starts when the filesystem is mounted
+log_must zpool set feature@userobj_accounting=enabled $TESTPOOL
+log_must test "enabled" == "$(get_pool_prop 'feature@userobj_accounting' $TESTPOOL)"
+
+# 4. Export the pool and re-import is readonly, without mounting any filesystem
+log_must zpool export $TESTPOOL
+log_must zpool import -o readonly=on -N -d "$(dirname $TMPDEV)" $TESTPOOL
+
+# 5. Try to mount the root dataset manually without the "ro" option, then verify
+#    filesystem status and the pool feature status (not "active") to ensure the
+#    pool "readonly" status is enforced.
+log_must mount -t zfs -o zfsutil $TESTPOOL $TESTDIR
+log_must stat "$TESTFILE"
+log_mustnot touch "$TESTFILE"
+log_must test "enabled" == "$(get_pool_prop 'feature@userobj_accounting' $TESTPOOL)"
+
+log_pass "User accounting upgrade is not executed on readonly pool"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to rescue data from a dying pool which was imported readonly, used `mount -t zfs -o zfsutil $mntpnt` to override the mountpoint:

```
VERIFY(tx->tx_threads == 2) failed
PANIC at txg.c:649:txg_wait_synced()
Showing stack for process 843
CPU: 0 PID: 843 Comm: z_upgrade Tainted: P           O  3.16.0-4-amd64 #1 Debian 3.16.51-3
Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
 0000000000000000 ffffffff8151ea00 ffffffffa070b8fa ffff8800d9883d08
 ffffffffa0447239 0000000000000003 0000000000000028 ffff8800d9883d18
 ffff8800d9883cb8 7428594649524556 68745f78743e2d78 3d3d207364616572
Call Trace:
 [<ffffffff8151ea00>] ? dump_stack+0x5d/0x78
 [<ffffffffa0447239>] ? spl_panic+0xc9/0x110 [spl]
 [<ffffffffa055e0d4>] ? dnode_next_offset+0x1d4/0x2c0 [zfs]
 [<ffffffffa0543296>] ? dmu_object_next+0xe6/0x130 [zfs]
 [<ffffffffa055b6d8>] ? dnode_rele_and_unlock+0x48/0xb0 [zfs]
 [<ffffffffa05b3fc1>] ? txg_wait_synced+0x1b1/0x1f0 [zfs]
 [<ffffffffa0546d7a>] ? dmu_objset_userobjspace_upgrade_cb+0xba/0xc0 [zfs]
 [<ffffffffa0544583>] ? dmu_objset_upgrade_task_cb+0xd3/0x150 [zfs]
 [<ffffffffa04449dc>] ? taskq_thread+0x2cc/0x5d0 [spl]
 [<ffffffff8109a8f0>] ? wake_up_state+0x10/0x10
 [<ffffffffa0444710>] ? taskq_thread_should_stop.part.3+0x70/0x70 [spl]
 [<ffffffff8108b13d>] ? kthread+0xbd/0xe0
 [<ffffffff8108b080>] ? kthread_create_on_node+0x180/0x180
 [<ffffffff81524c58>] ? ret_from_fork+0x58/0x90
 [<ffffffff8108b080>] ? kthread_create_on_node+0x180/0x180
```

This issue seems to affect both master and the zfs-0.7-release branch.

### Description
<!--- Describe your changes in detail -->

Trying to mount a dataset from a readonly pool could inadvertently start the user accounting upgrade task, leading to the following failure:

```
VERIFY3(tx->tx_threads == 2) failed (0 == 2)
PANIC at txg.c:680:txg_wait_synced()
Showing stack for process 2541
CPU: 2 PID: 2541 Comm: z_upgrade Tainted: P           O  3.16.0-4-amd64 #1 Debian 3.16.51-3
Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
Call Trace:
 [<0>] ? dump_stack+0x5d/0x78
 [<0>] ? spl_panic+0xc9/0x110 [spl]
 [<0>] ? dnode_next_offset+0x1d4/0x2c0 [zfs]
 [<0>] ? dmu_object_next+0x77/0x130 [zfs]
 [<0>] ? dnode_rele_and_unlock+0x4d/0x120 [zfs]
 [<0>] ? txg_wait_synced+0x91/0x220 [zfs]
 [<0>] ? dmu_objset_id_quota_upgrade_cb+0x10f/0x140 [zfs]
 [<0>] ? dmu_objset_upgrade_task_cb+0xe3/0x170 [zfs]
 [<0>] ? taskq_thread+0x2cc/0x5d0 [spl]
 [<0>] ? wake_up_state+0x10/0x10
 [<0>] ? taskq_thread_should_stop.part.3+0x70/0x70 [spl]
 [<0>] ? kthread+0xbd/0xe0
 [<0>] ? kthread_create_on_node+0x180/0x180
 [<0>] ? ret_from_fork+0x58/0x90
 [<0>] ? kthread_create_on_node+0x180/0x180
```

This patch updates both functions responsible for checking if we can perform user accounting to verify the pool is not readonly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested manually with following snippet:

```
POOLNAME='testpool'
TMPDIR='/var/tmp'
mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
zpool destroy -f $POOLNAME
rm -f $TMPDIR/zpool.dat
truncate -s 128m $TMPDIR/zpool.dat
zpool create -f -O mountpoint=none $POOLNAME $TMPDIR/zpool.dat
zpool export $POOLNAME
zpool import -o readonly=on -d $TMPDIR $POOLNAME
mount -t zfs -o zfsutil $POOLNAME /mnt
```
~~Will add test case to "upgrade" group later.~~. Done

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
