### PR TITLE
Reserve fields and values for redacted send/recv

### DIFF
--- a/cmd/zstreamdump/zstreamdump.c
+++ b/cmd/zstreamdump/zstreamdump.c
@@ -711,6 +711,7 @@ main(int argc, char *argv[])
 				    mac);
 			}
 			break;
+		case DRR_REDACT:
 		case DRR_NUMTYPES:
 			/* should never be reached */
 			exit(1);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -184,8 +184,6 @@ typedef enum {
 	ZFS_PROP_REMAPTXG,		/* not exposed to the user */
 	ZFS_PROP_SPECIAL_SMALL_BLOCKS,
 	ZFS_PROP_IVSET_GUID,		/* not exposed to the user */
-	ZFS_PROP_REDACTED,
-	ZFS_PROP_REDACT_SNAPS,
 	ZFS_NUM_PROPS
 } zfs_prop_t;
 

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -184,6 +184,8 @@ typedef enum {
 	ZFS_PROP_REMAPTXG,		/* not exposed to the user */
 	ZFS_PROP_SPECIAL_SMALL_BLOCKS,
 	ZFS_PROP_IVSET_GUID,		/* not exposed to the user */
+	ZFS_PROP_REDACTED,
+	ZFS_PROP_REDACT_SNAPS,
 	ZFS_NUM_PROPS
 } zfs_prop_t;
 
@@ -1272,6 +1274,8 @@ typedef enum zfs_ioc {
 	ZFS_IOC_POOL_DISCARD_CHECKPOINT,	/* 0x5a4e */
 	ZFS_IOC_POOL_INITIALIZE,		/* 0x5a4f */
 	ZFS_IOC_POOL_TRIM,			/* 0x5a50 */
+	ZFS_IOC_GET_BOOKMARK_PROPS,		/* 0x5a51 */
+	ZFS_IOC_REDACT,				/* 0x5a52 */
 
 	/*
 	 * Linux - 3/64 numbers reserved.
@@ -1317,6 +1321,7 @@ typedef enum {
 	ZFS_ERR_WRONG_PARENT,
 	ZFS_ERR_FROM_IVSET_GUID_MISSING,
 	ZFS_ERR_FROM_IVSET_GUID_MISMATCH,
+	ZFS_ERR_UNKNOWN_SEND_STREAM_FEATURE,
 } zfs_errno_t;
 
 /*

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -191,7 +191,7 @@ typedef struct dmu_replay_record {
 		DRR_BEGIN, DRR_OBJECT, DRR_FREEOBJECTS,
 		DRR_WRITE, DRR_FREE, DRR_END, DRR_WRITE_BYREF,
 		DRR_SPILL, DRR_WRITE_EMBEDDED, DRR_OBJECT_RANGE,
-		DRR_NUMTYPES
+		DRR_REDACT, DRR_NUMTYPES
 	} drr_type;
 	uint32_t drr_payloadlen;
 	union {


### PR DESCRIPTION
### Motivation and Context
With a change the size of redacted send and receive outstanding, there are many opportunities for merge conflicts.  To attempt to reduce them, or at least reduce conflicts with code that is likely to be integrated without significant change and can cause problems for the forked codebase, some portions of the change should be integrated as soon as possible.

### Description
This PR integrates a few enum values into zfs that are modified by the redacted send/recv code.  Until these values are integrated, any other change that modifies them causes a merge conflict. In addition, these enums are intended to be append-only, and violating that in a fork can cause numerous issues.

### How Has This Been Tested?
Checkstyle and the zfs test suite have been run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
