### PR TITLE
Let zfs mount all tolerate in-progress mounts

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6446,8 +6446,25 @@ share_mount_one(zfs_handle_t *zhp, int op, int flags, char *protocol,
 			return (1);
 		}
 
-		if (zfs_mount(zhp, options, flags) != 0)
+		if (zfs_mount(zhp, options, flags) != 0) {
+			/*
+			 * Check if a mount sneaked in after we checked
+			 */
+			if (!explicit &&
+			    libzfs_errno(g_zfs) == EZFS_MOUNTFAILED) {
+				usleep(10 * MILLISEC);
+				libzfs_mnttab_cache(g_zfs, B_FALSE);
+
+				if (zfs_is_mounted(zhp, NULL)) {
+					(void) fprintf(stderr, gettext(
+					    "Ignoring previous 'already "
+					    "mounted' error for '%s'\n"),
+					    zfs_get_name(zhp));
+					return (0);
+				}
+			}
 			return (1);
+		}
 		break;
 	}
 


### PR DESCRIPTION
### Motivation and Context
The `zfs-mount` service can unexpectedly fail to start when zfs encounters a mount that is in progress. This service uses `zfs mount -a`, which has a window between the time it checks if the dataset was mounted and when the actual mount (via `mount.zfs` binary) occurs.

### Description
Simple way to demonstrate this in-progress mount window:
```
$ for i in {1..20}; do sudo zfs create dozer/ds$i; done
$ sudo zfs unmount dozer/ds20
$ sudo zfs mount -a & sudo zfs mount -a &
[1] 8568
[2] 8569
$
filesystem 'dozer/ds20' is already mounted
cannot mount 'dozer/ds20': mountpoint or dataset is busy
[1]-  Exit 1                  sudo cmd/zfs/zfs mount -a
[2]+  Done                    sudo cmd/zfs/zfs mount -a
```

The suggested solution is to check if the failure was due to an in-progress mount and not treat it as an error.


### How Has This Been Tested?
Manually tested the simple case described above to confirm `zfs mount -a` is working as intended.

Tested with a suite of automated test that was routinely encountering this error.  A `journalctl` audit confirms that the `zfs-mount` service no longer fails to start when it encounters an in-progress mount.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
