### PR TITLE
zpool-features(5) and other man page fixes

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -377,8 +377,8 @@ Use \fB1\fR for yes (default) and \fB0\fR for no.
 .ad
 .RS 12n
 When set, the hole_birth optimization will not be used, and all holes will
-always be sent on zfs send. Useful if you suspect your datasets are affected
-by a bug in hole_birth.
+always be sent on zfs send.  This is useful if you suspect your datasets are
+affected by a bug in hole_birth.
 .sp
 Use \fB1\fR for on (default) and \fB0\fR for off.
 .RE

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -110,11 +110,7 @@ Default value: \fB6\fR.
 \fBignore_hole_birth\fR (int)
 .ad
 .RS 12n
-When set, the hole_birth optimization will not be used, and all holes will
-always be sent on zfs send. Useful if you suspect your datasets are affected
-by a bug in hole_birth.
-.sp
-Use \fB1\fR for on (default) and \fB0\fR for off.
+This is an alias for \fBsend_holes_without_birth_time\fR.
 .RE
 
 .sp
@@ -372,6 +368,19 @@ greater bandwidth as is typically the case on a modern constant
 angular velocity disk drive.
 .sp
 Use \fB1\fR for yes (default) and \fB0\fR for no.
+.RE
+
+.sp
+.ne 2
+.na
+\fBsend_holes_without_birth_time\fR (int)
+.ad
+.RS 12n
+When set, the hole_birth optimization will not be used, and all holes will
+always be sent on zfs send. Useful if you suspect your datasets are affected
+by a bug in hole_birth.
+.sp
+Use \fB1\fR for on (default) and \fB0\fR for off.
 .RE
 
 .sp

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -142,6 +142,28 @@ depends on.
 .sp
 .LP
 The following features are supported on this system:
+
+.sp
+.ne 2
+.na
+\fB\fBallocation_classes\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	org.zfsonlinux:allocation_classes
+READ\-ONLY COMPATIBLE	yes
+DEPENDENCIES	none
+.TE
+
+This feature enables support for separate allocation classes.
+
+This feature becomes \fBactive\fR when a dedicated allocation class vdev
+(dedup or special) is created with the \fBzpool create\fR or \fBzpool add\fR
+subcommands. With device removal, it can be returned to the \fBenabled\fR
+state if all the dedicated allocation class vdevs are removed.
+.RE
+
 .sp
 .ne 2
 .na
@@ -175,6 +197,133 @@ This feature is only \fBactive\fR while \fBfreeing\fR is non\-zero.
 .sp
 .ne 2
 .na
+\fB\fBbookmarks\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	com.delphix:bookmarks
+READ\-ONLY COMPATIBLE	yes
+DEPENDENCIES	extensible_dataset
+.TE
+
+This feature enables use of the \fBzfs bookmark\fR subcommand.
+
+This feature is \fBactive\fR while any bookmarks exist in the pool.
+All bookmarks in the pool can be listed by running
+\fBzfs list -t bookmark -r \fIpoolname\fR\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBbookmark_v2\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	com.datto:bookmark_v2
+READ\-ONLY COMPATIBLE	no
+DEPENDENCIES	bookmark, extensible_dataset
+.TE
+
+This feature enables the creation and management of larger bookmarks which are
+needed for other features in ZFS.
+
+This feature becomes \fBactive\fR when a v2 bookmark is created and will be
+returned to the \fBenabled\fR state when all v2 bookmarks are destroyed.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBdevice_removal\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	com.delphix:device_removal
+READ\-ONLY COMPATIBLE	no
+DEPENDENCIES	none
+.TE
+
+This feature enables the \fBzpool remove\fR subcommand to remove top-level
+vdevs, evacuating them to reduce the total size of the pool.
+
+This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is used
+on a top-level vdev, and will never return to being \fBenabled\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBedonr\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	org.illumos:edonr
+READ\-ONLY COMPATIBLE	no
+DEPENDENCIES	extensible_dataset
+.TE
+
+This feature enables the use of the Edon-R hash algorithm for checksum,
+including for nopwrite (if compression is also enabled, an overwrite of
+a block whose checksum matches the data being written will be ignored).
+In an abundance of caution, Edon-R requires verification when used with
+dedup: \fBzfs set dedup=edonr,verify\fR.  See \fBzfs\fR(8).
+
+Edon-R is a very high-performance hash algorithm that was part
+of the NIST SHA-3 competition. It provides extremely high hash
+performance (over 350% faster than SHA-256), but was not selected
+because of its unsuitability as a general purpose secure hash algorithm.
+This implementation utilizes the new salted checksumming functionality
+in ZFS, which means that the checksum is pre-seeded with a secret
+256-bit random key (stored on the pool) before being fed the data block
+to be checksummed. Thus the produced checksums are unique to a given
+pool.
+
+When the \fBedonr\fR feature is set to \fBenabled\fR, the administrator
+can turn on the \fBedonr\fR checksum on any dataset using the
+\fBzfs set checksum=edonr\fR. See zfs(8). This feature becomes
+\fBactive\fR once a \fBchecksum\fR property has been set to \fBedonr\fR,
+and will return to being \fBenabled\fR once all filesystems that have
+ever had their checksum set to \fBedonr\fR are destroyed.
+
+The \fBedonr\fR feature is not supported by GRUB and must not be used on
+the pool if GRUB needs to access the pool (e.g. for /boot).
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBembedded_data\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	com.delphix:embedded_data
+READ\-ONLY COMPATIBLE	no
+DEPENDENCIES	none
+.TE
+
+This feature improves the performance and compression ratio of
+highly-compressible blocks.  Blocks whose contents can compress to 112 bytes
+or smaller can take advantage of this feature.
+
+When this feature is enabled, the contents of highly-compressible blocks are
+stored in the block "pointer" itself (a misnomer in this case, as it contains
+the compressed data, rather than a pointer to its location on disk).  Thus
+the space of the block (one sector, typically 512 bytes or 4KB) is saved,
+and no additional i/o is needed to read and write the data block.
+
+This feature becomes \fBactive\fR as soon as it is enabled and will
+never return to being \fBenabled\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fB\fBempty_bpobj\fR\fR
 .ad
 .RS 4n
