### PR TITLE
ZFS reads may result in unnecessary calls to zil_commit

### DIFF
--- a/include/spl/sys/vnode.h
+++ b/include/spl/sys/vnode.h
@@ -58,7 +58,6 @@
 #define	FOFFMAX		O_LARGEFILE
 #define	FSYNC		O_SYNC
 #define	FDSYNC		O_DSYNC
-#define	FRSYNC		O_SYNC
 #define	FEXCL		O_EXCL
 #define	FDIRECT		O_DIRECT
 #define	FAPPEND		O_APPEND

--- a/lib/libspl/include/sys/file.h
+++ b/lib/libspl/include/sys/file.h
@@ -40,7 +40,6 @@
 #define	FOFFMAX	O_LARGEFILE
 #define	FSYNC	O_SYNC
 #define	FDSYNC	O_DSYNC
-#define	FRSYNC	O_RSYNC
 #define	FEXCL	O_EXCL
 
 #define	FNODSYNC	0x10000	/* fsync pseudo flag */


### PR DESCRIPTION
ZFS supports O_RSYNC for read operations and, when specified, will ensure the
same level of data integrity that O_DSYNC and O_SYNC provides for writes.
O_RSYNC by itself has no effect so it must be combined with either O_DSYNC
or O_SYNC. However, many platforms don't support O_RSYNC and have mapped
O_SYNC to mean O_RSYNC within ZFS. This is incorrect and causes unnecessary
calls to zil_commit. Only platforms which support O_RSYNC should implement
the zil_commit functionality in the read code path.

Signed-off-by: George Wilson <george.wilson@delphix.com>

