### PR TITLE
Use SEEK_{SET,CUR,END} for file seek "whence"

### DIFF
--- a/module/spl/spl-vnode.c
+++ b/module/spl/spl-vnode.c
@@ -426,7 +426,7 @@ int vn_space(vnode_t *vp, int cmd, struct flock *bfp, int flag,
 	int fstrans;
 #endif
 
-	if (cmd != F_FREESP || bfp->l_whence != 0)
+	if (cmd != F_FREESP || bfp->l_whence != SEEK_SET)
 		return (EOPNOTSUPP);
 
 	ASSERT(vp);

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -255,7 +255,7 @@ vdev_file_io_start(zio_t *zio)
 		flck.l_type = F_FREESP;
 		flck.l_start = zio->io_offset;
 		flck.l_len = zio->io_size;
-		flck.l_whence = 0;
+		flck.l_whence = SEEK_SET;
 
 		zio->io_error = VOP_SPACE(vf->vf_vnode, F_FREESP, &flck,
 		    0, 0, kcred, NULL);

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -792,7 +792,7 @@ zfs_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 
 	bzero(&fl, sizeof (fl));
 	fl.l_type = F_WRLCK;
-	fl.l_whence = 0;
+	fl.l_whence = SEEK_SET;
 	fl.l_start = lr->lr_offset;
 	fl.l_len = lr->lr_length;
 

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -4867,19 +4867,19 @@ convoff(struct inode *ip, flock64_t *lckdat, int  whence, offset_t offset)
 	vattr_t vap;
 	int error;
 
-	if ((lckdat->l_whence == 2) || (whence == 2)) {
+	if ((lckdat->l_whence == SEEK_END) || (whence == SEEK_END)) {
 		if ((error = zfs_getattr(ip, &vap, 0, CRED())))
 			return (error);
 	}
 
 	switch (lckdat->l_whence) {
-	case 1:
+	case SEEK_CUR:
 		lckdat->l_start += offset;
 		break;
-	case 2:
+	case SEEK_END:
 		lckdat->l_start += vap.va_size;
 		/* FALLTHRU */
-	case 0:
+	case SEEK_SET:
 		break;
 	default:
 		return (SET_ERROR(EINVAL));
@@ -4889,13 +4889,13 @@ convoff(struct inode *ip, flock64_t *lckdat, int  whence, offset_t offset)
 		return (SET_ERROR(EINVAL));
 
 	switch (whence) {
-	case 1:
+	case SEEK_CUR:
 		lckdat->l_start -= offset;
 		break;
-	case 2:
+	case SEEK_END:
 		lckdat->l_start -= vap.va_size;
 		/* FALLTHRU */
-	case 0:
+	case SEEK_SET:
 		break;
 	default:
 		return (SET_ERROR(EINVAL));
@@ -4950,7 +4950,7 @@ zfs_space(struct inode *ip, int cmd, flock64_t *bfp, int flag,
 		return (SET_ERROR(EROFS));
 	}
 
-	if ((error = convoff(ip, bfp, 0, offset))) {
+	if ((error = convoff(ip, bfp, SEEK_SET, offset))) {
 		ZFS_EXIT(zfsvfs);
 		return (error);
 	}

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -771,7 +771,7 @@ zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 	if (offset + len > olen)
 		len = olen - offset;
 	bf.l_type = F_WRLCK;
-	bf.l_whence = 0;
+	bf.l_whence = SEEK_SET;
 	bf.l_start = offset;
 	bf.l_len = len;
 	bf.l_pid = 0;

--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -636,7 +636,7 @@ zpl_truncate_range(struct inode *ip, loff_t start, loff_t end)
 	crhold(cr);
 
 	bf.l_type = F_WRLCK;
-	bf.l_whence = 0;
+	bf.l_whence = SEEK_SET;
 	bf.l_start = start;
 	bf.l_len = end - start;
 	bf.l_pid = 0;


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Use either SEEK_* or 0,1,2..., but not both.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
