### PR TITLE
Deprecate dedupditto

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -806,6 +806,9 @@ such that it is available even if the pool becomes faulted.
 An administrator can provide additional information about a pool using this
 property.
 .It Sy dedupditto Ns = Ns Ar number
+This property is deprecated.  In a future release, it will no longer have any
+effect.
+.Pp
 Threshold for the number of block ditto copies.
 If the reference count for a deduplicated block increases above this number, a
 new ditto copy of this block is automatically stored.


### PR DESCRIPTION
### Motivation and Context
As discussed in #8310, there seems to be a consensus that the `dedupditto` pool property should go away. This change documents that deprecation now, because we can, to give users more warning.

### Description
This documents, in zpool.8, that `dedupditto` is deprecated and will be made to have no effect in a future release.

### How Has This Been Tested?
I looked at the man page with `man`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
