### PR TITLE
Report holes when there are only metadata changes

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2366,14 +2366,39 @@ dmu_offset_next(objset_t *os, uint64_t object, boolean_t hole, uint64_t *off)
 		return (err);
 
 	/*
-	 * Check if dnode is dirty
+	 * Check if there are dirty data blocks or frees which have not been
+	 * synced.  Dirty spill and bonus blocks which are external to the
+	 * object can ignored when reporting holes.
 	 */
+	mutex_enter(&dn->dn_mtx);
 	for (i = 0; i < TXG_SIZE; i++) {
 		if (multilist_link_active(&dn->dn_dirty_link[i])) {
-			clean = B_FALSE;
-			break;
+
+			if (dn->dn_free_ranges[i] != NULL) {
+				clean = B_FALSE;
+				break;
+			}
+
+			list_t *list = &dn->dn_dirty_records[i];
+			dbuf_dirty_record_t *dr;
+
+			for (dr = list_head(list); dr != NULL;
+			    dr = list_next(list, dr)) {
+				dmu_buf_impl_t *db = dr->dr_dbuf;
+
+				if (db->db_blkid == DMU_SPILL_BLKID ||
+				    db->db_blkid == DMU_BONUS_BLKID)
+					continue;
+
+				clean = B_FALSE;
+				break;
+			}
 		}
+
+		if (clean == B_FALSE)
+			break;
 	}
+	mutex_exit(&dn->dn_mtx);
 
 	/*
 	 * If compatibility option is on, sync any current changes before


### PR DESCRIPTION
### Motivation and Context

Address the major concern in issue #6958 regarding holes not being reported after reading a file.  This is only a small incremental improvement.

Additional work is still required to always report holes without requiring a txg sync.  As with the existing code, setting `zfs_dmu_offset_next_sync=1` can be used to always report holes but it can have a negative impact system performance.

### Description

Update the dirty check in `dmu_offset_next()` such that dnode's are only considered dirty for the purpose or reporting holes when there are pending data blocks or frees to be synced.  This ensures that when there are only metadata updates to be synced (atime) that holes are reported.

### How Has This Been Tested?

Manually with @cwedgwood's test case from https://github.com/cwedgwood/unholey. 

With this change applied holes are correctly reported when there are uncommitted metadata changes.  In the test case below, the `atime` was the dirty metadata in the "immediately after a read" section below.   Note due to the performance concerned raised in #4306 files with pending dirty data block or frees still do not report holes, the "newly created" section below.

```
newly created
-------------
DATA            0      3145728 (     3145728)		1 segments

after a delay
-------------
HOLE            0      1048576 (     1048576)
DATA      1048576      1179648 (      131072)
HOLE      1179648      2097152 (      917504)
DATA      2097152      2228224 (      131072)		4 segments

immediately after a read
------------------------
HOLE            0      1048576 (     1048576)
DATA      1048576      1179648 (      131072)
HOLE      1179648      2097152 (      917504)
DATA      2097152      2228224 (      131072)		4 segments

delay...
--------
HOLE            0      1048576 (     1048576)
DATA      1048576      1179648 (      131072)
HOLE      1179648      2097152 (      917504)
DATA      2097152      2228224 (      131072)		4 segments

immediately after a read using NOATIME
--------------------------------------
HOLE            0      1048576 (     1048576)
DATA      1048576      1179648 (      131072)
HOLE      1179648      2097152 (      917504)
DATA      2097152      2228224 (      131072)		4 segments
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
