### PR TITLE
zfs-import: should be before swap

### DIFF
--- a/etc/init.d/zfs-import.in
+++ b/etc/init.d/zfs-import.in
@@ -38,6 +38,7 @@
 
 do_depend()
 {
+	before swap
 	after sysfs udev
 	keyword -lxc -openvz -prefix -vserver
 }


### PR DESCRIPTION
### Motivation and Context

zfs-import must be done before swap in order for swap on zvol to work

### Description

Make sure that zfs-import is done by openrc before activating swap.

### How Has This Been Tested?

Tested on Alpine Linux with zfs-import and swap openrc scripts in the `boot` runlevel

Before this change:
```log
 * Remounting root filesystem read/write ...
 [ ok ]
 * Remounting filesystems ...
 [ ok ]
 * Activating swap devices ...
swapon: cannot open /dev/zvol/bup/swap: No such file or directory
 [ ok ]
....
 * Importing ZFS pool(s)  ...
 [ ok ]
```

After this change
```log
 * Remounting filesystems ...
 [ ok ]
 * Importing ZFS pool(s)  ...
 [ ok ]
 * Activating swap devices ...
 [ ok ]
 * Mounting local filesystems ...
 [ ok ]
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