@@ -202,55 +351,19 @@ or snapshots which were created after enabling this feature.
 .sp
 .ne 2
 .na
-\fB\fBfilesystem_limits\fR\fR
+\fB\fBenabled_txg\fR\fR
 .ad
 .RS 4n
 .TS
 l l .
-GUID	com.joyent:filesystem_limits
+GUID	com.delphix:enabled_txg
 READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	extensible_dataset
-.TE
-
-This feature enables filesystem and snapshot limits. These limits can be used
-to control how many filesystems and/or snapshots can be created at the point in
-the tree on which the limits are set.
-
-This feature is \fBactive\fR once either of the limit properties has been
-set on a dataset. Once activated the feature is never deactivated.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBlz4_compress\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.illumos:lz4_compress
-READ\-ONLY COMPATIBLE	no
 DEPENDENCIES	none
 .TE
 
-\fBlz4\fR is a high-performance real-time compression algorithm that
-features significantly faster compression and decompression as well as a
-higher compression ratio than the older \fBlzjb\fR compression.
-Typically, \fBlz4\fR compression is approximately 50% faster on
-compressible data and 200% faster on incompressible data than
-\fBlzjb\fR. It is also approximately 80% faster on decompression, while
-giving approximately 10% better compression ratio.
-
-When the \fBlz4_compress\fR feature is set to \fBenabled\fR, the
-administrator can turn on \fBlz4\fR compression on any dataset on the
-pool using the zfs(8) command. Please note that doing so will
-immediately activate the \fBlz4_compress\fR feature on the underlying
-pool using the zfs(8) command. Also, all newly written metadata
-will be compressed with \fBlz4\fR algorithm. Since this feature is not
-read-only compatible, this operation will render the pool unimportable
-on systems without support for the \fBlz4_compress\fR feature.
-
-Booting off of \fBlz4\fR-compressed root pools is supported.
+Once this feature is enabled ZFS records the transaction group number
+in which new features are enabled. This has no user-visible impact,
+but other features may depend on this feature.
 
 This feature becomes \fBactive\fR as soon as it is enabled and will
 never return to being \fBenabled\fB.
@@ -259,49 +372,21 @@ never return to being \fBenabled\fB.
 .sp
 .ne 2
 .na
-\fB\fBspacemap_histogram\fR\fR
+\fB\fBencryption\fR\fR
 .ad
 .RS 4n
 .TS
 l l .
-GUID	com.delphix:spacemap_histogram
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
-This features allows ZFS to maintain more information about how free space
-is organized within the pool. If this feature is \fBenabled\fR, ZFS will
-set this feature to \fBactive\fR when a new space map object is created or
-an existing space map is upgraded to the new format. Once the feature is
-\fBactive\fR, it will remain in that state until the pool is destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBmulti_vdev_crash_dump\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.joyent:multi_vdev_crash_dump
+GUID	com.datto:encryption
 READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	none
+DEPENDENCIES	bookmark_v2, extensible_dataset
 .TE
 
-This feature allows a dump device to be configured with a pool comprised
-of multiple vdevs.  Those vdevs may be arranged in any mirrored or raidz
-configuration.
+This feature enables the creation and management of natively encrypted datasets.
 
-When the \fBmulti_vdev_crash_dump\fR feature is set to \fBenabled\fR,
-the administrator can use the \fBdumpadm\fR(1M) command to configure a
-dump device on a pool comprised of multiple vdevs.
-
-Under Linux this feature is registered for compatibility but not used.
-New pools created under Linux will have the feature \fBenabled\fR but
-will never transition to \fB\fBactive\fR.  This functionality is not
-required in order to support crash dumps under Linux.  Existing pools
-where this feature is \fB\fBactive\fR can be imported.
+This feature becomes \fBactive\fR when an encrypted dataset is created and will
+be returned to the \fBenabled\fR state when all datasets that use this feature
+are destroyed.
 .RE
 
 .sp
@@ -328,42 +413,22 @@ this feature are destroyed.
 .sp
 .ne 2
 .na
-\fB\fBbookmarks\fR\fR
+\fB\fBfilesystem_limits\fR\fR
 .ad
 .RS 4n
 .TS
 l l .
-GUID	com.delphix:bookmarks
+GUID	com.joyent:filesystem_limits
 READ\-ONLY COMPATIBLE	yes
 DEPENDENCIES	extensible_dataset
 .TE
 
