### PR TITLE
zstreamdump: include embedded writes in total_write_size

### DIFF
--- a/cmd/zstreamdump/zstreamdump.c
+++ b/cmd/zstreamdump/zstreamdump.c
@@ -679,6 +679,7 @@ main(int argc, char *argv[])
 			}
 			(void) ssread(buf,
 			    P2ROUNDUP(drrwe->drr_psize, 8), &zc);
+			total_write_size += P2ROUNDUP(drrwe->drr_psize, 8);
 			break;
 		case DRR_OBJECT_RANGE:
 			if (do_byteswap) {


### PR DESCRIPTION
Signed-off-by: Allan Jude <allanjude@freebsd.org>

### Motivation and Context
zstreamdump is a tool used to analyze the contents of ZFS replication streams.
zstreamdump outputs a summary at the end that includes the total byte
count of all DRR_WRITE records. This excludes the bytes from any
DRR_WRITE_EMBEDDED records, resulting in a total that is not accurate.

DRR_WRITE_EMBEDDED records are only included in a replication stream if it is
generated with `zfs send -e`.

### Description
This change includes the payload size of any embedded write records in the
`total_write_size` statistic displayed at the end of the zstreamdump run.

### How Has This Been Tested?
`zfs send -e dataset@snapshot | zstreamdump`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
