### PR TITLE
Python config cleanup

### DIFF
--- a/config/always-python.m4
+++ b/config/always-python.m4
@@ -1,48 +1,4 @@
 dnl #
-dnl # ZFS_AC_PYTHON_VERSION(version, [action-if-true], [action-if-false])
-dnl #
-dnl # Verify Python version
-dnl #
-AC_DEFUN([ZFS_AC_PYTHON_VERSION], [
-	ver_check=`$PYTHON -c "import sys; print (sys.version.split()[[0]] $1)"`
-	AS_IF([test "$ver_check" = "True"], [
-		m4_ifvaln([$2], [$2])
-	], [
-		m4_ifvaln([$3], [$3])
-	])
-])
-
-dnl #
-dnl # ZFS_AC_PYTHON_VERSION_IS_2
-dnl # ZFS_AC_PYTHON_VERSION_IS_3
-dnl #
-dnl # Tests if the $PYTHON_VERSION matches 2.x or 3.x.
-dnl #
-AC_DEFUN([ZFS_AC_PYTHON_VERSION_IS_2],
-	[test "${PYTHON_VERSION%%\.*}" = "2"])
-AC_DEFUN([ZFS_AC_PYTHON_VERSION_IS_3],
-	[test "${PYTHON_VERSION%%\.*}" = "3"])
-
-dnl #
-dnl # ZFS_AC_PYTHON_MODULE(module_name, [action-if-true], [action-if-false])
-dnl #
-dnl # Checks for Python module. Freely inspired by AX_PYTHON_MODULE
-dnl # https://www.gnu.org/software/autoconf-archive/ax_python_module.html
-dnl # Required by ZFS_AC_CONFIG_ALWAYS_PYZFS.
-dnl #
-AC_DEFUN([ZFS_AC_PYTHON_MODULE], [
-	PYTHON_NAME=`basename $PYTHON`
-	AC_MSG_CHECKING([for $PYTHON_NAME module: $1])
-	AS_IF([$PYTHON -c "import $1" 2>/dev/null], [
-		AC_MSG_RESULT(yes)
-		m4_ifvaln([$2], [$2])
-	], [
-		AC_MSG_RESULT(no)
-		m4_ifvaln([$3], [$3])
-	])
-])
-
-dnl #
 dnl # The majority of the python scripts are written to be compatible
 dnl # with Python 2.6 and Python 3.4.  Therefore, they may be installed
 dnl # and used with either interpreter.  This option is intended to
@@ -66,35 +22,38 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYTHON], [
 		[AC_MSG_ERROR([Unknown --with-python value '$with_python'])]
 	)
 
-	AS_IF([test $PYTHON != :], [
-		AS_IF([$PYTHON --version >/dev/null 2>&1],
-			[AM_PATH_PYTHON([2.6], [], [:])],
-			[AC_MSG_ERROR([Cannot find $PYTHON in your system path])]
-		)
-	])
-	AM_CONDITIONAL([USING_PYTHON], [test "$PYTHON" != :])
-	AM_CONDITIONAL([USING_PYTHON_2], [ZFS_AC_PYTHON_VERSION_IS_2])
-	AM_CONDITIONAL([USING_PYTHON_3], [ZFS_AC_PYTHON_VERSION_IS_3])
-
 	dnl #
 	dnl # Minimum supported Python versions for utilities:
-	dnl # Python 2.6.x, or Python 3.4.x
+	dnl # Python 2.6 or Python 3.4
 	dnl #