-This feature enables use of the \fBzfs bookmark\fR subcommand.
+This feature enables filesystem and snapshot limits. These limits can be used
+to control how many filesystems and/or snapshots can be created at the point in
+the tree on which the limits are set.
 
-This feature is \fBactive\fR while any bookmarks exist in the pool.
-All bookmarks in the pool can be listed by running
-\fBzfs list -t bookmark -r \fIpoolname\fR\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBenabled_txg\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:enabled_txg
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
-Once this feature is enabled ZFS records the transaction group number
-in which new features are enabled. This has no user-visible impact,
-but other features may depend on this feature.
-
-This feature becomes \fBactive\fR as soon as it is enabled and will
-never return to being \fBenabled\fB.
+This feature is \fBactive\fR once either of the limit properties has been
+set on a dataset. Once activated the feature is never deactivated.
 .RE
 
 .sp
@@ -418,121 +483,6 @@ never return to being \fBenabled\fB.
 .sp
 .ne 2
 .na
-\fB\fBembedded_data\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:embedded_data
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	none
-.TE
-
-This feature improves the performance and compression ratio of
-highly-compressible blocks.  Blocks whose contents can compress to 112 bytes
-or smaller can take advantage of this feature.
-
-When this feature is enabled, the contents of highly-compressible blocks are
-stored in the block "pointer" itself (a misnomer in this case, as it contains
-the compressed data, rather than a pointer to its location on disk).  Thus
-the space of the block (one sector, typically 512 bytes or 4KB) is saved,
-and no additional i/o is needed to read and write the data block.
-
-This feature becomes \fBactive\fR as soon as it is enabled and will
-never return to being \fBenabled\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBdevice_removal\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:device_removal
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	none
-.TE
-
-This feature enables the \fBzpool remove\fR subcommand to remove top-level
-vdevs, evacuating them to reduce the total size of the pool.
-
-This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is used
-on a top-level vdev, and will never return to being \fBenabled\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBobsolete_counts\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:obsolete_counts
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	device_removal
-.TE
-
-This feature is an enhancement of device_removal, which will over time
-reduce the memory used to track removed devices.  When indirect blocks
-are freed or remapped, we note that their part of the indirect mapping
-is "obsolete", i.e. no longer needed.
-
-This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is
-used on a top-level vdev, and will never return to being \fBenabled\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBzpool_checkpoint\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:zpool_checkpoint
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
-This feature enables the \fBzpool checkpoint\fR subcommand that can
-checkpoint the state of the pool at the time it was issued and later
-rewind back to it or discard it.
-
-This feature becomes \fBactive\fR when the \fBzpool checkpoint\fR subcommand
-is used to checkpoint the pool.
-The feature will only return back to being \fBenabled\fR when the pool
-is rewound or the checkpoint has been discarded.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBspacemap_v2\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.delphix:spacemap_v2
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
-This feature enables the use of the new space map encoding which
-consists of two words (instead of one) whenever it is advantageous.
-The new encoding allows space maps to represent large regions of
-space more efficiently on-disk while also increasing their maximum
-addressable offset.
-
-This feature becomes \fBactive\fR once it is \fBenabled\fR, and never
-returns back to being \fBenabled\fR.
-.RE
-
-.sp
-.ne 2
-.na
 \fB\fBlarge_blocks\fR\fR
 .ad
 .RS 4n
@@ -574,6 +524,146 @@ feature will return to being \fBenabled\fR once all filesystems that
 have ever contained a dnode larger than 512B are destroyed. Large dnodes
 allow more data to be stored in the bonus buffer, thus potentially
 improving performance by avoiding the use of spill blocks.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBlz4_compress\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	org.illumos:lz4_compress
