### PR TITLE
arc_summary: prefer python3 version and install when there is no python

### DIFF
--- a/cmd/arc_summary/Makefile.am
+++ b/cmd/arc_summary/Makefile.am
@@ -4,9 +4,7 @@ if USING_PYTHON_2
 dist_bin_SCRIPTS = arc_summary2
 install-exec-hook:
 	mv $(DESTDIR)$(bindir)/arc_summary2 $(DESTDIR)$(bindir)/arc_summary
-endif
-
-if USING_PYTHON_3
+else
 dist_bin_SCRIPTS = arc_summary3
 install-exec-hook:
 	mv $(DESTDIR)$(bindir)/arc_summary3 $(DESTDIR)$(bindir)/arc_summary


### PR DESCRIPTION
### Motivation and Context

Fixes installation in a minimal build chroot without python available.

### Description

This matches the behavior of other python scripts, such as arcstat and dbufstat, which are always installed but whose install-exec-hook actions will simply touch up the shebang if a python interpreter was configured *and* that interpreter is a python2 interpreter.

### How Has This Been Tested?

When configuring zfs with --enable-pyzfs=no, and with --with-python="$PWD/python3-fake" in order to fool the configure script into thinking python is available in order to work around #8731, the arc_summary script was not installed, while arcstat was installed (and used a python3 shebang). With this change, they are both installed, with a python3 shebang.

Tested in a minimal Arch Linux chroot without python available.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
