### PR TITLE
Add link count test for root inode (97aa3ba44)

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -635,7 +635,7 @@ tests = ['filesystem_count', 'filesystem_limit', 'snapshot_count',
 tags = ['functional', 'limits']
 
 [tests/functional/link_count]
-tests = ['link_count_001']
+tests = ['link_count_001', 'link_count_root_inode.ksh']
 tags = ['functional', 'link_count']
 
 [tests/functional/migration]

--- a/tests/zfs-tests/tests/functional/link_count/Makefile.am
+++ b/tests/zfs-tests/tests/functional/link_count/Makefile.am
@@ -2,4 +2,5 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/link_count
 dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	setup.ksh \
-	link_count_001.ksh
+	link_count_001.ksh \
+	link_count_root_inode.ksh

--- a/tests/zfs-tests/tests/functional/link_count/link_count_root_inode.ksh
+++ b/tests/zfs-tests/tests/functional/link_count/link_count_root_inode.ksh
@@ -1,0 +1,119 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Tomohiro Kusumi. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify root inode (directory) has correct link count.
+#
+# STRATEGY:
+# 1. Create pool and fs.
+# 2. Test link count of root inode.
+# 3. Create directories and test link count of root inode.
+# 4. Delete directories and test link count of root inode.
+# 5. Create regular file and test link count of root inode.
+# 6. Delete regular file and test link count of root inode.
+#
+
+function assert_link_count
+{
+	typeset dirpath="$1"
+	typeset value="$2"
+
+	log_must test "$(ls -ld $dirpath | awk '{ print $2 }')" == "$value"
+}
+
+verify_runnable "both"
+
+log_note "Verify root inode (directory) has correct link count."
+
+# Delete a directory from link_count_001.ksh.
+if [ -d "${TESTDIR}" -a -d "${TESTDIR}/tmp" ]; then
+	log_must rm -rf ${TESTDIR}/tmp
+fi
+
+#
+# Test with hidden '.zfs' directory.
+# This also tests general directories.
+#
+log_note "Testing with snapdir set to hidden (default)"
+
+for dst in $TESTPOOL $TESTPOOL/$TESTFS
+do
+	typeset mtpt=$(get_prop mountpoint $dst)
+	log_must zfs set snapdir=hidden $dst
+	log_must test -d "$mtpt/.zfs"
+	if test -n "$(ls $mtpt)"; then
+		ls $mtpt
+		log_note "$mtpt not empty, skipping"
+		continue
+	fi
+	assert_link_count $mtpt 2
+
+	log_must mkdir $mtpt/a
+	assert_link_count $mtpt 3
+	log_must rmdir $mtpt/a
+	assert_link_count $mtpt 2
+
+	log_must mkdir -p $mtpt/a/b
+	assert_link_count $mtpt 3
+	log_must rmdir $mtpt/a/b
+	log_must rmdir $mtpt/a
+	assert_link_count $mtpt 2
+
+	log_must touch $mtpt/a
+	assert_link_count $mtpt 2
+	log_must rm $mtpt/a
+	assert_link_count $mtpt 2
+done
+
+#
+# Test with visible '.zfs' directory.
+#
+log_note "Testing with snapdir set to visible"
+
+for dst in $TESTPOOL $TESTPOOL/$TESTFS
+do
+	typeset mtpt=$(get_prop mountpoint $dst)
+	log_must zfs set snapdir=visible $dst
+	log_must test -d "$mtpt/.zfs"
+	if test -n "$(ls $mtpt)"; then
+		ls $mtpt
+		log_note "$mtpt not empty, skipping"
+		continue
+	fi
+	assert_link_count $mtpt 3
+
+	log_must mkdir $mtpt/a
+	assert_link_count $mtpt 4
+	log_must rmdir $mtpt/a
+	assert_link_count $mtpt 3
+
+	log_must mkdir -p $mtpt/a/b
+	assert_link_count $mtpt 4
+	log_must rmdir $mtpt/a/b
+	log_must rmdir $mtpt/a
+	assert_link_count $mtpt 3
+
+	log_must touch $mtpt/a
+	assert_link_count $mtpt 3
+	log_must rm $mtpt/a
+	assert_link_count $mtpt 3
+done
+
+log_pass "Verify root inode (directory) has correct link count passed"


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add test for 97aa3ba44 `("Fix link count of root inode when snapdir is visible")`
as suggested in #8727.

### Description
Tests link count of root inode when `snapdir` is `hidden` or `visible`.

<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
