### PR TITLE
Fix `zfs set atime=off|on` behavior on inherited datasets

### DIFF
--- a/include/linux/vfs_compat.h
+++ b/include/linux/vfs_compat.h
@@ -207,6 +207,10 @@ zpl_bdi_destroy(struct super_block *sb)
 #define	SB_MANDLOCK	MS_MANDLOCK
 #endif
 
+#ifndef	SB_NOATIME
+#define	SB_NOATIME	MS_NOATIME
+#endif
+
 /*
  * 2.6.38 API change,
  * LOOKUP_RCU flag introduced to distinguish rcu-walk from ref-walk cases.

--- a/include/sys/zfs_vfsops.h
+++ b/include/sys/zfs_vfsops.h
@@ -98,7 +98,6 @@ struct zfsvfs {
 	zfs_case_t	z_case;		/* case-sense */
 	boolean_t	z_utf8;		/* utf8-only */
 	int		z_norm;		/* normalization flags */
-	boolean_t	z_atime;	/* enable atimes mount option */
 	boolean_t	z_relatime;	/* enable relatime mount option */
 	boolean_t	z_unmounted;	/* unmounted */
 	rrmlock_t	z_teardown_lock;

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -363,6 +363,7 @@ extern int	zfs_inode_alloc(struct super_block *, struct inode **ip);
 extern void	zfs_inode_destroy(struct inode *);
 extern void	zfs_inode_update(znode_t *);
 extern void	zfs_mark_inode_dirty(struct inode *);
