### PR TITLE
Restructure vec_idx loops

### DIFF
--- a/module/icp/io/sha1_mod.c
+++ b/module/icp/io/sha1_mod.c
@@ -266,7 +266,7 @@ sha1_digest_update_uio(SHA1_CTX *sha1_ctx, crypto_data_t *data)
 {
 	off_t offset = data->cd_offset;
 	size_t length = data->cd_length;
-	uint_t vec_idx;
+	uint_t vec_idx = 0;
 	size_t cur_len;
 
 	/* we support only kernel buffer */
@@ -277,10 +277,11 @@ sha1_digest_update_uio(SHA1_CTX *sha1_ctx, crypto_data_t *data)
 	 * Jump to the first iovec containing data to be
 	 * digested.
 	 */
-	for (vec_idx = 0; vec_idx < data->cd_uio->uio_iovcnt &&
-	    offset >= data->cd_uio->uio_iov[vec_idx].iov_len;
-	    offset -= data->cd_uio->uio_iov[vec_idx++].iov_len)
-		;
+	while (vec_idx < data->cd_uio->uio_iovcnt &&
+	    offset >= data->cd_uio->uio_iov[vec_idx].iov_len) {
+		offset -= data->cd_uio->uio_iov[vec_idx].iov_len;
+		vec_idx++;
+	}
 	if (vec_idx == data->cd_uio->uio_iovcnt) {
 		/*
 		 * The caller specified an offset that is larger than the
@@ -329,7 +330,7 @@ sha1_digest_final_uio(SHA1_CTX *sha1_ctx, crypto_data_t *digest,
     ulong_t digest_len, uchar_t *digest_scratch)
 {
 	off_t offset = digest->cd_offset;
-	uint_t vec_idx;
+	uint_t vec_idx = 0;
 
 	/* we support only kernel buffer */
 	if (digest->cd_uio->uio_segflg != UIO_SYSSPACE)
@@ -339,10 +340,11 @@ sha1_digest_final_uio(SHA1_CTX *sha1_ctx, crypto_data_t *digest,
 	 * Jump to the first iovec containing ptr to the digest to
 	 * be returned.
 	 */
-	for (vec_idx = 0; offset >= digest->cd_uio->uio_iov[vec_idx].iov_len &&
-	    vec_idx < digest->cd_uio->uio_iovcnt;
-	    offset -= digest->cd_uio->uio_iov[vec_idx++].iov_len)
-		;
+	while (vec_idx < digest->cd_uio->uio_iovcnt &&
+	    offset >= digest->cd_uio->uio_iov[vec_idx].iov_len) {
+		offset -= digest->cd_uio->uio_iov[vec_idx].iov_len;
+		vec_idx++;
+	}
 	if (vec_idx == digest->cd_uio->uio_iovcnt) {
 		/*
 		 * The caller specified an offset that is
@@ -1095,7 +1097,7 @@ sha1_mac_verify_atomic(crypto_provider_handle_t provider,
 
 	case CRYPTO_DATA_UIO: {
 		off_t offset = mac->cd_offset;
-		uint_t vec_idx;
+		uint_t vec_idx = 0;
 		off_t scratch_offset = 0;
 		size_t length = digest_len;
 		size_t cur_len;
@@ -1105,11 +1107,11 @@ sha1_mac_verify_atomic(crypto_provider_handle_t provider,
 			return (CRYPTO_ARGUMENTS_BAD);
 
 		/* jump to the first iovec containing the expected digest */
-		for (vec_idx = 0;
-		    offset >= mac->cd_uio->uio_iov[vec_idx].iov_len &&
-		    vec_idx < mac->cd_uio->uio_iovcnt;
-		    offset -= mac->cd_uio->uio_iov[vec_idx++].iov_len)
-			;
+		while (vec_idx < mac->cd_uio->uio_iovcnt &&
+		    offset >= mac->cd_uio->uio_iov[vec_idx].iov_len) {
+			offset -= mac->cd_uio->uio_iov[vec_idx].iov_len;
+			vec_idx++;
+		}
 		if (vec_idx == mac->cd_uio->uio_iovcnt) {
 			/*
 			 * The caller specified an offset that is

--- a/module/icp/io/skein_mod.c
+++ b/module/icp/io/skein_mod.c
@@ -269,7 +269,7 @@ skein_digest_update_uio(skein_ctx_t *ctx, const crypto_data_t *data)
 {
 	off_t		offset = data->cd_offset;
 	size_t		length = data->cd_length;
-	uint_t		vec_idx;
+	uint_t		vec_idx = 0;
 	size_t		cur_len;
 	const uio_t	*uio = data->cd_uio;
 
@@ -281,10 +281,11 @@ skein_digest_update_uio(skein_ctx_t *ctx, const crypto_data_t *data)
 	 * Jump to the first iovec containing data to be
 	 * digested.
 	 */
-	for (vec_idx = 0; vec_idx < uio->uio_iovcnt &&
-	    offset >= uio->uio_iov[vec_idx].iov_len;
-	    offset -= uio->uio_iov[vec_idx++].iov_len)
-		;
+	while (vec_idx < uio->uio_iovcnt &&
+	    offset >= uio->uio_iov[vec_idx].iov_len) {
+		offset -= uio->uio_iov[vec_idx].iov_len;
+		vec_idx++;
+	}
 	if (vec_idx == uio->uio_iovcnt) {
 		/*
 		 * The caller specified an offset that is larger than the
@@ -325,7 +326,7 @@ skein_digest_final_uio(skein_ctx_t *ctx, crypto_data_t *digest,
     crypto_req_handle_t req)
 {
 	off_t	offset = digest->cd_offset;
-	uint_t	vec_idx;
+	uint_t	vec_idx = 0;
 	uio_t	*uio = digest->cd_uio;
 
 	/* we support only kernel buffer */
@@ -335,10 +336,11 @@ skein_digest_final_uio(skein_ctx_t *ctx, crypto_data_t *digest,
 	/*
 	 * Jump to the first iovec containing ptr to the digest to be returned.
 	 */
-	for (vec_idx = 0; offset >= uio->uio_iov[vec_idx].iov_len &&
-	    vec_idx < uio->uio_iovcnt;
-	    offset -= uio->uio_iov[vec_idx++].iov_len)
-		;
+	while (vec_idx < uio->uio_iovcnt &&
+	    offset >= uio->uio_iov[vec_idx].iov_len) {
+		offset -= uio->uio_iov[vec_idx].iov_len;
+		vec_idx++;
+	}
 	if (vec_idx == uio->uio_iovcnt) {
 		/*
 		 * The caller specified an offset that is larger than the


### PR DESCRIPTION
### Motivation and Context
This replaces empty for loops with while loops to make the code easier to read, as discussed in #6683. See also #6681 and #6682.

### How Has This Been Tested?
I reviewed the diff. I also re-ran `cd module/icp/io ; cppcheck --enable=all *.c` to confirm all the vec_idx warnings were gone. I'm largely depending on the build bots and code review here.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).