### PR TITLE
Cleanup nits from ab7615d92

### DIFF
--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -1221,7 +1221,7 @@ main(int argc, char **argv)
 
 		if (dvas != 0) {
 			if (error == EACCES || error == EINVAL) {
-				(void) fprintf(stderr, "the '-c' option may "
+				(void) fprintf(stderr, "the '-C' option may "
 				    "not be used with logical data errors "
 				    "'decrypt' and 'decompress'\n");
 				libzfs_fini(g_zfs);

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -257,8 +257,6 @@ vdev_mirror_map_init(zio_t *zio)
 		dsl_scan_t *scn = spa->spa_dsl_pool->dp_scan;
 		dva_t dva_copy[SPA_DVAS_PER_BP];
 
-		c = BP_GET_NDVAS(zio->io_bp);
-
 		/*
 		 * The sequential scrub code sorts and issues all DVAs
 		 * of a bp separately. Each of these IOs includes all


### PR DESCRIPTION
This patch simply up cleans up a nit and corrects an error message
issue that were introduced in the Multiple DVA scrub patch.

Signed-off-by: Tom Caputi <tcaputi@datto.com>

### Motivation and Context
Issues found by @Ramzec and posted on the original PR.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
