### PR TITLE
Fix vdev_initialize_restart / removal race

### DIFF
--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -68,7 +68,7 @@ vdev_initialize_zap_update_sync(void *arg, dmu_tx_t *tx)
 	 * We pass in the guid instead of the vdev_t since the vdev may
 	 * have been freed prior to the sync task being processed. This
 	 * happens when a vdev is detached as we call spa_config_vdev_exit(),
-	 * stop the intializing thread, schedule the sync task, and free
+	 * stop the initializing thread, schedule the sync task, and free
 	 * the vdev. Later when the scheduled sync task is invoked, it would
 	 * find that the vdev has been freed.
 	 */
@@ -838,7 +838,9 @@ vdev_initialize_restart(vdev_t *vd)
 			/* load progress for reporting, but don't resume */
 			VERIFY0(vdev_initialize_load(vd));
 		} else if (vd->vdev_initialize_state ==
-		    VDEV_INITIALIZE_ACTIVE && vdev_writeable(vd)) {
+		    VDEV_INITIALIZE_ACTIVE && vdev_writeable(vd) &&
+		    !vd->vdev_top->vdev_removing &&
+		    vd->vdev_initialize_thread == NULL) {
 			vdev_initialize(vd);
 		}
 


### PR DESCRIPTION
### Motivation and Context

Observed during extended multi-day runs of ztest.

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007f4334f6f801 in __GI_abort () at abort.c:79
#2  0x00007f433592bbc5 in libspl_assert (buf=buf@entry=0x7f4335b17bd5 "!vd->vdev_top->vdev_removing", func=func@entry=0x7f4335b18350 <__FUNCTION__.17284> "vdev_initialize", line=line@entry=694, file=0x7f4335b17bf8 "../../module/zfs/vdev_initialize.c") at ../../lib/libspl/include/assert.h:41
#3  0x00007f43359f8b31 in vdev_initialize (vd=vd@entry=0x556edccb5ef0) at ../../module/zfs/vdev_initialize.c:694
#4  0x00007f43359f90c9 in vdev_initialize_restart (vd=0x556edccb5ef0) at ../../module/zfs/vdev_initialize.c:842
#5  0x00007f43359f8fae in vdev_initialize_restart (vd=0x556edce04410) at ../../module/zfs/vdev_initialize.c:849
#6  0x00007f43359f8fae in vdev_initialize_restart (vd=0x556edccd9440) at ../../module/zfs/vdev_initialize.c:849
#7  0x00007f43359d3dc8 in spa_load_impl (spa=spa@entry=0x556edcc227a0, type=type@entry=SPA_IMPORT_EXISTING, ereport=ereport@entry=0x7fff587d8ab0) at ../../module/zfs/spa.c:4257
#8  0x00007f43359d3e75 in spa_load (spa=spa@entry=0x556edcc227a0, state=state@entry=SPA_LOAD_OPEN, type=type@entry=SPA_IMPORT_EXISTING) at ../../module/zfs/spa.c:2375
#9  0x00007f43359d3fdf in spa_load_best (spa=spa@entry=0x556edcc227a0, state=state@entry=SPA_LOAD_OPEN, max_request=<optimized out>, rewind_flags=1) at ../../module/zfs/spa.c:4311
#10 0x00007f43359d4341 in spa_open_common (pool=0x556edb5e4e40 <ztest_opts> "ztest", spapp=0x7fff587d8bc0, tag=0x556edb3deb68 <__func__.25114>, nvpolicy=<optimized out>, config=0x0) at ../../module/zfs/spa.c:4446
#11 0x0000556edb3d90e7 in ztest_run (zs=0x7f43364124a8) at ztest.c:7012
#12 0x0000556edb3c98b9 in main (argc=<optimized out>, argv=<optimized out>) at ztest.c:7715
```

### Description

Resolve a vdev_initialize crash uncovered by ztest.  Similar to when starting a new initialization verify that a removal is not in progress.  Additionally, do not restart when the thread already exists.  This check is now congruent with the POOL_INITIALIZE_DO handling in spa_vdev_initialize_impl().

### How Has This Been Tested?

Locally ran ztest for 48 hours without reproducing this failure.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
