### PR TITLE
Code improvement and bug fixes for QAT support

### DIFF
--- a/module/zfs/qat.h
+++ b/module/zfs/qat.h
@@ -147,6 +147,9 @@ typedef struct qat_stats {
 	QAT_STAT_INCR(stat, 1)
 
 extern qat_stats_t qat_stats;
+extern int zfs_qat_compress_disable;
+extern int zfs_qat_checksum_disable;
+extern int zfs_qat_encrypt_disable;
 
 /* inlined for performance */
 static inline struct page *
@@ -167,8 +170,8 @@ void qat_mem_free_contig(void **pp_mem_addr);
 
 extern int qat_dc_init(void);
 extern void qat_dc_fini(void);
-extern int qat_crypt_init(void);
-extern void qat_crypt_fini(void);
+extern int qat_cy_init(void);
+extern void qat_cy_fini(void);
 extern int qat_init(void);
 extern void qat_fini(void);
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current implementation initializes the QAT support for ZFS when the ZFS kernel module is loaded.
A prerequisite for this initialization to succeed is that the Intel QAT driver has already been initialized.
If this is not the case the QAT support for ZFS will not be available even if the QAT driver becomes available at a later stage. #8323 

### Description
<!--- Describe your changes in detail -->
1. Support QAT when ZFS is root file-system:
   When ZFS module is loaded before QAT started, the QAT can
   be started again in post-process, e.g.:
   echo 0 > /sys/module/zfs/parameters/zfs_qat_compress_disable
   echo 0 > /sys/module/zfs/parameters/zfs_qat_encrypt_disable
   echo 0 > /sys/module/zfs/parameters/zfs_qat_checksum_disable
2. Verify alder checksum of the de-compress result
3. Allocate Digest, IV and AAD buffer in physical contiguous
   memory by QAT_PHYS_CONTIG_ALLOC.
4. Support session re-use feature in the new QAT driver, by
   waiting session lock before remove session.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Ran local tests when the QAT driver is available at a later time, it can enable QAT
support by command 'echo 0 > /sys/module/zfs/parameters/zfs_qat_*_disable' when the
QAT started.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
