### PR TITLE
Various documentation fixes

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -488,12 +488,6 @@ typedef enum zfs_key_location {
 #define	SPA_VERSION_28			28ULL
 #define	SPA_VERSION_5000		5000ULL
 
-/*
- * When bumping up SPA_VERSION, make sure GRUB ZFS understands the on-disk
- * format change. Go to usr/src/grub/grub-0.97/stage2/{zfs-include/, fsys_zfs*},
- * and do the appropriate changes.  Also bump the version number in
- * usr/src/grub/capability.
- */
 #define	SPA_VERSION			SPA_VERSION_5000
 #define	SPA_VERSION_STRING		"5000"
 
@@ -557,9 +551,6 @@ typedef enum zfs_key_location {
  * ZPL version - rev'd whenever an incompatible on-disk format change
  * occurs.  This is independent of SPA/DMU/ZAP versioning.  You must
  * also update the version_table[] and help message in zfs_prop.c.
- *
- * When changing, be sure to teach GRUB how to read the new format!
- * See usr/src/grub/grub-0.97/stage2/{zfs-include/,fsys_zfs*}
  */
 #define	ZPL_VERSION_1			1ULL
 #define	ZPL_VERSION_2			2ULL

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -488,6 +488,10 @@ typedef enum zfs_key_location {
 #define	SPA_VERSION_28			28ULL
 #define	SPA_VERSION_5000		5000ULL
 
+/*
+ * The incrementing pool version number has been replaced by pool feature
+ * flags.  For more details, see zfeature.c.
+ */
 #define	SPA_VERSION			SPA_VERSION_5000
 #define	SPA_VERSION_STRING		"5000"
 

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -598,7 +598,8 @@ can turn on the \fBsha512\fR checksum on any dataset using
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBsha512\fR are destroyed.
 
-Booting off of pools utilizing SHA-512/256 is supported.
+The \fBsha512\fR feature is not supported by GRUB and must not be used on
+the pool if GRUB needs to access the pool (e.g. for /boot).
 
 .RE
 
@@ -632,7 +633,8 @@ can turn on the \fBskein\fR checksum on any dataset using
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBskein\fR are destroyed.
 
-Booting off of pools using \fBskein\fR is supported.
+The \fBskein\fR feature is not supported by GRUB and must not be used on
+the pool if GRUB needs to access the pool (e.g. for /boot).
 
 .RE
 
@@ -672,7 +674,8 @@ can turn on the \fBedonr\fR checksum on any dataset using the
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBedonr\fR are destroyed.
 
-Booting off of pools using \fBedonr\fR is supported.
+The \fBedonr\fR feature is not supported by GRUB and must not be used on
+the pool if GRUB needs to access the pool (e.g. for /boot).
 
 .RE
 

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -652,8 +652,8 @@ DEPENDENCIES	extensible_dataset
 This feature enables the use of the Edon-R hash algorithm for checksum,
 including for nopwrite (if compression is also enabled, an overwrite of
 a block whose checksum matches the data being written will be ignored).
-In an abundance of caution, Edon-R can not be used with dedup
-(without verification).
+In an abundance of caution, Edon-R requires verification when used with
+dedup: \fBzfs set dedup=edonr,verify\fR.  See \fBzfs\fR(8).
 
 Edon-R is a very high-performance hash algorithm that was part
 of the NIST SHA-3 competition. It provides extremely high hash

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -794,8 +794,8 @@ This feature allows zfs to postpone new resilvers if an existing one is already
 in progress. Without this feature, any new resilvers will cause the currently
 running one to be immediately restarted from the beginning.
 
-This feature becomes \fBactive\fR once a resilver has been defered, and returns
-to being \fBenabled\fR when the defered resilver begins.
+This feature becomes \fBactive\fR once a resilver has been deferred, and
+returns to being \fBenabled\fR when the deferred resilver begins.
 
 .RE
 

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -38,15 +38,15 @@ this set may include unsupported features.
 .SS "Identifying features"
 .sp
 .LP
-Every feature has a guid of the form \fIcom.example:feature_name\fR. The reverse
-DNS name ensures that the feature's guid is unique across all ZFS
+Every feature has a GUID of the form \fIcom.example:feature_name\fR. The
+reverse DNS name ensures that the feature's GUID is unique across all ZFS
 implementations. When unsupported features are encountered on a pool they will
-be identified by their guids. Refer to the documentation for the ZFS
+be identified by their GUIDs. Refer to the documentation for the ZFS
 implementation that created the pool for information about those features.
 .sp
 .LP
 Each supported feature also has a short name. By convention a feature's short
-name is the portion of its guid which follows the ':' (e.g.
+name is the portion of its GUID which follows the ':' (e.g.
 \fIcom.example:feature_name\fR would have the short name \fIfeature_name\fR),
 however a feature's short name may differ across ZFS implementations if
 following the convention would result in name conflicts.
@@ -109,7 +109,7 @@ importing pools).
 .sp
 .LP
 For each unsupported feature enabled on an imported pool a pool property
-named \fIunsupported@feature_guid\fR will indicate why the import was allowed
+named \fIunsupported@feature_name\fR will indicate why the import was allowed
 despite the unsupported feature. Possible values for this property are:
 
 .sp

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -23,7 +23,7 @@ zpool\-features \- ZFS pool feature descriptions
 ZFS pool on\-disk format versions are specified via "features" which replace
 the old on\-disk format numbers (the last supported on\-disk format number is
 28). To enable a feature on a pool use the \fBupgrade\fR subcommand of the
-\fBzpool\fR(8) command, or set the \fBfeature@\fR\fIfeature_name\fR property
+zpool(8) command, or set the \fBfeature@\fR\fIfeature_name\fR property
 to \fBenabled\fR.
 .sp
 .LP
@@ -103,7 +103,7 @@ Some features may make on\-disk format changes that do not interfere with other
 software's ability to read from the pool. These features are referred to as
 "read\-only compatible". If all unsupported features on a pool are read\-only
 compatible, the pool can be imported in read\-only mode by setting the
-\fBreadonly\fR property during import (see \fBzpool\fR(8) for details on
+\fBreadonly\fR property during import (see zpool(8) for details on
 importing pools).
 .SS "Unsupported features"
 .sp
@@ -243,9 +243,9 @@ giving approximately 10% better compression ratio.
 
 When the \fBlz4_compress\fR feature is set to \fBenabled\fR, the
 administrator can turn on \fBlz4\fR compression on any dataset on the
-pool using the \fBzfs\fR(8) command. Please note that doing so will
+pool using the zfs(8) command. Please note that doing so will
 immediately activate the \fBlz4_compress\fR feature on the underlying
-pool using the \fBzfs\fR(1M) command. Also, all newly written metadata
+pool using the zfs(8) command. Also, all newly written metadata
 will be compressed with \fBlz4\fR algorithm. Since this feature is not
 read-only compatible, this operation will render the pool unimportable
 on systems without support for the \fBlz4_compress\fR feature.
@@ -383,7 +383,7 @@ READ\-ONLY COMPATIBLE	no
 DEPENDENCIES	enabled_txg
 .TE
 
-This feature improves performance of incremental sends ("zfs send -i")
+This feature improves performance of incremental sends (\fBzfs send -i\fR)
 and receives for objects with many holes. The most common case of
 hole-filled objects is zvols.
 
@@ -452,10 +452,10 @@ READ\-ONLY COMPATIBLE	no
 DEPENDENCIES	none
 .TE
 
-This feature enables the "zpool remove" subcommand to remove top-level
+This feature enables the \fBzpool remove\fR subcommand to remove top-level
 vdevs, evacuating them to reduce the total size of the pool.
 
-This feature becomes \fBactive\fR when the "zpool remove" command is used
+This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is used
 on a top-level vdev, and will never return to being \fBenabled\fR.
 
 .RE
@@ -477,7 +477,7 @@ reduce the memory used to track removed devices.  When indirect blocks
 are freed or remapped, we note that their part of the indirect mapping
 is "obsolete", i.e. no longer needed.
 
-This feature becomes \fBactive\fR when the "zpool remove" command is
+This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is
 used on a top-level vdev, and will never return to being \fBenabled\fR.
 
 .RE
@@ -494,11 +494,11 @@ READ\-ONLY COMPATIBLE	yes
 DEPENDENCIES	none
 .TE
 
-This feature enables the "zpool checkpoint" subcommand that can
+This feature enables the \fBzpool checkpoint\fR subcommand that can
 checkpoint the state of the pool at the time it was issued and later
 rewind back to it or discard it.
 
-This feature becomes \fBactive\fR when the "zpool checkpoint" command
+This feature becomes \fBactive\fR when the \fBzpool checkpoint\fR subcommand
 is used to checkpoint the pool.
 The feature will only return back to being \fBenabled\fR when the pool
 is rewound or the checkpoint has been discarded.
@@ -592,8 +592,8 @@ cannot for whatever reason utilize the faster \fBskein\fR and
 \fBedonr\fR algorithms.
 
 When the \fBsha512\fR feature is set to \fBenabled\fR, the administrator
-can turn on the \fBsha512\fR checksum on any dataset using the
-\fBzfs set checksum=sha512\fR(1M) command.  This feature becomes
+can turn on the \fBsha512\fR checksum on any dataset using
+\fBzfs set checksum=sha512\fR. See zfs(8). This feature becomes
 \fBactive\fR once a \fBchecksum\fR property has been set to \fBsha512\fR,
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBsha512\fR are destroyed.
@@ -626,8 +626,8 @@ block to be checksummed. Thus the produced checksums are unique to a
 given pool, preventing hash collision attacks on systems with dedup.
 
 When the \fBskein\fR feature is set to \fBenabled\fR, the administrator
-can turn on the \fBskein\fR checksum on any dataset using the
-\fBzfs set checksum=skein\fR(1M) command.  This feature becomes
+can turn on the \fBskein\fR checksum on any dataset using
+\fBzfs set checksum=skein\fR. See zfs(8). This feature becomes
 \fBactive\fR once a \fBchecksum\fR property has been set to \fBskein\fR,
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBskein\fR are destroyed.
@@ -667,7 +667,7 @@ pool.
 
 When the \fBedonr\fR feature is set to \fBenabled\fR, the administrator
 can turn on the \fBedonr\fR checksum on any dataset using the
-\fBzfs set checksum=edonr\fR(1M) command.  This feature becomes
+\fBzfs set checksum=edonr\fR. See zfs(8). This feature becomes
 \fBactive\fR once a \fBchecksum\fR property has been set to \fBedonr\fR,
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBedonr\fR are destroyed.
@@ -815,11 +815,11 @@ DEPENDENCIES	none
 This feature enables support for separate allocation classes.
 
 This feature becomes \fBactive\fR when a dedicated allocation class vdev
-(dedup or special) is created with zpool create or zpool add. With device
-removal, it can be returned to the \fBenabled\fR state if all the top-level
-vdevs from an allocation class are removed.
+(dedup or special) is created with the \fBzpool create\fR or \fBzpool add\fR
+subcommands. With device removal, it can be returned to the \fBenabled\fR
+state if all the dedicated allocation class vdevs are removed.
 
 .RE
 
 .SH "SEE ALSO"
-\fBzpool\fR(8)
+zpool(8)

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -78,10 +78,8 @@ some amount of consistency checking.
 It is a not a general purpose tool and options
 .Pq and facilities
 may change.
-This is neither a
-.Xr fsck 1M
-nor an
-.Xr fsdb 1M
+This is not a
+.Xr fsck 8
 utility.
 .Pp
 The output of this command in general reflects the on-disk structure of a ZFS

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1191,9 +1191,9 @@ The
 and
 .Sy edonr
 checksum algorithms require enabling the appropriate features on the pool.
-These algorithms are not supported by GRUB and should not be set on the
-.Sy bootfs
-filesystem when using GRUB to boot the system.
+These pool features are not supported by GRUB and must not be used on the
+pool if GRUB needs to access the pool (e.g. for /boot).
+.Pp
 Please see
 .Xr zpool-features 5
 for more information on these algorithms.

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -26,7 +26,7 @@
 .\" Copyright (c) 2014, Joyent, Inc. All rights reserved.
 .\" Copyright (c) 2014 by Adam Stevko. All rights reserved.
 .\" Copyright (c) 2014 Integros [integros.com]
-.\" Copyright 2016 Richard Laager. All rights reserved.
+.\" Copyright 2019 Richard Laager. All rights reserved.
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2018 Joyent, Inc.
 .\"
@@ -356,7 +356,7 @@ Applications that depend on standards conformance might fail due to non-standard
 behavior when checking file system free space.
 .It Sy volume
 A logical volume exported as a raw or block device.
-This type of dataset should only be used under special circumstances.
+This type of dataset should only be used when a block device is required.
 File systems are typically used in most environments.
 .It Sy snapshot
 A read-only version of a file system or volume at a given point in time.
@@ -2885,7 +2885,7 @@ A property for sorting the output by column in ascending order based on the
 value of the property.
 The property must be one of the properties described in the
 .Sx Properties
-section, or the special value
+section or the value
 .Sy name
 to sort by the dataset name.
 Multiple properties can be specified at one time using multiple
@@ -2976,7 +2976,7 @@ and
 .Sx User Properties
 sections.
 .Pp
-The special value
+The value
 .Sy all
 can be used to display all properties that apply to the given dataset's type
 .Pq filesystem, volume, snapshot, or bookmark .
@@ -4061,7 +4061,7 @@ leaves any existing local setting or explicit inheritance unchanged.
 .Pp
 All
 .Fl o
-restrictions on set-once and special properties apply equally to
+restrictions (e.g. set-once) apply equally to
 .Fl x .
 .El
 .It Xo

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -280,7 +280,7 @@ The minimum number of devices in a raidz group is one more than the number of
 parity disks.
 The recommended number is between 3 and 9 to help increase performance.
 .It Sy spare
-A special pseudo-vdev which keeps track of available hot spares for a pool.
+A pseudo-vdev which keeps track of available hot spares for a pool.
 For more information, see the
 .Sx Hot Spares
 section.
@@ -294,16 +294,16 @@ For more information, see the
 .Sx Intent Log
 section.
 .It Sy dedup
-A device dedicated solely for allocating dedup data.
+A device dedicated solely for dedup data.
 The redundancy of this device should match the redundancy of the other normal
 devices in the pool. If more than one dedup device is specified, then
-allocations are load-balanced between devices.
+allocations are load-balanced between those devices.
 .It Sy special
 A device dedicated solely for allocating various kinds of internal metadata,
 and optionally small file data.
 The redundancy of this device should match the redundancy of the other normal
 devices in the pool. If more than one special device is specified, then
-allocations are load-balanced between devices.
+allocations are load-balanced between those devices.
 .Pp
 For more information on special allocations, see the
 .Sx Special Allocation Class
@@ -574,7 +574,7 @@ Inclusion of small file blocks in the special class is opt-in. Each dataset
 can control the size of small file blocks allowed in the special class by
 setting the
 .Sy special_small_blocks
-dataset property. It defaults to zero so you must opt-in by setting it to a
+dataset property. It defaults to zero, so you must opt-in by setting it to a
 non-zero value. See
 .Xr zfs 8
 for more info on setting this property.
@@ -715,7 +715,7 @@ Pool sector size exponent, to the power of
 .Sy 2
 (internally referred to as
 .Sy ashift
-). Values from 9 to 16, inclusive, are valid; also, the special
+). Values from 9 to 16, inclusive, are valid; also, the
 value 0 (the default) means to auto-detect using the kernel's block
 layer and a ZFS internal exception list. I/O operations will be aligned
 to the specified size boundaries. Additionally, the minimum (disk)
@@ -785,9 +785,9 @@ imported.
 Setting this property caches the pool configuration in a different location that
 can later be imported with
 .Nm zpool Cm import Fl c .
-Setting it to the special value
+Setting it to the value
 .Sy none
-creates a temporary pool that is never cached, and the special value
+creates a temporary pool that is never cached, and the
 .Qq
 .Pq empty string
 uses the default location.

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -612,8 +612,8 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 				/*
 				 * Must be ZPL, and its property settings
 				 * must be supported by GRUB (compression
-				 * is not gzip, and large blocks or large
-				 * dnodes are not used).
+				 * is not gzip, and large dnodes are not
+				 * used).
 				 */
 
 				if (dmu_objset_type(os) != DMU_OST_ZFS) {

--- a/module/zfs/zfeature.c
+++ b/module/zfs/zfeature.c
@@ -41,9 +41,9 @@
  * spa_version() number.
  *
  * Each new on-disk format change will be given a uniquely identifying string
- * guid rather than a version number. This avoids the problem of different
+ * GUID rather than a version number. This avoids the problem of different
  * organizations creating new on-disk formats with the same version number. To
- * keep feature guids unique they should consist of the reverse dns name of the
+ * keep feature GUIDs unique they should consist of the reverse dns name of the
  * organization which implemented the feature and a short name for the feature,
  * separated by a colon (e.g. com.delphix:async_destroy).
  *
@@ -95,11 +95,11 @@
  * These objects are linked to by the following names in the pool directory
  * object:
  *
- * 1) features_for_read: feature guid -> reference count
+ * 1) features_for_read: feature GUID -> reference count
  *    Features needed to open the pool for reading.
- * 2) features_for_write: feature guid -> reference count
+ * 2) features_for_write: feature GUID -> reference count
  *    Features needed to open the pool for writing.
