### PR TITLE
fix panic on debug build

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1849,6 +1849,8 @@ arc_buf_try_copy_decompressed_data(arc_buf_t *buf)
 {
 	arc_buf_hdr_t *hdr = buf->b_hdr;
 	boolean_t copied = B_FALSE;
+	int cnt = 0;
+	zio_cksum_t *b_freeze_cksum = NULL;
 
 	ASSERT(HDR_HAS_L1HDR(hdr));
 	ASSERT3P(buf->b_data, !=, NULL);
@@ -1866,13 +1868,16 @@ arc_buf_try_copy_decompressed_data(arc_buf_t *buf)
 			copied = B_TRUE;
 			break;
 		}
+		b_freeze_cksum = from->b_hdr->b_l1hdr.b_freeze_cksum;
+		cnt++;
 	}
 
 	/*
 	 * There were no decompressed bufs, so there should not be a
 	 * checksum on the hdr either.
 	 */
-	EQUIV(!copied, hdr->b_l1hdr.b_freeze_cksum == NULL);
+	if (cnt > 0)
+		EQUIV(!copied, b_freeze_cksum == NULL);
 
 	return (copied);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
i have panic on DEBUG build on DilOS with test `send_mixed_raw`

```
panic[cpu3]/thread=fffffe0bf62f6c40:
assertion failed: (!copied) is equivalent to (hdr->b_l1hdr.b_freeze_cksum == NULL), file: ../../common/fs/zfs/arc.c, line: 1839


fffffe0012014700 genunix:process_type+1946ed ()
fffffe0012014730 zfs:arc_buf_try_copy_decompressed_data+b7 ()
fffffe00120147c0 zfs:arc_buf_fill+2e3 ()
fffffe0012014810 zfs:arc_untransform+25 ()
fffffe00120148a0 zfs:dbuf_read+4a1 ()
fffffe0012014910 zfs:dmu_buf_hold+80 ()
fffffe00120149f0 zfs:zap_lockdir+5e ()
fffffe0012014aa0 zfs:zap_lookup_norm+6c ()
fffffe0012014b00 zfs:zap_lookup+36 ()
fffffe0012014b60 zfs:zfs_get_zplprop+fc ()
fffffe0012014bc0 zfs:nvl_add_zplprop+36 ()
fffffe0012014c10 zfs:zfs_ioc_objset_zplprops+f5 ()
fffffe0012014cc0 zfs:zfsdev_ioctl+524 ()
fffffe0012014d00 genunix:cdev_ioctl+25 ()
fffffe0012014d50 specfs:spec_ioctl+4d ()
fffffe0012014de0 genunix:fop_ioctl+55 ()
fffffe0012014ef0 genunix:ioctl+a4 ()
fffffe0012014f00 unix:brand_sys_syscall+320 ()
```
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

based on research and comments, we should to check b_freeze_cksum in loop

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
test `send_mixed_raw ` PASS after changes
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).