### PR TITLE
zfs-tests: verify zfs(8) and zpool(8) help message is under 80 columns

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_user/misc/zfs_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/zfs_001_neg.ksh
@@ -44,16 +44,20 @@
 
 function cleanup
 {
-	if [ -e $TEST_BASE_DIR/zfs_001_neg.$$.txt ]
+	if [ -e "$TEMPFILE" ]
 	then
-		rm $TEST_BASE_DIR/zfs_001_neg.$$.txt
+		rm -f "$TEMPFILE"
 	fi
 }
 
 log_onexit cleanup
 log_assert "zfs shows a usage message when run as a user"
 
-eval "zfs > $TEST_BASE_DIR/zfs_001_neg.$$.txt 2>&1"
-log_must grep "usage: zfs command args" $TEST_BASE_DIR/zfs_001_neg.$$.txt
+TEMPFILE="$TEST_BASE_DIR/zfs_001_neg.$$.txt"
+
+eval "zfs > $TEMPFILE 2>&1"
+log_must grep "usage: zfs command args" "$TEMPFILE"
+
+log_must eval "awk '{if (length(\$0) > 80) exit 1}' < $TEMPFILE"
 
 log_pass "zfs shows a usage message when run as a user"

--- a/tests/zfs-tests/tests/functional/cli_user/misc/zpool_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/misc/zpool_001_neg.ksh
@@ -45,16 +45,20 @@
 
 function cleanup
 {
-	if [ -e $TEST_BASE_DIR/zpool_001_neg.$$.txt ]
+	if [ -e "$TEMPFILE" ]
 	then
-		rm $TEST_BASE_DIR/zpool_001_neg.$$.txt
+		rm -f "$TEMPFILE"
 	fi
 }
+
+TEMPFILE="$TEST_BASE_DIR/zpool_001_neg.$$.txt"
 
 log_onexit cleanup
 log_assert "zpool shows a usage message when run as a user"
 
-eval "zpool > $TEST_BASE_DIR/zpool_001_neg.$$.txt 2>&1"
-log_must grep "usage: zpool command args" $TEST_BASE_DIR/zpool_001_neg.$$.txt
+eval "zpool > $TEMPFILE 2>&1"
+log_must grep "usage: zpool command args" "$TEMPFILE"
+
+log_must eval "awk '{if (length(\$0) > 80) exit 1}' < $TEMPFILE"
 
 log_pass "zpool shows a usage message when run as a user"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Automagically detect this kind of issues: https://github.com/zfsonlinux/zfs/pull/8410#pullrequestreview-204056286

### Description
<!--- Describe your changes in detail -->
This commit updates the ZFS Test Suite to detect incorrect wrapping of bothThis commit updates the ZFS Test Suite to detect incorrect wrapping of both zfs(8) and zpool(8) help message.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
