### PR TITLE
Correct man page dates

### DIFF
--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -15,7 +15,7 @@
 .\" Copyright (c) 2017 Lawrence Livermore National Security, LLC.
 .\" Copyright (c) 2017 Intel Corporation.
 .\"
-.Dd April 14, 2017
+.Dd April 14, 2019
 .Dt ZDB 8 SMM
 .Os Linux
 .Sh NAME

--- a/man/man8/zfs-program.8
+++ b/man/man8/zfs-program.8
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright (c) 2016, 2019 by Delphix. All Rights Reserved.
 .\"
-.Dd January 21, 2016
+.Dd February 26, 2019
 .Dt ZFS-PROGRAM 8
 .Os
 .Sh NAME

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -30,7 +30,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2018 Joyent, Inc.
 .\"
-.Dd February 26, 2019
+.Dd April 30, 2019
 .Dt ZFS 8 SMM
 .Os Linux
 .Sh NAME

--- a/man/man8/zgenhostid.8
+++ b/man/man8/zgenhostid.8
@@ -21,7 +21,7 @@
 .\"
 .\" Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
 .\"
-.Dd July 24, 2017
+.Dd September 16, 2017
 .Dt ZGENHOSTID 8 SMM
 .Os Linux
 .Sh NAME

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -27,7 +27,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd November 29, 2018
+.Dd May 2, 2019
 .Dt ZPOOL 8 SMM
 .Os Linux
 .Sh NAME

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -8,8 +8,9 @@ dist_pkgdata_SCRIPTS = \
 	$(top_srcdir)/scripts/zfs-helpers.sh
 
 EXTRA_DIST = \
-	common.sh.in \
 	commitcheck.sh \
+	common.sh.in \
+	cstyle.pl \
 	dkms.mkconf \
 	dkms.postbuild \
 	enum-extract.pl \
@@ -18,7 +19,7 @@ EXTRA_DIST = \
 	man-dates.sh \
 	paxcheck.sh \
 	zfs2zol-patch.sed \
-	cstyle.pl
+	zol2zfs-patch.sed
 
 define EXTRA_ENVIRONMENT
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -15,6 +15,7 @@ EXTRA_DIST = \
 	enum-extract.pl \
 	kmodtool \
 	make_gitrev.sh \
+	man-dates.sh \
 	paxcheck.sh \
 	zfs2zol-patch.sed \
 	cstyle.pl

--- a/scripts/man-dates.sh
+++ b/scripts/man-dates.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This script updates the date lines in the man pages to the date of the last
+# commit to that file.
+
+set -eu
+
+find man -type f | while read -r i ; do
+    git_date=$(git log -1 --date=short --format="%ad" -- "$i")
+    [ "x$git_date" = "x" ] && continue
+    sed -i "s|^\.Dd.*|.Dd $(date -d "$git_date" "+%B %-d, %Y")|" "$i"
+done


### PR DESCRIPTION
### Motivation and Context
Various changes (many by me) have been made to the man pages without bumping their dates.

### Description
I have now corrected them based on the last commit to each file.  I also added the script I used to make these changes.

### How Has This Been Tested?
The script was tested by using it to generate these changes. I verified the dates were correct for each man page by checking the git log manually.

I verified the man page changes by viewing them with `man`.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