-	AS_IF([ZFS_AC_PYTHON_VERSION_IS_2], [
-		ZFS_AC_PYTHON_VERSION([>= '2.6'], [ true ],
-			[AC_MSG_ERROR("Python >= 2.6.x is not available")])
+	AM_PATH_PYTHON([], [], [:])
+	AS_IF([test -z "$PYTHON_VERSION"], [
+		PYTHON_VERSION=$(basename $PYTHON | tr -cd 0-9.)
 	])
+	PYTHON_MINOR=${PYTHON_VERSION#*\.}
 
-	AS_IF([ZFS_AC_PYTHON_VERSION_IS_3], [
-		ZFS_AC_PYTHON_VERSION([>= '3.4'], [ true ],
-			[AC_MSG_ERROR("Python >= 3.4.x is not available")])
-	])
+	AS_CASE([$PYTHON_VERSION],
+		[2.*], [
+			AS_IF([test $PYTHON_MINOR -lt 6],
+				[AC_MSG_ERROR("Python >= 2.6 is required")])
+		],
+		[3.*], [
+			AS_IF([test $PYTHON_MINOR -lt 4],
+				[AC_MSG_ERROR("Python >= 3.4 is required")])
+		],
+		[:|2|3], [],
+		[PYTHON_VERSION=3]
+	)
+
+	AM_CONDITIONAL([USING_PYTHON], [test "$PYTHON" != :])
+	AM_CONDITIONAL([USING_PYTHON_2], [test "x${PYTHON_VERSION%%\.*}" = x2])
+	AM_CONDITIONAL([USING_PYTHON_3], [test "x${PYTHON_VERSION%%\.*}" = x3])
 
 	dnl #
 	dnl # Request that packages be built for a specific Python version.
 	dnl #
-	AS_IF([test $with_python != check], [
-		PYTHON_PKG_VERSION=`echo ${PYTHON} | tr -d 'a-zA-Z.'`
+	AS_IF([test "x$with_python" != xcheck], [
+		PYTHON_PKG_VERSION=$(echo $PYTHON_VERSION | tr -d .)
 		DEFINE_PYTHON_PKG_VERSION='--define "__use_python_pkg_version '${PYTHON_PKG_VERSION}'"'
 		DEFINE_PYTHON_VERSION='--define "__use_python '${PYTHON}'"'
 	], [

--- a/config/always-pyzfs.m4
+++ b/config/always-pyzfs.m4
@@ -1,5 +1,24 @@
 dnl #
-dnl # Determines if pyzfs can be built, requires Python 2.7 or latter.
+dnl # ZFS_AC_PYTHON_MODULE(module_name, [action-if-true], [action-if-false])
+dnl #
+dnl # Checks for Python module. Freely inspired by AX_PYTHON_MODULE
+dnl # https://www.gnu.org/software/autoconf-archive/ax_python_module.html
+dnl # Required by ZFS_AC_CONFIG_ALWAYS_PYZFS.
+dnl #
+AC_DEFUN([ZFS_AC_PYTHON_MODULE], [
+	PYTHON_NAME=$(basename $PYTHON)
+	AC_MSG_CHECKING([for $PYTHON_NAME module: $1])
+	AS_IF([$PYTHON -c "import $1" 2>/dev/null], [
+		AC_MSG_RESULT(yes)
+		m4_ifvaln([$2], [$2])
+	], [
+		AC_MSG_RESULT(no)
+		m4_ifvaln([$3], [$3])
+	])
+])
+
+dnl #
+dnl # Determines if pyzfs can be built, requires Python 2.7 or later.
 dnl #
 AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 	AC_ARG_ENABLE([pyzfs],
@@ -18,7 +37,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 			DEFINE_PYZFS='--without pyzfs'
 		])
 	], [
-		AS_IF([test $PYTHON != :], [
+		AS_IF([test "$PYTHON" != :], [
 			DEFINE_PYZFS=''
 		], [
 			enable_pyzfs=no
@@ -31,20 +50,16 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 	dnl # Require python-devel libraries
 	dnl #
 	AS_IF([test "x$enable_pyzfs" = xcheck  -o "x$enable_pyzfs" = xyes], [
-		AS_IF([ZFS_AC_PYTHON_VERSION_IS_2], [
-			PYTHON_REQUIRED_VERSION=">= '2.7.0'"
-		], [
-			AS_IF([ZFS_AC_PYTHON_VERSION_IS_3], [
-				PYTHON_REQUIRED_VERSION=">= '3.4.0'"
-			], [
-				AC_MSG_ERROR("Python $PYTHON_VERSION unknown")
-			])
-		])
+		AS_CASE([$PYTHON_VERSION],
+			[3.*], [PYTHON_REQUIRED_VERSION=">= '3.4.0'"],
+			[2.*], [PYTHON_REQUIRED_VERSION=">= '2.7.0'"],
+			[AC_MSG_ERROR("Python $PYTHON_VERSION unknown")]
+		)
 
 		AX_PYTHON_DEVEL([$PYTHON_REQUIRED_VERSION], [
 			AS_IF([test "x$enable_pyzfs" = xyes], [
 				AC_MSG_ERROR("Python $PYTHON_REQUIRED_VERSION development library is not installed")
-			], [test ! "x$enable_pyzfs" = xno], [
+			], [test "x$enable_pyzfs" != xno], [
 				enable_pyzfs=no
 			])
 		])
@@ -57,7 +72,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 		ZFS_AC_PYTHON_MODULE([setuptools], [], [
 			AS_IF([test "x$enable_pyzfs" = xyes], [
 				AC_MSG_ERROR("Python $PYTHON_VERSION setuptools is not installed")
-			], [test ! "x$enable_pyzfs" = xno], [
+			], [test "x$enable_pyzfs" != xno], [
 				enable_pyzfs=no
 			])
 		])
@@ -70,7 +85,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 		ZFS_AC_PYTHON_MODULE([cffi], [], [
 			AS_IF([test "x$enable_pyzfs" = xyes], [
 				AC_MSG_ERROR("Python $PYTHON_VERSION cffi is not installed")
-			], [test ! "x$enable_pyzfs" = xno], [
+			], [test "x$enable_pyzfs" != xno], [
 				enable_pyzfs=no
 			])
 		])
@@ -81,7 +96,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_PYZFS], [
 	dnl #
 	AS_IF([test "x$enable_pyzfs" = xcheck], [enable_pyzfs=yes])
 
-	AM_CONDITIONAL([PYZFS_ENABLED], [test x$enable_pyzfs = xyes])
+	AM_CONDITIONAL([PYZFS_ENABLED], [test "x$enable_pyzfs" = xyes])
 	AC_SUBST([PYZFS_ENABLED], [$enable_pyzfs])
 	AC_SUBST(pythonsitedir, [$PYTHON_SITE_PKG])
 


### PR DESCRIPTION
### Motivation and Context

* Reducing dependencies between files, simplifying nested tests, and improving style consistency eases code maintenance.
* Reducing build-time dependencies helps with use cases like #8851 where Python is not available when building ZFS but the Python scripts are still desired.

### Description

Don't require Python at configure/build unless building pyzfs.
Move ZFS_AC_PYTHON_MODULE to always-pyzfs.m4 where it is used.
Simplify nested tests to flat case pattern-matching statements.
Make test syntax more consistent.

### How Has This Been Tested?

I've tested the following configurations:

* no options, with no python installed
* no options, with python3
* `--without-python`
* `--disable-pyzfs`
* `--with-python=python2 --disable-pyzfs`
* `--with-python=3 --disable-pyzfs` with no python installed
* `--with-python=2 --disable-pyzfs` with python3 installed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
