### PR TITLE
Fix overly broad spa config lock

### DIFF
--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -414,9 +414,9 @@ spa_txg_history_init_io(spa_t *spa, uint64_t txg, dsl_pool_t *dp)
 
 	ts = kmem_alloc(sizeof (txg_stat_t), KM_SLEEP);
 
-	spa_config_enter(spa, SCL_ALL, FTAG, RW_READER);
+	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 	vdev_get_stats(spa->spa_root_vdev, &ts->vs1);
-	spa_config_exit(spa, SCL_ALL, FTAG);
+	spa_config_exit(spa, SCL_CONFIG, FTAG);
 
 	ts->txg = txg;
 	ts->ndirty = dp->dp_dirty_pertxg[txg & TXG_MASK];
@@ -437,9 +437,9 @@ spa_txg_history_fini_io(spa_t *spa, txg_stat_t *ts)
 		return;
 	}
 
-	spa_config_enter(spa, SCL_ALL, FTAG, RW_READER);
+	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 	vdev_get_stats(spa->spa_root_vdev, &ts->vs2);
-	spa_config_exit(spa, SCL_ALL, FTAG);
+	spa_config_exit(spa, SCL_CONFIG, FTAG);
 
 	spa_txg_history_set(spa, ts->txg, TXG_STATE_SYNCED, gethrtime());
 	spa_txg_history_set_io(spa, ts->txg,

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3892,7 +3892,6 @@ vdev_get_stats_ex(vdev_t *vd, vdev_stat_t *vs, vdev_stat_ex_t *vsx)
 			vs->vs_resilver_deferred = vd->vdev_resilver_deferred;
 	}
 
-	ASSERT(spa_config_held(vd->vdev_spa, SCL_ALL, RW_READER) != 0);
 	vdev_get_stats_ex_impl(vd, vs, vsx);
 	mutex_exit(&vd->vdev_stat_lock);
 }


### PR DESCRIPTION
### Motivation and Context

Resolves a deadlock observed while running `ztest` involving the txg history.

### Description

The spa_txg_history_init_io() and spa_txg_history_fini_io() were
mistakenly taking SCL_ALL when only SCL_CONFIG is required to
access the vdev stats.  This could result in a deadlock which
was observed when running ztest.

### How Has This Been Tested?

Locally running ztest along with a full ZTS run.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
