### PR TITLE
Fix race in vdev_initialize_thread

### DIFF
--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -628,6 +628,13 @@ vdev_initialize_thread(void *arg)
 
 		spa_config_exit(spa, SCL_CONFIG, FTAG);
 		error = vdev_initialize_ranges(vd, deadbeef);
+
+		/*
+		 * Wait for the outstanding IO to be synced to prevent
+		 * newly allocated blocks from being overwritten.
+		 */
+		txg_wait_synced(spa_get_dsl(spa), 0);
+
 		vdev_initialize_ms_unmark(msp);
 		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 


### PR DESCRIPTION
### Motivation and Context

Resolve a race condition which can occur when initializing a vdev.

### Description

Before allowing new allocations to the metaslab we need to ensure that any issued initializing writes have been synced.  Otherwise, it's possible for` metaslab_block_alloc()` to allocate a range which is about to be overwritten by an initializing IO.

### How Has This Been Tested?

Locally via the ZTS tests.  This issue is identical to one discovered when stress testing the TRIM patches under a heavy concurrent write workload.  I've been unable to reproduce it with initializing writes, but it's relatively easy to do so when issuing discards instead.  Since this code is identical to the TRIM the same fix was applied.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
