### PR TITLE
OpenZFS 10473 - zfs(1M) missing cross-reference to zfs-program(1M)

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -30,7 +30,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2018 Joyent, Inc.
 .\"
-.Dd Jan 05, 2019
+.Dd February 26, 2019
 .Dt ZFS 8 SMM
 .Os Linux
 .Sh NAME
@@ -5086,4 +5086,5 @@ command will be undone if the share is ever unshared (such as at a reboot etc).
 .Xr mount 8 ,
 .Xr net 8 ,
 .Xr selinux 8 ,
+.Xr zfs-program 8 ,
 .Xr zpool 8


### PR DESCRIPTION
### Motivation and Context
This ports an OpenZFS commit:
OpenZFS-issue: https://www.illumos.org/issues/10473
OpenZFS-commit: https://github.com/illumos/illumos-gate/commit/736e67003

### Description
One part of this commit was already applied. The only remaining substance is to add a cross-reference to `zfs-program.8` at the end of `zfs.8`.

The date change will ultimately conflict with #8710 since there were later changes. If this is accepted first, the porting will be closer to 1:1, but it really doesn't matter, as long as the latter date is kept in the end.

### How Has This Been Tested?
I viewed the man page with `man`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Note that this does NOT have a Signed-off-by, as the convention seems to be to omit that when porting OpenZFS commits, in favor of Ported-by:.