### PR TITLE
ZTS: Detect e2fsprogs verity issue

### DIFF
--- a/tests/zfs-tests/tests/functional/projectquota/projectid_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectid_001_pos.ksh
@@ -55,6 +55,16 @@ if ! lsattr -pd > /dev/null 2>&1; then
 	log_unsupported "Current e2fsprogs does not support set/show project ID"
 fi
 
+#
+# e2fsprogs-1.44.4 incorrectly reports verity 'V' bit when the project 'P'
+# bit is set.  Skip this test when 1.44.4 is installed to prevent failures.
+#
+# https://github.com/tytso/e2fsprogs/commit/7e5a95e3d
+#
+if lsattr -V 2>&1 | grep "lsattr 1.44.4"; then
+	log_unsupported "Current e2fsprogs incorrectly reports 'V' verity bit"
+fi
+
 log_onexit cleanup
 
 log_assert "Check project ID/flags can be set/inherited properly"

--- a/tests/zfs-tests/tests/functional/projectquota/projecttree_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projecttree_001_pos.ksh
@@ -56,6 +56,16 @@ if ! lsattr -pd > /dev/null 2>&1; then
 	log_unsupported "Current e2fsprogs does not support set/show project ID"
 fi
 
+#
+# e2fsprogs-1.44.4 incorrectly reports verity 'V' bit when the project 'P'
+# bit is set.  Skip this test when 1.44.4 is installed to prevent failures.
+#
+# https://github.com/tytso/e2fsprogs/commit/7e5a95e3d
+#
+if lsattr -V 2>&1 | grep "lsattr 1.44.4"; then
+	log_unsupported "Current e2fsprogs incorrectly reports 'V' verity bit"
+fi
+
 log_onexit cleanup
 
 log_assert "Check 'zfs project' is compatible with chattr/lsattr"


### PR DESCRIPTION
### Motivation and Context

The `projectid_001_pos` and `projecttree_001_pos` test cases always fail on the Fedora 29 builder due to [an issue](https://bugzilla.redhat.com/show_bug.cgi?id=1687003) with the distribution provided version of e2fsprogs.  Resolve the issue by checking the `lsattr` version and skipping the test case when it is expected to fail.

### Description

The `projectid_001_pos` and `projecttree_001_pos` test cases use the `lsattr` command to detect that the project quota bit is set correctly.  Due to a bug in `e2fsprogs-1.44.4` setting the Project 'P' bit also results in the Verity 'V' bit being reported as set.  This will result in the test case failing.

The issue has been resolved in e2fsprogs but in order to avoid testing failures these two test cases are skipped when `e2fsprogs-1.44.4` is installed.

### How Has This Been Tested?

Locally verified the test cases are skipped on Fedora 29 default install. 


```
$ lsattr -V | grep lsatt
lsattr 1.44.4 (18-Aug-2018)

Test: projectquota/setup (run as root) [00:01] [PASS]
Test: projectquota/projectid_001_pos (run as root) [00:00] [SKIP]
Test: projectquota/projectid_002_pos (run as root) [00:00] [PASS]
Test: projectquota/projectid_003_pos (run as root) [00:00] [PASS]
Test: projectquota/projectquota_001_pos (run as root) [00:01] [PASS]
Test: projectquota/projectquota_002_pos (run as root) [00:02] [PASS]
Test: projectquota/projectquota_003_pos (run as root) [00:01] [PASS]
Test: projectquota/projectquota_004_neg (run as root) [00:01] [PASS]
Test: projectquota/projectquota_005_pos (run as root) [00:00] [PASS]
Test: projectquota/projectquota_006_pos (run as root) [00:01] [PASS]
Test: projectquota/projectquota_007_pos (run as root) [00:00] [PASS]
Test: projectquota/projectquota_008_pos (run as root) [00:00] [PASS]
Test: projectquota/projectquota_009_pos (run as root) [00:01] [PASS]
Test: projectquota/projectspace_001_pos (run as root) [00:02] [PASS]
Test: projectquota/projectspace_002_pos (run as root) [00:01] [PASS]
Test: projectquota/projectspace_003_pos (run as root) [00:01] [PASS]
Test: projectquota/projectspace_004_pos (run as root) [00:00] [PASS]
Test: projectquota/projecttree_001_pos (run as root) [00:00] [SKIP]
Test: projectquota/projecttree_002_pos (run as root) [00:01] [PASS]
Test: projectquota/projecttree_003_neg (run as root) [00:01] [PASS]
Test: projectquota/cleanup (run as root) [00:01] [PASS]

Results Summary
SKIP       2
PASS      19
```

```
Test: .../projectquota/projecttree_001_pos (run as root) [00:00] [SKIP]
14:52:49.50 lsattr 1.44.4 (18-Aug-2018)
14:52:49.50 Current e2fsprogs incorrectly reports 'V' verity bit
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
