### PR TITLE
Prevent pointer to an out-of-scope local variable

### DIFF
--- a/module/zfs/zfs_sysfs.c
+++ b/module/zfs/zfs_sysfs.c
@@ -264,6 +264,7 @@ zprop_sysfs_show(const char *attr_name, const zprop_desc_t *property,
     char *buf, size_t buflen)
 {
 	const char *show_str;
+	char number[32];
 
 	/* For dataset properties list the dataset types that apply */
 	if (strcmp(attr_name, "datasets") == 0 &&
@@ -291,8 +292,6 @@ zprop_sysfs_show(const char *attr_name, const zprop_desc_t *property,
 	} else if (strcmp(attr_name, "values") == 0) {
 		show_str = property->pd_values ? property->pd_values : "";
 	} else if (strcmp(attr_name, "default") == 0) {
-		char number[32];
-
 		switch (property->pd_proptype) {
 		case PROP_TYPE_NUMBER:
 			(void) snprintf(number, sizeof (number), "%llu",


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#8924 

### Description
<!--- Describe your changes in detail -->

`show_str` could be a pointer to a local variable in stack which is out-of-scope by the time
`return (snprintf(buf, buflen, "%s\n", show_str));`
is called.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