+READ\-ONLY COMPATIBLE	no
+DEPENDENCIES	none
+.TE
+
+\fBlz4\fR is a high-performance real-time compression algorithm that
+features significantly faster compression and decompression as well as a
+higher compression ratio than the older \fBlzjb\fR compression.
+Typically, \fBlz4\fR compression is approximately 50% faster on
+compressible data and 200% faster on incompressible data than
+\fBlzjb\fR. It is also approximately 80% faster on decompression, while
+giving approximately 10% better compression ratio.
+
+When the \fBlz4_compress\fR feature is set to \fBenabled\fR, the
+administrator can turn on \fBlz4\fR compression on any dataset on the
+pool using the zfs(8) command. Please note that doing so will
+immediately activate the \fBlz4_compress\fR feature on the underlying
+pool using the zfs(8) command. Also, all newly written metadata
+will be compressed with \fBlz4\fR algorithm. Since this feature is not
+read-only compatible, this operation will render the pool unimportable
+on systems without support for the \fBlz4_compress\fR feature.
+
+Booting off of \fBlz4\fR-compressed root pools is supported.
+
+This feature becomes \fBactive\fR as soon as it is enabled and will
+never return to being \fBenabled\fB.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBmulti_vdev_crash_dump\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	com.joyent:multi_vdev_crash_dump
+READ\-ONLY COMPATIBLE	no
+DEPENDENCIES	none
+.TE
+
+This feature allows a dump device to be configured with a pool comprised
+of multiple vdevs.  Those vdevs may be arranged in any mirrored or raidz
+configuration.
+
+When the \fBmulti_vdev_crash_dump\fR feature is set to \fBenabled\fR,
+the administrator can use the \fBdumpadm\fR(1M) command to configure a
+dump device on a pool comprised of multiple vdevs.
+
+Under Linux this feature is registered for compatibility but not used.
+New pools created under Linux will have the feature \fBenabled\fR but
+will never transition to \fB\fBactive\fR.  This functionality is not
+required in order to support crash dumps under Linux.  Existing pools
+where this feature is \fB\fBactive\fR can be imported.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBobsolete_counts\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	com.delphix:obsolete_counts
+READ\-ONLY COMPATIBLE	yes
+DEPENDENCIES	device_removal
+.TE
+
+This feature is an enhancement of device_removal, which will over time
+reduce the memory used to track removed devices.  When indirect blocks
+are freed or remapped, we note that their part of the indirect mapping
+is "obsolete", i.e. no longer needed.
+
+This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is
+used on a top-level vdev, and will never return to being \fBenabled\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBproject_quota\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	org.zfsonlinux:project_quota
+READ\-ONLY COMPATIBLE	yes
+DEPENDENCIES	extensible_dataset
+.TE
+
+This feature allows administrators to account the spaces and objects usage
+information against the project identifier (ID).
+
+The project ID is new object-based attribute. When upgrading an existing
+filesystem, object without project ID attribute will be assigned a zero
+project ID. After this feature is enabled, newly created object will inherit
+its parent directory's project ID if the parent inherit flag is set (via
+\fBchattr +/-P\fR or \fBzfs project [-s|-C]\fR). Otherwise, the new object's
+project ID will be set as zero. An object's project ID can be changed at
+anytime by the owner (or privileged user) via \fBchattr -p $prjid\fR or
+\fBzfs project -p $prjid\fR.
+
+This feature will become \fBactive\fR as soon as it is enabled and will never
+return to being \fBdisabled\fR. Each filesystem will be upgraded automatically
+when remounted or when new file is created under that filesystem. The upgrade
+can also be triggered on filesystems via `zfs set version=current <pool/fs>`.
+The upgrade process runs in the background and may take a while to complete
+for the filesystems containing a large number of files.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBresilver_defer\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	com.datto:resilver_defer
+READ\-ONLY COMPATIBLE	yes
+DEPENDENCIES	none
+.TE
+
+This feature allows zfs to postpone new resilvers if an existing one is already
+in progress. Without this feature, any new resilvers will cause the currently
+running one to be immediately restarted from the beginning.
+
+This feature becomes \fBactive\fR once a resilver has been deferred, and
+returns to being \fBenabled\fR when the deferred resilver begins.
 .RE
 
 .sp
@@ -645,41 +735,44 @@ the pool if GRUB needs to access the pool (e.g. for /boot).
 .sp
 .ne 2
 .na
-\fB\fBedonr\fR\fR
+\fB\fBspacemap_histogram\fR\fR
 .ad
 .RS 4n
 .TS
 l l .
-GUID	org.illumos:edonr
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
+GUID	com.delphix:spacemap_histogram
+READ\-ONLY COMPATIBLE	yes
+DEPENDENCIES	none
 .TE
 
-This feature enables the use of the Edon-R hash algorithm for checksum,
-including for nopwrite (if compression is also enabled, an overwrite of
-a block whose checksum matches the data being written will be ignored).
-In an abundance of caution, Edon-R requires verification when used with
-dedup: \fBzfs set dedup=edonr,verify\fR.  See \fBzfs\fR(8).
+This features allows ZFS to maintain more information about how free space
+is organized within the pool. If this feature is \fBenabled\fR, ZFS will
+set this feature to \fBactive\fR when a new space map object is created or
+an existing space map is upgraded to the new format. Once the feature is
+\fBactive\fR, it will remain in that state until the pool is destroyed.
+.RE
 
-Edon-R is a very high-performance hash algorithm that was part
-of the NIST SHA-3 competition. It provides extremely high hash
-performance (over 350% faster than SHA-256), but was not selected
-because of its unsuitability as a general purpose secure hash algorithm.
-This implementation utilizes the new salted checksumming functionality
-in ZFS, which means that the checksum is pre-seeded with a secret
-256-bit random key (stored on the pool) before being fed the data block
-to be checksummed. Thus the produced checksums are unique to a given
-pool.
+.sp
+.ne 2
+.na
+\fB\fBspacemap_v2\fR\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	com.delphix:spacemap_v2
+READ\-ONLY COMPATIBLE	yes
+DEPENDENCIES	none
+.TE
 
-When the \fBedonr\fR feature is set to \fBenabled\fR, the administrator
-can turn on the \fBedonr\fR checksum on any dataset using the
-\fBzfs set checksum=edonr\fR. See zfs(8). This feature becomes
-\fBactive\fR once a \fBchecksum\fR property has been set to \fBedonr\fR,
-and will return to being \fBenabled\fR once all filesystems that have
-ever had their checksum set to \fBedonr\fR are destroyed.
+This feature enables the use of the new space map encoding which
+consists of two words (instead of one) whenever it is advantageous.
+The new encoding allows space maps to represent large regions of
+space more efficiently on-disk while also increasing their maximum
+addressable offset.
 
-The \fBedonr\fR feature is not supported by GRUB and must not be used on
-the pool if GRUB needs to access the pool (e.g. for /boot).
+This feature becomes \fBactive\fR once it is \fBenabled\fR, and never
+returns back to being \fBenabled\fR.
 .RE
 
 .sp
