### PR TITLE
improve ZTS block_device_wait debugging

### DIFF
--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -18,6 +18,7 @@
 # Copyright (c) 2017 Lawrence Livermore National Security, LLC.
 # Copyright (c) 2017 Datto Inc.
 # Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+# Copyright 2019 Richard Elling
 #
 
 #
@@ -55,12 +56,26 @@ function scan_scsi_hosts
 
 #
 # Wait for newly created block devices to have their minors created.
+# Additional arguments can be passed to udevadm trigger, with the expected
+# arguments to typically be a block device pathname. This is useful when
+# checking waiting on a specific device to settle rather than triggering
+# all devices and waiting for them all to settle.
+#
+# The udevadm settle timeout can be 120 or 180 seconds by default for
+# some distros. If a long delay is experienced, it could be due to some
+# strangeness in a malfunctioning device that isn't related to the devices
+# under test. To help debug this condition, a notice is given if settle takes
+# too long.
 #
 function block_device_wait
 {
 	if is_linux; then
-		udevadm trigger
+		udevadm trigger $*
+		typeset local start=$SECONDS
 		udevadm settle
+		typeset local elapsed=$((SECONDS - start))
+		[[ $elapsed > 60 ]] && \
+		    log_note udevadm settle time too long: $elapsed
 	fi
 }
 

--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -67,6 +67,9 @@ function scan_scsi_hosts
 # under test. To help debug this condition, a notice is given if settle takes
 # too long.
 #
