### PR TITLE
Linux 5.1 compat: get_ds() removed

### DIFF
--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -83,7 +83,7 @@ spl_kernel_write(struct file *file, const void *buf, size_t count, loff_t *pos)
 	ssize_t ret;
 
 	saved_fs = get_fs();
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 
 	ret = vfs_write(file, (__force const char __user *)buf, count, pos);
 
@@ -103,7 +103,7 @@ spl_kernel_read(struct file *file, void *buf, size_t count, loff_t *pos)
 	ssize_t ret;
 
 	saved_fs = get_fs();
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 
 	ret = vfs_read(file, (void __user *)buf, count, pos);
 
@@ -682,7 +682,7 @@ vn_set_pwd(const char *filename)
 	 * size to ensure strncpy_from_user() does not fail with -EFAULT.
 	 */
 	saved_fs = get_fs();
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 
 	rc = user_path_dir(filename, &path);
 	if (rc)


### PR DESCRIPTION
### Motivation and Context

Resolve build failure for in development 5.1 kernel.

### Description

Commit torvalds/linux@736706bee has removed the get_fs() function
as a bit of cleanup.  It has been defined as KERNEL_DS on all
architectures for all supported kernels.  Replace get_fs() with
KERNEL_DS as was done in the kernel.

### How Has This Been Tested?

Locally built and tested,  Pending full test results for CI for testing on more distributions and kernels.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
