### PR TITLE
Revert "Report holes when there are only metadata changes"

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2373,39 +2373,14 @@ dmu_offset_next(objset_t *os, uint64_t object, boolean_t hole, uint64_t *off)
 		return (err);
 
 	/*
-	 * Check if there are dirty data blocks or frees which have not been
-	 * synced.  Dirty spill and bonus blocks which are external to the
-	 * object can ignored when reporting holes.
+	 * Check if dnode is dirty
 	 */
-	mutex_enter(&dn->dn_mtx);
 	for (i = 0; i < TXG_SIZE; i++) {
 		if (multilist_link_active(&dn->dn_dirty_link[i])) {
-
-			if (dn->dn_free_ranges[i] != NULL) {
-				clean = B_FALSE;
-				break;
-			}
-
-			list_t *list = &dn->dn_dirty_records[i];
-			dbuf_dirty_record_t *dr;
-
-			for (dr = list_head(list); dr != NULL;
-			    dr = list_next(list, dr)) {
-				dmu_buf_impl_t *db = dr->dr_dbuf;
-
-				if (db->db_blkid == DMU_SPILL_BLKID ||
-				    db->db_blkid == DMU_BONUS_BLKID)
-					continue;
-
-				clean = B_FALSE;
-				break;
-			}
-		}
-
-		if (clean == B_FALSE)
+			clean = B_FALSE;
 			break;
+		}
 	}
-	mutex_exit(&dn->dn_mtx);
 
 	/*
 	 * If compatibility option is on, sync any current changes before


### PR DESCRIPTION
### Motivation and Context

Issue #8816.

### Description

This reverts commit ec4f9b8f30 which introduced a narrow race which can lead to lseek(, SEEK_DATA) incorrectly returning ENXIO.  Resolve the issue by revering this change to restore the previous behavior which depends solely on checking the dirty list.

### How Has This Been Tested?

The [test case]( https://gist.github.com/abrasive/f062f967cc41c797bd08ec11f30f8fbf) provided in #8816 was able to consistently reproduce this issue.  After reverting the commit the problem could no longer be reproduced.  Additionally, the issue was first observed when running portage on gentoo and reverting the commit resolved the issue as expected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
