### PR TITLE
Add support for birthtime

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2641,6 +2641,7 @@ zfs_getattr_fast(struct inode *ip, struct kstat *sp)
 	zfsvfs_t *zfsvfs = ITOZSB(ip);
 	uint32_t blksize;
 	u_longlong_t nblocks;
+	uint64_t btime[2];
 
 	ZFS_ENTER(zfsvfs);
 	ZFS_VERIFY_ZP(zp);
@@ -2648,6 +2649,13 @@ zfs_getattr_fast(struct inode *ip, struct kstat *sp)
 	mutex_enter(&zp->z_lock);
 
 	generic_fillattr(ip, sp);
+
+#ifdef HAVE_PATH_IOPS_GETATTR
+	(void) sa_lookup(zp->z_sa_hdl, SA_ZPL_CRTIME(zfsvfs),
+	    btime, sizeof (uint64_t) * 2);
+	ZFS_TIME_DECODE(&sp->btime, btime);
+	stat->result_mask |= STATX_BTIME;
+#endif
 
 	sa_object_size(zp->z_sa_hdl, &blksize, &nblocks);
 	sp->blksize = blksize;


### PR DESCRIPTION
@rlaager and others wanted btime support, so I threw this together. I am relying on the buildbot and those who want it to do testing. At present, you can do `zdb -dddd $DATASET $OBJSETID` to view this information. With this, we should in theory be able to view it on Linux 4.11 or later, with glibc 2.28 or later and the latest coreutils as of two weeks ago from what I am told. This has yet to be verified, so I will rely on those who want it to test that.