### PR TITLE
initramfs/debian: use panic() instead of directly calling /bin/sh

### DIFF
--- a/contrib/initramfs/scripts/zfs.in
+++ b/contrib/initramfs/scripts/zfs.in
@@ -16,6 +16,20 @@ ZPOOL="@sbindir@/zpool"
 ZPOOL_CACHE="@sysconfdir@/zfs/zpool.cache"
 export ZFS ZPOOL ZPOOL_CACHE
 
+
+# Start interactive shell.
+# Use debian's panic() if defined, because it allows to prevent shell access
+# by setting panic in cmdline (e.g. panic=0 or panic=15).
+# See "4.5 Disable root prompt on the initramfs" of Securing Debian Manual:
+# https://www.debian.org/doc/manuals/securing-debian-howto/ch4.en.html
+shell() {
+	if type panic > /dev/null 2>&1; then
+		panic $@
+	else
+		/bin/sh
+	fi
+}
+
 # This runs any scripts that should run before we start importing
 # pools and mounting any filesystems.
 pre_mountroot()
@@ -256,7 +270,7 @@ import_pool()
 			echo ""
 			echo "Failed to import pool '$pool'."
 			echo "Manually import the pool and exit."
-			/bin/sh
+			shell
 		fi
 	fi
 
@@ -379,7 +393,7 @@ mount_fs()
 		echo ""
 		echo "Failed to mount ${fs} on ${rootmnt}/${mountpoint}."
 		echo "Manually mount the filesystem and exit."
-		/bin/sh
+		shell
 	else
 		[ "$quiet" != "y" ] && zfs_log_end_msg
 	fi
@@ -451,7 +465,7 @@ destroy_fs()
 		echo "Failed to destroy '$fs'. Please make sure that '$fs' is not available."
 		echo "Hint: Try:  zfs destroy -Rfn $fs"
 		echo "If this dryrun looks good, then remove the 'n' from '-Rfn' and try again."
-		/bin/sh
+		shell
 	else
 		[ "$quiet" != "y" ] && zfs_log_end_msg
 	fi
@@ -494,7 +508,7 @@ clone_snap()
 		echo "Failed to clone snapshot."
 		echo "Make sure that the any problems are corrected and then make sure"
 		echo "that the dataset '$destfs' exists and is bootable."
-		/bin/sh
+		shell
 	else
 		[ "$quiet" != "y" ] && zfs_log_end_msg
 	fi
@@ -523,7 +537,7 @@ rollback_snap()
 		echo "Error: $ZFS_ERROR"
 		echo ""
 		echo "Failed to rollback snapshot."
-		/bin/sh
+		shell
 	else
 		[ "$quiet" != "y" ] && zfs_log_end_msg
 	fi
@@ -684,7 +698,7 @@ mountroot()
 		echo ""
 		echo "Failed to load ZFS modules."
 		echo "Manually load the modules and exit."
-		/bin/sh
+		shell
 	fi
 
 	# ------------
@@ -857,7 +871,7 @@ mountroot()
 		echo "No pool imported. Manually import the root pool"
 		echo "at the command prompt and then exit."
 		echo "Hint: Try:  zpool import -R ${rootmnt} -N ${ZFS_RPOOL}"
-		/bin/sh
+		shell
 	fi
 
 	# In case the pool was specified as guid, resolve guid to name
@@ -908,7 +922,7 @@ mountroot()
 		echo ""
 		echo "Manually mount the root filesystem on $rootmnt and then exit."
 		echo "Hint: Try:  mount -o zfsutil -t zfs ${ZFS_RPOOL-rpool}/ROOT/system $rootmnt"
-		/bin/sh
+		shell
 	fi
 
 	# ----------------------------------------------------------------


### PR DESCRIPTION
Debian has a panic() function which makes it possible to disable shell
access in initramfs by setting the panic kernel parameter. Use it.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
