### PR TITLE
zfs_rename: support RENAME_* flags

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ CONTRIBUTORS:
     Albert Lee <trisk@nexenta.com>
     Alec Salazar <alec.j.salazar@gmail.com>
     Alejandro R. Sedeño <asedeno@mit.edu>
+    Aleksa Sarai <cyphar@cyphar.com>
     Alek Pinchuk <alek@nexenta.com>
     Alex Braunegg <alex.braunegg@gmail.com>
     Alex McWhirter <alexmcwhirter@triadic.us>

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/cmd/randfree_file/Makefile
 	tests/zfs-tests/cmd/randwritecomp/Makefile
 	tests/zfs-tests/cmd/readmmap/Makefile
+	tests/zfs-tests/cmd/renameat2/Makefile
 	tests/zfs-tests/cmd/rename_dir/Makefile
 	tests/zfs-tests/cmd/rm_lnkcnt_zero_file/Makefile
 	tests/zfs-tests/cmd/threadsappend/Makefile
@@ -319,6 +320,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/refquota/Makefile
 	tests/zfs-tests/tests/functional/refreserv/Makefile
 	tests/zfs-tests/tests/functional/removal/Makefile
+	tests/zfs-tests/tests/functional/renameat2/Makefile
 	tests/zfs-tests/tests/functional/rename_dirs/Makefile
 	tests/zfs-tests/tests/functional/replacement/Makefile
 	tests/zfs-tests/tests/functional/reservation/Makefile

--- a/include/linux/vfs_compat.h
+++ b/include/linux/vfs_compat.h
@@ -548,6 +548,19 @@ static inline void zfs_gid_write(struct inode *ip, gid_t gid)
 #endif
 
 /*
+ * 3.15 API change
+ */
+#ifndef RENAME_NOREPLACE
+#define	RENAME_NOREPLACE	(1 << 0) /* Don't overwrite target */
+#endif
+#ifndef RENAME_EXCHANGE
+#define	RENAME_EXCHANGE		(1 << 1) /* Exchange source and dest */
+#endif
+#ifndef RENAME_WHITEOUT
+#define	RENAME_WHITEOUT		(1 << 2) /* Whiteout source */
+#endif
+
+/*
  * 4.9 API change
  */
 #ifndef HAVE_SETATTR_PREPARE

