### PR TITLE
Additional safe guards for `zpool labelclear`

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -392,7 +392,8 @@ tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
 tags = ['functional', 'cli_root', 'zpool_import']
 
 [tests/functional/cli_root/zpool_labelclear]
-tests = ['zpool_labelclear_active', 'zpool_labelclear_exported']
+tests = ['zpool_labelclear_active', 'zpool_labelclear_exported',
+    'zpool_labelclear_removed', 'zpool_labelclear_valid']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zpool_labelclear']

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_attach/attach-o_ashift.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_attach/attach-o_ashift.ksh
@@ -51,8 +51,8 @@ log_onexit cleanup
 
 disk1=$TEST_BASE_DIR/$FILEDISK0
 disk2=$TEST_BASE_DIR/$FILEDISK1
-log_must mkfile $SIZE $disk1
-log_must mkfile $SIZE $disk2
+log_must truncate -s $SIZE $disk1
+log_must truncate -s $SIZE $disk2
 
 typeset ashifts=("9" "10" "11" "12" "13" "14" "15" "16")
 for ashift in ${ashifts[@]}
@@ -84,13 +84,7 @@ do
 		# clean things for the next run
 		log_must zpool destroy $TESTPOOL1
 		log_must zpool labelclear $disk1
-		# depending on if we expect to have failed the 'zpool attach'
-		if [[ $cmdval -le $ashift ]]
-		then
-			log_must zpool labelclear $disk2
-		else
-			log_mustnot zpool labelclear $disk2
-		fi
+		log_must zpool labelclear $disk2
 	done
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/Makefile.am
@@ -1,7 +1,9 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_labelclear
 dist_pkgdata_SCRIPTS = \
 	zpool_labelclear_active.ksh \
-	zpool_labelclear_exported.ksh
+	zpool_labelclear_exported.ksh \
+	zpool_labelclear_removed.ksh \
+	zpool_labelclear_valid.ksh
 
 dist_pkgdata_DATA = \
 	labelclear.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
@@ -15,9 +15,6 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-typeset LABELCLEAR="zpool labelclear"
-typeset LABELREAD="zdb -lq"
-
 typeset disks=(${DISKS[*]})
 typeset disk1=${disks[0]}
 typeset disk2=${disks[1]}

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_active.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_active.ksh
@@ -43,26 +43,26 @@ log_assert "zpool labelclear will fail on all vdevs of imported pool"
 log_must zpool create -O mountpoint=none -f $TESTPOOL $disk1 log $disk2
 
 # Check that labelclear [-f] will fail on ACTIVE pool vdevs
-log_mustnot $LABELCLEAR $disk1
-log_must $LABELREAD $disk1
-log_mustnot $LABELCLEAR -f $disk1
-log_must $LABELREAD $disk1
-log_mustnot $LABELCLEAR $disk2
-log_must $LABELREAD $disk2
-log_mustnot $LABELCLEAR -f $disk2
-log_must $LABELREAD $disk2
+log_mustnot zpool labelclear $disk1
+log_must zdb -lq $disk1
+log_mustnot zpool labelclear -f $disk1
+log_must zdb -lq $disk1
+log_mustnot zpool labelclear $disk2
+log_must zdb -lq $disk2
+log_mustnot zpool labelclear -f $disk2
+log_must zdb -lq $disk2
 
 # Add a cache/spare to the pool, check that labelclear [-f] will fail
 # on the vdev and will succeed once it's removed from pool config
 for vdevtype in "cache" "spare"; do
 	log_must zpool add $TESTPOOL $vdevtype $disk3
-	log_mustnot $LABELCLEAR $disk3
-	log_must $LABELREAD $disk3
-	log_mustnot $LABELCLEAR -f $disk3
-	log_must $LABELREAD $disk3
+	log_mustnot zpool labelclear $disk3
+	log_must zdb -lq $disk3
+	log_mustnot zpool labelclear -f $disk3
+	log_must zdb -lq $disk3
 	log_must zpool remove $TESTPOOL $disk3
-	log_must $LABELCLEAR $disk3
-	log_mustnot $LABELREAD $disk3
+	log_must zpool labelclear $disk3
+	log_mustnot zdb -lq $disk3
 done
 
 log_pass "zpool labelclear will fail on all vdevs of imported pool"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_exported.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_exported.ksh
@@ -52,21 +52,21 @@ for vdevtype in "" "cache" "spare"; do
 	log_must zpool export $TESTPOOL
 
 	# Check that labelclear will fail without -f
