### PR TITLE
Appended corrupted blocks offset range in zpool status command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ cscope.*
 *.orig
 *.log
 venv
+# Ignore Eclipse files
+/.cproject
+/.project
 
 #
 # Module leftovers

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -7253,22 +7253,23 @@ print_error_log(zpool_handle_t *zhp)
 	elem = NULL;
 	while ((elem = nvlist_next_nvpair(nverrlist, elem)) != NULL) {
 		uint64_t data_block_size, indirect_block_size;
+		unsigned int error_count_blkids, error_count_levels;
+		uint64_t *block_ids;
+		int64_t *indirect_levels;
+
+		nvlist_t *object_nv = fnvpair_value_nvlist(elem);
+		uint64_t dsobj = fnvlist_lookup_uint64(object_nv,
+		    ZPOOL_ERR_DATASET);
+		uint64_t obj = fnvlist_lookup_uint64(object_nv,
+		    ZPOOL_ERR_OBJECT);
 		zpool_obj_to_path(zhp, dsobj, obj, pathname, len);
 
 		if (zpool_get_block_size(zhp, dsobj, obj, &data_block_size,
-		    &indirect_block_size) == 0) {
-
-			unsigned int error_count_blkids, error_count_levels;
-
-		    	nvlist_t *object_nv = fnvpair_value_nvlist(elem);
-			uint64_t dsobj = fnvlist_lookup_uint64(object_nv,
-			    ZPOOL_ERR_DATASET);
-			uint64_t obj = fnvlist_lookup_uint64(object_nv,
-			    ZPOOL_ERR_OBJECT);
-			uint64_t *block_ids = fnvlist_lookup_uint64_array(
-			    object_nv, ZPOOL_ERR_BLOCKID, &error_count_blkids);
-			int64_t *indirect_levels = fnvlist_lookup_int64_array(
-			    object_nv, ZPOOL_ERR_LEVEL, &error_count_levels);
+		    &indirect_block_size) == 0 && nvlist_lookup_uint64_array(
+		    object_nv, ZPOOL_ERR_BLOCKID, &block_ids,
+		    &error_count_blkids) == 0 && nvlist_lookup_int64_array(
+		    object_nv, ZPOOL_ERR_LEVEL, &indirect_levels,
+		    &error_count_levels) == 0) {
 
 			ASSERT(error_count_blkids == error_count_levels);
 

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -7252,16 +7252,71 @@ print_error_log(zpool_handle_t *zhp)
 	pathname = safe_malloc(len);
 	elem = NULL;
 	while ((elem = nvlist_next_nvpair(nverrlist, elem)) != NULL) {
-		nvlist_t *nv;
-		uint64_t dsobj, obj;
-
-		verify(nvpair_value_nvlist(elem, &nv) == 0);
-		verify(nvlist_lookup_uint64(nv, ZPOOL_ERR_DATASET,
-		    &dsobj) == 0);
-		verify(nvlist_lookup_uint64(nv, ZPOOL_ERR_OBJECT,
-		    &obj) == 0);
+		uint64_t data_block_size, indirect_block_size;
 		zpool_obj_to_path(zhp, dsobj, obj, pathname, len);
-		(void) printf("%7s %s\n", "", pathname);
+
+		if (zpool_get_block_size(zhp, dsobj, obj, &data_block_size,
+		    &indirect_block_size) == 0) {
+
+			unsigned int error_count_blkids, error_count_levels;
+
+		    	nvlist_t *object_nv = fnvpair_value_nvlist(elem);
+			uint64_t dsobj = fnvlist_lookup_uint64(object_nv,
+			    ZPOOL_ERR_DATASET);
+			uint64_t obj = fnvlist_lookup_uint64(object_nv,
+			    ZPOOL_ERR_OBJECT);
+			uint64_t *block_ids = fnvlist_lookup_uint64_array(
+			    object_nv, ZPOOL_ERR_BLOCKID, &error_count_blkids);
+			int64_t *indirect_levels = fnvlist_lookup_int64_array(
+			    object_nv, ZPOOL_ERR_LEVEL, &error_count_levels);
+
+			ASSERT(error_count_blkids == error_count_levels);
+
+			uint64_t blkptr_size = (uint64_t)sizeof (blkptr_t);
+			uint8_t blkptr_size_shift = 0;
+			uint8_t indirect_block_shift = 0;
+			uint64_t min_offset_blk = UINT64_MAX;
+			uint64_t max_offset_blk = 0;
+			while (indirect_block_size > 1) {
+				indirect_block_size = indirect_block_size >> 1;
+				indirect_block_shift++;
+			}
+
+			while (blkptr_size > 1) {
+				blkptr_size = blkptr_size >> 1;
+				blkptr_size_shift++;
+			}
+			/*
+			 * Iterate through the error blockids and find minimum
+			 * and maximum offset.
+			 */
+			for (int i = 0; i < error_count_blkids; i++) {
+				uint64_t start_offset = block_ids[i] <<
+				    ((indirect_block_shift -
+				    blkptr_size_shift) * indirect_levels[i]);
+				uint64_t end_offset = (block_ids[i] + 1) <<
+				    ((indirect_block_shift -
+				    blkptr_size_shift) * indirect_levels[i]);
+				min_offset_blk =
+				    MIN(min_offset_blk, start_offset);
+				max_offset_blk =
+				    MAX(max_offset_blk, end_offset);
+			}
+			uint64_t min_offset_byte =
+			    data_block_size * min_offset_blk;
+			uint64_t max_offset_byte =
+			    data_block_size * max_offset_blk;
+			char size_buf[16];
+			nicenum(data_block_size, size_buf, sizeof (size_buf));
+			(void) printf("%7s %s: errors in %u blocks "
+			    "(size %s), between offset %#llx and %#llx "
+			    "bytes\n", "", pathname, error_count_blkids,
+			    size_buf, (u_longlong_t)min_offset_byte,
+			    (u_longlong_t)max_offset_byte);
+		} else {
+			(void) printf("%7s %s %s\n", "", pathname, " (can not "
+			    "determine error offset)");
+		}
 	}
 	free(pathname);
 	nvlist_free(nverrlist);

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -432,6 +432,8 @@ extern int zpool_events_clear(libzfs_handle_t *, int *);
 extern int zpool_events_seek(libzfs_handle_t *, uint64_t, int);
 extern void zpool_obj_to_path(zpool_handle_t *, uint64_t, uint64_t, char *,
     size_t len);
+extern int zpool_get_block_size(zpool_handle_t *, uint64_t, uint64_t,
+    uint64_t *, uint64_t *);
 extern int zfs_ioctl(libzfs_handle_t *, int, struct zfs_cmd *);
 extern int zpool_get_physpath(zpool_handle_t *, char *, size_t);
 extern void zpool_explain_recover(libzfs_handle_t *, const char *, int,

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -675,6 +675,7 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_VDEV_ENC_SYSFS_PATH	"vdev_enc_sysfs_path"
 
 #define	ZPOOL_CONFIG_WHOLE_DISK		"whole_disk"
+#define	ZPOOL_CONFIG_ERRLIST		"error_list"
 #define	ZPOOL_CONFIG_ERRCOUNT		"error_count"
 #define	ZPOOL_CONFIG_NOT_PRESENT	"not_present"
 #define	ZPOOL_CONFIG_SPARES		"spares"
@@ -1346,6 +1347,8 @@ typedef enum {
 #define	ZPOOL_ERR_LIST		"error list"
 #define	ZPOOL_ERR_DATASET	"dataset"
 #define	ZPOOL_ERR_OBJECT	"object"
+#define	ZPOOL_ERR_LEVEL		"level"
+#define	ZPOOL_ERR_BLOCKID	"block id"
 
 #define	HIS_MAX_RECORD_LEN	(MAXPATHLEN + MAXPATHLEN + 1)
 

--- a/include/sys/zfs_stat.h
+++ b/include/sys/zfs_stat.h
@@ -44,6 +44,8 @@ typedef struct zfs_stat {
 	uint64_t	zs_mode;
 	uint64_t	zs_links;
 	uint64_t	zs_ctime[2];
+	uint64_t	zs_data_block_size;
+	uint64_t	zs_indirect_block_size;
 } zfs_stat_t;
 
 extern int zfs_obj_to_stats(objset_t *osp, uint64_t obj, zfs_stat_t *sb,

--- a/module/zfs/zfs_znode.c
+++ b/module/zfs/zfs_znode.c
@@ -2071,6 +2071,11 @@ zfs_obj_to_stats_impl(sa_handle_t *hdl, sa_attr_type_t *sa_table,
 	sa_bulk_attr_t bulk[4];
 	int count = 0;
 
+	dmu_object_info_t doi;
+	sa_object_info(hdl, &doi);
+	sb->zs_data_block_size = doi.doi_data_block_size;
+	sb->zs_indirect_block_size = doi.doi_metadata_block_size;
+
 	SA_ADD_BULK_ATTR(bulk, count, sa_table[ZPL_MODE], NULL,
 	    &sb->zs_mode, sizeof (sb->zs_mode));
 	SA_ADD_BULK_ATTR(bulk, count, sa_table[ZPL_GEN], NULL,

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -462,7 +462,7 @@ tests = ['zpool_split_cliargs', 'zpool_split_devices',
 tags = ['functional', 'cli_root', 'zpool_split']
 
 [tests/functional/cli_root/zpool_status]
-tests = ['zpool_status_001_pos', 'zpool_status_002_pos']
+tests = ['zpool_status_001_pos', 'zpool_status_002_pos', 'zpool_status_-v' ]
 tags = ['functional', 'cli_root', 'zpool_status']
 
 [tests/functional/cli_root/zpool_sync]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/Makefile.am
@@ -3,4 +3,5 @@ dist_pkgdata_SCRIPTS = \
 	setup.ksh \
 	cleanup.ksh \
 	zpool_status_001_pos.ksh \
-	zpool_status_002_pos.ksh
+	zpool_status_002_pos.ksh \
+	zpool_status_-v.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_-v.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_-v.ksh
@@ -1,0 +1,72 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify correct output with 'zpool status -v' after corrupting a file
+#
+# STRATEGY:
+# 1. Create a file
+# 2. zinject checksum errors
+# 3. Read the file
+# 4. Verify we see "file corrupted" output in 'zpool status -v'
+#
+
+verify_runnable "both"
+
+
+log_assert "Verify correct 'zpool status -v' output with a corrupted file"
+
+log_must mkfile 10m $TESTDIR/10m_file
+log_must mkfile 1m $TESTDIR/1m_file
+
+log_must zpool export $TESTPOOL
+log_must zpool import $TESTPOOL
+
+log_must zinject -t data -e checksum -f 100 $TESTDIR/10m_file
+log_must zinject -t data -e checksum -f 100 $TESTDIR/1m_file
+
+# Try to read the entire file.  This should stop after the first 128k block
+# of each file errors out.
+cat $TESTDIR/*file || true
+
+# Try to read the 2nd megabyte of 10m_file
+dd if=$TESTDIR/10m_file bs=1M skip=1 count=1 || true
+dd if=$TESTDIR/1m_file bs=128K count=1 || true
+
+log_must zinject -c all
+
+# Look to see that both our files report errors
+log_must eval "zpool status -v | grep '10m_file: errors'"
+log_must eval "zpool status -v | grep '1m_file: errors'"
+
+log_pass "'zpool status -v' output is correct"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
`zpool status -vx` outputs name of file containing corrupted error blocks if any, but says nothing about probable error blocks location. This pull request appends with file name corrupted blocks offset range to the file name.
**Sample output Earlier**
`/{file_system_path}/myfile`
**Sample output now**
`/{file_system_path}/myfile errors: in 236 blocks (size 128KB), between offset 0x1002a0000 and 0x102000000 bytes`
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Using dd command I created a file under filesystem as following 
`dd if=/dev/urandom of=/{file_system_path}/myfile bs=128k count=50000`. 
Then I directly wrote to disk device as following 
`dd if=/dev/urandom of=/dev/{disk_name} bs=1024 seek=10000 count=30000 conv=notrunc`. 
This causes file to get corrupted. Earlier it was only name of the file i.e  `/{file_system_path}/myfile` now updated error message is `/{file_system_path}/myfile errors: in 236 blocks (size 128KB), between offset 0x1002a0000 and 0x102000000 bytes`

Also added a test cases provided by @tonyhutter. It works as follows:
1. Create new file
2. Add checksum error using `zinject` 
3. Read using `dd` 
4. Verifies that filename is logged in `zpool status -vx `command
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
