### PR TITLE
Fix %post and %postun generation in kmodtool

### DIFF
--- a/scripts/kmodtool
+++ b/scripts/kmodtool
@@ -178,9 +178,9 @@ EOF
 	else
 	  cat <<EOF
 %post          -n kmod-${kmodname}-${kernel_uname_r}
-[[ "$(uname -r)" == "${kernel_uname_r}"  ]] && ${prefix}/sbin/depmod -a > /dev/null || :
+[[ "\$(uname -r)" == "${kernel_uname_r}"  ]] && ${prefix}/sbin/depmod -a > /dev/null || :
 %postun        -n kmod-${kmodname}-${kernel_uname_r}
-[[ "$(uname -r)" == "${kernel_uname_r}"  ]] && ${prefix}/sbin/depmod -a > /dev/null || :
+[[ "\$(uname -r)" == "${kernel_uname_r}"  ]] && ${prefix}/sbin/depmod -a > /dev/null || :
 
 EOF
 	fi


### PR DESCRIPTION
During zfs-kmod RPM build, $(uname -r) gets unintentionally evaluated on
the build host, once and for all. It should be evaluated during the
execution of the scriptlets on the installation host. Escaping the $
character avoids evaluating it during build.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'm maintaining the zfs packages for XCP-ng, a free virtualization solution forked from XenServer (https://xcp-ng.org/). I noticed that `depmod -a` was not executed after the module RPM was installed and this led me to discovering this bug in `kmodtool` as shipped by the project with the source RPMs.

The `%post` and `%postun` scriptlets generated by kmodtool are broken: either the build host has the same running kernel as the target kernel and then `depmod -a` will be executed each time a zfs-kmod-xxx package is installed, or the version is different (as in my example below) and `depmod -a` is never executed because the test always evaluates to false.

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
Escape `$(uname -r)` so that it's not evaluated on the build host.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
RPM built in a docker container then checked with `rpm -qp nameoffile --scripts` and installed on an XCP-ng host (centos based with custom kernel). `modprobe zfs` worked without the need to run `depmod -a` manually whereas it didn't before the fix on similar hosts.

Output of `rpm -qp nameoffile --scripts` before the change:
```
$ rpm -qp kmod-zfs-4.19.0+1-0.8.0-1.xcpng8.0.x86_64.rpm --scripts                                                                 
postinstall scriptlet (using /bin/sh):
[[ "3.10.0-957.12.1.el7.x86_64" == "4.19.0+1"  ]] && /sbin/depmod -a > /dev/null || :
postuninstall scriptlet (using /bin/sh):
[[ "3.10.0-957.12.1.el7.x86_64" == "4.19.0+1"  ]] && /sbin/depmod -a > /dev/null || :
```
Output after the fix:
```
$ rpm -qp --scripts RPMS/x86_64/kmod-zfs-4.19.0+1-0.8.0-1.1.xcpng8.0.x86_64.rpm
postinstall scriptlet (using /bin/sh):
[[ "$(uname -r)" == "4.19.0+1"  ]] && /sbin/depmod -a > /dev/null || :
postuninstall scriptlet (using /bin/sh):
[[ "$(uname -r)" == "4.19.0+1"  ]] && /sbin/depmod -a > /dev/null || :
```
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
