### PR TITLE
Correct snprintf() size argument

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -971,7 +971,7 @@ send_iterate_fs(zfs_handle_t *zhp, void *arg)
 		char snapname[MAXPATHLEN] = { 0 };
 		zfs_handle_t *snap;
 
-		(void) snprintf(snapname, sizeof (snapname) - 1, "%s@%s",
+		(void) snprintf(snapname, sizeof (snapname), "%s@%s",
 		    zhp->zfs_name, sd->tosnap);
 		if (sd->fromsnap != NULL)
 			sd->seenfrom = B_TRUE;
@@ -1524,7 +1524,7 @@ dump_filesystem(zfs_handle_t *zhp, void *arg)
 		zfs_handle_t *snap;
 
 		if (!sdd->seenfrom) {
-			(void) snprintf(snapname, sizeof (snapname) - 1,
+			(void) snprintf(snapname, sizeof (snapname),
 			    "%s@%s", zhp->zfs_name, sdd->fromsnap);
 			snap = zfs_open(zhp->zfs_hdl, snapname,
 			    ZFS_TYPE_SNAPSHOT);
@@ -1535,7 +1535,7 @@ dump_filesystem(zfs_handle_t *zhp, void *arg)
 		}
 
 		if (rv == 0) {
-			(void) snprintf(snapname, sizeof (snapname) - 1,
+			(void) snprintf(snapname, sizeof (snapname),
 			    "%s@%s", zhp->zfs_name, sdd->tosnap);
 			snap = zfs_open(zhp->zfs_hdl, snapname,
 			    ZFS_TYPE_SNAPSHOT);

--- a/module/spl/spl-err.c
+++ b/module/spl/spl-err.c
@@ -86,7 +86,7 @@ vcmn_err(int ce, const char *fmt, va_list ap)
 {
 	char msg[MAXMSGLEN];
 
-	vsnprintf(msg, MAXMSGLEN - 1, fmt, ap);
+	vsnprintf(msg, MAXMSGLEN, fmt, ap);
 
 	switch (ce) {
 	case CE_IGNORE:

--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -766,8 +766,7 @@ zfsctl_snapshot_path_objset(zfsvfs_t *zfsvfs, uint64_t objsetid,
 			break;
 	}
 
-	memset(full_path, 0, path_len);
-	snprintf(full_path, path_len - 1, "%s/.zfs/snapshot/%s",
+	snprintf(full_path, path_len, "%s/.zfs/snapshot/%s",
 	    zfsvfs->z_vfs->vfs_mntpoint, snapname);
 out:
 	kmem_free(snapname, ZFS_MAX_DATASET_NAME_LEN);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Correct snprintf() size argument for libc and in-kernel snprintf().
Not security vuln.

### Description
<!--- Describe your changes in detail -->
The size argument of snprintf(3) in glibc and snprintf() in Linux
kernel includes trailing \0, as snprintf(3) man page explains it as
"write at most size bytes (including the trailing null byte ('\0'))",
i.e. snprintf() can just take buffer size.

e.g. For snprintf() in module/zfs/zfs_ctldir.c, a buffer size is
MAXPATHLEN, and a caller is passing MAXPATHLEN to snprintf(), so size
should just be `path_len` to do what the caller is trying to do.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

unit tests

```
# cat ./snprintf1.c
#include <stdio.h>

int main(void) {
        char buf[6] = {1,2,3,4,5,6};
        snprintf(buf, sizeof(buf), "hello world");
        printf("\"%s\"\n", buf);
        printf("%d\n", buf[5]);
        return 0;
}
# gcc ./snprintf1.c
# ./a.out
"hello"
0
```

```
# cat ./snprintf1.c
#include <linux/kernel.h>
#include <linux/module.h>

static int __init init_snprintf1(void)
{
        char buf[6] = {1,2,3,4,5,6};
        snprintf(buf, sizeof(buf), "hello world");
        printk("\"%s\"\n", buf);
        printk("%d\n", buf[5]);
        return 0;
}

static void __exit exit_snprintf1(void)
{
}

module_init(init_snprintf1);
module_exit(exit_snprintf1);

MODULE_DESCRIPTION("snprintf1");
MODULE_LICENSE("GPL");
# make
# insmod ./snprintf1.ko
# dmesg | tail -2
[413720.330005] "hello"
[413720.330009] 0
# rmmod snprintf1
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
