### PR TITLE
Add libnvpair to libzfs pkg-config

### DIFF
--- a/lib/libzfs/libzfs.pc.in
+++ b/lib/libzfs/libzfs.pc.in
@@ -9,4 +9,4 @@ Version: @VERSION@
 URL: http://zfsonlinux.org
 Requires: libzfs_core
 Cflags: -I${includedir}/libzfs -I${includedir}/libspl
-Libs: -L${libdir} -lzfs
+Libs: -L${libdir} -lzfs -lnvpair


### PR DESCRIPTION
Functions such as `fnvlist_lookup_nvlist` need libnvpair to be linked.
Default pkg-config file did not contain it.

Signed-off-by: Harry Mallon <hjmallon@gmail.com>

### Motivation and Context
Building purely using pkg-config for libzfs was failing for me.

### Description
Functions such as `fnvlist_lookup_nvlist` need libnvpair to be linked.
Default pkg-config file did not contain it.

### How Has This Been Tested?
Ran on my local machine (CentOS 7, ZFS 0.7.12)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
