### PR TITLE
Add separate aggregation limit for non-rotating media.

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -2364,6 +2364,17 @@ Default value: \fB5\fR.
 .RS 12n
 Max vdev I/O aggregation size
 .sp
+Default value: \fB1,048,576\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_vdev_aggregation_limit_non_rotating\fR (int)
+.ad
+.RS 12n
+Max vdev I/O aggregation size for non-rotating media
+.sp
 Default value: \fB131,072\fR.
 .RE
 


### PR DESCRIPTION
Before sequential scrub patches ZFS never aggregated I/Os above 128KB.
Sequential scrub bumped that to 1MB, supposedly to reduce number of head
seeks for spinning disks.  But for SSDs it makes little to no sense,
especially on FreeBSD, where due to MAXPHYS limitation device will likely
still see bunch of 128KB I/Os instead of one large.  Having more strict
aggregation limit for SSDs allows to avoid allocation of large memory
buffer and copy to/from it, that is a serious problem when throughput
reaches gigabytes per second.

Signed-off-by:	Alexander Motin <mav@FreeBSD.org>

### How Has This Been Tested?
The patch is tested on FreeBSD.  According to CPU profiler it removes large memory copy operation by I/O aggregation code during sequential write to dataset with recordsize=128K on SSD-backed zpool.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
