### PR TITLE
zstreamdump: add per-record-type counters and an overhead counter

### DIFF
--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -754,7 +754,7 @@ function verify_stream_size
 	datasetexists $ds || log_fail "No such dataset: $ds"
 
 	typeset stream_size=$(cat $stream | zstreamdump | sed -n \
-	    's/	Total write size = \(.*\) (0x.*)/\1/p')
+	    's/	Total payload size = \(.*\) (0x.*)/\1/p')
 
 	typeset inc_size=0
 	if [[ -n $inc_src ]]; then


### PR DESCRIPTION
Signed-off-by: Allan Jude <allanjude@freebsd.org>

### Motivation and Context
zstreamdump is a tool used to analyze the contents of ZFS replication streams.
I am using zstreamdump to debug zfs send size estimation, and found it
useful to get a breakdown of the actual size of the replication stream, and
what that size was made up of.

### Description
Count the bytes of payload for each replication record type
Count the bytes of overhead (replication records themselves)
Include these counters in the output summary at the end of the run.

Example output:
```
SUMMARY:
SUMMARY:
        Total DRR_BEGIN records = 5 (752 bytes)
        Total DRR_END records = 6 (0 bytes)
        Total DRR_OBJECT records = 764290 (130437264 bytes)
        Total DRR_FREEOBJECTS records = 39 (0 bytes)
        Total DRR_WRITE records = 504587 (3902546432 bytes)
        Total DRR_WRITE_BYREF records = 0 (0 bytes)
        Total DRR_WRITE_EMBEDDED records = 267961 (17836736 bytes)
        Total DRR_FREE records = 768868 (0 bytes)
        Total DRR_SPILL records = 0 (0 bytes)
        Total records = 2305756
        Total payload size = 4050821184 (0xf172a040)
        Total header overhead = 719395872 (0x2ae11c20)
        Total stream length = 4770217056 (0x11c53bc60)
```

### How Has This Been Tested?
The counters correctly sum up to the total stream length, which matches the actual stream length.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
