### PR TITLE
Clarify and improve encryption documentation

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -2375,17 +2375,19 @@ configuration is not supported.
 .Ss Encryption
 Enabling the
 .Sy encryption
-feature allows for the creation of encrypted filesystems and volumes.
-.Nm
-will encrypt all user data including file and zvol data, file attributes,
-ACLs, permission bits, directory listings, FUID mappings, and userused /
-groupused data.
-.Nm
-will not encrypt metadata related to the pool structure, including dataset
-names, dataset hierarchy, file size, file holes, and dedup tables. Key rotation
-is managed internally by the  kernel module and changing the user's key does not
-require re-encrypting the entire dataset. Datasets can be scrubbed, resilvered,
-renamed, and deleted without the encryption keys being loaded (see the
+feature allows for the creation of encrypted filesystems and volumes.  ZFS
+will encrypt file and zvol data, file attributes, ACLs, permission bits,
+directory listings, FUID mappings, and
+.Sy userused
+/
+.Sy groupused
+data.  ZFS will not encrypt metadata related to the pool structure, including
+dataset and snapshot names, dataset hierarchy, properties, file size, file
+holes, and deduplication tables.
+.Pp
+Key rotation is managed by ZFS.  Changing the user's key (e.g. a passphrase)
+does not require re-encrypting the entire dataset.  Datasets can be scrubbed,
+resilvered, renamed, and deleted without the encryption keys being loaded (see the
 .Nm zfs Cm load-key
 subcommand for more info on key loading).
 .Pp
@@ -2427,8 +2429,7 @@ read-only
 .Sy encryptionroot
 property.
 .Pp
-Encryption changes the behavior of a few
-.Nm
+Encryption changes the behavior of a few ZFS
 operations. Encryption is applied after compression so compression ratios are
 preserved. Normally checksums in ZFS are 256 bits long, but for encrypted data
 the checksum is 128 bits of the user-chosen checksum and 128 bits of MAC from


### PR DESCRIPTION
### Motivation and Context
I've been reviewing documentation, especially that related to new features like encryption. I have a tendency to edit everything under my cursor. ;)

### Description
- Remove the language that "all user data" is encrypted.  This is to avoid misunderstandings or arguments about what is "user data", especially in light of "user properties".
- Document that properties are unencrypted.
- Document that snapshot names are unencrypted.
- For consistency with the rest of the zfs.8 man page, use "ZFS" as the generic noun, not (bolded) "zfs".  The latter refers to the command. Likewise, use "ZFS" instead of "the kernel module".
- Give "a passphrase" as an example of a "user's key".

### How Has This Been Tested?
I reviewed the changes with `man`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
