### PR TITLE
Linux 5.2 compat: Fix config/kernel-shrink.m4 test failure

### DIFF
--- a/config/kernel-shrink.m4
+++ b/config/kernel-shrink.m4
@@ -144,7 +144,9 @@ AC_DEFUN([ZFS_AC_KERNEL_SHRINKER_CALLBACK],[
 	ZFS_LINUX_TRY_COMPILE([
 		#include <linux/mm.h>
 
-		int shrinker_cb(int nr_to_scan, gfp_t gfp_mask);
+		int shrinker_cb(int nr_to_scan, gfp_t gfp_mask) {
+			return 0;
+		}
 	],[
 		struct shrinker cache_shrinker = {
 			.shrink = shrinker_cb,
@@ -166,8 +168,10 @@ AC_DEFUN([ZFS_AC_KERNEL_SHRINKER_CALLBACK],[
 		ZFS_LINUX_TRY_COMPILE([
 			#include <linux/mm.h>
 
-			int shrinker_cb(struct shrinker *, int nr_to_scan,
-					gfp_t gfp_mask);
+			int shrinker_cb(struct shrinker *shrink, int nr_to_scan,
+					gfp_t gfp_mask) {
+				return 0;
+			}
 		],[
 			struct shrinker cache_shrinker = {
 				.shrink = shrinker_cb,
@@ -190,8 +194,10 @@ AC_DEFUN([ZFS_AC_KERNEL_SHRINKER_CALLBACK],[
 			ZFS_LINUX_TRY_COMPILE([
 				#include <linux/mm.h>
 
-				int shrinker_cb(struct shrinker *,
-						struct shrink_control *sc);
+				int shrinker_cb(struct shrinker *shrink,
+						struct shrink_control *sc) {
+					return 0;
+				}
 			],[
 				struct shrinker cache_shrinker = {
 					.shrink = shrinker_cb,
@@ -215,8 +221,10 @@ AC_DEFUN([ZFS_AC_KERNEL_SHRINKER_CALLBACK],[
 					#include <linux/mm.h>
 
 					unsigned long shrinker_cb(
-						struct shrinker *,
-						struct shrink_control *sc);
+						struct shrinker *shrink,
+						struct shrink_control *sc) {
+						return 0;
+					}
 				],[
 					struct shrinker cache_shrinker = {
 						.count_objects = shrinker_cb,


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix ./configure failure on 5.2-rc1.
Note that ZoL still doesn't compile on 5.2 due to several other kernel side changes.

### Description
<!--- Describe your changes in detail -->
`whether ->count_objects callback exists` test failed with
`error: error` message (at AC_MSG_ERROR(error)) for using
an incomplete function shrinker_cb().

Confirmed on Fedora 29 with 5.2-rc1 (but not 5.1 with same gcc).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