+extern boolean_t zfs_relatime_need_update(const struct inode *);
 
 extern void zfs_log_create(zilog_t *zilog, dmu_tx_t *tx, uint64_t txtype,
     znode_t *dzp, znode_t *zp, char *name, vsecattr_t *, zfs_fuid_info_t *,

--- a/module/zfs/zpl_file.c
+++ b/module/zfs/zpl_file.c
@@ -289,6 +289,8 @@ zpl_iter_read_common(struct kiocb *kiocb, const struct iovec *iovp,
 {
 	cred_t *cr = CRED();
 	struct file *filp = kiocb->ki_filp;
+	struct inode *ip = filp->f_mapping->host;
+	zfsvfs_t *zfsvfs = ZTOZSB(ITOZ(ip));
 	ssize_t read;
 	unsigned int f_flags = filp->f_flags;
 
@@ -298,7 +300,20 @@ zpl_iter_read_common(struct kiocb *kiocb, const struct iovec *iovp,
 	    nr_segs, &kiocb->ki_pos, seg, f_flags, cr, skip);
 	crfree(cr);
 
-	file_accessed(filp);
+	/*
+	 * If relatime is enabled, call file_accessed() only if
+	 * zfs_relatime_need_update() is true.  This is needed since datasets
+	 * with inherited "relatime" property aren't necessarily mounted with
+	 * MNT_RELATIME flag (e.g. after `zfs set relatime=...`), which is what
+	 * relatime test in VFS by relatime_need_update() is based on.
+	 */
+	if (!IS_NOATIME(ip) && zfsvfs->z_relatime) {
+		if (zfs_relatime_need_update(ip))
+			file_accessed(filp);
+	} else {
+		file_accessed(filp);
+	}
+
 	return (read);
 }
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -37,7 +37,8 @@ tests = ['dbufstats_001_pos', 'dbufstats_002_pos']
 tags = ['functional', 'arc']
 
 [tests/functional/atime]
-tests = ['atime_001_pos', 'atime_002_neg', 'atime_003_pos']
+tests = ['atime_001_pos', 'atime_002_neg', 'atime_003_pos', 'root_atime_off',
+    'root_atime_on', 'root_relatime_on']
 tags = ['functional', 'atime']
 
 [tests/functional/bootfs]

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -214,6 +214,13 @@ function default_setup
 	log_pass
 }
 
+function default_setup_no_mountpoint
+{
+	default_setup_noexit "$1" "$2" "$3" "yes"
+
+	log_pass
+}
+
 #
 # Given a list of disks, setup storage pools and datasets.
 #
@@ -222,6 +229,7 @@ function default_setup_noexit
 	typeset disklist=$1
 	typeset container=$2
 	typeset volume=$3
+	typeset no_mountpoint=$4
 	log_note begin default_setup_noexit
 
 	if is_global_zone; then
@@ -238,7 +246,9 @@ function default_setup_noexit
 	mkdir -p $TESTDIR || log_unresolved Could not create $TESTDIR
 
 	log_must zfs create $TESTPOOL/$TESTFS
-	log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
+	if [[ -z $no_mountpoint ]]; then
+		log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
+	fi
 
 	if [[ -n $container ]]; then
 		rm -rf $TESTDIR1  || \
@@ -249,8 +259,10 @@ function default_setup_noexit
 		log_must zfs create $TESTPOOL/$TESTCTR
 		log_must zfs set canmount=off $TESTPOOL/$TESTCTR
 		log_must zfs create $TESTPOOL/$TESTCTR/$TESTFS1
-		log_must zfs set mountpoint=$TESTDIR1 \
-		    $TESTPOOL/$TESTCTR/$TESTFS1
+		if [[ -z $no_mountpoint ]]; then
+			log_must zfs set mountpoint=$TESTDIR1 \
+			    $TESTPOOL/$TESTCTR/$TESTFS1
+		fi
 	fi
 
 	if [[ -n $volume ]]; then

--- a/tests/zfs-tests/tests/functional/atime/Makefile.am
+++ b/tests/zfs-tests/tests/functional/atime/Makefile.am
@@ -4,7 +4,10 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	atime_001_pos.ksh \
 	atime_002_neg.ksh \
-	atime_003_pos.ksh
+	atime_003_pos.ksh \
+	root_atime_off.ksh \
+	root_atime_on.ksh \
+	root_relatime_on.ksh
 
 dist_pkgdata_DATA = \
 	atime.cfg \

--- a/tests/zfs-tests/tests/functional/atime/atime_common.kshlib
+++ b/tests/zfs-tests/tests/functional/atime/atime_common.kshlib
@@ -68,11 +68,26 @@ function check_atime_updated
 
 function setup_snap_clone
 {
-	# Create two file to verify snapshot.
-	log_must touch $TESTDIR/$TESTFILE
+	if [ -d "/$TESTPOOL/$TESTFS" ]; then
+		# No mountpoint case (default).
+		log_must touch /$TESTPOOL/$TESTFS/$TESTFILE
+	else
+		# Create two file to verify snapshot.
+		log_must touch $TESTDIR/$TESTFILE
+	fi
 
 	create_snapshot $TESTPOOL/$TESTFS $TESTSNAP
 	create_clone $TESTPOOL/$TESTFS@$TESTSNAP $TESTPOOL/$TESTCLONE
+}
+
+function reset_atime
+{
+	zfs inherit atime $TESTPOOL
+	zfs inherit atime $TESTPOOL/$TESTFS
+	zfs inherit atime $TESTPOOL/$TESTCLONE
+	zfs inherit relatime $TESTPOOL
+	zfs inherit relatime $TESTPOOL/$TESTFS
+	zfs inherit relatime $TESTPOOL/$TESTCLONE
 }
 
 function cleanup

--- a/tests/zfs-tests/tests/functional/atime/root_atime_off.ksh
+++ b/tests/zfs-tests/tests/functional/atime/root_atime_off.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2019 by Tomohiro Kusumi. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/atime/atime_common.kshlib
+
+#
+# DESCRIPTION:
+# When atime=off, verify the access time for files is not updated when read.
+# It is available to pool, fs snapshot and clone.
+#
+# STRATEGY:
+# 1. Create pool, fs.
+# 2. Create '$TESTFILE' for fs.
+# 3. Create snapshot and clone.
+# 4. Setting atime=off on dataset and read '$TESTFILE'.
+# 5. Verify the access time is not updated.
+#
+
+verify_runnable "both"
+
+log_assert "Setting atime=off, the access time for files will not be updated \
+	when read."
+log_onexit cleanup
+
+#
+# Create $TESTFILE, snapshot and clone.
+# Same as 002 except that atime applies to root dataset (ZoL#8675).
+#
+setup_snap_clone
+reset_atime
+
+for dst in $TESTPOOL/$TESTFS $TESTPOOL/$TESTCLONE $TESTPOOL/$TESTFS@$TESTSNAP
+do
+	typeset mtpt=$(get_prop mountpoint $dst)
+
+	if [[ $dst == $TESTPOOL/$TESTFS@$TESTSNAP ]]; then
+		mtpt=$(snapshot_mountpoint $dst)
+	else
+		log_must zfs set atime=off $(dirname $dst)
+	fi
+
+	log_mustnot check_atime_updated $mtpt/$TESTFILE
+done
+
+log_pass "Verify the property atime=off passed."

--- a/tests/zfs-tests/tests/functional/atime/root_atime_on.ksh
+++ b/tests/zfs-tests/tests/functional/atime/root_atime_on.ksh
@@ -1,0 +1,78 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2019 by Tomohiro Kusumi. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/atime/atime_common.kshlib
+
+#
+# DESCRIPTION:
+# When atime=on, verify the access time for files is updated when read. It
+# is available to fs and clone. To snapshot, it is unavailable.
+#
+# STRATEGY:
+# 1. Create pool and fs.
+# 2. Create '$TESTFILE' for fs.
+# 3. Create snapshot and clone.
+# 4. Setting atime=on on datasets except snapshot, and read '$TESTFILE'.
+# 5. Expect the access time is updated on datasets except snapshot.
+#
+
+verify_runnable "both"
+
+log_assert "Setting atime=on, the access time for files is updated when read."
+log_onexit cleanup
+
+#
+# Create $TESTFILE, snapshot and clone.
+# Same as 001 except that atime/relatime applies to root dataset (ZoL#8675).
+#
+setup_snap_clone
+reset_atime
+
+for dst in $TESTPOOL/$TESTFS $TESTPOOL/$TESTCLONE $TESTPOOL/$TESTFS@$TESTSNAP
+do
+	typeset mtpt=$(get_prop mountpoint $dst)
+
+	if [[ $dst == $TESTPOOL/$TESTFS@$TESTSNAP ]]; then
+		mtpt=$(snapshot_mountpoint $dst)
+		log_mustnot check_atime_updated $mtpt/$TESTFILE
+	else
+		if is_linux; then
+			log_must zfs set relatime=off $(dirname $dst)
+		fi
+
+		log_must zfs set atime=on $(dirname $dst)
+		log_must check_atime_updated $mtpt/$TESTFILE
+		log_must check_atime_updated $mtpt/$TESTFILE
+	fi
+done
+
+log_pass "Verify the property atime=on passed."

--- a/tests/zfs-tests/tests/functional/atime/root_relatime_on.ksh
+++ b/tests/zfs-tests/tests/functional/atime/root_relatime_on.ksh
@@ -1,0 +1,76 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2019 by Tomohiro Kusumi. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/atime/atime_common.kshlib
+
+#
+# DESCRIPTION:
+# When relatime=on, verify the access time for files is updated when first
+# read but not on second.
+# It is available to fs and clone. To snapshot, it is unavailable.
+#
+# STRATEGY:
+# 1. Create pool and fs.
+# 2. Create '$TESTFILE' for fs.
+# 3. Create snapshot and clone.
+# 4. Setting atime=on and relatime=on on datasets.
+# 5. Expect the access time is updated for first read but not on second.
+#
+
+verify_runnable "both"
+
+log_assert "Setting relatime=on, the access time for files is updated when \
+	when read the first time, but not second time."
+log_onexit cleanup
+
+#
+# Create $TESTFILE, snapshot and clone.
+# Same as 003 except that atime/relatime applies to root dataset (ZoL#8675).
+#
+setup_snap_clone
+reset_atime
+
+for dst in $TESTPOOL/$TESTFS $TESTPOOL/$TESTCLONE $TESTPOOL/$TESTFS@$TESTSNAP
+do
+	typeset mtpt=$(get_prop mountpoint $dst)
+
+	if [[ $dst == $TESTPOOL/$TESTFS@$TESTSNAP ]]; then
+		mtpt=$(snapshot_mountpoint $dst)
+		log_mustnot check_atime_updated $mtpt/$TESTFILE
+	else
+		log_must zfs set atime=on $(dirname $dst)
+		log_must zfs set relatime=on $(dirname $dst)
+		log_must check_atime_updated $mtpt/$TESTFILE
+		log_mustnot check_atime_updated $mtpt/$TESTFILE
+	fi
+done
+
+log_pass "Verify the property relatime=on passed."

--- a/tests/zfs-tests/tests/functional/atime/setup.ksh
+++ b/tests/zfs-tests/tests/functional/atime/setup.ksh
@@ -28,4 +28,4 @@
 . $STF_SUITE/include/libtest.shlib
 
 DISK=${DISKS%% *}
-default_setup $DISK
+default_setup_no_mountpoint $DISK


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/zfsonlinux/zfs/issues/8674 .

### Description
<!--- Describe your changes in detail -->

1
```
    Fix `zfs set atime=off|on` behavior on inherited datasets

    `zfs set atime=off|on` doesn't disable or enable atime on read for
    datasets whose "atime" property was inherited from its parent, until
    a filesystem is once unmounted and mounted again.

    ("atime" starts to work properly if a filesystem is once unmounted and
    mounted again. The difference comes from regular mount process, e.g.
    via zpool import, uses mount options based on zpool properties read
    from ondisk layout for each dataset, whereas `zfs set atime=off|on`
    just remounts a specified dataset.)

    --
     # zpool create p1 <device>
     # zfs create p1/f1
     # zfs set atime=off p1
     # echo test > /p1/f1/test
     # sync
     # zfs list
     NAME    USED  AVAIL     REFER  MOUNTPOINT
     p1      176K  18.9G     25.5K  /p1
     p1/f1    26K  18.9G       26K  /p1/f1
     # zfs get atime
     NAME   PROPERTY  VALUE  SOURCE
     p1     atime     off    local
     p1/f1  atime     off    inherited from p1
     # stat /p1/f1/test | grep Access | tail -1
     Access: 2019-04-26 23:32:33.741205192 +0900
     # cat /p1/f1/test
     test
     # stat /p1/f1/test | grep Access | tail -1
     Access: 2019-04-26 23:32:50.173231861 +0900
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ changed by read(2)
    --

    The problem is that zfsvfs::z_atime which was probably intended to keep
    incore atime state just gets updated by a callback function of "atime"
    property change, atime_changed_cb(), and never used for anything else.

    Since now that all file read and atime update use a common function
    zpl_iter_read_common() -> file_accessed(), and whether to update atime
    via ->dirty_inode() is determined by atime_needs_update(),
    atime_needs_update() needs to return false once atime is turned off.
    It currently continues to return true on `zfs set atime=off`.

    Fix atime_changed_cb() by setting or dropping SB_NOATIME in VFS super
    block depending on a new atime value, so that atime_needs_update() works
    as expected after property change.
```

2
```
    Fix `zfs set relatime=off|on` behavior on inherited datasets

    `zfs set relatime=off|on` doesn't disable or enable relatime on read
    for datasets whose "relatime" property was inherited from its parent,
    until a filesystem is once unmounted and mounted again.

    The "atime" problem mentioned and fixed in the previous commit
    also applies to "relatime" behavior. This commit is to fix "relatime".

    The basic idea is similar to the previous commit, except that relatime
    test needs to be handled in ZoL code rather than updating super block
    and make VFS handle it properly. This is because relatime_need_update()
    is based on a mount option flag MNT_RELATIME, which is not what the
    datasets with inherited "relatime" property via `zfs set relatime=...`
    have, hence it needs its own relatime test zfs_relatime_need_update().
```

3
```
    Drop no longer used zfsvfs::z_atime

    This hasn't been used and atime works without this flag.
```

4
```
    Drop zfs_compare_timespec() and use equivalents from Linux kernel

    Linux kernel has the exact same function as zfs_compare_timespec()
    for both timespec and timespec64, so zfs_compare_timespec() can be
    defined as a macro using existing functions just as inode_timespec_t
    is a typedef for timespec or timespec64.

    Note that timespec_compare() first appeared in Linux kernel 2.6.16,
    so this compiles on 2.6.32, which is the oldest supported kernel.
    e.g. this compiled on RHEL6.
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested locally, but maybe add one if there's no atime related one ?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
