### PR TITLE
Minor cleanups for Debian packaging (lintian warnings and errors)

### DIFF
--- a/tests/test-runner/bin/test-runner.py
+++ b/tests/test-runner/bin/test-runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 #
 # This file and its contents are supplied under the terms of the

--- a/tests/zfs-tests/tests/functional/alloc_class/Makefile.am
+++ b/tests/zfs-tests/tests/functional/alloc_class/Makefile.am
@@ -1,7 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/alloc_class
 dist_pkgdata_SCRIPTS = \
-	alloc_class.cfg \
-	alloc_class.kshlib \
 	setup.ksh \
 	cleanup.ksh \
 	alloc_class_001_pos.ksh \
@@ -17,3 +15,7 @@ dist_pkgdata_SCRIPTS = \
 	alloc_class_011_neg.ksh \
 	alloc_class_012_pos.ksh \
 	alloc_class_013_pos.ksh
+
+dist_pkgdata_DATA = \
+	alloc_class.cfg \
+	alloc_class.kshlib

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.kshlib
@@ -1,5 +1,3 @@
-#!/bin/ksh
-
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/Makefile.am
@@ -3,7 +3,6 @@ dist_pkgdata_SCRIPTS = \
 	cleanup.ksh \
 	zpool_initialize_attach_detach_add_remove.ksh \
 	zpool_initialize_import_export.ksh \
-	zpool_initialize.kshlib \
 	zpool_initialize_offline_export_import_online.ksh \
 	zpool_initialize_online_offline.ksh \
 	zpool_initialize_split.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/Makefile.am
@@ -2,7 +2,6 @@ pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zpool_trim
 dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
-	zpool_trim.kshlib \
 	zpool_trim_attach_detach_add_remove.ksh \
 	zpool_trim_import_export.ksh \
 	zpool_trim_multiple.ksh \
@@ -20,3 +19,6 @@ dist_pkgdata_SCRIPTS = \
 	zpool_trim_unsupported_vdevs.ksh \
 	zpool_trim_verify_checksums.ksh \
 	zpool_trim_verify_trimmed.ksh
+
+dist_pkgdata_DATA = \
+	zpool_trim.kshlib

--- a/tests/zfs-tests/tests/functional/removal/Makefile.am
+++ b/tests/zfs-tests/tests/functional/removal/Makefile.am
@@ -28,6 +28,9 @@ dist_pkgdata_SCRIPTS = \
 	removal_with_send.ksh removal_with_send_recv.ksh \
 	removal_with_snapshot.ksh removal_with_write.ksh \
 	removal_with_zdb.ksh remove_mirror.ksh remove_mirror_sanity.ksh \
-	remove_raidz.ksh remove_expanded.ksh removal.kshlib
+	remove_raidz.ksh remove_expanded.ksh
+
+dist_pkgdata_DATA = \
+	removal.kshlib
 
 pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/removal

--- a/tests/zfs-tests/tests/perf/Makefile.am
+++ b/tests/zfs-tests/tests/perf/Makefile.am
@@ -1,5 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/perf
-dist_pkgdata_SCRIPTS = \
+dist_pkgdata_DATA = \
 	nfs-sample.cfg \
 	perf.shlib
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The 2 commits fix cosmetic issues I encountered while packaging zfs-0.8.0-rc5 for PVE/Debian.


### Description
<!--- Describe your changes in detail -->
* the shebang of `tests/test-runner/bin/test-runner.py` was changed from `/usr/bin/python` to `/usr/bin/python3` - the buildsystem replaces this with python2, if it is the version used/found during `./configure`
* .shlib, .kshlib and .cfg files listed  in `dist_pkgdata_SCRIPTS` were instead put into `dist_pkgdata_DATA` in order to be installed 0644 instead of 0755
* the shebang was removed from one .kshlib file.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
* the zfs-test package was build on Debian and run through lintian, which produced fewer warnings with those patches
* additionally `make rpm-build` was run on a fedora 30 installation - once with python3 only installed and once after running `./configure --with-python=2` - I checked the resulting files in the rpms

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
