### PR TITLE
Duplicate the encryption copies=3 limitation

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1342,6 +1342,11 @@ create, for example a two-disk striped pool and set
 on some datasets thinking you have setup redundancy for them. When a disk
 fails you will not be able to import the pool and will have lost all of your
 data.
+.Pp
+Encrypted datasets may not have
+.Sy copies Ns = Ns Em 3
+since the implementation stores some encryption metadata where the third copy
+would normally be.
 .It Sy devices Ns = Ns Sy on Ns | Ns Sy off
 Controls whether device nodes can be opened on this file system.
 The default value is


### PR DESCRIPTION
### Motivation and Context
With encryption, `copies=3` cannot be set. This is mentioned, but only in the encryption section, so someone looking at the `copies` section would not see it. I believe we should mention it in both places.

### Description
This adds the encryption copies=3 limitation language into the copies property section.

### How Has This Been Tested?
I looked at the man page with `man`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
