### PR TITLE
Linux 5.0 compat: Remove incorrect ASSERT

### DIFF
--- a/module/zfs/vdev_disk.c
+++ b/module/zfs/vdev_disk.c
@@ -543,7 +543,6 @@ vdev_bio_associate_blkg(struct bio *bio)
 	struct request_queue *q = bio->bi_disk->queue;
 
 	ASSERT3P(q, !=, NULL);
-	ASSERT3P(q->root_blkg, !=, NULL);
 	ASSERT3P(bio->bi_blkg, ==, NULL);
 
 	if (blkg_tryget(q->root_blkg))


### PR DESCRIPTION
### Motivation and Context

Resolve Fedora 29 testing failures observed by the CI.

http://build.zfsonlinux.org/builders/Fedora%2029%20x86_64%20%28TEST%29/builds/1259/steps/shell_9/logs/console

Hitting this issue requires running a DEBUG version of ZFS,
on top of scsi_debug based vdevs using a 5.0 or newer kernel. 

### Description

Not all block devices, notably scsi_debug, set a root_blkg on the
request queue.  Remove this asserition and allow the the existing
call to blkg_tryget() to gracefully handle the NULL (which it does).

### How Has This Been Tested?

Locally compiled on Fedora 29 and the ZTS fault test group was
manually run.  Pending full results from the CI which was previously
consistently failing with Fedora 29 on these tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).