### PR TITLE
Avoid updating zfs_gitrev.h when rev is unchanged.

### DIFF
--- a/scripts/make_gitrev.sh
+++ b/scripts/make_gitrev.sh
@@ -39,3 +39,7 @@ trap cleanup EXIT
 git rev-parse --git-dir > /dev/null 2>&1
 # Get the git current git revision
 ZFS_GIT_REV=$(git describe --always --long --dirty 2>/dev/null)
+# Check if header file already contain the exact string
+grep -sq "\"${ZFS_GIT_REV}\"" "$(dirname "$0")"/../include/zfs_gitrev.h &&
+	trap - EXIT
+exit 0


### PR DESCRIPTION
Build process would always re-compile spa_history.c due to touching
zfs_gitrev.h - avoid if no change in gitrev.

Signed-off-by: Jorgen Lundman <lundman@lundman.net>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Currently `make_gitrev.h` is always executed by the build framework, which touches the `zfs_gitrev.h` file. Naturally make will then recompile any source file which includes this header file, every time.

Simply compare the gitrev to that which is in the `zfs_gitrev.h` file - and if identical, skip re-writing the header file.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For the betterment of Computers. CPU abuse must be stopped!

### Description
<!--- Describe your changes in detail -->
Simple grep to check existence.  

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested by running `make` many times. Observed no needless recompiles. Standing ovations.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
