### PR TITLE
hkdf_test binary should only have one icp instance

### DIFF
--- a/tests/zfs-tests/tests/functional/hkdf/Makefile.am
+++ b/tests/zfs-tests/tests/functional/hkdf/Makefile.am
@@ -2,8 +2,7 @@ include $(top_srcdir)/config/Rules.am
 
 AM_CPPFLAGS += -I$(top_srcdir)/include
 AM_CPPFLAGS += -I$(top_srcdir)/lib/libspl/include
-LDADD = $(top_srcdir)/lib/libicp/libicp.la
-LDADD += $(top_srcdir)/lib/libzpool/libzpool.la
+LDADD = $(top_srcdir)/lib/libzpool/libzpool.la
 
 AUTOMAKE_OPTIONS = subdir-objects
 


### PR DESCRIPTION
### Motivation and Context
The build for test binary `hkdf_test` was linking both against `libicp` and `libzpool`. This results in two instances of `libicp` inside the binary but the call to `icp_init()` only initializes one of them!

In some environments this can lead to calls to the uninitialized instance which will fail.  In our case a `kcf_new_ctx()` is called in the other instance which has not initialized its `kcf_context_cache` global variable.

```
(gdb) bt
#0  umem_cache_alloc (cp=0x0, flags=256) at ../../lib/libspl/include/umem.h:175
#1  0x00007ffff797dcab in kcf_new_ctx (crq=<optimized out>, pd=0x5555557ace40, sid=0) at ../../module/icp/core/kcf_sched.c:92
#2  0x00007ffff7962ee1 in crypto_mac_init_prov (provider=provider@entry=0x5555557ace40, sid=0, mech=mech@entry=0x7fffffffe170, key=key@entry=0x7fffffffe190, tmpl=tmpl@entry=0x0, ctxp=ctxp@entry=0x7fffffffe168,
    crq=0x0) at ../../module/icp/api/kcf_mac.c:392
#3  0x00007ffff7963324 in crypto_mac_init (mech=0x7fffffffe170, key=0x7fffffffe190, tmpl=0x0, ctxp=0x7fffffffe168, crq=0x0) at ../../module/icp/api/kcf_mac.c:485
#4  0x00007ffff7874629 in hkdf_sha512_expand (
    extract_key=extract_key@entry=0x7fffffffe2d0 "fW\231\202\067\067\336\320J\210\344~T\245\211\v\262\303\322GǤ%J\216a5\a#Y\n&\303b8\022}\206a\270\214\370\016\370\002\325~/|\353\317\036",
    info=info@entry=0x555555580de7 "\360\361\362\363\364\365\366\367\370", <incomplete sequence \371>, info_len=info_len@entry=10, out_buf=out_buf@entry=0x7fffffffe360 "", out_len=out_len@entry=42)
    at ../../module/zfs/hkdf.c:113
#5  0x00007ffff78747ce in hkdf_sha512 (key_material=<optimized out>, km_len=<optimized out>, salt=<optimized out>, salt_len=<optimized out>,
    info=0x555555580de7 "\360\361\362\363\364\365\366\367\370", <incomplete sequence \371>, info_len=10, output_key=0x7fffffffe360 "", out_len=42) at ../../module/zfs/hkdf.c:165
#6  0x0000555555559f16 in run_test (i=<optimized out>, tv=0x55555578c020 <test_vectors>) at hkdf_test.c:194
#7  0x0000555555559cf5 in main (argc=<optimized out>, argv=<optimized out>) at hkdf_test.c:221
```

### Description
The fix is to only link against libzpool

### How Has This Been Tested?
Confirmed with gdb that the `hkdf_test` binary now only has once instance of `libipc`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