@@ -710,116 +803,24 @@ files.
 .sp
 .ne 2
 .na
-\fB\fBbookmark_v2\fR\fR
+\fB\fBzpool_checkpoint\fR\fR
 .ad
 .RS 4n
 .TS
 l l .
-GUID	com.datto:bookmark_v2
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	bookmark, extensible_dataset
-.TE
-
-This feature enables the creation and management of larger bookmarks which are
-needed for other features in ZFS.
-
-This feature becomes \fBactive\fR when a v2 bookmark is created and will be
-returned to the \fBenabled\fR state when all v2 bookmarks are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBencryption\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.datto:encryption
-READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	bookmark_v2, extensible_dataset
-.TE
-
-This feature enables the creation and management of natively encrypted datasets.
-
-This feature becomes \fBactive\fR when an encrypted dataset is created and will
-be returned to the \fBenabled\fR state when all datasets that use this feature
-are destroyed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBproject_quota\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.zfsonlinux:project_quota
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	extensible_dataset
-.TE
-
-This feature allows administrators to account the spaces and objects usage
-information against the project identifier (ID).
-
-The project ID is new object-based attribute. When upgrading an existing
-filesystem, object without project ID attribute will be assigned a zero
-project ID. After this feature is enabled, newly created object will inherit
-its parent directory's project ID if the parent inherit flag is set (via
-\fBchattr +/-P\fR or \fBzfs project [-s|-C]\fR). Otherwise, the new object's
-project ID will be set as zero. An object's project ID can be changed at
-anytime by the owner (or privileged user) via \fBchattr -p $prjid\fR or
-\fBzfs project -p $prjid\fR.
-
-This feature will become \fBactive\fR as soon as it is enabled and will never
-return to being \fBdisabled\fR. Each filesystem will be upgraded automatically
-when remounted or when new file is created under that filesystem. The upgrade
-can also be triggered on filesystems via `zfs set version=current <pool/fs>`.
-The upgrade process runs in the background and may take a while to complete
-for the filesystems containing a large number of files.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBresilver_defer\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	com.datto:resilver_defer
+GUID	com.delphix:zpool_checkpoint
 READ\-ONLY COMPATIBLE	yes
 DEPENDENCIES	none
 .TE
 
-This feature allows zfs to postpone new resilvers if an existing one is already
-in progress. Without this feature, any new resilvers will cause the currently
-running one to be immediately restarted from the beginning.
+This feature enables the \fBzpool checkpoint\fR subcommand that can
+checkpoint the state of the pool at the time it was issued and later
+rewind back to it or discard it.
 
-This feature becomes \fBactive\fR once a resilver has been deferred, and
-returns to being \fBenabled\fR when the deferred resilver begins.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBallocation_classes\fR\fR
-.ad
-.RS 4n
-.TS
-l l .
-GUID	org.zfsonlinux:allocation_classes
-READ\-ONLY COMPATIBLE	yes
-DEPENDENCIES	none
-.TE
-
-This feature enables support for separate allocation classes.
-
-This feature becomes \fBactive\fR when a dedicated allocation class vdev
-(dedup or special) is created with the \fBzpool create\fR or \fBzpool add\fR
-subcommands. With device removal, it can be returned to the \fBenabled\fR
-state if all the dedicated allocation class vdevs are removed.
+This feature becomes \fBactive\fR when the \fBzpool checkpoint\fR subcommand
+is used to checkpoint the pool.
+The feature will only return back to being \fBenabled\fR when the pool
+is rewound or the checkpoint has been discarded.
 .RE
 
 .SH "SEE ALSO"

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -383,6 +383,14 @@ READ\-ONLY COMPATIBLE	no
 DEPENDENCIES	enabled_txg
 .TE
 
+This feature has/had bugs, the result of which is that, if you do a
+\fBzfs send -i\fR (or \fB-R\fR, since it uses \fB-i\fR) from an affected
+dataset, the receiver will not see any checksum or other errors, but the
+resulting destination snapshot will not match the source.  Its use by
+\fBzfs send -i\fR has been disabled by default.  See the
+\fBsend_holes_without_birth_time\fR module parameter in
+zfs-module-parameters(5).
+
 This feature improves performance of incremental sends (\fBzfs send -i\fR)
 and receives for objects with many holes. The most common case of
 hole-filled objects is zvols.

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -581,6 +581,9 @@ allow more data to be stored in the bonus buffer, thus potentially
 improving performance by avoiding the use of spill blocks.
 .RE
 
+.sp
+.ne 2
+.na
 \fB\fBsha512\fR\fR
 .ad
 .RS 4n

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -285,9 +285,9 @@ an existing space map is upgraded to the new format. Once the feature is
 .RS 4n
 .TS
 l l .
-GUID    com.joyent:multi_vdev_crash_dump
-READ\-ONLY COMPATIBLE   no
-DEPENDENCIES    none
+GUID	com.joyent:multi_vdev_crash_dump
+READ\-ONLY COMPATIBLE	no
+DEPENDENCIES	none
 .TE
 
 This feature allows a dump device to be configured with a pool comprised

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -57,7 +57,7 @@ Features can be in one of three states:
 .sp
 .ne 2
 .na
