### PR TITLE
Remove arch and zfs version dependency

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -255,7 +255,8 @@ validating the file system.
 %package dracut
 Summary:        Dracut module
 Group:          System Environment/Kernel
-Requires:       %{name}%{?_isa} = %{version}-%{release}
+BuildArch:	noarch
+Requires:       %{name} >= %{version}-%{release}
 Requires:       dracut
 Requires:       /usr/bin/awk
 Requires:       grep

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -256,7 +256,7 @@ validating the file system.
 Summary:        Dracut module
 Group:          System Environment/Kernel
 BuildArch:	noarch
-Requires:       %{name} >= %{version}-%{release}
+Requires:       %{name} >= %{version}
 Requires:       dracut
 Requires:       /usr/bin/awk
 Requires:       grep


### PR DESCRIPTION
Remove arch and zfs version dependency

Signed-off-by: Gordan Bobic <gordan@redsleeve.org>

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

zfs-dracut is automatically built for whatever architecture zfs is being compiled for. This is incorrect since zfs-dracut only contains bash scripts and is thus compatible with any arch.

Additionally, version dependency is unnecessary since this only requires a set of functionality basic enough to import the rootfs. For example, zfs-dracut 0.7.x works absolutely fine for creating bootable initramfs using zfs 0.8.x binaries.

<!--- If it fixes an open issue, please link to the issue here. -->

It doesn't fix this issue, but it does help produce a zfs-dracut rpm that can be installed without errors and overrides when combating a regression situation:
https://github.com/zfsonlinux/zfs/issues/8913

### Description
<!--- Describe your changes in detail -->

It's a relatively trivial change - it makes zfs-dracut build as a noarch package since it only contains bash scripts. It also removes the package's dependency on zfs of a particular arch and version since the functionality it needs is minimal.