-	log_mustnot $LABELCLEAR $disk1
-	log_must $LABELREAD $disk1
-	log_mustnot $LABELCLEAR $disk2
-	log_must $LABELREAD $disk2
+	log_mustnot zpool labelclear $disk1
+	log_must zdb -lq $disk1
+	log_mustnot zpool labelclear $disk2
+	log_must zdb -lq $disk2
 
 	# Check that labelclear will succeed with -f
-	log_must $LABELCLEAR -f $disk1
-	log_mustnot $LABELREAD $disk1
-	log_must $LABELCLEAR -f $disk2
-	log_mustnot $LABELREAD $disk2
+	log_must zpool labelclear -f $disk1
+	log_mustnot zdb -lq $disk1
+	log_must zpool labelclear -f $disk2
+	log_mustnot zdb -lq $disk2
 
 	# Check that labelclear on auxilary vdevs will succeed
 	if [[ -n $vdevtype ]]; then
-		log_must $LABELCLEAR $disk3
-		log_mustnot $LABELREAD $disk3
+		log_must zpool labelclear $disk3
+		log_mustnot zdb -lq $disk3
 	fi
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_removed.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_removed.ksh
@@ -1,0 +1,62 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc.
+# Copyright (c) 2019 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+
+# DESCRIPTION:
+#    Check that `zpool labelclear` can clear labels on removed devices.
+#
+# STRATEGY:
+# 1. Create a pool with primary, log, spare and cache devices.
+# 2. Remove a top-level vdev, log, spare, and cache device.
+# 3. Run `zpool labelclear` on the removed device.
+# 4. Verify the label has been removed.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -f $DEVICE1 $DEVICE2 $DEVICE3 $DEVICE4 $DEVICE5
+}
+
+log_onexit cleanup
+log_assert "zpool labelclear works for removed devices"
+
+DEVICE1="$TEST_BASE_DIR/device-1"
+DEVICE2="$TEST_BASE_DIR/device-2"
+DEVICE3="$TEST_BASE_DIR/device-3"
+DEVICE4="$TEST_BASE_DIR/device-4"
+DEVICE5="$TEST_BASE_DIR/device-5"
+
+log_must truncate -s $((SPA_MINDEVSIZE * 8)) $DEVICE1
+log_must truncate -s $SPA_MINDEVSIZE $DEVICE2 $DEVICE3 $DEVICE4 $DEVICE5
+
+log_must zpool create -f $TESTPOOL $DEVICE1 $DEVICE2 \
+    log $DEVICE3 cache $DEVICE4 spare $DEVICE5
+log_must zpool sync
+
+# Remove each type of vdev and verify the label can be cleared.
+for dev in $DEVICE5 $DEVICE4 $DEVICE3 $DEVICE2; do
+	log_must zpool remove $TESTPOOL $dev
+	log_must zpool sync $TESTPOOL
+	log_must zpool labelclear $dev
+	log_mustnot zdb -lq $dev
+done
+
+log_pass "zpool labelclear works for removed devices"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_valid.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_valid.ksh
@@ -1,0 +1,91 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc.
+# Copyright (c) 2019 by Lawrence Livermore National Security, LLC.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+
+# DESCRIPTION:
+#    Check that `zpool labelclear` only clears valid labels.  Expected
+#    label offsets which do not contain intact labels are left untouched.
+#
+# STRATEGY:
+# 1. Create a pool with primary, log, spare and cache devices.
+# 2. Export the pool.
+# 3. Write a known pattern over the first two device labels.
+# 4. Verify with zdb that only the last two device labels are intact.
+# 5. Verify the pool could be imported using those labels.
+# 6. Run `zpool labelclear` to destroy those last two labels.
+# 7. Verify the pool can no longer be found; let alone imported.
+# 8. Verify the pattern is intact to confirm `zpool labelclear` did
+#    not write to first two label offsets.
+# 9. Verify that no valid label remain.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -f $PATTERN_FILE $DEVICE1 $DEVICE2 $DEVICE3 $DEVICE4
+}
+
+log_onexit cleanup
+log_assert "zpool labelclear will only clear valid labels"
+
+PATTERN_FILE=$TEST_BASE_DIR/pattern
+
+DEVICE1="$TEST_BASE_DIR/device-1"
+DEVICE2="$TEST_BASE_DIR/device-2"
+DEVICE3="$TEST_BASE_DIR/device-3"
+DEVICE4="$TEST_BASE_DIR/device-4"
+
+log_must dd if=/dev/urandom of=$PATTERN_FILE bs=1048576 count=4
+
+log_must truncate -s $SPA_MINDEVSIZE $DEVICE1 $DEVICE2 $DEVICE3 $DEVICE4
+
+log_must zpool create -O mountpoint=none -f $TESTPOOL $DEVICE1 \
+     log $DEVICE2 cache $DEVICE3 spare $DEVICE4
+log_must zpool export $TESTPOOL
+
+# Overwrite the first 4M of each device and verify the expected labels.
+for dev in $DEVICE1 $DEVICE2 $DEVICE3 $DEVICE4; do
+	dd if=$PATTERN_FILE of=$dev bs=1048576 conv=notrunc
+	log_must eval "zdb -l $dev | grep 'labels = 2 3'"
+done
+
+# Verify the pool could be imported using those labels.
+log_must eval "zpool import -d $TEST_BASE_DIR | grep $TESTPOOL"
+
+# Verify the last two labels on each vdev can be cleared.
+for dev in $DEVICE1 $DEVICE2 $DEVICE3 $DEVICE4; do
+	log_must zpool labelclear -f $dev
+done
+
+# Verify there is no longer a pool which can be imported.
+log_mustnot eval "zpool import -d $TEST_BASE_DIR | grep $TESTPOOL"
+
+# Verify the original pattern over the first two labels is intact
+for dev in $DEVICE1 $DEVICE2 $DEVICE3 $DEVICE4; do
+	log_must cmp -n $((4 * 1048576)) $dev $PATTERN_FILE
+	log_mustnot zdb -lq $dev
+done
+
+# Verify an error is reported when there are no labels to clear.
+for dev in $DEVICE1 $DEVICE2 $DEVICE3 $DEVICE4; do
+	log_mustnot zpool labelclear -f $dev
+done
+
+log_pass "zpool labelclear will only clear valid labels"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_replace/replace-o_ashift.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_replace/replace-o_ashift.ksh
@@ -51,8 +51,8 @@ log_onexit cleanup
 
 disk1=$TEST_BASE_DIR/$FILEDISK0
 disk2=$TEST_BASE_DIR/$FILEDISK1