- * 3) feature_descriptions: feature guid -> descriptive string
+ * 3) feature_descriptions: feature GUID -> descriptive string
  *    A human readable string.
  *
  * All enabled features appear in either features_for_read or

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -1320,7 +1320,7 @@ zil_lwb_set_zio_dependency(zilog_t *zilog, lwb_t *lwb)
 		 * root zios). This is required because of how we can
 		 * defer the DKIOCFLUSHWRITECACHE commands for each lwb.
 		 *
-		 * When the DKIOCFLUSHWRITECACHE commands are defered,
+		 * When the DKIOCFLUSHWRITECACHE commands are deferred,
 		 * the previous lwb will rely on this lwb to flush the
 		 * vdevs written to by that previous lwb. Thus, we need
 		 * to ensure this lwb doesn't issue the flush until


### PR DESCRIPTION
### Motivation and Context
This started as a change to eliminate the word "special" from the "spares" pseudo-vdev type, since "special" now has a specific meaning in the context of vdevs. It spiraled into a loosely-related pile of small documentation fixes.

### Description
1) I eliminated almost all instances of the word "special" that are not referencing the allocation_classes feature.
2) I cleaned up zpool-features.5's references to commands. I fixed man page section references from 1M (Solaris) to 8 (Linux).
3) I updated a fsck reference in zdb.8 and eliminated the fsdb reference, since the latter does not exist on Linux.
4) I fixed the spelling of deferred in a man page and a code comment.
5) I consistently capitalized GUID in zpool-features.5.
6) I reworded the Edon-R dedup limitation in zpool-features.5 so it isn't worded as "You can not use this (except you can)".
7) I removed an old note about updating GRUB when bumping SPA_VERSION.
8) I updated a code comment to match the code. GRUB supports large_blocks.
9) I clarified GRUB's lack of support for the sha512, skein, and edonr features, including fixing contradictions (arguable contradictions, if you want to be pedantic) between different man pages.

If some of these commits should be squashed, I'm open to that, but I would really prefer that they not _all_ be squashed into one commit.

### How Has This Been Tested?
I viewed the man pages with `man`.

GRUB's large_blocks support can be confirmed here: http://git.savannah.gnu.org/cgit/grub.git/tree/grub-core/fs/zfs/zfs.c#n276

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
