### PR TITLE
Clearer wording on Errata #4 for non-destructive remedy

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2567,20 +2567,19 @@ show_import(nvlist_t *config)
 				break;
 
 			case ZPOOL_ERRATA_ZOL_8308_ENCRYPTION:
-				(void) printf(gettext(" action: Any existing "
-				    "encrypted datasets contain an on-disk "
-				    "incompatibility\n\twhich may cause "
-				    "on-disk corruption with 'zfs recv' and "
-				    "which needs\n\tto be corrected. Enable "
-				    "the bookmark_v2 feature and destroy all "
-				    "snapshots and bookmarks (on encrypted "
-				    "datasets) that were created before "
-				    "enabling bookmark_v2. If preserving "
-				    "those snapshots and bookmarks is required, "
-				    "send (non-raw) them to new encrypted "
-				    "datasets. If this pool does\n\tnot contain "
-				    "any encrypted datasets, simply enable the "
-				    "bookmark_v2 \n\tfeature.\n"));
+				(void) printf(gettext(" action: Existing "
+				    "encrypted snapshots and bookmarks contain "
+				    "an on-disk\n\tincompatibility. This may "
+				    "cause on-disk corruption if they are used "
+				    "with\n\t'zfs recv'. To correct the issue, "
+				    "enable the bookmark_v2 feature. No "
+				    "additional\n\taction is needed if there "
+				    "are no encrypted snapshots or bookmarks. "
+				    "If preserving\n\tthe encrypted snapshots "
+				    "and bookmarks is required, use a non-raw "
+				    "send to backup\n\tand restore them. "
+				    "Alternately, they may be removed to "
+				    "resolve the\n\tincompatibility.\n"));
 				break;
 			default:
 				/*
@@ -7636,18 +7635,19 @@ status_callback(zpool_handle_t *zhp, void *data)
 			break;
 
 		case ZPOOL_ERRATA_ZOL_8308_ENCRYPTION:
-			(void) printf(gettext("\tExisting encrypted datasets "
-			    "contain an on-disk incompatibility\n\twhich "
-			    "needs to be corrected.\n"));
-			(void) printf(gettext("action: To correct the issue "
-			    "enable the bookmark_v2 feature and destroy all "
-			    "snapshots and bookmarks (on encrypted datasets) "
-			    "that were created before enabling bookmark_v2. "
-			    "If preserving those snapshots and bookmarks is "
-			    "required, send (non-raw) them to new encrypted "
-			    "datasets. If this pool does\n\tnot contain any "
-			    "encrypted datasets, simply enable the "
-			    "bookmark_v2 \n\tfeature.\n"));
+			(void) printf(gettext("Existing encrypted snapshots "
+			    "and bookmarks contain an on-disk "
+			    "incompatibility.\n\tThis may cause on-disk "
+			    "corruption if they are used with 'zfs recv'."));
+			(void) printf(gettext(" action:  To correct the issue, "
+			    "enable the bookmark_v2 feature. No "
+			    "additional\n\taction is needed if there "
+			    "are no encrypted snapshots or bookmarks. "
+			    "If preserving\n\tthe encrypted snapshots "
+			    "and bookmarks is required, use a non-raw "
+			    "send to backup\n\tand restore them. "
+			    "Alternately, they may be removed to "
+			    "resolve the\n\tincompatibility.\n"));
 			break;
 
 		default:

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2572,15 +2572,15 @@ show_import(nvlist_t *config)
 				    "incompatibility\n\twhich may cause "
 				    "on-disk corruption with 'zfs recv' and "
 				    "which needs\n\tto be corrected. Enable "
-				    "the bookmark_v2 feature. Destroy all "
-				    "snapshots (on encrypted datasets) that "
-				    "were created before enabling bookmark_v2. "
-				    "If preserving those snapshots is "
-				    "required, send (non-raw) them to new "
-				    "encrypted datasets. If this pool "
-				    "does\n\tnot contain any encrypted "
-				    "datasets, simply enable the bookmark_v2 "
-				    "\n\tfeature.\n"));
+				    "the bookmark_v2 feature and destroy all "
+				    "snapshots and bookmarks (on encrypted "
+				    "datasets) that were created before "
+				    "enabling bookmark_v2. If preserving "
+				    "those snapshots and bookmarks is required, "
+				    "send (non-raw) them to new encrypted "
+				    "datasets. If this pool does\n\tnot contain "
+				    "any encrypted datasets, simply enable the "
+				    "bookmark_v2 \n\tfeature.\n"));
 				break;
 			default:
 				/*
@@ -7640,15 +7640,14 @@ status_callback(zpool_handle_t *zhp, void *data)
 			    "contain an on-disk incompatibility\n\twhich "
 			    "needs to be corrected.\n"));
 			(void) printf(gettext("action: To correct the issue "
-			    "enable the bookmark_v2 feature. Destroy all "
-			    "snapshots (on encrypted datasets) that "
-			    "were created before enabling bookmark_v2. "
-			    "If preserving those snapshots is "
-			    "required, send (non-raw) them to new "
-			    "encrypted datasets. If this pool "
-			    "does\n\tnot contain any encrypted "
-			    "datasets, simply enable the bookmark_v2 "
-			    "\n\tfeature.\n"));
+			    "enable the bookmark_v2 feature and destroy all "
+			    "snapshots and bookmarks (on encrypted datasets) "
+			    "that were created before enabling bookmark_v2. "
+			    "If preserving those snapshots and bookmarks is "
+			    "required, send (non-raw) them to new encrypted "
+			    "datasets. If this pool does\n\tnot contain any "
+			    "encrypted datasets, simply enable the "
+			    "bookmark_v2 \n\tfeature.\n"));
 			break;
 
 		default:

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -2572,12 +2572,15 @@ show_import(nvlist_t *config)
 				    "incompatibility\n\twhich may cause "
 				    "on-disk corruption with 'zfs recv' and "
 				    "which needs\n\tto be corrected. Enable "
-				    "the bookmark_v2 feature, backup "
-				    "these datasets\n\tto new encrypted "
-				    "datasets, and destroy the old ones. "
-				    "If this pool does\n\tnot contain any "
-				    "encrypted datasets, simply enable the "
-				    "bookmark_v2\n\tfeature.\n"));
+				    "the bookmark_v2 feature. Destroy all "
+				    "snapshots (on encrypted datasets) that "
+				    "were created before enabling bookmark_v2. "
+				    "If preserving those snapshots is "
+				    "required, send (non-raw) them to new "
+				    "encrypted datasets. If this pool "
+				    "does\n\tnot contain any encrypted "
+				    "datasets, simply enable the bookmark_v2 "
+				    "\n\tfeature.\n"));
 				break;
 			default:
 				/*
@@ -7637,12 +7640,15 @@ status_callback(zpool_handle_t *zhp, void *data)
 			    "contain an on-disk incompatibility\n\twhich "
 			    "needs to be corrected.\n"));
 			(void) printf(gettext("action: To correct the issue "
-			    "enable the bookmark_v2 feature, backup\n\tany "
-			    "existing encrypted datasets to new encrypted "
-			    "datasets,\n\tand destroy the old ones. If this "
-			    "pool does not contain any\n\tencrypted "
+			    "enable the bookmark_v2 feature. Destroy all "
+			    "snapshots (on encrypted datasets) that "
+			    "were created before enabling bookmark_v2. "
+			    "If preserving those snapshots is "
+			    "required, send (non-raw) them to new "
+			    "encrypted datasets. If this pool "
+			    "does\n\tnot contain any encrypted "
 			    "datasets, simply enable the bookmark_v2 "
-			    "feature.\n"));
+			    "\n\tfeature.\n"));
 			break;
 
 		default:


### PR DESCRIPTION
Errata #4 doesn’t mention a non-destructive way to clear it. This commits fixes #8682

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Motivation and Context
Users of existing pools, especially pools with top-level encrypted datasets could run into trouble trying to work around Errata #4. After @behlendorf's clarification, there is a non-destructive way that is possible. This commit mentions that.

This commit attempts to fix #8682.

### Description
Just a documentation change where previous Errata #4 changes were made-

### How Has This Been Tested?
only documentation changes, haven't tested them myself.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