--- a/include/sys/zfs_dir.h
+++ b/include/sys/zfs_dir.h
@@ -52,6 +52,7 @@ extern "C" {
 extern int zfs_dirent_lock(zfs_dirlock_t **, znode_t *, char *, znode_t **,
     int, int *, pathname_t *);
 extern void zfs_dirent_unlock(zfs_dirlock_t *);
+extern int zfs_drop_nlink(znode_t *, dmu_tx_t *, boolean_t *);
 extern int zfs_link_create(zfs_dirlock_t *, znode_t *, dmu_tx_t *, int);
 extern int zfs_link_destroy(zfs_dirlock_t *, znode_t *, dmu_tx_t *, int,
     boolean_t *);

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -162,7 +162,9 @@ typedef enum zil_create {
 #define	TX_MKDIR_ATTR		18	/* mkdir with attr */
 #define	TX_MKDIR_ACL_ATTR	19	/* mkdir with ACL + attrs */
 #define	TX_WRITE2		20	/* dmu_sync EALREADY write */
-#define	TX_MAX_TYPE		21	/* Max transaction type */
+#define	TX_EXCHANGE		21	/* Exchange two paths */
+#define	TX_WHITEOUT		22	/* Rename a file, leaving a whiteout */
+#define	TX_MAX_TYPE		23	/* Max transaction type */
 
 /*
  * The transactions for mkdir, symlink, remove, rmdir, link, and rename

--- a/module/zfs/zfs_dir.c
+++ b/module/zfs/zfs_dir.c
@@ -906,6 +906,74 @@ zfs_dropname(zfs_dirlock_t *dl, znode_t *zp, znode_t *dzp, dmu_tx_t *tx,
 	return (error);
 }
 
+static int
+zfs_drop_nlink_locked(znode_t *zp, dmu_tx_t *tx, boolean_t *unlinkedp)
+{
+	zfsvfs_t	*zfsvfs = ZTOZSB(zp);
+	int		zp_is_dir = S_ISDIR(ZTOI(zp)->i_mode);
+	boolean_t	unlinked = B_FALSE;
+	sa_bulk_attr_t	bulk[3];
+	uint64_t	mtime[2], ctime[2];
+	uint64_t	links;
+	int		count = 0;
+	int		error;
+
+	if (zp_is_dir && !zfs_dirempty(zp))
+		return (SET_ERROR(ENOTEMPTY));
+
+	if (ZTOI(zp)->i_nlink <= zp_is_dir) {
+		zfs_panic_recover("zfs: link count on %lu is %u, "
+		    "should be at least %u", zp->z_id,
+		    (int)ZTOI(zp)->i_nlink, zp_is_dir + 1);
+		set_nlink(ZTOI(zp), zp_is_dir + 1);
+	}
+	drop_nlink(ZTOI(zp));
+	if (ZTOI(zp)->i_nlink == zp_is_dir) {
+		zp->z_unlinked = B_TRUE;
+		clear_nlink(ZTOI(zp));
+		unlinked = B_TRUE;
+	} else {
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs),
+		    NULL, &ctime, sizeof (ctime));
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs),
+		    NULL, &zp->z_pflags, sizeof (zp->z_pflags));
+		zfs_tstamp_update_setup(zp, STATE_CHANGED, mtime,
+		    ctime);
+	}
+	links = ZTOI(zp)->i_nlink;
+	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zfsvfs),
+	    NULL, &links, sizeof (links));
+	error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
+	ASSERT3U(error, ==, 0);
+
+	if (unlinkedp != NULL)
+		*unlinkedp = unlinked;
+	else if (unlinked)
+		zfs_unlinked_add(zp, tx);
+
+	return (0);
+}
+
+/*
+ * Forcefully drop an nlink reference from (zp) and mark it for deletion if it
+ * was the last link. This *must* only be done to znodes which have already
+ * been zfs_link_destroy()'d with ZRENAMING. This is explicitly only used in
+ * the error path of zfs_rename(), where we have to correct the nlink count if
+ * we failed to link the target as well as failing to re-link the original
+ * znodes.
+ */
+int
+zfs_drop_nlink(znode_t *zp, dmu_tx_t *tx, boolean_t *unlinkedp)
+{
+	int error;
+
+	mutex_enter(&zp->z_lock);
+	error = zfs_drop_nlink_locked(zp, tx, unlinkedp);
+	mutex_exit(&zp->z_lock);
+
+	return (error);
+}
+
 /*
  * Unlink zp from dl, and mark zp for deletion if this was the last link. Can
  * fail if zp is a mount point (EBUSY) or a non-empty directory (ENOTEMPTY).
@@ -946,31 +1014,8 @@ zfs_link_destroy(zfs_dirlock_t *dl, znode_t *zp, dmu_tx_t *tx, int flag,
 			return (error);
 		}
 
-		if (ZTOI(zp)->i_nlink <= zp_is_dir) {
-			zfs_panic_recover("zfs: link count on %lu is %u, "
-			    "should be at least %u", zp->z_id,
-			    (int)ZTOI(zp)->i_nlink, zp_is_dir + 1);
-			set_nlink(ZTOI(zp), zp_is_dir + 1);
-		}
-		drop_nlink(ZTOI(zp));
-		if (ZTOI(zp)->i_nlink == zp_is_dir) {
-			zp->z_unlinked = B_TRUE;
-			clear_nlink(ZTOI(zp));
-			unlinked = B_TRUE;
-		} else {
-			SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(zfsvfs),
-			    NULL, &ctime, sizeof (ctime));
-			SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(zfsvfs),
-			    NULL, &zp->z_pflags, sizeof (zp->z_pflags));
-			zfs_tstamp_update_setup(zp, STATE_CHANGED, mtime,
-			    ctime);
-		}
-		links = ZTOI(zp)->i_nlink;
-		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_LINKS(zfsvfs),
-		    NULL, &links, sizeof (links));
-		error = sa_bulk_update(zp->z_sa_hdl, bulk, count, tx);
-		count = 0;
-		ASSERT(error == 0);
+		/* The only error is !zfs_dirempty() and we checked earlier. */
+		ASSERT3U(zfs_drop_nlink_locked(zp, tx, &unlinked), ==, 0);
 		mutex_exit(&zp->z_lock);
 	} else {
 		error = zfs_dropname(dl, zp, dzp, tx, flag);

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -460,7 +460,9 @@ zfs_log_symlink(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
 }
 
 /*
- * Handles TX_RENAME transactions.
+ * Handles TX_{RENAME,EXCHANGE,WHITEOUT} transactions. They all have the same
+ * underyling structure (lr_rename_t) but have different txtypes to indicate
+ * different renameat2(2) flags.
  */
 void
 zfs_log_rename(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -625,7 +625,7 @@ zfs_replay_link(void *arg1, void *arg2, boolean_t byteswap)
 }
 
 static int
-zfs_replay_rename(void *arg1, void *arg2, boolean_t byteswap)
+_zfs_replay_renameat2(void *arg1, void *arg2, boolean_t byteswap, int vflg)
 {
 	zfsvfs_t *zfsvfs = arg1;
 	lr_rename_t *lr = arg2;
@@ -633,7 +633,6 @@ zfs_replay_rename(void *arg1, void *arg2, boolean_t byteswap)
 	char *tname = sname + strlen(sname) + 1;
 	znode_t *sdzp, *tdzp;
 	int error;
-	int vflg = 0;
 
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -655,6 +654,24 @@ zfs_replay_rename(void *arg1, void *arg2, boolean_t byteswap)
 	iput(ZTOI(sdzp));
 
 	return (error);
+}
+
+static int
+zfs_replay_rename(void *arg1, void *arg2, boolean_t byteswap)
+{
+	return (_zfs_replay_renameat2(arg1, arg2, byteswap, 0));
+}
+
+static int
+zfs_replay_exchange(void *arg1, void *arg2, boolean_t byteswap)
+{
+	return (_zfs_replay_renameat2(arg1, arg2, byteswap, RENAME_EXCHANGE));
+}
+
+static int
+zfs_replay_whiteout(void *arg1, void *arg2, boolean_t byteswap)
+{
+	return (_zfs_replay_renameat2(arg1, arg2, byteswap, RENAME_WHITEOUT));
 }
 
 static int
@@ -981,4 +998,6 @@ zil_replay_func_t *zfs_replay_vector[TX_MAX_TYPE] = {
 	zfs_replay_create,	/* TX_MKDIR_ATTR */
 	zfs_replay_create_acl,	/* TX_MKDIR_ACL_ATTR */
 	zfs_replay_write2,	/* TX_WRITE2 */
+	zfs_replay_exchange,	/* TX_EXCHANGE */
+	zfs_replay_whiteout,	/* TX_WHITEOUT */
 };

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -3666,9 +3666,23 @@ zfs_rename(struct inode *sdip, char *snm, struct inode *tdip, char *tnm,
 	int		error = 0;
 	int		zflg = 0;
 	boolean_t	waited = B_FALSE;
+	uint64_t	txtype;
+	/* Needed for whiteout inode creation. */
+	vattr_t		wo_vap;
+	uint64_t	wo_projid;
+	boolean_t	fuid_dirtied;
+	zfs_acl_ids_t	acl_ids;
+	boolean_t	have_acl = B_FALSE;
 
 	if (snm == NULL || tnm == NULL)
 		return (SET_ERROR(EINVAL));
+
+	if (flags & RENAME_EXCHANGE)
+		txtype = TX_EXCHANGE;
+	else if (flags & RENAME_WHITEOUT)
+		txtype = TX_WHITEOUT;
+	else
+		txtype = TX_RENAME;
 
 	ZFS_ENTER(zfsvfs);
 	zilog = zfsvfs->z_log;
@@ -3837,6 +3851,7 @@ top:
 		error = SET_ERROR(EXDEV);
 		goto out;
 	}
+	wo_projid = szp->z_projid;
 
 	/*
 	 * Must have write access at the source to remove the old entry
@@ -3844,7 +3859,6 @@ top:
 	 * Note that if target and source are the same, this can be
 	 * done in a single check.
 	 */
-
 	if ((error = zfs_zaccess_rename(sdzp, szp, tdzp, tzp, cr)))
 		goto out;
 
@@ -3861,15 +3875,21 @@ top:
 	 * Does target exist?
 	 */
 	if (tzp) {
-		/*
-		 * Source and target must be the same type.
-		 */
-		boolean_t s_is_dir = S_ISDIR(ZTOI(szp)->i_mode) != 0;
-		boolean_t t_is_dir = S_ISDIR(ZTOI(tzp)->i_mode) != 0;
-
-		if (s_is_dir != t_is_dir) {
-			error = SET_ERROR(s_is_dir ? ENOTDIR : EISDIR);
+		if (flags & RENAME_NOREPLACE) {
+			error = SET_ERROR(EEXIST);
 			goto out;
+		}
+		/*
+		 * Source and target must be the same type (unless exchanging).
+		 */
+		if (txtype != TX_EXCHANGE) {
+			boolean_t s_is_dir = S_ISDIR(ZTOI(szp)->i_mode) != 0;
+			boolean_t t_is_dir = S_ISDIR(ZTOI(tzp)->i_mode) != 0;
+
+			if (s_is_dir != t_is_dir) {
+				error = SET_ERROR(s_is_dir ? ENOTDIR : EISDIR);
+				goto out;
+			}
 		}
 		/*
 		 * POSIX dictates that when the source and target
@@ -3881,11 +3901,38 @@ top:
 			goto out;
 		}
 	}
+	/* Target must exist for RENAME_EXCHANGE. */
+	if (!tzp && txtype == TX_EXCHANGE) {
+		error = SET_ERROR(ENOENT);
+		goto out;
+	}
+
+	/* Set up inode creation for RENAME_WHITEOUT. */
+	if (txtype == TX_WHITEOUT) {
+		error = zfs_zaccess(sdzp, ACE_ADD_FILE, 0, B_FALSE, cr);
+		if (error)
+			goto out;
+
+		zpl_vap_init(&wo_vap, ZTOI(sdzp), S_IFCHR, cr);
+		/* Can't use of makedevice() here, so hard-code it. */
+		wo_vap.va_rdev = 0;
+
+		error = zfs_acl_ids_create(sdzp, 0, &wo_vap, cr, NULL,
+		    &acl_ids);
+		if (error)
+			goto out;
+		have_acl = B_TRUE;
+
+		if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, wo_projid)) {
+			error = SET_ERROR(EDQUOT);
+			goto out;
+		}
+	}
 
 	tx = dmu_tx_create(zfsvfs->z_os);
 	dmu_tx_hold_sa(tx, szp->z_sa_hdl, B_FALSE);
 	dmu_tx_hold_sa(tx, sdzp->z_sa_hdl, B_FALSE);
-	dmu_tx_hold_zap(tx, sdzp->z_id, FALSE, snm);
+	dmu_tx_hold_zap(tx, sdzp->z_id, txtype == TX_EXCHANGE, snm);
 	dmu_tx_hold_zap(tx, tdzp->z_id, TRUE, tnm);
 	if (sdzp != tdzp) {
 		dmu_tx_hold_sa(tx, tdzp->z_sa_hdl, B_FALSE);
@@ -3895,7 +3942,21 @@ top:
 		dmu_tx_hold_sa(tx, tzp->z_sa_hdl, B_FALSE);
 		zfs_sa_upgrade_txholds(tx, tzp);
 	}
+	if (txtype == TX_WHITEOUT) {
+		dmu_tx_hold_sa_create(tx, acl_ids.z_aclp->z_acl_bytes +
+		    ZFS_SA_BASE_ATTR_SIZE);
 
+		dmu_tx_hold_zap(tx, sdzp->z_id, TRUE, snm);
+		dmu_tx_hold_sa(tx, sdzp->z_sa_hdl, B_FALSE);
+		if (!zfsvfs->z_use_sa &&
+		    acl_ids.z_aclp->z_acl_bytes > ZFS_ACE_SPACE) {
+			dmu_tx_hold_write(tx, DMU_NEW_OBJECT,
+			    0, acl_ids.z_aclp->z_acl_bytes);
+		}
+	}
+	fuid_dirtied = zfsvfs->z_fuid_dirty;
+	if (fuid_dirtied)
+		zfs_fuid_txhold(zfsvfs, tx);
 	zfs_sa_upgrade_txholds(tx, szp);
 	dmu_tx_hold_zap(tx, zfsvfs->z_unlinkedobj, FALSE, NULL);
 	error = dmu_tx_assign(tx, (waited ? TXG_NOTHROTTLE : 0) | TXG_NOWAIT);
@@ -3944,13 +4005,30 @@ top:
 	 * Unlink the target.
 	 */
 	if (tzp) {
-		error = zfs_link_destroy(tdl, tzp, tx, zflg, NULL);
+		int tzflg = zflg;
+
+		if (txtype == TX_EXCHANGE) {
+			/* This inode will be re-linked soon. */
+			tzflg |= ZRENAMING;
+
+			tzp->z_pflags |= ZFS_AV_MODIFIED;
+			if (sdzp->z_pflags & ZFS_PROJINHERIT)
+				tzp->z_pflags |= ZFS_PROJINHERIT;
+
+			error = sa_update(tzp->z_sa_hdl, SA_ZPL_FLAGS(zfsvfs),
+			    (void *)&tzp->z_pflags, sizeof (uint64_t), tx);
+			ASSERT0(error);
+		}
+		error = zfs_link_destroy(tdl, tzp, tx, tzflg, NULL);
 		if (error)
 			goto commit_link_szp;
 	}
 
 	/*
-	 * Create a new link at the target.
+	 * Create the new target links:
+	 *   * We always link the target.
+	 *   * RENAME_WHITEOUT: Create a whiteout inode in-place of the source.
+	 *   * RENAME_EXCHANGE: Link the old target to the source.
 	 */
 	error = zfs_link_create(tdl, szp, tx, ZRENAMING);
 	if (error) {
@@ -3963,13 +4041,45 @@ top:
 		goto commit_link_tzp;
 	}
 
-	zfs_log_rename(zilog, tx, TX_RENAME |
+	switch (txtype) {
+		case TX_EXCHANGE:
+			error = zfs_link_create(sdl, tzp, tx, ZRENAMING);
+			/*
+			 * The same argument as zfs_link_create() failing for
+			 * szp applies here, since the source directory must
+			 * have had an entry we are replacing.
+			 */
+			ASSERT3U(error, ==, 0);
+			if (error)
+				goto commit_unlink_td_szp;
+			break;
+		case TX_WHITEOUT: {
+			znode_t		*wzp;
+
+			zfs_mknode(sdzp, &wo_vap, tx, cr, 0, &wzp, &acl_ids);
+			error = zfs_link_create(sdl, wzp, tx, ZNEW);
+			if (error) {
+				zfs_znode_delete(wzp, tx);
+				remove_inode_hash(ZTOI(wzp));
+				goto commit_unlink_td_szp;
+			}
+			/* No need to zfs_log_create_txtype here. */
+		}
+	}
+
+	if (fuid_dirtied)
+		zfs_fuid_sync(zfsvfs, tx);
+
+	zfs_log_rename(zilog, tx, txtype |
 	    (flags & FIGNORECASE ? TX_CI : 0), sdzp,
 	    sdl->dl_name, tdzp, tdl->dl_name, szp);
 
 commit:
 	dmu_tx_commit(tx);
 out:
+	if (have_acl)
+		zfs_acl_ids_free(&acl_ids);
+
 	if (zl != NULL)
 		zfs_rename_unlock(&zl);
 
@@ -4000,15 +4110,23 @@ out:
 	 * Clean-up path for broken link state.
 	 *
 	 * At this point we are in a (very) bad state, so we need to do our
-	 * best to correct the state. In particular, the nlink of szp is wrong
-	 * because we were destroying and creating links with ZRENAMING.
+	 * best to correct the state. In particular, all of the nlinks are
+	 * wrong because we were destroying and creating links with ZRENAMING.
 	 *
-	 * link_create()s are allowed to fail (though they shouldn't because we
-	 * only just unlinked them and are putting the entries back during
-	 * clean-up). But if they fail, we can just forcefully drop the nlink
-	 * value to (at the very least) avoid broken nlink values -- though in
-	 * the case of non-empty directories we will have to panic.
+	 * In some form, all of thee operations have to resolve the state:
+	 *
+	 *  * link_destroy() *must* succeed. Fortunately, this is very likely
+	 *    since we only just created it.
+	 *
+	 *  * link_create()s are allowed to fail (though they shouldn't because
+	 *    we only just unlinked them and are putting the entries back
+	 *    during clean-up). But if they fail, we can just forcefully drop
+	 *    the nlink value to (at the very least) avoid broken nlink values
+	 *    -- though in the case of non-empty directories we will have to
+	 *    panic (otherwise we'd have a leaked directory with a broken ..).
 	 */
+commit_unlink_td_szp:
+	VERIFY3U(zfs_link_destroy(tdl, szp, tx, ZRENAMING, NULL), ==, 0);
 commit_link_tzp:
 	if (tzp) {
 		if (zfs_link_create(tdl, tzp, tx, ZRENAMING))

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -3656,8 +3656,7 @@ int
 zfs_rename(struct inode *sdip, char *snm, struct inode *tdip, char *tnm,
     cred_t *cr, int flags)
 {
-	znode_t		*tdzp, *szp, *tzp;
-	znode_t		*sdzp = ITOZ(sdip);
+	znode_t		*sdzp, *tdzp, *szp, *tzp;
 	zfsvfs_t	*zfsvfs = ITOZSB(sdip);
 	zilog_t		*zilog;
 	zfs_dirlock_t	*sdl, *tdl;
@@ -3672,9 +3671,10 @@ zfs_rename(struct inode *sdip, char *snm, struct inode *tdip, char *tnm,
 		return (SET_ERROR(EINVAL));
 
 	ZFS_ENTER(zfsvfs);
-	ZFS_VERIFY_ZP(sdzp);
 	zilog = zfsvfs->z_log;
 
+	sdzp = ITOZ(sdip);
+	ZFS_VERIFY_ZP(sdzp);
 	tdzp = ITOZ(tdip);
 	ZFS_VERIFY_ZP(tdzp);
 
@@ -3864,16 +3864,12 @@ top:
 		/*
 		 * Source and target must be the same type.
 		 */
-		if (S_ISDIR(ZTOI(szp)->i_mode)) {
-			if (!S_ISDIR(ZTOI(tzp)->i_mode)) {
-				error = SET_ERROR(ENOTDIR);
-				goto out;
-			}
-		} else {
-			if (S_ISDIR(ZTOI(tzp)->i_mode)) {
-				error = SET_ERROR(EISDIR);
-				goto out;
-			}
+		boolean_t s_is_dir = S_ISDIR(ZTOI(szp)->i_mode) != 0;
+		boolean_t t_is_dir = S_ISDIR(ZTOI(tzp)->i_mode) != 0;
+
+		if (s_is_dir != t_is_dir) {
+			error = SET_ERROR(s_is_dir ? ENOTDIR : EISDIR);
+			goto out;
 		}
 		/*
 		 * POSIX dictates that when the source and target
@@ -3929,51 +3925,49 @@ top:
 		return (error);
 	}
 
-	if (tzp)	/* Attempt to remove the existing target */
+	/*
+	 * Unlink the source.
+	 */
+	szp->z_pflags |= ZFS_AV_MODIFIED;
+	if (tdzp->z_pflags & ZFS_PROJINHERIT)
+		szp->z_pflags |= ZFS_PROJINHERIT;
+
+	error = sa_update(szp->z_sa_hdl, SA_ZPL_FLAGS(zfsvfs),
+	    (void *)&szp->z_pflags, sizeof (uint64_t), tx);
+	ASSERT0(error);
+
+	error = zfs_link_destroy(sdl, szp, tx, ZRENAMING, NULL);
+	if (error)
+		goto commit;
+
+	/*
+	 * Unlink the target.
+	 */
+	if (tzp) {
 		error = zfs_link_destroy(tdl, tzp, tx, zflg, NULL);
-
-	if (error == 0) {
-		error = zfs_link_create(tdl, szp, tx, ZRENAMING);
-		if (error == 0) {
-			szp->z_pflags |= ZFS_AV_MODIFIED;
-			if (tdzp->z_pflags & ZFS_PROJINHERIT)
-				szp->z_pflags |= ZFS_PROJINHERIT;
-
-			error = sa_update(szp->z_sa_hdl, SA_ZPL_FLAGS(zfsvfs),
-			    (void *)&szp->z_pflags, sizeof (uint64_t), tx);
-			ASSERT0(error);
-
-			error = zfs_link_destroy(sdl, szp, tx, ZRENAMING, NULL);
-			if (error == 0) {
-				zfs_log_rename(zilog, tx, TX_RENAME |
-				    (flags & FIGNORECASE ? TX_CI : 0), sdzp,
-				    sdl->dl_name, tdzp, tdl->dl_name, szp);
-			} else {
-				/*
-				 * At this point, we have successfully created
-				 * the target name, but have failed to remove
-				 * the source name.  Since the create was done
-				 * with the ZRENAMING flag, there are
-				 * complications; for one, the link count is
-				 * wrong.  The easiest way to deal with this
-				 * is to remove the newly created target, and
-				 * return the original error.  This must
-				 * succeed; fortunately, it is very unlikely to
-				 * fail, since we just created it.
-				 */
-				VERIFY3U(zfs_link_destroy(tdl, szp, tx,
-				    ZRENAMING, NULL), ==, 0);
-			}
-		} else {
-			/*
-			 * If we had removed the existing target, subsequent
-			 * call to zfs_link_create() to add back the same entry
-			 * but, the new dnode (szp) should not fail.
-			 */
-			ASSERT(tzp == NULL);
-		}
+		if (error)
+			goto commit_link_szp;
 	}
 
+	/*
+	 * Create a new link at the target.
+	 */
+	error = zfs_link_create(tdl, szp, tx, ZRENAMING);
+	if (error) {
+		/*
+		 * If we have removed the existing target, a subsequent call to
+		 * zfs_link_create() to add back the same entry, but with a new
+		 * dnode (szp), should not fail.
+		 */
+		ASSERT3P(tzp, ==, NULL);
+		goto commit_link_tzp;
+	}
+
+	zfs_log_rename(zilog, tx, TX_RENAME |
+	    (flags & FIGNORECASE ? TX_CI : 0), sdzp,
+	    sdl->dl_name, tdzp, tdl->dl_name, szp);
+
+commit:
 	dmu_tx_commit(tx);
 out:
 	if (zl != NULL)
@@ -4001,6 +3995,29 @@ out:
 
 	ZFS_EXIT(zfsvfs);
 	return (error);
+
+	/*
+	 * Clean-up path for broken link state.
+	 *
+	 * At this point we are in a (very) bad state, so we need to do our
+	 * best to correct the state. In particular, the nlink of szp is wrong
+	 * because we were destroying and creating links with ZRENAMING.
+	 *
+	 * link_create()s are allowed to fail (though they shouldn't because we
+	 * only just unlinked them and are putting the entries back during
+	 * clean-up). But if they fail, we can just forcefully drop the nlink
+	 * value to (at the very least) avoid broken nlink values -- though in
+	 * the case of non-empty directories we will have to panic.
+	 */
+commit_link_tzp:
+	if (tzp) {
+		if (zfs_link_create(tdl, tzp, tx, ZRENAMING))
+			VERIFY3U(zfs_drop_nlink(tzp, tx, NULL), ==, 0);
+	}
+commit_link_szp:
+	if (zfs_link_create(sdl, szp, tx, ZRENAMING))
+		VERIFY3U(zfs_drop_nlink(szp, tx, NULL), ==, 0);
+	goto commit;
 }
 
 /*

--- a/module/zfs/zpl_inode.c
+++ b/module/zfs/zpl_inode.c
@@ -410,13 +410,13 @@ zpl_rename2(struct inode *sdip, struct dentry *sdentry,
 	int error;
 	fstrans_cookie_t cookie;
 
-	/* We don't have renameat2(2) support */
-	if (flags)
+	if (flags & ~(RENAME_NOREPLACE | RENAME_EXCHANGE | RENAME_WHITEOUT))
 		return (-EINVAL);
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_rename(sdip, dname(sdentry), tdip, dname(tdentry), cr, 0);
+	error = -zfs_rename(sdip, dname(sdentry), tdip, dname(tdentry), cr,
+	    flags);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 	ASSERT3S(error, <=, 0);

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -22,6 +22,7 @@ SUBDIRS = \
 	randfree_file \
 	randwritecomp \
 	readmmap \
+	renameat2 \
 	rename_dir \
 	rm_lnkcnt_zero_file \
 	threadsappend \

--- a/tests/zfs-tests/cmd/renameat2/.gitignore
+++ b/tests/zfs-tests/cmd/renameat2/.gitignore
@@ -1,0 +1,1 @@
+/renameat2

--- a/tests/zfs-tests/cmd/renameat2/Makefile.am
+++ b/tests/zfs-tests/cmd/renameat2/Makefile.am
@@ -1,0 +1,6 @@
+include $(top_srcdir)/config/Rules.am
+
+pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/bin
+
+pkgexec_PROGRAMS = renameat2
+renameat2_SOURCES = renameat2.c

--- a/tests/zfs-tests/cmd/renameat2/renameat2.c
+++ b/tests/zfs-tests/cmd/renameat2/renameat2.c
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: CDDL-1.0 OR MPL-2.0 */
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (C) 2019 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019 SUSE LLC
+ */
+
+/*
+ * mv(1) doesn't currently support RENAME_{EXCHANGE,WHITEOUT} so this is a very
+ * simple renameat2(2) wrapper for the OpenZFS self-tests.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+
+#ifndef SYS_renameat2
+#ifdef __NR_renameat2
+#define	SYS_renameat2 __NR_renameat2
+#elif defined(__x86_64__)
+#define	SYS_renameat2 316
+#elif defined(__i386__)
+#define	SYS_renameat2 353
+#elif defined(__arm__) || defined(__aarch64__)
+#define	SYS_renameat2 382
+#else
+#error "SYS_renameat2 not known for this architecture."
+#endif
+#endif
+
+#ifndef RENAME_NOREPLACE
+#define	RENAME_NOREPLACE	(1 << 0) /* Don't overwrite target */
+#endif
+#ifndef RENAME_EXCHANGE
+#define	RENAME_EXCHANGE		(1 << 1) /* Exchange source and dest */
+#endif
+#ifndef RENAME_WHITEOUT
+#define	RENAME_WHITEOUT		(1 << 2) /* Whiteout source */
+#endif
+
+static int
+sys_renameat2(int olddirfd, const char *oldpath,
+    int newdirfd, const char *newpath, unsigned int flags)
+{
+	int ret = syscall(SYS_renameat2, olddirfd, oldpath, newdirfd, newpath,
+	    flags);
+	return ((ret < 0) ? -errno : ret);
+}
+
+static void
+usage(void)
+{
+	fprintf(stderr, "usage: renameat2 [-Cnwx] src dst\n");
+	exit(1);
+}
+
+static void
+check(void)
+{
+	int err = sys_renameat2(AT_FDCWD, ".", AT_FDCWD, ".", RENAME_EXCHANGE);
+	exit(err == -ENOSYS);
+}
+
+int
+main(int argc, char **argv)
+{
+	char *src, *dst;
+	int ch, err;
+	unsigned int flags = 0;
+
+	while ((ch = getopt(argc, argv, "Cnwx")) >= 0) {
+		switch (ch) {
+			case 'C':
+				check();
+				break;
+			case 'n':
+				flags |= RENAME_NOREPLACE;
+				break;
+			case 'w':
+				flags |= RENAME_WHITEOUT;
+				break;
+			case 'x':
+				flags |= RENAME_EXCHANGE;
+				break;
+			default:
+				usage();
+				break;
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc != 2)
+		usage();
+	src = argv[0];
+	dst = argv[1];
+
+	err = sys_renameat2(AT_FDCWD, src, AT_FDCWD, dst, flags);
+	if (err < 0)
+		fprintf(stderr, "renameat2: %s", strerror(-err));
+	return (err != 0);
+}

--- a/tests/zfs-tests/tests/functional/Makefile.am
+++ b/tests/zfs-tests/tests/functional/Makefile.am
@@ -57,6 +57,7 @@ SUBDIRS = \
 	refquota \
 	refreserv \
 	removal \
+	renameat2 \
 	rename_dirs \
 	replacement \
 	reservation \

--- a/tests/zfs-tests/tests/functional/renameat2/Makefile.am
+++ b/tests/zfs-tests/tests/functional/renameat2/Makefile.am
@@ -1,0 +1,7 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/renameat2
+dist_pkgdata_SCRIPTS = \
+	setup.ksh \
+	cleanup.ksh \
+	renameat2_001_noreplace.ksh \
+	renameat2_002_exchange.ksh \
+	renameat2_003_whiteout.ksh

--- a/tests/zfs-tests/tests/functional/renameat2/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/renameat2/cleanup.ksh
@@ -1,0 +1,34 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/renameat2/renameat2_001_noreplace.ksh
+++ b/tests/zfs-tests/tests/functional/renameat2/renameat2_001_noreplace.ksh
@@ -1,0 +1,59 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0 OR MPL-2.0
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (C) 2019 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2019 SUSE LLC
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "both"
+
+if ! is_linux ; then
+	log_unsupported "renameat2 is linux-only"
+elif ! renameat2 -C ; then
+	log_unsupported "renameat2 not supported on this (pre-3.15) linux kernel"
+fi
+
+function cleanup
+{
+	log_must rm -rf $TESTDIR/*
+}
+
+log_assert "ZFS supports RENAME_NOREPLACE."
+log_onexit cleanup
+
+cd $TESTDIR
+touch foo bar
+
+# Clobbers should always fail.
+log_mustnot renameat2 -n foo foo
+log_mustnot renameat2 -n foo bar
+log_mustnot renameat2 -n bar foo
+
+# Regular renames should succeed.
+log_must renameat2 -n bar baz
+
+log_pass "ZFS supports RENAME_NOREPLACE as expected."

--- a/tests/zfs-tests/tests/functional/renameat2/renameat2_002_exchange.ksh
+++ b/tests/zfs-tests/tests/functional/renameat2/renameat2_002_exchange.ksh
@@ -1,0 +1,69 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0 OR MPL-2.0
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (C) 2019 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2019 SUSE LLC
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "both"
+
+if ! is_linux ; then
+	log_unsupported "renameat2 is linux-only"
+elif ! renameat2 -C ; then
+	log_unsupported "renameat2 not supported on this (pre-3.15) linux kernel"
+fi
+
+function cleanup
+{
+	log_must rm -rf $TESTDIR/*
+}
+
+log_assert "ZFS supports RENAME_EXCHANGE."
+log_onexit cleanup
+
+cd $TESTDIR
+echo "foo" > foo
+echo "bar" > bar
+
+# Self-exchange is a no-op.
+log_must renameat2 -x foo foo
+log_must grep '^foo$' foo
+
+# Basic exchange.
+log_must renameat2 -x foo bar
+log_must grep '^bar$' foo
+log_must grep '^foo$' bar
+
+# And exchange back.
+log_must renameat2 -x foo bar
+log_must grep '^foo$' foo
+log_must grep '^bar$' bar
+
+# Exchange with a bad path should fail.
+log_mustnot renameat2 -x bar baz
+
+log_pass "ZFS supports RENAME_EXCHANGE as expected."

--- a/tests/zfs-tests/tests/functional/renameat2/renameat2_003_whiteout.ksh
+++ b/tests/zfs-tests/tests/functional/renameat2/renameat2_003_whiteout.ksh
@@ -1,0 +1,58 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0 OR MPL-2.0
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (C) 2019 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2019 SUSE LLC
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "both"
+
+if ! is_linux ; then
+	log_unsupported "renameat2 is linux-only"
+elif ! renameat2 -C ; then
+	log_unsupported "renameat2 not supported on this (pre-3.15) linux kernel"
+fi
+
+function cleanup
+{
+	log_must rm -rf $TESTDIR/*
+}
+
+log_assert "ZFS supports RENAME_WHITEOUT."
+log_onexit cleanup
+
+cd $TESTDIR
+echo "whiteout" > whiteout
+
+# Straight-forward rename-with-whiteout.
+log_must renameat2 -w whiteout new
+# Check new file.
+log_must grep '^whiteout$' new
+# Check that the whiteout is actually a {0,0} char device.
+log_must grep '^character special file:0:0$' <<<"$(stat -c '%F:%t:%T' whiteout)"
+
+log_pass "ZFS supports RENAME_WHITEOUT as expected."

--- a/tests/zfs-tests/tests/functional/renameat2/setup.ksh
+++ b/tests/zfs-tests/tests/functional/renameat2/setup.ksh
@@ -1,0 +1,35 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+default_setup $DISK

--- a/tests/zfs-tests/tests/functional/slog/slog_replay_fs.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_replay_fs.ksh
@@ -160,6 +160,22 @@ log_must attr -qs fileattr -V HelloWorld /$TESTPOOL/$TESTFS/xattr.file
 log_must attr -qs tmpattr -V HelloWorld /$TESTPOOL/$TESTFS/xattr.file
 log_must attr -qr tmpattr /$TESTPOOL/$TESTFS/xattr.file
 
+# We can't test TX_EXCHANGE or TX_WHITEOUT without renameat2(2) support.
+if ! is_linux ; then
+	log_note "renameat2 is linux-only"
+elif ! renameat2 -C ; then
+	log_note "renameat2 not supported on this (pre-3.15) linux kernel"
+else
+	# TX_EXCHANGE
+	log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/xchg-a bs=1k count=1
+	log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/xchg-b bs=1k count=1
+	log_must renameat2 -x /$TESTPOOL/$TESTFS/xchg-{a,b}
+
+	# TX_WHITEOUT
+	log_must mkfile 1k /$TESTPOOL/$TESTFS/whiteout
+	log_must renameat2 -w /$TESTPOOL/$TESTFS/whiteout{,-moved}
+fi
+
 #
 # 4. Copy TESTFS to temporary location (TESTDIR/copy)
 #


### PR DESCRIPTION
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
In order to allow overlayfs-on-ZFS (#8648), we need to support the renameat(2)
flags (most importantly, RENAME_WHITEOUT and RENAME_EXCHANGE). This
requires quite a few changes to the ordering of link operations during
rename (and the related error paths).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

I conducted a variety of smoke-tests to check that all of the `renameat(2)` flags (and ordinary `rename`) all operated correctly. After all the runs, I checked that there were no leaks with `zdb -bbb`. However, I have not tested the error path **at all** (and I have a feeling this is almost certainly where I've made mistakes).

* [ ] TODO: Run the rename-related xfstests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