-\fB\fBactive\fR\fR
+\fBactive\fR
 .ad
 .RS 12n
 This feature's on\-disk format changes are in effect on the pool. Support for
@@ -69,7 +69,7 @@ in read\-only mode (see "Read\-only compatibility").
 .sp
 .ne 2
 .na
-\fB\fBenabled\fR\fR
+\fBenabled\fR
 .ad
 .RS 12n
 An administrator has marked this feature as enabled on the pool, but the
@@ -115,7 +115,7 @@ despite the unsupported feature. Possible values for this property are:
 .sp
 .ne 2
 .na
-\fB\fBinactive\fR\fR
+\fBinactive\fR
 .ad
 .RS 12n
 The feature is in the \fBenabled\fR state and therefore the pool's on\-disk
@@ -125,7 +125,7 @@ format is still compatible with software that does not support this feature.
 .sp
 .ne 2
 .na
-\fB\fBreadonly\fR\fR
+\fBreadonly\fR
 .ad
 .RS 12n
 The feature is read\-only compatible and the pool has been imported in
@@ -146,7 +146,7 @@ The following features are supported on this system:
 .sp
 .ne 2
 .na
-\fB\fBallocation_classes\fR\fR
+\fBallocation_classes\fR
 .ad
 .RS 4n
 .TS
@@ -167,7 +167,7 @@ state if all the dedicated allocation class vdevs are removed.
 .sp
 .ne 2
 .na
-\fB\fBasync_destroy\fR\fR
+\fBasync_destroy\fR
 .ad
 .RS 4n
 .TS
@@ -197,7 +197,7 @@ This feature is only \fBactive\fR while \fBfreeing\fR is non\-zero.
 .sp
 .ne 2
 .na
-\fB\fBbookmarks\fR\fR
+\fBbookmarks\fR
 .ad
 .RS 4n
 .TS
@@ -217,7 +217,7 @@ All bookmarks in the pool can be listed by running
 .sp
 .ne 2
 .na
-\fB\fBbookmark_v2\fR\fR
+\fBbookmark_v2\fR
 .ad
 .RS 4n
 .TS
@@ -237,7 +237,7 @@ returned to the \fBenabled\fR state when all v2 bookmarks are destroyed.
 .sp
 .ne 2
 .na
-\fB\fBdevice_removal\fR\fR
+\fBdevice_removal\fR
 .ad
 .RS 4n
 .TS
@@ -257,7 +257,7 @@ on a top-level vdev, and will never return to being \fBenabled\fR.
 .sp
 .ne 2
 .na
-\fB\fBedonr\fR\fR
+\fBedonr\fR
 .ad
 .RS 4n
 .TS
@@ -297,7 +297,7 @@ the pool if GRUB needs to access the pool (e.g. for /boot).
 .sp
 .ne 2
 .na
-\fB\fBembedded_data\fR\fR
+\fBembedded_data\fR
 .ad
 .RS 4n
 .TS
@@ -324,7 +324,7 @@ never return to being \fBenabled\fR.
 .sp
 .ne 2
 .na
-\fB\fBempty_bpobj\fR\fR
+\fBempty_bpobj\fR
 .ad
 .RS 4n
 .TS
@@ -351,7 +351,7 @@ or snapshots which were created after enabling this feature.
 .sp
 .ne 2
 .na
-\fB\fBenabled_txg\fR\fR
+\fBenabled_txg\fR
 .ad
 .RS 4n
 .TS
@@ -372,7 +372,7 @@ never return to being \fBenabled\fB.
 .sp
 .ne 2
 .na
-\fB\fBencryption\fR\fR
+\fBencryption\fR
 .ad
 .RS 4n
 .TS
@@ -392,7 +392,7 @@ are destroyed.
 .sp
 .ne 2
 .na
-\fB\fBextensible_dataset\fR\fR
+\fBextensible_dataset\fR
 .ad
 .RS 4n
 .TS
@@ -413,7 +413,7 @@ this feature are destroyed.
 .sp
 .ne 2
 .na
-\fB\fBfilesystem_limits\fR\fR
+\fBfilesystem_limits\fR
 .ad
 .RS 4n
 .TS
@@ -434,7 +434,7 @@ set on a dataset. Once activated the feature is never deactivated.
 .sp
 .ne 2
 .na
-\fB\fBhole_birth\fR\fR
+\fBhole_birth\fR
 .ad
 .RS 4n
 .TS
@@ -483,7 +483,7 @@ never return to being \fBenabled\fB.
 .sp
 .ne 2
 .na
-\fB\fBlarge_blocks\fR\fR
+\fBlarge_blocks\fR
 .ad
 .RS 4n
 .TS
@@ -504,7 +504,7 @@ filesystems that have ever had their recordsize larger than 128KB are destroyed.
 .sp
 .ne 2
 .na
-\fB\fBlarge_dnode\fR\fR
+\fBlarge_dnode\fR
 .ad
 .RS 4n
 .TS
@@ -529,7 +529,7 @@ improving performance by avoiding the use of spill blocks.
 .sp
 .ne 2
 .na
-\fB\fBlz4_compress\fR\fR
+\fBlz4_compress\fR
 .ad
 .RS 4n
 .TS
@@ -565,7 +565,7 @@ never return to being \fBenabled\fB.
 .sp
 .ne 2
 .na
