### PR TITLE
Make zfs_special_class_metadata_reserve_pct into a parameter

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -2388,6 +2388,20 @@ Default value: \fB16,777,216\fR.
 .sp
 .ne 2
 .na
+\fBzfs_special_class_metadata_reserve_pct\fR (int)
+.ad
+.RS 12n
+Only allow small data blocks to be allocated on the special and dedup vdev
+types when the available free space percentage on these vdevs exceeds this
+value. This ensures reserved space is available for pool meta data as the
+special vdevs approach capacity.
+.sp
+Default value: \fB25\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_sync_pass_dont_compress\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2689,5 +2689,10 @@ MODULE_PARM_DESC(zfs_ddt_data_is_special,
 module_param(zfs_user_indirect_is_special, int, 0644);
 MODULE_PARM_DESC(zfs_user_indirect_is_special,
 	"Place user data indirect blocks into the special class");
+
+module_param(zfs_special_class_metadata_reserve_pct, int, 0644);
+MODULE_PARM_DESC(zfs_special_class_metadata_reserve_pct,
+	"Small file blocks in special vdevs depends on this much "
+	"free space available");
 /* END CSTYLED */
 #endif


### PR DESCRIPTION
Signed-off-by: DHE <git@dehacked.net>

### Motivation and Context
The man page says:
```
Special Allocation Class
     ...The class can also be provisioned to accept a limited percentage of small file data blocks.
```
But this "percentage" is not clearly understood. This variable seems like the closest thing to the intended meaning, plus it is an interesting value for users to be able to control anyway.

### Description
Exported and documented a new module parameter

### How Has This Been Tested?
Build test and checkstyle as best I can on this system.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
