### PR TITLE
make zfs_async_block_max_blocks handle zero correctly

### DIFF
--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -3025,7 +3025,8 @@ dsl_scan_async_block_should_pause(dsl_scan_t *scn)
 	if (zfs_recover)
 		return (B_FALSE);
 
-	if (scn->scn_visited_this_txg >= zfs_async_block_max_blocks)
+	if (zfs_async_block_max_blocks != 0 && scn->scn_visited_this_txg >=
+	    zfs_async_block_max_blocks)
 		return (B_TRUE);
 
 	elapsed_nanosecs = gethrtime() - scn->scn_sync_start_time;

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -3025,9 +3025,10 @@ dsl_scan_async_block_should_pause(dsl_scan_t *scn)
 	if (zfs_recover)
 		return (B_FALSE);
 
-	if (zfs_async_block_max_blocks != 0 && scn->scn_visited_this_txg >=
-	    zfs_async_block_max_blocks)
-		return (B_TRUE);
+	if (zfs_async_block_max_blocks != 0 && 
+		scn->scn_visited_this_txg >= zfs_async_block_max_blocks) {
+			return (B_TRUE);
+	}
 
 	elapsed_nanosecs = gethrtime() - scn->scn_sync_start_time;
 	return (elapsed_nanosecs / NANOSEC > zfs_txg_timeout ||

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -3026,8 +3026,8 @@ dsl_scan_async_block_should_pause(dsl_scan_t *scn)
 		return (B_FALSE);
 
 	if (zfs_async_block_max_blocks != 0 && 
-		scn->scn_visited_this_txg >= zfs_async_block_max_blocks) {
-			return (B_TRUE);
+	    scn->scn_visited_this_txg >= zfs_async_block_max_blocks) {
+		return (B_TRUE);
 	}
 
 	elapsed_nanosecs = gethrtime() - scn->scn_sync_start_time;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixed this issue https://github.com/zfsonlinux/zfs/issues/8289
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
frees all data when zfs_async_black_max_blocks is set to 0.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
build the load in ubuntu VM. set the zfs_async_black_max_blocks to 0 and everything worked as expected.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
