### PR TITLE
make zed.rc values reflect their default value

### DIFF
--- a/cmd/zed/zed.d/zed.rc
+++ b/cmd/zed/zed.d/zed.rc
@@ -52,9 +52,9 @@
 
 ##
 # Send notifications for 'ereport.fs.zfs.data' events.
-# Disabled by default
+# Disabled by default, any non-empty value will enable the feature.
 #
-#ZED_NOTIFY_DATA=1
+#ZED_NOTIFY_DATA=
 
 ##
 # Pushbullet access token.
@@ -88,7 +88,8 @@ ZED_USE_ENCLOSURE_LEDS=1
 
 ##
 # Run a scrub after every resilver
-#ZED_SCRUB_AFTER_RESILVER=1
+# Disabled by default, 1 to enable and 0 to disable.
+#ZED_SCRUB_AFTER_RESILVER=0
 
 ##
 # The syslog priority (e.g., specified as a "facility.level" pair).


### PR DESCRIPTION
this helps avoid confusion if a user expects functionality to be enabled.

Signed-off-by: Kash Pande <kash@tripleback.net>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
I thought that scrub after resilver was enabled by default, since it is commented out with a value of 1. The default is 0. This was undocumented.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
