### PR TITLE
Double-free of encryption wrapping key due to invalid pool properties

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_encrypted.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_encrypted.ksh
@@ -45,6 +45,7 @@
 # N	1	1	no	keyformat given, but crypt off
 # Y	0	0	no	no keyformat specified for new key
 # Y	0	1	no	no keyformat specified for new key
+# Y	1	1	no	unsupported combination of non-encryption props
 # Y	1	0	yes	new encryption root
 # Y	1	1	yes	new encryption root
 #
@@ -82,6 +83,10 @@ log_mustnot zpool create -O encryption=off -O keyformat=passphrase \
 log_mustnot zpool create -O encryption=on $TESTPOOL $DISKS
 log_mustnot zpool create -O encryption=on -O keylocation=prompt \
 	$TESTPOOL $DISKS
+
+log_mustnot eval "echo $PASSPHRASE | zpool create -O encryption=on" \
+	"-O keyformat=passphrase -O keylocation=prompt" \
+	"-o feature@lz4_compress=disabled -O compression=lz4 $TESTPOOL $DISKS"
 
 log_must eval "echo $PASSPHRASE | zpool create -O encryption=on" \
 	"-O keyformat=passphrase $TESTPOOL $DISKS"


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This commits fixes a double-free in zfs_ioc_pool_create() triggered by specifying an unsupported combination of properties when creating a pool with encryption enabled.

```
root@linux:/usr/src/zfs# truncate -s 1024m /var/tmp/1
root@linux:/usr/src/zfs# dd if=/dev/urandom of=/var/tmp/key bs=32 count=1
1+0 records in
1+0 records out
32 bytes (32 B) copied, 0.0017121 s, 18.7 kB/s
root@linux:/usr/src/zfs# zpool create -f -O encryption=on -O compression=lz4 -O keyformat=raw -O keylocation=file:///var/tmp/key -o feature@encryption=enabled -d rpool /var/tmp/1
[ 2493.031066] general protection fault: 0000 [#1] SMP 
[ 2493.031914] Modules linked in: zfs(PO) zunicode(PO) zlua(PO) zcommon(PO) znvpair(PO) icp(PO) zavl(PO) spl(O) joydev crc32_pclmul ppdev evdev aesni_intel aes_x86_64 lrw gf128mul glue_helper psmouse serio_raw ablk_helper cryptd pcspkr virtio_balloon i2c_piix4 i2c_core parport_pc parport pvpanic virtio_console processor thermal_sys button autofs4 ext4 crc16 mbcache jbd2 hid_generic usbhid hid sg sr_mod cdrom ata_generic virtio_scsi virtio_blk virtio_net crct10dif_pclmul crct10dif_common crc32c_intel ahci libahci ata_piix floppy xhci_hcd usbcore usb_common virtio_pci virtio_ring virtio libata scsi_mod
[ 2493.034969] CPU: 0 PID: 17613 Comm: zpool Tainted: P           O  3.16.0-4-amd64 #1 Debian 3.16.51-2
[ 2493.034969] Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
[ 2493.034969] task: ffff880039bcab30 ti: ffff880038218000 task.ti: ffff880038218000
[ 2493.034969] RIP: 0010:[<ffffffffa056cb18>]  [<ffffffffa056cb18>] list_del+0x11/0x51 [zfs]
[ 2493.034969] RSP: 0018:ffff88003821bcf0  EFLAGS: 00010286
[ 2493.034969] RAX: dead000000000100 RBX: ffff880037b89400 RCX: ffff8800b7865180
[ 2493.034969] RDX: 0000000000000000 RSI: dead000000000100 RDI: dead000000000100
[ 2493.034969] RBP: ffff88003821bd00 R08: ffff880039a82600 R09: ffff880037865180
[ 2493.034969] R10: ffff880039a82800 R11: ffff880039a82c00 R12: 00007ffd490e5f90
[ 2493.034969] R13: 0000000000005a00 R14: 00007ffd490e5f90 R15: 0000000000000000
[ 2493.034969] FS:  00007f58be0b1780(0000) GS:ffff88003e400000(0000) knlGS:0000000000000000
[ 2493.034969] CS:  0010 DS: 0000 ES: 0000 CR0: 000000008005003b
[ 2493.034969] CR2: 00007f58be0bf000 CR3: 0000000039335000 CR4: 00000000000006f0
[ 2493.034969] Stack:
[ 2493.034969]  dead000000000100 ffff880037b89400 ffff88003821bd20 ffffffffa056ce7b
[ 2493.034969]  dead000000000100 ffff880037998b88 ffff88003821bd78 ffffffffa056d1bd
[ 2493.034969]  0000000000000000 ffff880037998b48 00007ffd490e5f90 0000000000005a00
[ 2493.034969] Call Trace:
[ 2493.034969]  [<ffffffffa056ce7b>] ? list_remove+0x27/0x29 [zfs]
[ 2493.034969]  [<ffffffffa056d1bd>] ? zfs_refcount_destroy_many+0x79/0x20d [zfs]
[ 2493.034969]  [<ffffffffa0309876>] ? spl_kmem_free_impl+0x3a/0x3c [spl]
[ 2493.034969]  [<ffffffffa056d373>] ? zfs_refcount_destroy+0x22/0x24 [zfs]
[ 2493.034969]  [<ffffffffa05267f9>] ? dsl_wrapping_key_free+0xf2/0x105 [zfs]
[ 2493.034969]  [<ffffffffa0526d96>] ? dsl_crypto_params_free+0x5d/0x70 [zfs]
[ 2493.034969]  [<ffffffffa0636785>] ? zfs_ioc_pool_create+0x394/0x399 [zfs]
[ 2493.034969]  [<ffffffffa0643660>] ? zfsdev_ioctl+0x69b/0x799 [zfs]
[ 2493.034969]  [<ffffffff811c1baf>] ? do_vfs_ioctl+0x2cf/0x4b0
[ 2493.034969]  [<ffffffff811760a9>] ? do_munmap+0x299/0x3a0
[ 2493.034969]  [<ffffffff811c1e11>] ? SyS_ioctl+0x81/0xa0
[ 2493.034969]  [<ffffffff81525d0d>] ? system_call_fast_compare_end+0x10/0x15
[ 2493.034969] Code: f0 48 8b 45 f0 48 8b 55 f8 48 89 50 08 48 8b 45 f8 48 8b 55 f0 48 89 10 c9 c3 55 48 89 e5 53 48 83 ec 08 48 89 7d f0 48 8b 45 f0 <48> 8b 10 48 8b 45 f0 48 8b 40 08 48 89 d6 48 89 c7 e8 b0 ff ff 
[ 2493.034969] RIP  [<ffffffffa056cb18>] list_del+0x11/0x51 [zfs]
[ 2493.034969]  RSP <ffff88003821bcf0>
[ 2493.107718] ---[ end trace 67e0fd68c393fe39 ]---
root@linux:/usr/src/zfs# 
```

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on a Debian with updated test case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
