### PR TITLE
Exclude log device ashift from normal class

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1852,13 +1852,10 @@ vdev_open(vdev_t *vd)
 
 	/*
 	 * Track the min and max ashift values for normal data devices.
-	 *
-	 * DJB - TBD these should perhaps be tracked per allocation class
-	 * (e.g. spa_min_ashift is used to round up post compression buffers)
 	 */
 	if (vd->vdev_top == vd && vd->vdev_ashift != 0 &&
 	    vd->vdev_alloc_bias == VDEV_BIAS_NONE &&
-	    vd->vdev_aux == NULL) {
+	    vd->vdev_islog == 0 && vd->vdev_aux == NULL) {
 		if (vd->vdev_ashift > spa->spa_max_ashift)
 			spa->spa_max_ashift = vd->vdev_ashift;
 		if (vd->vdev_ashift < spa->spa_min_ashift)


### PR DESCRIPTION
### Motivation and Context

By creating a mirrored (or striped) pool with devices using ashift=9,
and then adding a log device using ashift=12.  It was possible to
incorrectly inflate the maximum a shift in the normal allocation class
and thereby prevent top-level device removal.

```
$ zpool status
  pool: tank
 state: ONLINE
  scan: none requested
config:

	NAME                 STATE     READ WRITE CKSUM
	tank                 ONLINE       0     0     0
	  mirror-0           ONLINE       0     0     0
	    A1               ONLINE       0     0     0     (ashift 9)
	    A2               ONLINE       0     0     0     (ashift 9)
	  mirror-1           ONLINE       0     0     0
	    A3               ONLINE       0     0     0     (ashift 9)
	    A4               ONLINE       0     0     0     (ashift 9)
	logs	
	  A5                 ONLINE       0     0     0     (ashift 12)
	cache
	  A6                 ONLINE       0     0     0

$ zpool remove tank mirror-1
cannot remove mirror-1: invalid config; all top-level vdevs must have the same sector size and not be raidz.
```

### Description

When opening a log device during import its allocation bias will
not yet have been set by `vdev_load()`.  This results in the log
device's ashift being incorrectly applied to the maximum ashift
of the vdevs in the normal class.  Which in turn prevents the
removal of any top-level devices due to the ashift check in the
`spa_vdev_remove_top_check()` function.

This issue is resolved by including vdev_islog in the check since
it will be set correctly during `vdev_open()`.

### How Has This Been Tested?

Manually tested using the pool configuration above using an
instrumented version of the code.  With this change I was able
to successfully remove the top-level vdev, without it I was not
due to the posted error.

Posted for review and a full ZTS run from the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
