### PR TITLE
Fix typo in arc_summary3

### DIFF
--- a/cmd/arc_summary/arc_summary3
+++ b/cmd/arc_summary/arc_summary3
@@ -594,7 +594,7 @@ def section_archits(kstats_dict):
     print()
     print('Cache hits by data type:')
     dt_todo = (('Demand data:', arc_stats['demand_data_hits']),
-               ('Demand perfetch data:', arc_stats['prefetch_data_hits']),
+               ('Demand prefetch data:', arc_stats['prefetch_data_hits']),
                ('Demand metadata:', arc_stats['demand_metadata_hits']),
                ('Demand prefetch metadata:',
                 arc_stats['prefetch_metadata_hits']))


### PR DESCRIPTION
This is a simple fix for a typo ("perfetch" rather than "prefetch")
in arc_summary3.

Signed-off-by: Jason Cohen <jwittlincohen@gmail.com>

### Motivation and Context

This is a simple fix for a typo ("perfetch" rather than "prefetch")
in arc_summary3.  arc_summary2 did not have this typo.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