-\fB\fBmulti_vdev_crash_dump\fR\fR
+\fBmulti_vdev_crash_dump\fR
 .ad
 .RS 4n
 .TS
@@ -593,7 +593,7 @@ where this feature is \fB\fBactive\fR can be imported.
 .sp
 .ne 2
 .na
-\fB\fBobsolete_counts\fR\fR
+\fBobsolete_counts\fR
 .ad
 .RS 4n
 .TS
@@ -615,7 +615,7 @@ used on a top-level vdev, and will never return to being \fBenabled\fR.
 .sp
 .ne 2
 .na
-\fB\fBproject_quota\fR\fR
+\fBproject_quota\fR
 .ad
 .RS 4n
 .TS
@@ -648,7 +648,7 @@ for the filesystems containing a large number of files.
 .sp
 .ne 2
 .na
-\fB\fBresilver_defer\fR\fR
+\fBresilver_defer\fR
 .ad
 .RS 4n
 .TS
@@ -669,7 +669,7 @@ returns to being \fBenabled\fR when the deferred resilver begins.
 .sp
 .ne 2
 .na
-\fB\fBsha512\fR\fR
+\fBsha512\fR
 .ad
 .RS 4n
 .TS
@@ -701,7 +701,7 @@ the pool if GRUB needs to access the pool (e.g. for /boot).
 .sp
 .ne 2
 .na
-\fB\fBskein\fR\fR
+\fBskein\fR
 .ad
 .RS 4n
 .TS
@@ -735,7 +735,7 @@ the pool if GRUB needs to access the pool (e.g. for /boot).
 .sp
 .ne 2
 .na
-\fB\fBspacemap_histogram\fR\fR
+\fBspacemap_histogram\fR
 .ad
 .RS 4n
 .TS
@@ -755,7 +755,7 @@ an existing space map is upgraded to the new format. Once the feature is
 .sp
 .ne 2
 .na
-\fB\fBspacemap_v2\fR\fR
+\fBspacemap_v2\fR
 .ad
 .RS 4n
 .TS
@@ -778,7 +778,7 @@ returns back to being \fBenabled\fR.
 .sp
 .ne 2
 .na
-\fB\fBuserobj_accounting\fR\fR
+\fBuserobj_accounting\fR
 .ad
 .RS 4n
 .TS
@@ -803,7 +803,7 @@ files.
 .sp
 .ne 2
 .na
-\fB\fBzpool_checkpoint\fR\fR
+\fBzpool_checkpoint\fR
 .ad
 .RS 4n
 .TS

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -715,7 +715,7 @@ files.
 l l .
 GUID	com.datto:bookmark_v2
 READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
+DEPENDENCIES	bookmark, extensible_dataset
 .TE
 
 This feature enables the creation and management of larger bookmarks which are
@@ -736,7 +736,7 @@ returned to the \fBenabled\fR state when all v2 bookmarks are destroyed.
 l l .
 GUID	com.datto:encryption
 READ\-ONLY COMPATIBLE	no
-DEPENDENCIES	extensible_dataset
+DEPENDENCIES	bookmark_v2, extensible_dataset
 .TE
 
 This feature enables the creation and management of natively encrypted datasets.

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -274,7 +274,6 @@ is organized within the pool. If this feature is \fBenabled\fR, ZFS will
 set this feature to \fBactive\fR when a new space map object is created or
 an existing space map is upgraded to the new format. Once the feature is
 \fBactive\fR, it will remain in that state until the pool is destroyed.
-
 .RE
 
 .sp
@@ -324,7 +323,6 @@ and exists for other features to depend on.
 This feature will be \fBactive\fR when the first dependent feature uses it,
 and will be returned to the \fBenabled\fR state when all datasets that use
 this feature are destroyed.
-
 .RE
 
 .sp
@@ -345,7 +343,6 @@ This feature enables use of the \fBzfs bookmark\fR subcommand.
 This feature is \fBactive\fR while any bookmarks exist in the pool.
 All bookmarks in the pool can be listed by running
 \fBzfs list -t bookmark -r \fIpoolname\fR\fR.
-
 .RE
 
 .sp
@@ -367,7 +364,6 @@ but other features may depend on this feature.
 
 This feature becomes \fBactive\fR as soon as it is enabled and will
 never return to being \fBenabled\fB.
-
 .RE
 
 .sp
@@ -417,7 +413,6 @@ sending information about holes that already exist on the receiving side.
 
 This feature becomes \fBactive\fR as soon as it is enabled and will
 never return to being \fBenabled\fB.
-
 .RE
 
 .sp
@@ -445,8 +440,8 @@ and no additional i/o is needed to read and write the data block.
 
 This feature becomes \fBactive\fR as soon as it is enabled and will
 never return to being \fBenabled\fR.
-
 .RE
+
 .sp
 .ne 2
 .na
@@ -465,8 +460,8 @@ vdevs, evacuating them to reduce the total size of the pool.
 
 This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is used
 on a top-level vdev, and will never return to being \fBenabled\fR.
-
 .RE
+
 .sp
 .ne 2
 .na
@@ -487,8 +482,8 @@ is "obsolete", i.e. no longer needed.
 
 This feature becomes \fBactive\fR when the \fBzpool remove\fR subcommand is
 used on a top-level vdev, and will never return to being \fBenabled\fR.
