### PR TITLE
Clarify that deduped data is encrypted

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -2388,7 +2388,8 @@ directory listings, FUID mappings, and
 .Sy groupused
 data.  ZFS will not encrypt metadata related to the pool structure, including
 dataset and snapshot names, dataset hierarchy, properties, file size, file
-holes, and deduplication tables.
+holes, and deduplication tables (though the deduplicated data itself is
+encrypted).
 .Pp
 Key rotation is managed by ZFS.  Changing the user's key (e.g. a passphrase)
 does not require re-encrypting the entire dataset.  Datasets can be scrubbed,


### PR DESCRIPTION
### Motivation and Context
@tcaputi asked for this in https://github.com/zfsonlinux/zfs/pull/8652#pullrequestreview-228959510. I said I added it, but apparently failed to commit it.

### Description
In zfs.8, where we say that deduplication tables are not encrypted, we now explicitly say that deduplicated data is encrypted. This is to avoid any misunderstandings.

### How Has This Been Tested?
I looked at it with `man`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
