### PR TITLE
fix kstat state update during pool transition

### DIFF
--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2588,11 +2588,12 @@ spa_state_to_name(spa_t *spa)
 	 * it is possible for the spa to exist, without root vdev
 	 * as the spa transitions during import/export
 	 */
-	if (spa->spa_root_vdev == NULL) {
+	vdev_t *rvd = spa->spa_root_vdev;
+	if (rvd == NULL) {
 		return ("TRANSITIONING");
 	}
-	vdev_state_t state = spa->spa_root_vdev->vdev_state;
-	vdev_aux_t aux = spa->spa_root_vdev->vdev_stat.vs_aux;
+	vdev_state_t state = rvd->vdev_state;
+	vdev_aux_t aux = rvd->vdev_stat.vs_aux;
 
 	if (spa_suspended(spa) &&
 	    (spa_get_failmode(spa) != ZIO_FAILURE_MODE_CONTINUE))

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2582,6 +2582,15 @@ spa_set_missing_tvds(spa_t *spa, uint64_t missing)
 const char *
 spa_state_to_name(spa_t *spa)
 {
+	ASSERT3P(spa, !=, NULL);
+
+	/*
+	 * it is possible for the spa to exist, without root vdev
+	 * as the spa transitions during import/export
+	 */
+	if (spa->spa_root_vdev == NULL) {
+		return ("TRANSITIONING");
+	}
 	vdev_state_t state = spa->spa_root_vdev->vdev_state;
 	vdev_aux_t aux = spa->spa_root_vdev->vdev_stat.vs_aux;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
When reading kstats, the health (aka state) of the pool is stored into /proc/spl/kstat/zfs/POOLNAME/state via spa_state_to_name().
However, during import/export there is a case where the spa exists,
but the root vdev does not exist. This fix checks that case and sets
the state to "TRANSITIONING"

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The backtrace prior to this fix is:
```
[Mon May 13 17:21:00 2019] RIP: 0010:spa_state_to_name+0x10/0xb0 [zfs]
...
Mon May 13 17:21:00 2019] Call Trace:
[Mon May 13 17:21:00 2019]  spa_state_data+0x1a/0x40 [zfs]
[Mon May 13 17:21:00 2019]  kstat_seq_show+0x117/0x440 [spl]
[Mon May 13 17:21:00 2019]  seq_read+0xe5/0x430
[Mon May 13 17:21:00 2019]  proc_reg_read+0x45/0x70
[Mon May 13 17:21:00 2019]  __vfs_read+0x1b/0x40
[Mon May 13 17:21:00 2019]  vfs_read+0x8e/0x130
[Mon May 13 17:21:00 2019]  SyS_read+0x55/0xc0
[Mon May 13 17:21:00 2019]  ? SyS_fcntl+0x5d/0xb0
[Mon May 13 17:21:00 2019]  do_syscall_64+0x73/0x130
[Mon May 13 17:21:00 2019]  entry_SYSCALL_64_after_hwframe+0x3d/0xa2
```

### Description
<!--- Describe your changes in detail -->
Updated `spa_state_to_name()` to check for `spa_root_vdev == NULL`

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Unfortunately, it is not easy to reproduce this condition. It was detected
randomly during ZTS runs while kstats were also being sampled regularly.
After this change, further testing did not trip on the case and the TRANSITIONING
state was collected at least once by the kstats and stored in the TSDB.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Signed-off-by: Richard Elling <Richard.Elling@RichardElling.com>
