### PR TITLE
Make zstreamdump -v more greppable

### DIFF
--- a/cmd/zstreamdump/zstreamdump.c
+++ b/cmd/zstreamdump/zstreamdump.c
@@ -523,8 +523,8 @@ main(int argc, char *argv[])
 				    ZIO_DATA_MAC_LEN);
 
 				(void) printf("WRITE object = %llu type = %u "
-				    "checksum type = %u compression type = %u\n"
-				    "    flags = %u offset = %llu "
+				    "checksum type = %u compression type = %u "
+				    "flags = %u offset = %llu "
 				    "logical_size = %llu "
 				    "compressed_size = %llu "
 				    "payload_size = %llu props = %llx "
@@ -578,10 +578,10 @@ main(int argc, char *argv[])
 			}
 			if (verbose) {
 				(void) printf("WRITE_BYREF object = %llu "
-				    "checksum type = %u props = %llx\n"
-				    "    offset = %llu length = %llu\n"
-				    "toguid = %llx refguid = %llx\n"
-				    "    refobject = %llu refoffset = %llu\n",
+				    "checksum type = %u props = %llx "
+				    "offset = %llu length = %llu "
+				    "toguid = %llx refguid = %llx "
+				    "refobject = %llu refoffset = %llu\n",
 				    (u_longlong_t)drrwbr->drr_object,
 				    drrwbr->drr_checksumtype,
 				    (u_longlong_t)drrwbr->drr_key.ddk_prop,
@@ -665,8 +665,8 @@ main(int argc, char *argv[])
 			}
 			if (verbose) {
 				(void) printf("WRITE_EMBEDDED object = %llu "
-				    "offset = %llu length = %llu\n"
-				    "    toguid = %llx comp = %u etype = %u "
+				    "offset = %llu length = %llu "
+				    "toguid = %llx comp = %u etype = %u "
 				    "lsize = %u psize = %u\n",
 				    (u_longlong_t)drrwe->drr_object,
 				    (u_longlong_t)drrwe->drr_offset,

--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -620,27 +620,6 @@ function stream_has_features
 }
 
 #
-# Parse zstreamdump -v output.  The output varies for each kind of record:
-# BEGIN records are simply output as "BEGIN"
-# END records are output as "END"
-# OBJECT records become "OBJECT <object num>"
-# FREEOBJECTS records become "FREEOBJECTS <startobj> <numobjs>"
-# FREE records become "<record type> <start> <length>"
-# WRITE records become:
-# "<record type> <compression type> <start> <logical size> <compressed size>
-#  <data size>"
-#
-function parse_dump
-{
-	sed '/^WRITE/{N;s/\n/ /;}' | grep "^[A-Z]" | awk '{
-	    if ($1 == "BEGIN" || $1 == "END") print $1
-	    if ($1 == "OBJECT") print $1" "$4
-	    if ($1 == "FREEOBJECTS") print $1" "$4" "$7
-	    if ($1 == "FREE") print $1" "$7" "$10
-	    if ($1 == "WRITE") print $1" "$15" "$21" "$24" "$27" "$30}'
-}
-
-#
 # Given a send stream, verify that the size of the stream matches what's
 # expected based on the source or target dataset. If the stream is an
 # incremental stream, subtract the size of the source snapshot before

--- a/tests/zfs-tests/tests/functional/rsend/send-c_zstreamdump.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_zstreamdump.ksh
@@ -42,15 +42,15 @@ log_must zfs snapshot $sendfs@full
 
 log_must eval "zfs send -c $sendfs@full >$BACKDIR/full"
 log_must stream_has_features $BACKDIR/full lz4 compressed
-cat $BACKDIR/full | zstreamdump -v | parse_dump > $BACKDIR/dump.out
+cat $BACKDIR/full | zstreamdump -v > $BACKDIR/dump.out
 
-lsize=$(awk '/^WRITE [^0]/ {lsize += $4} END {printf("%d", lsize)}' \
+lsize=$(awk '/^WRITE [^0]/ {lsize += $24} END {printf("%d", lsize)}' \
     $BACKDIR/dump.out)
 lsize_prop=$(get_prop logicalused $sendfs)
 within_percent $lsize $lsize_prop 90 || log_fail \
     "$lsize and $lsize_prop differed by too much"
 
-csize=$(awk '/^WRITE [^0]/ {csize += $5} END {printf("%d", csize)}' \
+csize=$(awk '/^WRITE [^0]/ {csize += $27} END {printf("%d", csize)}' \
     $BACKDIR/dump.out)
 csize_prop=$(get_prop used $sendfs)
 within_percent $csize $csize_prop 90 || log_fail \


### PR DESCRIPTION
Currently, the verbose output of zstreamdump includes new line
characters within some individual records. Presumably, this was
originally done to keep the output from getting too wide to fit
on a terminal. However, since new flags and struct members have
been added, these rules have not been maintained consistently. In
addition, these newlines can make it hard to grep the output in
some scenarios. This patch simply removes these newlines, making
the output easier to grep and removing the inconsistency.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
