### PR TITLE
allow CONFIG_TRIM_UNUSED_KSYM to be enabled when build as a builtin-module

### DIFF
--- a/config/kernel.m4
+++ b/config/kernel.m4
@@ -529,10 +529,11 @@ AC_DEFUN([ZFS_AC_KERNEL_CONFIG_TRIM_UNUSED_KSYMS], [
 		AC_MSG_RESULT([yes])
 	],[
 		AC_MSG_RESULT([no])
-		AC_MSG_ERROR([
+		AS_IF([test "x$enable_linux_builtin" != xyes], [
+			AC_MSG_ERROR([
 	*** This kernel has unused symbols trimming enabled, please disable.
 	*** Rebuild the kernel with CONFIG_TRIM_UNUSED_KSYMS=n set.])
-	])
+	])])
 ])
 
 dnl #


### PR DESCRIPTION
### Motivation and Context
When ZFS is built into the kernel, ZFS seems to work perfectly fine even when unused kernel symbols are removed.

### Description
This patch allows `CONFIG_TRIM_UNUSED_KSYM` when `enable_linux_builtin` is used.

### How Has This Been Tested?
Compiled 0.8.0 with this patch and used zfs (Archlinux, linux-lts).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
