### PR TITLE
Fix hierarchy misspellings

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -2759,13 +2759,13 @@ created_before(libzfs_handle_t *hdl, avl_tree_t *avl,
 }
 
 /*
- * This function reestablishes the heirarchy of encryption roots after a
+ * This function reestablishes the hierarchy of encryption roots after a
  * recursive incremental receive has completed. This must be done after the
  * second call to recv_incremental_replication() has renamed and promoted all
- * sent datasets to their final locations in the dataset heriarchy.
+ * sent datasets to their final locations in the dataset hierarchy.
  */
 static int
-recv_fix_encryption_heirarchy(libzfs_handle_t *hdl, const char *destname,
+recv_fix_encryption_hierarchy(libzfs_handle_t *hdl, const char *destname,
     nvlist_t *stream_nv, avl_tree_t *stream_avl)
 {
 	int err;
@@ -3406,7 +3406,7 @@ zfs_receive_package(libzfs_handle_t *hdl, int fd, const char *destname,
 	}
 
 	if (raw && softerr == 0) {
-		softerr = recv_fix_encryption_heirarchy(hdl, destname,
+		softerr = recv_fix_encryption_hierarchy(hdl, destname,
 		    stream_nv, stream_avl);
 	}
 
@@ -3815,7 +3815,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		/*
 		 * The keylocation property may only be set on encryption roots,
 		 * but this dataset might not become an encryption root until
-		 * recv_fix_encryption_heirarchy() is called. That function
+		 * recv_fix_encryption_hierarchy() is called. That function
 		 * will fixup the keylocation anyway, so we temporarily unset
 		 * the keylocation for now to avoid any errors from the receive
 		 * ioctl.

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -803,7 +803,7 @@ tests = ['rsend_001_pos', 'rsend_002_pos', 'rsend_003_pos', 'rsend_004_pos',
     'send-c_lz4_disabled', 'send-c_recv_lz4_disabled',
     'send-c_mixed_compression', 'send-c_stream_size_estimate', 'send-cD',
     'send-c_embedded_blocks', 'send-c_resume', 'send-cpL_varied_recsize',
-    'send-c_recv_dedup', 'send_encrypted_files', 'send_encrypted_heirarchy',
+    'send-c_recv_dedup', 'send_encrypted_files', 'send_encrypted_hierarchy',
     'send_encrypted_props', 'send_freeobjects', 'send_realloc_dnode_size',
     'send_realloc_files', 'send_holds', 'send_hole_birth', 'send_mixed_raw',
     'send-wDR_encrypted_zvol']

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_003_pos.ksh
@@ -135,7 +135,7 @@ for obj in $child_fs $child_fs1 $ctr $ctr1; do
 	log_mustnot zfs destroy -r $obj
 	datasetexists $obj || \
 		log_fail "'zfs destroy -r' fails to keep dependent " \
-			"clone outside the hirearchy."
+			"clone outside the hierarchy."
 done
 
 

--- a/tests/zfs-tests/tests/functional/rsend/Makefile.am
+++ b/tests/zfs-tests/tests/functional/rsend/Makefile.am
@@ -22,7 +22,7 @@ dist_pkgdata_SCRIPTS = \
 	rsend_022_pos.ksh \
 	rsend_024_pos.ksh \
 	send_encrypted_files.ksh \
-	send_encrypted_heirarchy.ksh \
+	send_encrypted_hierarchy.ksh \
 	send_encrypted_props.ksh \
 	send-cD.ksh \
 	send-c_embedded_blocks.ksh \

--- a/tests/zfs-tests/tests/functional/rsend/send_encrypted_hierarchy.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_encrypted_hierarchy.ksh
@@ -46,7 +46,7 @@ function cleanup
 log_assert "Raw recursive sends preserve filesystem structure."
 log_onexit cleanup
 
-# Create the filesystem heirarchy
+# Create the filesystem hierarchy
 log_must cleanup_pool $POOL
 log_must eval "echo $PASSPHRASE | zfs create -o encryption=on" \
 	"-o keyformat=passphrase $POOL/$FS"
@@ -72,7 +72,7 @@ log_must verify_origin $POOL/clone "$POOL/$FS@snap"
 log_must verify_encryption_root $POOL/$FS/child $POOL/$FS
 log_must verify_keylocation $POOL/$FS/child "none"
 
-# Alter the heirarchy and re-send
+# Alter the hierarchy and re-send
 log_must eval "echo $PASSPHRASE1 | zfs change-key -o keyformat=passphrase" \
 	"$POOL/$FS/child"
 log_must zfs promote $POOL/clone


### PR DESCRIPTION
Reported-by: Matthew Ahrens <mahrens@delphix.com>
Signed-off-by: Richard Laager <rlaager@wiktel.com>
Closes #8563

### Motivation and Context
In several places, "hierarchy" is misspelled.

### Description
This fixes the various misspellings of "hierarchy".

### How Has This Been Tested?
I have manually read the diff to confirm the correct spelling. I have grepped the source tree for "archy" and confirmed everything is spelling correctly after these changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
