### PR TITLE
make man happy

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -864,12 +864,12 @@ When a pool is determined to be active it cannot be imported, even with the
 .Fl f
 option.  This property is intended to be used in failover configurations
 where multiple hosts have access to a pool on shared storage.
-
+.Pp
 Multihost provides protection on import only.  It does not protect against an
 individual device being used in multiple pools, regardless of the type of vdev.
 See the discussion under
 .Sy zpool create.
-
+.Pp
 When this property is on, periodic writes to storage occur to show the pool is
 in use.  See
 .Sy zfs_multihost_interval
@@ -1103,7 +1103,7 @@ or
 .Sy zpool labelclear ,
 do not refer to the same device.  Using the same device in two pools will
 result in pool corruption.
-
+.Pp
 There are some uses, such as being currently mounted, or specified as the
 dedicated dump device, that prevents a device from ever being used by ZFS.
 Other uses, such as having a preexisting UFS file system, can be overridden with


### PR DESCRIPTION
The macOS `man` app strenuously objects to blank lines in man files...

### Motivation and Context

```
mdoc warning: Empty input line #867
mdoc warning: Empty input line #872
mdoc warning: Empty input line #1106
```

### Description

Replacing blank lines w/ `.Pp` assuming that's the intent...

### How Has This Been Tested?

Tested on macOS 10.14

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
