### PR TITLE
libzfs_sendrecv.c: Append snapshot name to "TIME SENT SNAPSHOT" output

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -1225,7 +1225,8 @@ send_progress_thread(void *arg)
 	(void) strlcpy(zc.zc_name, zhp->zfs_name, sizeof (zc.zc_name));
 
 	if (!pa->pa_parsable)
-		(void) fprintf(stderr, "TIME        SENT   SNAPSHOT\n");
+		(void) fprintf(stderr, "TIME        SENT   SNAPSHOT %s\n",
+		    zhp->zfs_name);
 
 	/*
 	 * Print the progress from ZFS_IOC_SEND_PROGRESS every second.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Simply appends zhp->zfs_name to the "TIME SENT SNAPSHOT" output.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provides better optics to the zfs send progress.

Prior to this, I'd see a bunch of:
TIME SENT SNAPSHOT
TIME SENT SNAPSHOT
TIME SENT SNAPSHOT
TIME SENT SNAPSHOT
...

With this small change, it will now output:
TIME SENT SNAPSHOT zpool@today
TIME SENT SNAPSHOT zpool/a@today
TIME SENT SNAPSHOT zpool/a/b@today
TIME SENT SNAPSHOT zpool/b@today
...

### Description
<!--- Describe your changes in detail -->
Simply appends zhp->zfs_name to the "TIME SENT SNAPSHOT" output when it happens faster than the worker thread can be triggered to show progress output.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
By running the backups and inspecting the logs.  This was with a patched: zfs-0.7.13

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