-
 .RE
+
 .sp
 .ne 2
 .na
@@ -510,8 +505,8 @@ This feature becomes \fBactive\fR when the \fBzpool checkpoint\fR subcommand
 is used to checkpoint the pool.
 The feature will only return back to being \fBenabled\fR when the pool
 is rewound or the checkpoint has been discarded.
-
 .RE
+
 .sp
 .ne 2
 .na
@@ -533,8 +528,8 @@ addressable offset.
 
 This feature becomes \fBactive\fR once it is \fBenabled\fR, and never
 returns back to being \fBenabled\fR.
-
 .RE
+
 .sp
 .ne 2
 .na
@@ -611,7 +606,6 @@ ever had their checksum set to \fBsha512\fR are destroyed.
 
 The \fBsha512\fR feature is not supported by GRUB and must not be used on
 the pool if GRUB needs to access the pool (e.g. for /boot).
-
 .RE
 
 .sp
@@ -646,7 +640,6 @@ ever had their checksum set to \fBskein\fR are destroyed.
 
 The \fBskein\fR feature is not supported by GRUB and must not be used on
 the pool if GRUB needs to access the pool (e.g. for /boot).
-
 .RE
 
 .sp
@@ -687,7 +680,6 @@ ever had their checksum set to \fBedonr\fR are destroyed.
 
 The \fBedonr\fR feature is not supported by GRUB and must not be used on
 the pool if GRUB needs to access the pool (e.g. for /boot).
-
 .RE
 
 .sp
@@ -713,7 +705,6 @@ The upgrade can also be started manually on filesystems by running
 `zfs set version=current <pool/fs>`. The upgrade process runs in the background
 and may take a while to complete for filesystems containing a large number of
 files.
-
 .RE
 
 .sp
@@ -734,7 +725,6 @@ needed for other features in ZFS.
 
 This feature becomes \fBactive\fR when a v2 bookmark is created and will be
 returned to the \fBenabled\fR state when all v2 bookmarks are destroyed.
-
 .RE
 
 .sp
@@ -755,7 +745,6 @@ This feature enables the creation and management of natively encrypted datasets.
 This feature becomes \fBactive\fR when an encrypted dataset is created and will
 be returned to the \fBenabled\fR state when all datasets that use this feature
 are destroyed.
-
 .RE
 
 .sp
@@ -789,8 +778,8 @@ when remounted or when new file is created under that filesystem. The upgrade
 can also be triggered on filesystems via `zfs set version=current <pool/fs>`.
 The upgrade process runs in the background and may take a while to complete
 for the filesystems containing a large number of files.
-
 .RE
+
 .sp
 .ne 2
 .na
@@ -810,7 +799,6 @@ running one to be immediately restarted from the beginning.
 
 This feature becomes \fBactive\fR once a resilver has been deferred, and
 returns to being \fBenabled\fR when the deferred resilver begins.
-
 .RE
 
 .sp
@@ -832,7 +820,6 @@ This feature becomes \fBactive\fR when a dedicated allocation class vdev
 (dedup or special) is created with the \fBzpool create\fR or \fBzpool add\fR
 subcommands. With device removal, it can be returned to the \fBenabled\fR
 state if all the dedicated allocation class vdevs are removed.
-
 .RE
 
 .SH "SEE ALSO"

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -543,7 +543,7 @@ returns back to being \fBenabled\fR.
 .RS 4n
 .TS
 l l .
-GUID	org.open-zfs:large_block
+GUID	org.open-zfs:large_blocks
 READ\-ONLY COMPATIBLE	no
 DEPENDENCIES	extensible_dataset
 .TE

--- a/man/man8/zstreamdump.8
+++ b/man/man8/zstreamdump.8
@@ -25,7 +25,7 @@ The following options are supported:
 .sp
 .ne 2
 .na
-\fB\fB-C\fR\fR
+\fB-C\fR
 .ad
 .sp .6
 .RS 4n
@@ -35,7 +35,7 @@ Suppress the validation of checksums.
 .sp
 .ne 2
 .na
-\fB\fB-v\fR\fR
+\fB-v\fR
 .ad
 .sp .6
 .RS 4n
@@ -45,7 +45,7 @@ Verbose. Dump all headers, not only begin and end headers.
 .sp
 .ne 2
 .na
-\fB\fB-d\fR\fR
+\fB-d\fR
 .ad
 .sp .6
 .RS 4n


### PR DESCRIPTION
### Motivation and Context
This fixes some issues with zpool-features(5) and zfs-module-parameters(5)

### Description
- `multi_vdev_crash_dump`'s information now lines up visually.
- `encryption depends on `bookmarks_v2`
- `bookmark_v2` depends on `bookmarks`
- Document `send_holes_without_birth_time` in zfs-module-parameters(5). This is a dependency of the following change.
- Document that `hole_birth` is effectively useless to fix #8642 (which I opened).
- Change wording in zfs-module-parameters.5 (from a review comment here by @tcaputi)
- Correct GUID for `large_blocks`
- Add missing formatting for `sha512`
- Standardize `.RE` placement
- Alphabetize zpool-features.5 by short name
- Eliminate useless double bolding commands in zpool-features.5 and and zstreamdump.8 (the only two places where this occurred).

### How Has This Been Tested?
I looked at the man pages with `man`.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
