### PR TITLE
Better user experience for errata 4

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2479,15 +2479,17 @@ show_import(nvlist_t *config)
 				break;
 
 			case ZPOOL_ERRATA_ZOL_8308_ENCRYPTION:
-				(void) printf(gettext(" action: Existing "
+				(void) printf(gettext(" action: Any existing "
 				    "encrypted datasets contain an on-disk "
-				    "incompatibility which\n\tmay cause "
+				    "incompatibility\n\twhich may cause "
 				    "on-disk corruption with 'zfs recv' and "
-				    "which needs to be\n\tcorrected. Enable "
-				    "the bookmark_v2 feature and backup "
-				    "these datasets to new encrypted "
-				    "datasets and\n\tdestroy the "
-				    "old ones.\n"));
+				    "which needs\n\tto be corrected. Enable "
+				    "the bookmark_v2 feature, backup "
+				    "these datasets\n\tto new encrypted "
+				    "datasets, and destroy the old ones. "
+				    "If this pool does\n\tnot contain any "
+				    "encrypted datasets, simply enable the "
+				    "bookmark_v2\n\tfeature.\n"));
 				break;
 			default:
 				/*
@@ -7417,10 +7419,12 @@ status_callback(zpool_handle_t *zhp, void *data)
 			    "contain an on-disk incompatibility\n\twhich "
 			    "needs to be corrected.\n"));
 			(void) printf(gettext("action: To correct the issue "
-			    "enable the bookmark_v2 feature and "
-			    "backup\n\texisting encrypted datasets to new "
-			    "encrypted datasets and\n\tdestroy the old "
-			    "ones.\n"));
+			    "enable the bookmark_v2 feature, backup\n\tany "
+			    "existing encrypted datasets to new encrypted "
+			    "datasets,\n\tand destroy the old ones. If this "
+			    "pool does not contain any\n\tencrypted "
+			    "datasets, simply enable the bookmark_v2 "
+			    "feature.\n"));
 			break;
 
 		default:

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -1837,6 +1837,13 @@ dmu_objset_create_crypt_check(dsl_dir_t *parentdd, dsl_crypto_params_t *dcp,
 		return (SET_ERROR(EOPNOTSUPP));
 	}
 
+	/* Check for errata #4 (encryption enabled, bookmark_v2 disabled) */
+	if (parentdd != NULL &&
+	    !spa_feature_is_enabled(parentdd->dd_pool->dp_spa,
+	    SPA_FEATURE_BOOKMARK_V2)) {
+		return (SET_ERROR(EOPNOTSUPP));
+	}
+
 	/* handle inheritance */
 	if (dcp->cp_wkey == NULL) {
 		ASSERT3P(parentdd, !=, NULL);

--- a/module/zfs/zfeature.c
+++ b/module/zfs/zfeature.c
@@ -376,6 +376,19 @@ feature_enable_sync(spa_t *spa, zfeature_info_t *feature, dmu_tx_t *tx)
 		    spa->spa_feat_enabled_txg_obj, feature->fi_guid,
 		    sizeof (uint64_t), 1, &enabling_txg, tx));
 	}
+
+	/*
+	 * Errata #4 is mostly a problem with encrypted datasets, but it
+	 * is also a problem where the old encryption feature did not
+	 * depend on the bookmark_v2 feature. If the pool does not have
+	 * any encrypted datasets we can resolve this issue simply by
+	 * enabling this dependency.
+	 */
+	if (spa->spa_errata == ZPOOL_ERRATA_ZOL_8308_ENCRYPTION &&
+	    spa_feature_is_enabled(spa, SPA_FEATURE_ENCRYPTION) &&
+	    !spa_feature_is_active(spa, SPA_FEATURE_ENCRYPTION) &&
+	    feature->fi_feature == SPA_FEATURE_BOOKMARK_V2)
+		spa->spa_errata = 0;
 }
 
 static void

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_errata3.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_errata3.ksh
@@ -75,9 +75,12 @@ log_must eval "ls $old_mntpnt | grep -q testfile"
 block_device_wait
 log_mustnot dd if=/dev/zero of=/dev/zvol/$POOL_NAME/testvol bs=512 count=1
 log_must dd if=/dev/zvol/$POOL_NAME/testvol of=/dev/null bs=512 count=1
+
+log_must zpool set feature@bookmark_v2=enabled $POOL_NAME # necessary for Errata #4
+
 log_must eval "echo 'password' | zfs create \
 	-o encryption=on -o keyformat=passphrase -o keylocation=prompt \
-	cryptv0/encroot"
+	$POOL_NAME/encroot"
 log_mustnot eval "zfs send -w $POOL_NAME/testfs@snap1 | \
 	zfs recv $POOL_NAME/encroot/testfs"
 log_mustnot eval "zfs send -w $POOL_NAME/testvol@snap1 | \


### PR DESCRIPTION
This patch attempts to address some user concerns that have arisen
since errata 4 was introduced.

* The errata warning has been made less scary for users without
  any encrypted datasets.

* The errata warning now clears itself without a pool reimport if
  the bookmark_v2 feature is enabled and no encrypted datasets
  exist.

* It is no longer possible to create new encrypted datasets without
  enabling the bookmark_v2 feature, thus helping to ensure that the
  errata is resolved.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Motivation and Context
#8503 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
