### PR TITLE
Eliminate a ./configure bashism

### DIFF
--- a/config/always-python.m4
+++ b/config/always-python.m4
@@ -68,19 +68,19 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYTHON], [
 
 	AM_PATH_PYTHON([2.6], [], [:])
 	AM_CONDITIONAL([USING_PYTHON], [test "$PYTHON" != :])
-	AM_CONDITIONAL([USING_PYTHON_2], [test "${PYTHON_VERSION:0:2}" = "2."])
-	AM_CONDITIONAL([USING_PYTHON_3], [test "${PYTHON_VERSION:0:2}" = "3."])
+	AM_CONDITIONAL([USING_PYTHON_2], [echo "${PYTHON_VERSION}" | grep -q "^2\\."])
+	AM_CONDITIONAL([USING_PYTHON_3], [echo "${PYTHON_VERSION}" | grep -q "^3\\."])
 
 	dnl #
 	dnl # Minimum supported Python versions for utilities:
 	dnl # Python 2.6.x, or Python 3.4.x
 	dnl #
-	AS_IF([test "${PYTHON_VERSION:0:2}" = "2."], [
+	AS_IF([echo "${PYTHON_VERSION}" | grep -q "^2\\."], [
 		ZFS_AC_PYTHON_VERSION([>= '2.6'], [ /bin/true ],
 			[AC_MSG_ERROR("Python >= 2.6.x is not available")])
 	])
 
-	AS_IF([test "${PYTHON_VERSION:0:2}" = "3."], [
+	AS_IF([echo "${PYTHON_VERSION}" | grep -q "^3\\."], [
 		ZFS_AC_PYTHON_VERSION([>= '3.4'], [ /bin/true ],
 			[AC_MSG_ERROR("Python >= 3.4.x is not available")])
 	])

--- a/config/always-pyzfs.m4
+++ b/config/always-pyzfs.m4
@@ -26,10 +26,10 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 	dnl # Require python-devel libraries
 	dnl #
 	AS_IF([test "x$enable_pyzfs" = xcheck  -o "x$enable_pyzfs" = xyes], [
-		AS_IF([test "${PYTHON_VERSION:0:2}" = "2."], [
+		AS_IF([echo "${PYTHON_VERSION}" | grep -q "^2\\."], [
 			PYTHON_REQUIRED_VERSION=">= '2.7.0'"
 		], [
-			AS_IF([test "${PYTHON_VERSION:0:2}" = "3."], [
+			AS_IF([echo "${PYTHON_VERSION}" | grep -q "^3\\."], [
 				PYTHON_REQUIRED_VERSION=">= '3.4.0'"
 			], [
 				AC_MSG_ERROR("Python $PYTHON_VERSION unknown")


### PR DESCRIPTION
### Motivation and Context
`configure` fails when `/bin/sh` is not bash. See #8809.

### Description
This replaces `test "${PYTHON_VERSION:0:2}" = "2."` with `echo "${PYTHON_VERSION}" | grep -q "^2\\."`.

### How Has This Been Tested?
I tested the individual snippets of code in `dash` and `bash`. I can reproduce the problem that way. I haven't yet figured out how to reproduce the failure with `./configure` from #8809. I probably need to be passing different arguments or something.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