-log_must mkfile $SIZE $disk1
-log_must mkfile $SIZE $disk2
+log_must truncate -s $SIZE $disk1
+log_must truncate -s $SIZE $disk2
 
 typeset ashifts=("9" "10" "11" "12" "13" "14" "15" "16")
 for ashift in ${ashifts[@]}
@@ -84,15 +84,8 @@ do
 		fi
 		# clean things for the next run
 		log_must zpool destroy $TESTPOOL1
-		# depending on if we expect to have failed the 'zpool replace'
-		if [[ $cmdval -le $ashift ]]
-		then
-			log_mustnot zpool labelclear $disk1
-			log_must zpool labelclear $disk2
-		else
-			log_must zpool labelclear $disk1
-			log_mustnot zpool labelclear $disk2
-		fi
+		log_must zpool labelclear $disk1
+		log_must zpool labelclear $disk2
 	done
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_replace/replace_prop_ashift.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_replace/replace_prop_ashift.ksh
@@ -52,8 +52,8 @@ log_onexit cleanup
 
 disk1=$TEST_BASE_DIR/$FILEDISK0
 disk2=$TEST_BASE_DIR/$FILEDISK1
-log_must mkfile $SIZE $disk1
-log_must mkfile $SIZE $disk2
+log_must truncate -s $SIZE $disk1
+log_must truncate -s $SIZE $disk2
 
 typeset ashifts=("9" "10" "11" "12" "13" "14" "15" "16")
 for ashift in ${ashifts[@]}
@@ -89,7 +89,7 @@ do
 		fi
 		# clean things for the next run
 		log_must zpool destroy $TESTPOOL1
-		log_mustnot zpool labelclear $disk1
+		log_must zpool labelclear $disk1
 		log_must zpool labelclear $disk2
 	done
 done


### PR DESCRIPTION
### Motivation and Context

Issue #6261, #8373, openzfs/openzfs#424

The `zpool labelclear` should never be allowed to zero a label offset when it can't verify a valid label exists there.

### Description

`zpool labelclear` improvements:
    
* As implemented the `zpool labelclear` command overwrites the calculated offsets of all four vdev labels even when only a single valid label is found.  If the device as been repurposed but still contains a valid label this can result in space no longer owned by ZFS being zeroed.  Prevent this by verifying every label removed is intact.
    
* Address a small bug in zpool_do_labelclear() which prevented labelclear from working on file vdevs.  Only block devices support BLKFLSBUF, try the ioctl() but when it's reported as unsupported this should not be fatal.
    
* Fix `zpool labelclear` so it can be run on vdevs which were removed from the pool with `zpool remove`.
    
* Remove LABELCLEAR and LABELREAD variables for test cases.

### How Has This Been Tested?

A new `zpool_labelclear_valid.ksh` test was added which verifies that only known valid labels are overwritten.  A new `zpool_labelclear_removed.ksh` test was added to verify labels can cleared from removed vdevs.  The existing label clear test cases were also run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
