### PR TITLE
zfs:zfs_main: Round up near block size multiple in command line utility

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -904,7 +904,7 @@ zfs_do_create(int argc, char **argv)
 			if (nvlist_add_uint64(props,
 			    zfs_prop_to_name(ZFS_PROP_VOLSIZE), intval) != 0)
 				nomem();
-			volsize = intval;
+			volsize = P2ROUNDUP(intval, align);
 			break;
 		case 'p':
 			parents = B_TRUE;

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -2511,8 +2511,7 @@ The size represents the logical size as exported by the device.
 By default, a reservation of equal size is created.
 .Pp
 .Ar size
-is automatically rounded up to the nearest 128 Kbytes to ensure that the volume
-has an integral number of blocks regardless of
+is automatically rounded up to the nearest multiple of
 .Sy blocksize .
 .Bl -tag -width "-b"
 .It Fl b Ar blocksize


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Provide a general summary of your changes in the Title above

While running the command `zfs create -V`, the patch rounds up near block size multiple in command line utility.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/8541.

### Description
<!--- Describe your changes in detail -->

Calling the macro which would round up near block size multiple while using it in command line utility.

### How Has This Been Tested?
#### Please describe in detail how you tested your changes.

I installed and ran the command. 

#### Include details of your testing environment, and the tests you ran to

I ran the test case. I don't think any test case got affected by this change.

#### see how your change affects other areas of the code, etc.

`zfs_ioc_create()` is affected as the size would be now rounded up near kernel block size multiple 

#### If your change is a performance enhancement, please provide benchmarks here.

No.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).