+# Note: there is no meaningful return code if udevadm fails. Consumers
+# should not expect a return code (do not call as argument to log_must)
+#
 function block_device_wait
 {
 	if is_linux; then

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -861,7 +861,8 @@ function zero_partitions #<whole_disk_name>
 # best to retire this interface and replace it with something more flexible.
 # At the moment a best effort is made.
 #
-function set_partition #<slice_num> <slice_start> <size_plus_units>  <whole_disk_name>
+# arguments: <slice_num> <slice_start> <size_plus_units>  <whole_disk_name>
+function set_partition
 {
 	typeset -i slicenum=$1
 	typeset start=$2
@@ -872,6 +873,7 @@ function set_partition #<slice_num> <slice_start> <size_plus_units>  <whole_disk
 		if [[ -z $size || -z $disk ]]; then
 			log_fail "The size or disk name is unspecified."
 		fi
+		[[ -n $DEV_DSKDIR ]] && disk=$DEV_DSKDIR/$disk
 		typeset size_mb=${size%%[mMgG]}
 
 		size_mb=${size_mb%%[mMgG][bB]}
@@ -881,10 +883,10 @@ function set_partition #<slice_num> <slice_start> <size_plus_units>  <whole_disk
 
 		# Create GPT partition table when setting slice 0 or
 		# when the device doesn't already contain a GPT label.
-		parted $DEV_DSKDIR/$disk -s -- print 1 >/dev/null
+		parted $disk -s -- print 1 >/dev/null
 		typeset ret_val=$?
 		if [[ $slicenum -eq 0 || $ret_val -ne 0 ]]; then
-			parted $DEV_DSKDIR/$disk -s -- mklabel gpt
+			parted $disk -s -- mklabel gpt
 			if [[ $? -ne 0 ]]; then
 				log_note "Failed to create GPT partition table on $disk"
 				return 1
@@ -899,20 +901,21 @@ function set_partition #<slice_num> <slice_start> <size_plus_units>  <whole_disk
 		# Determine the cylinder size for the device and using
 		# that calculate the end offset in cylinders.
 		typeset -i cly_size_kb=0
-		cly_size_kb=$(parted -m $DEV_DSKDIR/$disk -s -- \
+		cly_size_kb=$(parted -m $disk -s -- \
 			unit cyl print | head -3 | tail -1 | \
 			awk -F '[:k.]' '{print $4}')
 		((end = (size_mb * 1024 / cly_size_kb) + start))
 
-		parted $DEV_DSKDIR/$disk -s -- \
+		parted $disk -s -- \
 		    mkpart part$slicenum ${start}cyl ${end}cyl
-		if [[ $? -ne 0 ]]; then
+		typeset ret_val=$?
+		if [[ $ret_val -ne 0 ]]; then
 			log_note "Failed to create partition $slicenum on $disk"
 			return 1
 		fi
 
-		blockdev --rereadpt $DEV_DSKDIR/$disk 2>/dev/null
-		block_device_wait
+		blockdev --rereadpt $disk 2>/dev/null
+		block_device_wait $disk
 	else
 		if [[ -z $slicenum || -z $size || -z $disk ]]; then
 			log_fail "The slice, size or disk name is unspecified."
@@ -932,9 +935,10 @@ function set_partition #<slice_num> <slice_start> <size_plus_units>  <whole_disk
 		echo "q" >> $format_file
 
 		format -e -s -d $disk -f $format_file
+		typeset ret_val=$?
+		rm -f $format_file
 	fi
 
-	typeset ret_val=$?
 	rm -f $format_file
 	if [[ $ret_val -ne 0 ]]; then
 		log_note "Unable to format $disk slice $slicenum to $size"

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -939,7 +939,6 @@ function set_partition
 		rm -f $format_file
 	fi
 
-	rm -f $format_file
 	if [[ $ret_val -ne 0 ]]; then
 		log_note "Unable to format $disk slice $slicenum to $size"
 		return 1

--- a/tests/zfs-tests/tests/functional/rsend/send-wDR_encrypted_zvol.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-wDR_encrypted_zvol.ksh
@@ -62,7 +62,7 @@ log_must eval "echo 'password' > $keyfile"
 
 log_must zfs create -o dedup=on -o encryption=on -o keyformat=passphrase \
 	-o keylocation=file://$keyfile -V 128M $TESTPOOL/$TESTVOL
-log_must block_device_wait
+block_device_wait
 
 log_must eval "echo 'y' | newfs -t ext4 -v $zdev"
 log_must mkdir -p $mntpnt
@@ -82,7 +82,7 @@ done
 log_must eval "zfs send -wDR $TESTPOOL/$TESTVOL@snap$snap_count > $sendfile"
 log_must eval "zfs recv $TESTPOOL/recv < $sendfile"
 log_must zfs load-key $TESTPOOL/recv
-log_must block_device_wait
+block_device_wait
 
 log_must mount $recvdev $recvmnt
 

--- a/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
@@ -86,7 +86,7 @@ log_must zfs create -V 128M $TESTPOOL/$TESTVOL
 log_must zfs set compression=on $TESTPOOL/$TESTVOL
 log_must zfs set sync=always $TESTPOOL/$TESTVOL
 log_must mkdir -p $TESTDIR
-log_must block_device_wait
+block_device_wait
 echo "y" | newfs -t ext4 -v $VOLUME
 log_must mkdir -p $MNTPNT
 log_must mount -o discard $VOLUME $MNTPNT
@@ -149,7 +149,7 @@ log_must zpool export $TESTPOOL
 # `zpool import -f` because we can't write a frozen pool's labels!
 #
 log_must zpool import -f $TESTPOOL
-log_must block_device_wait
+block_device_wait
 log_must mount $VOLUME $MNTPNT
 
 #

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_009_pos.ksh
@@ -88,7 +88,7 @@ else
 fi
 
 log_must zfs snapshot -r $snappool
-log_must block_device_wait
+block_device_wait
 
 #verify the snapshot -r results
 for snap in $snappool $snapfs $snapvol $snapctr $snapctrvol \

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_010_pos.ksh
@@ -83,7 +83,7 @@ else
 fi
 
 log_must zfs snapshot -r $snappool
-log_must block_device_wait
+block_device_wait
 
 #select the $TESTCTR as destroy point, $TESTCTR is a child of $TESTPOOL
 log_must zfs destroy -r $snapctr
@@ -92,7 +92,7 @@ for snap in $snapctr $snapctrvol $snapctrclone $snapctrfs; do
 		log_fail "The snapshot $snap is not destroyed correctly."
 done
 
-for snap in $snappool $snapfs $snapvol $ctrfs@$TESTSNAP1;do
+for snap in $snappool $snapfs $snapvol $ctrfs@$TESTSNAP1; do
 	! snapexists $snap && \
 		log_fail "The snapshot $snap should be not destroyed."
 done


### PR DESCRIPTION

Signed-off-by: Richard Elling <Richard.Elling@RichardElling.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Improve ZTS block_device_wait function debugging.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The udevadm settle timeout can be 120 or 180 seconds by
default for some distros. If a long delay is experienced, it could
be due to some strangeness in a malfunctioning device that
isn't related to the devices under test. 

### Description
<!--- Describe your changes in detail -->
To help debug this condition, a notice is given if settle takes too
long.

Arguments can now be passed to block_device_wait. The
expected arguments are block device pathnames. The arguments
are passed directly to `udevadm trigger`

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
No changes to existing ZTS tests are included, so they should test
as normal.  If the slow condition is experienced, it will be noted in
the logs. Future tests can take advantage of specific device path
triggering.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
