### PR TITLE
Improve rate at which new zvols are processed

### DIFF
--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -23,7 +23,7 @@
  * Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  * Rewritten for Linux by Brian Behlendorf <behlendorf1@llnl.gov>.
  * LLNL-CODE-403049.
- * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2019 by Delphix. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -56,7 +56,7 @@ typedef struct dio_request {
 } dio_request_t;
 
 
-#ifdef HAVE_OPEN_BDEV_EXCLUSIVE
+#if defined(HAVE_OPEN_BDEV_EXCLUSIVE) || defined(HAVE_BLKDEV_GET_BY_PATH)
 static fmode_t
 vdev_bdev_mode(int smode)
 {


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The kernel function which adds new zvols as disks to the system, `add_disk()`, briefly opens and closes the zvol as part of its work. Closing a zvol involves waiting for two txgs to sync. This, combined with the fact that the taskq processing new zvols is single threaded, can make this processing of new zvols quite slow.

Issue #8526

### Description
<!--- Describe your changes in detail -->

Waiting for these txgs to sync is only necessary if the zvol has been written to, which is not the case during `add_disk()`. This change adds tracking of whether a zvol has been opened in write mode so that we can skip the `txg_wait_synced()` calls when they are unnecessary.

One of the `txg_wait_synced()` calls happens in `zil_close()`. To prevent this wait, this change avoids opening a ZIL for the zvol until the zvol is opened in write mode, so that the call to `zil_close()` can be skipped entirely when the zvol is closed. It might also be possible to prevent `zil_close()` from calling `txg_wait_synced()` if no data has been written to the ZIL. However, `zil_close()` calls `zil_commit()` which dirties the ZIL even if nothing has been written to it yet. Not being too familiar with how the ZIL works, I wasn't sure how best to prevent that, so I opted to avoid opening a ZIL until it was needed.

This change also fixes the flags passed to `blkdev_get_by_path()` by `vdev_disk_open()` to be `FMODE_READ | FMODE_WRITE | FMODE_EXCL` instead of just `FMODE_EXCL`. The flags were being incorrectly calculated because we were using the wrong version of `vdev_bdev_mode()`. Without this change tests which create a zpool on top of a zvol would cause crashes because we would write to the zvol even though we hadn't passed in the `FMODE_WRITE` flag when we opened it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested by creating a large number of zvols in succession in a pool with a moderate write load and then waiting for all of the links to appear in `/dev/zvol`:
```
for i in `seq 1 100`; do sudo zfs create -V 8M rpool/zvol$i & done; time while [[ $(find /dev/zvol/rpool | wc -l) -lt 100 ]]; do sleep .05; done
```
This test ran ~500x faster with this change than it did without (5sec vs 41min).

Tested that writes to a zvol are still handled correctly when the zvol is opened multiple times concurrently in different modes, using variations of
```
$ zfs create -V 1M rpool/vol1
$ dd if=/dev/urandom of=test.dat bs=1M count=1
# Open zvol in read mode, then in write mode. Then open in write mode again and write to it.
$ { { dd if=test.dat of=/dev/zvol/rpool/vol1; } >/dev/zvol/rpool/vol1; } </dev/zvol/rpool/vol1
$ cmp test.dat /dev/zvol/rpool/vol1 || echo "Do not match"
```

Also used bpftrace to confirm that the correct flags (`FMODE_READ | FMODE_WRITE | FMODE_EXCL`) are being passed into `blkdev_get_by_path()`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
