### PR TITLE
Make Python detection optional and more portable

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,3 +1,8 @@
 SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest
-SUBDIRS += mount_zfs fsck_zfs zvol_id vdev_id arcstat dbufstat zed
-SUBDIRS += arc_summary raidz_test zgenhostid
+SUBDIRS += fsck_zfs vdev_id raidz_test zgenhostid
+
+if USING_PYTHON
+SUBDIRS += arcstat arc_summary dbufstat
+endif
+
+SUBDIRS += mount_zfs zed zvol_id

--- a/config/always-pyzfs.m4
+++ b/config/always-pyzfs.m4
@@ -18,7 +18,12 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 			DEFINE_PYZFS='--without pyzfs'
 		])
 	], [
-		DEFINE_PYZFS=''
+		AS_IF([test $PYTHON != :], [
+			DEFINE_PYZFS=''
+		], [
+			enable_pyzfs=no
+			DEFINE_PYZFS='--without pyzfs'
+		])
 	])
 	AC_SUBST(DEFINE_PYZFS)
 
@@ -26,10 +31,10 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 	dnl # Require python-devel libraries
 	dnl #
 	AS_IF([test "x$enable_pyzfs" = xcheck  -o "x$enable_pyzfs" = xyes], [
-		AS_IF([test "${PYTHON_VERSION:0:2}" = "2."], [
+		AS_IF([ZFS_AC_PYTHON_VERSION_IS_2], [
 			PYTHON_REQUIRED_VERSION=">= '2.7.0'"
 		], [
-			AS_IF([test "${PYTHON_VERSION:0:2}" = "3."], [
+			AS_IF([ZFS_AC_PYTHON_VERSION_IS_3], [
 				PYTHON_REQUIRED_VERSION=">= '3.4.0'"
 			], [
 				AC_MSG_ERROR("Python $PYTHON_VERSION unknown")


### PR DESCRIPTION
### Summary
When detecting the Python version, don't assume the path to binaries.
Make sure --without-python works.

### Motivation and Context
These changes make it easier to build the zfsonlinux code on platforms like FreeBSD, where `true` is `/usr/bin/true` and `python3` is `/usr/local/bin/python3` or might not exist at all (i.e. in the base system).

### Description
Previously, --without-python would cause ./configure to fail. Now it is able to proceed, and the Python scripts will not be built.

Use portable regular expression matching instead of nonstandard substring expansion to detect the Python version.  This test is duplicated in several places, so define a function for it.

Don't hard-code paths to binaries such as `true`and `python3`.

The `cmd/` subdirs have been split up to only build the Python subdirs when configured to use Python. Coincidentally, Linux-specific subdirs are also split out from the same line, reducing the diff from ZoF.

### How Has This Been Tested?
These changes are based on work in progress in porting zol to FreeBSD. I have built ZFS on FreeBSD with these changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
