### PR TITLE
 dracut: set none/noop io scheduler at import time

### DIFF
--- a/contrib/dracut/90zfs/zfs-lib.sh.in
+++ b/contrib/dracut/90zfs/zfs-lib.sh.in
@@ -66,6 +66,47 @@ import_pool() {
             warn "ZFS: Unable to import pool ${pool}"
             return 1
         fi
+
+	# Set elevator=none or noop on the root pool's vdevs' disks.  ZFS
+	# already does this for whole_disk vdevs (for all pools), so this is
+	# only important for partitions.
+	if getargbool 0 zfs_elevator ; then
+		zpool status -L "${pool}" 2> /dev/null |
+		    awk '/^\t / && !/(mirror|raidz|cache|logs|special|dedup)/'\
+				'&& !/(nvme)/ {
+			dev=$1;
+			sub(/[0-9]+$/, "", dev);
+			print dev
+		    }' |
+		    while read -r i ; do
+			# Determine the current scheduler
+			if [ -e "/sys/block/$i/queue/scheduler" ] ; then
+				scheduler="$(cut -d "[" -f2 \
+				    /sys/block/"$i"/queue/scheduler | \
+				    cut -d "]" -f1)"
+			else
+				warn "ZFS: ${i} missing IO scheduler file"
+				continue
+			fi
+
+			# Skip if we are already set correctly
+			if [ "$scheduler" == "none" ] ; then continue ; fi
+			if [ "$scheduler" == "noop" ] ; then continue ; fi
+
+			# Set the scheduler, prefer none over noop
+			if grep -sq none /sys/block/"$i"/queue/scheduler ; then
+				echo none > /sys/block/"$i"/queue/scheduler
+				continue
+			fi
+			if grep -sq noop /sys/block/"$i"/queue/scheduler ; then
+				echo noop > /sys/block/"$i"/queue/scheduler
+				continue
+			fi
+
+			# Should never get here, but not fatal
+			warn "ZFS: ${i} missing none or noop IO scheduler"
+		    done
+	fi
     fi
 
     return 0

--- a/contrib/dracut/README.dracut.markdown
+++ b/contrib/dracut/README.dracut.markdown
@@ -45,6 +45,11 @@ cases where storage is on a shared fabric such as iSCSI where multiple hosts
 can access storage devices concurrently.  _Please understand the implications
 of force-importing a pool before enabling this option!_
 
+* `zfs_elevator=0`: If set to 1, the initramfs will attempt to change the IO
+scheduler (also referred to as the elevator) of the root pool's vdevs' disks to
+"none" for mq systems, or "noop" for iosched systems.  ZFS already does this
+for whole_disk vdevs (for all pools), so this is only important for partitions.
+
 * `spl_hostid`: By default, the hostid used by the SPL module is read from
 /etc/hostid inside the initramfs.  This file is placed there from the host
 system when the initramfs is built which effectively ties the ramdisk to the


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the case of pools not using whole disks, we should set the io
scheduler to none for mq systems and noop for iosched systems.

### Description
<!--- Describe your changes in detail -->
Partial for #8427 
Dracut portion of the update, initramfs might want these changes as well.  Kernel bits need updating as well.
Note: nvme disks by default don't have an io scheduler, so they should always be none/noop.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Hand tested shell code, should still work in initrd environment

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
