### PR TITLE
zfs:zfs_main: Round up zfs create volblocksize in command line utility

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -79,6 +79,8 @@
 #include "libzfs_impl.h"
 #include "zfs_projectutil.h"
 
+#define ROUND_UP_128K(SIZE) (SIZE + 128) - (SIZE % 128)
+
 libzfs_handle_t *g_zfs;
 
 static FILE *mnttab_file;
@@ -905,6 +907,7 @@ zfs_do_create(int argc, char **argv)
 			    zfs_prop_to_name(ZFS_PROP_VOLSIZE), intval) != 0)
 				nomem();
 			volsize = intval;
+			volsize = ROUND_UP_128K(intval);
 			break;
 		case 'p':
 			parents = B_TRUE;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

While running the command `zfs create -V`, the patch rounds up to the nearest 128 Kbytes.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/8541.

### Description
<!--- Describe your changes in detail -->
I added a macro which can be used in rounding up. I am calling the macro in the command `zfs create -V`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

I installed and ran the command. 

<!--- Include details of your testing environment, and the tests you ran to -->

I ran the test case. I don't think any test case got affected by this change.

<!--- see how your change affects other areas of the code, etc. -->

`zfs_ioc_create()` is affected as the size would be now rounded up.

<!--- If your change is a performance enhancement, please provide benchmarks here. -->

No.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.

I don't think any change in the documentation is required as the documentation say round up by 128K and that's what this patch does.

- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
