### PR TITLE
Multiple systemd/dracut fixes/changes

### DIFF
--- a/contrib/dracut/90zfs/.gitignore
+++ b/contrib/dracut/90zfs/.gitignore
@@ -6,3 +6,4 @@ zfs-generator.sh
 zfs-lib.sh
 zfs-load-key.sh
 zfs-needshutdown.sh
+zfs-env-bootfs.service

--- a/contrib/dracut/90zfs/Makefile.am
+++ b/contrib/dracut/90zfs/Makefile.am
@@ -9,6 +9,9 @@ pkgdracut_SCRIPTS = \
 	zfs-needshutdown.sh \
 	zfs-lib.sh
 
+pkgdracut_DATA = \
+	zfs-env-bootfs.service
+
 EXTRA_DIST = \
 	$(top_srcdir)/contrib/dracut/90zfs/export-zfs.sh.in \
 	$(top_srcdir)/contrib/dracut/90zfs/module-setup.sh.in \
@@ -17,9 +20,10 @@ EXTRA_DIST = \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-generator.sh.in \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-load-key.sh.in \
 	$(top_srcdir)/contrib/dracut/90zfs/zfs-needshutdown.sh.in \
-	$(top_srcdir)/contrib/dracut/90zfs/zfs-lib.sh.in
+	$(top_srcdir)/contrib/dracut/90zfs/zfs-lib.sh.in \
+	$(top_srcdir)/contrib/dracut/90zfs/zfs-env-bootfs.service.in
 
-$(pkgdracut_SCRIPTS):%:%.in
+$(pkgdracut_SCRIPTS) $(pkgdracut_DATA) :%:%.in
 	-$(SED) -e 's,@bindir\@,$(bindir),g' \
 		-e 's,@sbindir\@,$(sbindir),g' \
 		-e 's,@udevdir\@,$(udevdir),g' \
@@ -30,4 +34,4 @@ $(pkgdracut_SCRIPTS):%:%.in
 		$< >'$@'
 
 distclean-local::
-	-$(RM) $(pkgdracut_SCRIPTS)
+	-$(RM) $(pkgdracut_SCRIPTS) $(pkgdracut_DATA)

--- a/contrib/dracut/90zfs/module-setup.sh.in
+++ b/contrib/dracut/90zfs/module-setup.sh.in
@@ -98,6 +98,9 @@ install() {
 				type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-import-$_item.service
 			fi
 		done
+		inst "${moddir}"/zfs-env-bootfs.service "${systemdsystemunitdir}"/zfs-env-bootfs.service
+		ln -s ../zfs-env-bootfs.service "${initdir}/${systemdsystemunitdir}/zfs-import.target.wants"/zfs-env-bootfs.service
+		type mark_hostonly >/dev/null 2>&1 && mark_hostonly @systemdunitdir@/zfs-env-bootfs.service
 		dracut_install systemd-ask-password
 		dracut_install systemd-tty-ask-password-agent
 		mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"

--- a/contrib/dracut/90zfs/zfs-env-bootfs.service.in
+++ b/contrib/dracut/90zfs/zfs-env-bootfs.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=Set BOOTFS environment for dracut
+Documentation=man:zpool(8)
+DefaultDependencies=no
+After=zfs-import-cache.service
+After=zfs-import-scan.service
+Before=zfs-import.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "/bin/systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -v '^-$')"
+
+[Install]
+WantedBy=zfs-import.target

--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -13,7 +13,6 @@ ConditionPathExists=@sysconfdir@/zfs/zpool.cache
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
-ExecStartPost=/bin/sh -c "/bin/systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -v '^-$')"
 
 [Install]
 WantedBy=zfs-import.target

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -12,7 +12,6 @@ ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@sbindir@/zpool import -aN -o cachefile=none
-ExecStartPost=/bin/sh -c "/bin/systemctl set-environment BOOTFS=$(@sbindir@/zpool list -H -o bootfs | grep -m1 -v '^-$')"
 
 [Install]
 WantedBy=zfs-import.target


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context / Description
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. Remove hard dependency on bash

    zfs-import-* services have a hard dependency on bash while not everyone
    has bash installed. At this point /bin/sh is sufficient, so use that.

2. Fix systemd-import services

    On debian systemd complains about missing /bin/awk because it actually
    is located at /usr/bin/awk. It is not a good idea to hardcode binary
    paths because linux distros use different paths. According to systemd's
    man page it is absolutely safe to miss paths for binary located at
    standard locations (/bin, /sbin, /usr/bin, ...).

    Further, replace this more or less complicated awk command by egrep.

3. Move dracut specifics to dracut mount unit

    Dracut depends on BOOTFS environment variable to be set after pool
    import. This dracut specific systemd ExecStartPost command should not be
    called for any non-dracut systems, so let's move it to a static systemd
    unit that gets pulled in by the generated mount unit.


~~*At the moment, the new systemd service does not get installed / packaged. I did not get this to work... any hint from you would be great :-)*~~ **Update: Fixed.**

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Tested WITHOUT dracut! Maybe someome with a dracut (test) setup can test this?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
