### PR TITLE
use 'printf %s' instead of 'echo -n' for compatibility with others platforms

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_format.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_format.ksh
@@ -16,6 +16,7 @@
 
 #
 # Copyright (c) 2017 Datto, Inc. All rights reserved.
+# Copyright (c) 2019 DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -61,11 +62,11 @@ log_must verify_keyformat $TESTPOOL/$TESTFS1 "hex"
 log_must zfs unload-key $TESTPOOL/$TESTFS1
 log_must eval "echo $HEXKEY | zfs load-key $TESTPOOL/$TESTFS1"
 
-log_must eval "echo -n $RAWKEY | zfs change-key -o keyformat=raw" \
+log_must eval "printf '%s' $RAWKEY | zfs change-key -o keyformat=raw" \
 	"$TESTPOOL/$TESTFS1"
 log_must verify_keyformat $TESTPOOL/$TESTFS1 "raw"
 
 log_must zfs unload-key $TESTPOOL/$TESTFS1
-log_must eval "echo -n $RAWKEY | zfs load-key $TESTPOOL/$TESTFS1"
+log_must eval "printf '%s' $RAWKEY | zfs load-key $TESTPOOL/$TESTFS1"
 
 log_pass "'zfs change-key -o' changes the key format"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_crypt_combos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_crypt_combos.ksh
@@ -16,6 +16,7 @@
 
 #
 # Copyright (c) 2017, Datto, Inc. All rights reserved.
+# Copyright (c) 2019, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -75,7 +76,7 @@ typeset -i i=0
 while (( i < ${#ENCRYPTION_ALGS[*]} )); do
 	typeset -i j=0
 	while (( j < ${#KEYFORMATS[*]} )); do
-		log_must eval "echo -n ${USER_KEYS[j]} | zfs create" \
+		log_must eval "printf '%s' ${USER_KEYS[j]} | zfs create" \
 			"-o ${ENCRYPTION_ALGS[i]} -o ${KEYFORMATS[j]}" \
 			"$TESTPOOL/$TESTFS1"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_crypt_combos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_crypt_combos.ksh
@@ -16,6 +16,7 @@
 
 #
 # Copyright (c) 2017, Datto, Inc. All rights reserved.
+# Copyright (c) 2019, DilOS
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -70,13 +71,13 @@ typeset -i i=0
 while (( i < ${#ENCRYPTION_ALGS[*]} )); do
 	typeset -i j=0
 	while (( j < ${#KEYFORMATS[*]} )); do
-		log_must eval "echo -n ${USER_KEYS[j]} | zpool create" \
+		log_must eval "printf '%s' ${USER_KEYS[j]} | zpool create" \
 		"-O ${ENCRYPTION_ALGS[i]} -O ${KEYFORMATS[j]}" \
 		"$TESTPOOL $DISKS"
 
 		propertycheck $TESTPOOL ${ENCRYPTION_PROPS[i]} || \
 			log_fail "failed to set ${ENCRYPTION_ALGS[i]}"
-		propertycheck $TESTPOOL ${KEY_FORMATS[j]} || \
+		propertycheck $TESTPOOL ${KEYFORMATS[j]} || \
 			log_fail "failed to set ${KEYFORMATS[j]}"
 
 		log_must zpool destroy $TESTPOOL


### PR DESCRIPTION
use 'printf %s' instead of 'echo -n' for compatibility with others platforms

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
we can see differences with 'echo -n' with ksh on illumos and on linux.
to be more compatible will be better to use "printf '%s' <var>"

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).