### PR TITLE
Update raw send documentation

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -3500,7 +3500,11 @@ set when the stream is received.
 If the
 .Fl F
 flag is specified when this stream is received, snapshots and file systems that
-do not exist on the sending side are destroyed.
+do not exist on the sending side are destroyed. If the
+.Fl R
+flag is used to send encrypted datasets, then
+.Fl w
+must also be specified.
 .It Fl e, -embed
 Generate a more compact stream by using
 .Sy WRITE_EMBEDDED
@@ -3573,7 +3577,7 @@ system for incrementals.
 Generate a stream package that includes any snapshot holds (created with the
 .Sy zfs hold
 command), and indicating to
-.Sy zfs receive 
+.Sy zfs receive
 that the holds be applied to the dataset on the receiving system.
 .It Fl i Ar snapshot
 Generate an incremental stream from the first
@@ -3843,7 +3847,13 @@ recompressed by the receive process. Unencrypted streams can be received as
 encrypted datasets, either through inheritance or by specifying encryption
 parameters with the
 .Fl o
-options.
+options. Note that the
+.Sy keylocation
+property cannot be overridden to
+.Sy prompt
+during a receive. This is because the receive process itself is already using
+stdin for the send stream. Instead, the property can be overridden after the
+receive completes.
 .Pp
 The added security provided by raw sends adds some restrictions to the send
 and receive process. ZFS will not allow a mix of raw receives and non-raw
@@ -3930,7 +3940,7 @@ snapshot as described in the paragraph above.
 Discard all but the last element of the sent snapshot's file system name, using
 that element to determine the name of the target file system for the new
 snapshot as described in the paragraph above.
-.It Fl h 
+.It Fl h
 Skip the receive of holds.  There is no effect if holds are not sent.
 .It Fl n
 Do not actually receive the stream.


### PR DESCRIPTION
This patch simply clarifies some of the limitations related to
raw sends in the man page. No functional changes.

Fixes: #8503

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
