### PR TITLE
Restrict permissions for zfs/dbgmsg and other kstats, print real pointers

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -6468,7 +6468,7 @@ ztest_initialize(ztest_ds_t *zd, uint64_t id)
 	char *path = strdup(rand_vd->vdev_path);
 	boolean_t active = rand_vd->vdev_initialize_thread != NULL;
 
-	zfs_dbgmsg("vd %p, guid %llu", rand_vd, guid);
+	zfs_dbgmsg("vd %px, guid %llu", rand_vd, guid);
 	spa_config_exit(spa, SCL_VDEV, FTAG);
 
 	uint64_t cmd = ztest_random(POOL_INITIALIZE_FUNCS);

--- a/include/spl/sys/debug.h
+++ b/include/spl/sys/debug.h
@@ -102,7 +102,7 @@ void spl_dumpstack(void);
 		if (!(_verify3_left OP _verify3_right))			\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
-		    "failed (%p " #OP " %p)\n",				\
+		    "failed (%px" #OP " %px)\n",			\
 		    (void *) (_verify3_left),				\
 		    (void *) (_verify3_right));				\
 	} while (0)

--- a/include/spl/sys/kstat.h
+++ b/include/spl/sys/kstat.h
@@ -196,7 +196,7 @@ extern kstat_t *__kstat_create(const char *ks_module, int ks_instance,
 extern void kstat_proc_entry_init(kstat_proc_entry_t *kpep,
     const char *module, const char *name);
 extern void kstat_proc_entry_delete(kstat_proc_entry_t *kpep);
-extern void kstat_proc_entry_install(kstat_proc_entry_t *kpep,
+extern void kstat_proc_entry_install(kstat_proc_entry_t *kpep, mode_t mode,
     const struct file_operations *file_ops, void *data);
 
 extern void __kstat_install(kstat_t *ksp);

--- a/include/spl/sys/procfs_list.h
+++ b/include/spl/sys/procfs_list.h
@@ -58,6 +58,7 @@ typedef struct procfs_list_node {
 
 void procfs_list_install(const char *module,
     const char *name,
+    mode_t mode,
     procfs_list_t *procfs_list,
     int (*show)(struct seq_file *f, void *p),
     int (*show_header)(struct seq_file *f),

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -375,6 +375,7 @@ typedef struct procfs_list_node {
 
 void procfs_list_install(const char *module,
     const char *name,
+    mode_t mode,
     procfs_list_t *procfs_list,
     int (*show)(struct seq_file *f, void *p),
     int (*show_header)(struct seq_file *f),

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -437,6 +437,7 @@ seq_printf(struct seq_file *m, const char *fmt, ...)
 void
 procfs_list_install(const char *module,
     const char *name,
+    mode_t mode,
     procfs_list_t *procfs_list,
     int (*show)(struct seq_file *f, void *p),
     int (*show_header)(struct seq_file *f),

--- a/module/spl/spl-procfs-list.c
+++ b/module/spl/spl-procfs-list.c
@@ -201,6 +201,7 @@ static struct file_operations procfs_list_operations = {
 void
 procfs_list_install(const char *module,
     const char *name,
+    mode_t mode,
     procfs_list_t *procfs_list,
     int (*show)(struct seq_file *f, void *p),
     int (*show_header)(struct seq_file *f),
@@ -218,7 +219,7 @@ procfs_list_install(const char *module,
 	procfs_list->pl_node_offset = procfs_list_node_off;
 
 	kstat_proc_entry_init(&procfs_list->pl_kstat_entry, module, name);
-	kstat_proc_entry_install(&procfs_list->pl_kstat_entry,
+	kstat_proc_entry_install(&procfs_list->pl_kstat_entry, mode,
 	    &procfs_list_operations, procfs_list);
 }
 EXPORT_SYMBOL(procfs_list_install);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -2266,7 +2266,7 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 			 */
 			if (error != 0) {
 				zfs_dbgmsg(
-				    "hdr %p, compress %d, psize %d, lsize %d",
+				    "hdr %px, compress %d, psize %d, lsize %d",
 				    hdr, arc_hdr_get_compress(hdr),
 				    HDR_GET_PSIZE(hdr), HDR_GET_LSIZE(hdr));
 				if (hash_lock != NULL)

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -2643,7 +2643,7 @@ metaslab_condense(metaslab_t *msp, uint64_t txg, dmu_tx_t *tx)
 	ASSERT(msp->ms_loaded);
 
 
-	zfs_dbgmsg("condensing: txg %llu, msp[%llu] %p, vdev id %llu, "
+	zfs_dbgmsg("condensing: txg %llu, msp[%llu] %px, vdev id %llu, "
 	    "spa %s, smp size %llu, segments %lu, forcing condense=%s", txg,
 	    msp->ms_id, msp, msp->ms_group->mg_vd->vdev_id,
 	    msp->ms_group->mg_vd->vdev_spa->spa_name,

--- a/module/zfs/range_tree.c
+++ b/module/zfs/range_tree.c
@@ -118,7 +118,7 @@ range_tree_stat_verify(range_tree_t *rt)
 
 	for (i = 0; i < RANGE_TREE_HISTOGRAM_SIZE; i++) {
 		if (hist[i] != rt->rt_histogram[i]) {
-			zfs_dbgmsg("i=%d, hist=%p, hist=%llu, rt_hist=%llu",
+			zfs_dbgmsg("i=%d, hist=%px, hist=%llu, rt_hist=%llu",
 			    i, hist, hist[i], rt->rt_histogram[i]);
 		}
 		VERIFY3U(hist[i], ==, rt->rt_histogram[i]);

--- a/module/zfs/spa_stats.c
+++ b/module/zfs/spa_stats.c
@@ -131,6 +131,7 @@ spa_read_history_init(spa_t *spa)
 	shl->procfs_list.pl_private = shl;
 	procfs_list_install(module,
 	    "reads",
+	    0600,
 	    &shl->procfs_list,
 	    spa_read_history_show,
 	    spa_read_history_show_header,
@@ -301,6 +302,7 @@ spa_txg_history_init(spa_t *spa)
 	shl->procfs_list.pl_private = shl;
 	procfs_list_install(module,
 	    "txgs",
+	    0644,
 	    &shl->procfs_list,
 	    spa_txg_history_show,
 	    spa_txg_history_show_header,
@@ -706,6 +708,7 @@ spa_mmp_history_init(spa_t *spa)
 	shl->procfs_list.pl_private = shl;
 	procfs_list_install(module,
 	    "multihost",
+	    0644,
 	    &shl->procfs_list,
 	    spa_mmp_history_show,
 	    spa_mmp_history_show_header,

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -848,7 +848,7 @@ space_map_truncate(space_map_t *sm, int blocksize, dmu_tx_t *tx)
 	    doi.doi_bonus_size != sizeof (space_map_phys_t)) ||
 	    doi.doi_data_block_size != blocksize ||
 	    doi.doi_metadata_block_size != 1 << space_map_ibs) {
-		zfs_dbgmsg("txg %llu, spa %s, sm %p, reallocating "
+		zfs_dbgmsg("txg %llu, spa %s, sm %px, reallocating "
 		    "object[%llu]: old bonus %u, old blocksz %u",
 		    dmu_tx_get_txg(tx), spa_name(spa), sm, sm->sm_object,
 		    doi.doi_bonus_size, doi.doi_data_block_size);

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -340,7 +340,7 @@ vdev_remove_initiate_sync(void *arg, dmu_tx_t *tx)
 	 */
 	vdev_config_dirty(vd);
 
-	zfs_dbgmsg("starting removal thread for vdev %llu (%p) in txg %llu "
+	zfs_dbgmsg("starting removal thread for vdev %llu (%px) in txg %llu "
 	    "im_obj=%llu", vd->vdev_id, vd, dmu_tx_get_txg(tx),
 	    vic->vic_mapping_object);
 

--- a/module/zfs/zfs_debug.c
+++ b/module/zfs/zfs_debug.c
@@ -94,6 +94,7 @@ zfs_dbgmsg_init(void)
 {
 	procfs_list_install("zfs",
 	    "dbgmsg",
+	    0600,
 	    &zfs_dbgmsgs,
 	    zfs_dbgmsg_show,
 	    zfs_dbgmsg_show_header,

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -3232,7 +3232,7 @@ zil_close(zilog_t *zilog)
 		txg_wait_synced(zilog->zl_dmu_pool, txg);
 
 	if (zilog_is_dirty(zilog))
-		zfs_dbgmsg("zil (%p) is dirty, txg %llu", zilog, txg);
+		zfs_dbgmsg("zil (%px) is dirty, txg %llu", zilog, txg);
 	if (txg < spa_freeze_txg(zilog->zl_spa))
 		VERIFY(!zilog_is_dirty(zilog));
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1893,7 +1893,7 @@ zio_deadman_impl(zio_t *pio, int ziodepth)
 		uint64_t delta = gethrtime() - pio->io_timestamp;
 		uint64_t failmode = spa_get_deadman_failmode(pio->io_spa);
 
-		zfs_dbgmsg("slow zio[%d]: zio=%p timestamp=%llu "
+		zfs_dbgmsg("slow zio[%d]: zio=%px timestamp=%llu "
 		    "delta=%llu queued=%llu io=%llu "
 		    "path=%s last=%llu "
 		    "type=%d priority=%d flags=0x%x "
@@ -3444,7 +3444,7 @@ zio_dva_allocate(zio_t *zio)
 	}
 
 	if (error != 0) {
-		zfs_dbgmsg("%s: metaslab allocation failure: zio %p, "
+		zfs_dbgmsg("%s: metaslab allocation failure: zio %px, "
 		    "size %llu, error %d", spa_name(spa), zio, zio->io_size,
 		    error);
 		if (error == ENOSPC && zio->io_size > SPA_MINBLOCKSIZE)

--- a/tests/zfs-tests/tests/functional/cli_user/misc/dbufstat_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/dbufstat_001_pos.ksh
@@ -33,11 +33,11 @@ log_assert "dbufstat generates output and doesn't return an error code"
 
 typeset -i i=0
 while [[ $i -lt ${#args[*]} ]]; do
-        log_must eval "dbufstat ${args[i]} > /dev/null"
+        log_must eval "sudo dbufstat ${args[i]} > /dev/null"
         ((i = i + 1))
 done
 
 # A simple test of dbufstat filter functionality
-log_must eval "dbufstat -F object=10,dbc=1,pool=$TESTPOOL > /dev/null"
+log_must eval "sudo dbufstat -F object=10,dbc=1,pool=$TESTPOOL > /dev/null"
 
 log_pass "dbufstat generates output and doesn't return an error code"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is addressing this issue: https://github.com/zfsonlinux/zfs/issues/8467

There are several places where we use zfs_dbgmsg and `%p` to print pointers. In the Linux kernel, these values obfuscated to prevent information leaks (which makes sense, as `/proc/spl/kstat/zfs/dbgmsg` is world readable). However, this means the pointers aren't very useful for debugging crash dumps since you can't find the location of the struct they refer to.

### Description
<!--- Describe your changes in detail -->
I found that kstat proc creation always uses the same permission mode (`0644`). I abstracted out the mode so that different kstats can be created with different permissions. Upon suggestion, I reduced the permissions of `dbufs` and `pool/reads` along with `dbgmsg` to `0600` but left all other kstats with the original mode. 

Then, I looked for occurrences of `%p` in calls to `zfs_dbgmsg` and replaced them with `%px` so that the actual pointer is printed. 

Finally, as proposed by @pcd1193182 in https://github.com/delphix/zfs/pull/40, I changed `spl_dumpstack` to use `px` as well.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Loaded changes on a VM and verififed that the `kstat` permissions changed as expected. 

**Before**
```
> ls -l  /proc/spl/kstat/zfs/
-rw-r--r-- 1 root root 0 Mar 29 22:17 abdstats
-rw-r--r-- 1 root root 0 Mar 29 22:17 arcstats
-rw-r--r-- 1 root root 0 Mar 29 22:17 dbgmsg
-rw-r--r-- 1 root root 0 Mar 29 22:17 dbufs
-rw-r--r-- 1 root root 0 Mar 29 22:17 dbufstats
...
> ls -l /proc/spl/kstat/zfs/rpool/
-rw-r--r-- 1 root root 0 Mar 29 22:18 dmu_tx_assign
...
-rw-r--r-- 1 root root 0 Mar 29 22:18 reads
...
```
**After**
```
> ls -l  /proc/spl/kstat/zfs/
-rw-r--r-- 1 root root 0 Mar 29 22:16 abdstats
-rw-r--r-- 1 root root 0 Mar 29 22:16 arcstats
-rw------- 1 root root 0 Mar 29 22:16 dbgmsg
-rw------- 1 root root 0 Mar 29 22:16 dbufs
-rw-r--r-- 1 root root 0 Mar 29 22:16 dbufstats
...
> ls -l /proc/spl/kstat/zfs/rpool/
total 0
-rw-r--r-- 1 root root 0 Mar 29 22:19 dmu_tx_assign
...
-rw------- 1 root root 0 Mar 29 22:19 reads
...

```

Inspected `/proc/spl/kstat/zfs/dbgmsg` and saw that the logged pointers from `metaslab_condense` now look legitimate. 

**Before** 
`metaslab_condense(): condensing: txg 352980, msp[49] 000000003159e1df, vdev id 0, spa rpool, smp size 17056, segents 703, forcing condense=FALSE`

**After** (requires sudo to access)
`metaslab_condense(): condensing: txg 84170, msp[51] ffff9619a0271800, vdev id 0, spa rpool, smp size 16520, segments 421, forcing condense=FALSE`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
