### PR TITLE
Fix out-of-tree build failures

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,7 +52,8 @@ distclean-local::
 		-type f -print | xargs $(RM)
 
 all-local:
-	-${top_srcdir}/scripts/zfs-tests.sh -c
+	-[ -x ${top_builddir}/scripts/zfs-tests.sh ] && \
+	    ${top_builddir}/scripts/zfs-tests.sh -c
 
 dist-hook: gitrev
 	cp ${top_srcdir}/include/zfs_gitrev.h $(distdir)/include; \

--- a/cmd/zed/Makefile.am
+++ b/cmd/zed/Makefile.am
@@ -1,11 +1,10 @@
+SUBDIRS = zed.d
+
 include $(top_srcdir)/config/Rules.am
 
 DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/lib/libspl/include
-
-EXTRA_DIST = zed.d/README \
-	zed.d/history_event-zfs-list-cacher.sh.in
 
 sbin_PROGRAMS = zed
 
@@ -47,55 +46,3 @@ zed_LDADD = \
 
 zed_LDADD += -lrt
 zed_LDFLAGS = -pthread
-
-zedconfdir = $(sysconfdir)/zfs/zed.d
-
-dist_zedconf_DATA = \
-	zed.d/zed-functions.sh \
-	zed.d/zed.rc
-
-zedexecdir = $(zfsexecdir)/zed.d
-
-dist_zedexec_SCRIPTS = \
-	zed.d/all-debug.sh \
-	zed.d/all-syslog.sh \
-	zed.d/data-notify.sh \
-	zed.d/generic-notify.sh \
-	zed.d/resilver_finish-notify.sh \
-	zed.d/scrub_finish-notify.sh \
-	zed.d/statechange-led.sh \
-	zed.d/statechange-notify.sh \
-	zed.d/vdev_clear-led.sh \
-	zed.d/vdev_attach-led.sh \
-	zed.d/pool_import-led.sh \
-	zed.d/resilver_finish-start-scrub.sh
-
-nodist_zedexec_SCRIPTS = zed.d/history_event-zfs-list-cacher.sh
-
-$(nodist_zedexec_SCRIPTS): %: %.in
-	-$(SED) -e 's,@bindir\@,$(bindir),g' \
-		-e 's,@runstatedir\@,$(runstatedir),g' \
-		-e 's,@sbindir\@,$(sbindir),g' \
-		-e 's,@sysconfdir\@,$(sysconfdir),g' \
-		$< >'$@'
-
-zedconfdefaults = \
-	all-syslog.sh \
-	data-notify.sh \
-	resilver_finish-notify.sh \
-	scrub_finish-notify.sh \
-	statechange-led.sh \
-	statechange-notify.sh \
-	vdev_clear-led.sh \
-	vdev_attach-led.sh \
-	pool_import-led.sh \
-	resilver_finish-start-scrub.sh
-
-install-data-hook:
-	$(MKDIR_P) "$(DESTDIR)$(zedconfdir)"
-	for f in $(zedconfdefaults); do \
-	  test -f "$(DESTDIR)$(zedconfdir)/$${f}" -o \
-	       -L "$(DESTDIR)$(zedconfdir)/$${f}" || \
-	    ln -s "$(zedexecdir)/$${f}" "$(DESTDIR)$(zedconfdir)"; \
-	done
-	chmod 0600 "$(DESTDIR)$(zedconfdir)/zed.rc"

--- a/cmd/zed/zed.d/Makefile.am
+++ b/cmd/zed/zed.d/Makefile.am
@@ -1,0 +1,57 @@
+include $(top_srcdir)/config/Rules.am
+
+EXTRA_DIST = \
+	README \
+	history_event-zfs-list-cacher.sh.in
+
+zedconfdir = $(sysconfdir)/zfs/zed.d
+
+dist_zedconf_DATA = \
+	zed-functions.sh \
+	zed.rc
+
+zedexecdir = $(zfsexecdir)/zed.d
+
+dist_zedexec_SCRIPTS = \
+	all-debug.sh \
+	all-syslog.sh \
+	data-notify.sh \
+	generic-notify.sh \
+	resilver_finish-notify.sh \
+	scrub_finish-notify.sh \
+	statechange-led.sh \
+	statechange-notify.sh \
+	vdev_clear-led.sh \
+	vdev_attach-led.sh \
+	pool_import-led.sh \
+	resilver_finish-start-scrub.sh
+
+nodist_zedexec_SCRIPTS = history_event-zfs-list-cacher.sh
+
+$(nodist_zedexec_SCRIPTS): %: %.in
+	-$(SED) -e 's,@bindir\@,$(bindir),g' \
+		-e 's,@runstatedir\@,$(runstatedir),g' \
+		-e 's,@sbindir\@,$(sbindir),g' \
+		-e 's,@sysconfdir\@,$(sysconfdir),g' \
+		$< >'$@'
+
+zedconfdefaults = \
+	all-syslog.sh \
+	data-notify.sh \
+	resilver_finish-notify.sh \
+	scrub_finish-notify.sh \
+	statechange-led.sh \
+	statechange-notify.sh \
+	vdev_clear-led.sh \
+	vdev_attach-led.sh \
+	pool_import-led.sh \
+	resilver_finish-start-scrub.sh
+
+install-data-hook:
+	$(MKDIR_P) "$(DESTDIR)$(zedconfdir)"
+	for f in $(zedconfdefaults); do \
+	  test -f "$(DESTDIR)$(zedconfdir)/$${f}" -o \
+	       -L "$(DESTDIR)$(zedconfdir)/$${f}" || \
+	    ln -s "$(zedexecdir)/$${f}" "$(DESTDIR)$(zedconfdir)"; \
+	done
+	chmod 0600 "$(DESTDIR)$(zedconfdir)/zed.rc"

--- a/configure.ac
+++ b/configure.ac
@@ -120,6 +120,7 @@ AC_CONFIG_FILES([
 	cmd/dbufstat/Makefile
 	cmd/arc_summary/Makefile
 	cmd/zed/Makefile
+	cmd/zed/zed.d/Makefile
 	cmd/raidz_test/Makefile
 	cmd/zgenhostid/Makefile
 	contrib/Makefile

--- a/contrib/initramfs/Makefile.am
+++ b/contrib/initramfs/Makefile.am
@@ -11,13 +11,18 @@ EXTRA_DIST = \
 	$(top_srcdir)/contrib/initramfs/README.initramfs.markdown
 
 install-initrdSCRIPTS: $(EXTRA_DIST)
-	for d in conf.d conf-hooks.d hooks scripts scripts/local-top; do \
-	  $(MKDIR_P) $(DESTDIR)$(initrddir)/$$d; \
-	  cp $(top_srcdir)/contrib/initramfs/$$d/zfs \
-	    $(DESTDIR)$(initrddir)/$$d/; \
+	for d in conf.d conf-hooks.d scripts/local-top; do \
+		$(MKDIR_P) $(DESTDIR)$(initrddir)/$$d; \
+		cp $(top_srcdir)/contrib/initramfs/$$d/zfs \
+		    $(DESTDIR)$(initrddir)/$$d/; \
 	done
-	if [ -f etc/init.d/zfs ]; then \
-	  $(MKDIR_P) $(DESTDIR)$(DEFAULT_INITCONF_DIR); \
-	  cp $(top_srcdir)/etc/init.d/zfs \
-	    $(DESTDIR)$(DEFAULT_INITCONF_DIR)/; \
+	for d in hooks scripts; do \
+		$(MKDIR_P) $(DESTDIR)$(initrddir)/$$d; \
+		cp $(top_builddir)/contrib/initramfs/$$d/zfs \
+		    $(DESTDIR)$(initrddir)/$$d/; \
+	done
+	if [ -f $(top_builddir)/etc/init.d/zfs ]; then \
+		$(MKDIR_P) $(DESTDIR)$(DEFAULT_INITCONF_DIR); \
+		cp $(top_builddir)/etc/init.d/zfs \
+		    $(DESTDIR)$(DEFAULT_INITCONF_DIR)/; \
 	fi

--- a/contrib/pyzfs/Makefile.am
+++ b/contrib/pyzfs/Makefile.am
@@ -24,7 +24,7 @@ all-local:
 # files are later created by manually loading the Python modules.
 #
 install-exec-local:
-	$(PYTHON) $(srcdir)/setup.py install \
+	$(PYTHON) $(builddir)/setup.py install \
 	--prefix $(prefix) \
 	--root $(DESTDIR)/ \
 	--install-lib $(pythonsitedir) \

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -66,8 +66,9 @@ modules_uninstall:
 
 distdir:
 	list='$(subdir-m)'; for subdir in $$list; do \
-		(cd @top_srcdir@/module && find $$subdir -name '*.c' -o -name '*.h' -o -name '*.S' |\
-		xargs cp --parents -t $$distdir); \
+		(cd @top_srcdir@/module && find $$subdir \
+		-name '*.c' -o -name '*.h' -o -name '*.S' | \
+		xargs cp --parents -t @abs_top_builddir@/module/$$distdir); \
 	done
 
 distclean maintainer-clean: clean

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -60,7 +60,7 @@ all-local:
 		-e '\|^export SBIN_DIR=|s|$$|@abs_top_builddir@/bin|' \
 		-e '\|^export ZTS_DIR=|s|$$|@abs_top_srcdir@/tests|' \
 		-e '\|^export SCRIPT_DIR=|s|$$|@abs_top_srcdir@/scripts|' \
-		common.sh.in >common.sh
+		$(abs_top_srcdir)/scripts/common.sh.in >common.sh
 	-echo "$$EXTRA_ENVIRONMENT" >>common.sh
 
 clean-local:
@@ -71,4 +71,5 @@ install-data-hook:
 		-e '\|^export SBIN_DIR=|s|$$|@sbindir@|' \
 		-e '\|^export ZTS_DIR=|s|$$|@datadir@/@PACKAGE@|' \
 		-e '\|^export SCRIPT_DIR=|s|$$|@datadir@/@PACKAGE@|' \
-		common.sh.in >$(DESTDIR)$(datadir)/@PACKAGE@/common.sh
+		$(abs_top_srcdir)/scripts/common.sh.in \
+		>$(DESTDIR)$(datadir)/@PACKAGE@/common.sh

--- a/tests/runfiles/Makefile.am
+++ b/tests/runfiles/Makefile.am
@@ -1,2 +1,5 @@
 pkgdatadir = $(datadir)/@PACKAGE@/runfiles
-dist_pkgdata_DATA = *.run
+dist_pkgdata_DATA = \
+	linux.run \
+	longevity.run \
+	perf-regression.run

--- a/tests/zfs-tests/tests/functional/checksum/Makefile.am
+++ b/tests/zfs-tests/tests/functional/checksum/Makefile.am
@@ -1,7 +1,7 @@
 include $(top_srcdir)/config/Rules.am
 
 AM_CPPFLAGS += -I$(top_srcdir)/include
-LDADD = $(top_srcdir)/lib/libicp/libicp.la
+LDADD = $(top_builddir)/lib/libicp/libicp.la
 
 AUTOMAKE_OPTIONS = subdir-objects
 

--- a/tests/zfs-tests/tests/functional/hkdf/Makefile.am
+++ b/tests/zfs-tests/tests/functional/hkdf/Makefile.am
@@ -2,7 +2,7 @@ include $(top_srcdir)/config/Rules.am
 
 AM_CPPFLAGS += -I$(top_srcdir)/include
 AM_CPPFLAGS += -I$(top_srcdir)/lib/libspl/include
-LDADD = $(top_srcdir)/lib/libzpool/libzpool.la
+LDADD = $(top_builddir)/lib/libzpool/libzpool.la
 
 AUTOMAKE_OPTIONS = subdir-objects
 


### PR DESCRIPTION
### Motivation and Context

Issue #8921.

### Description

Resolve the incorrect use of srcdir and builddir references for various files
in the build system.  These have crept in over time and went unnoticed because
when building in the top level directory srcdir and builddir are identical.

With this change it's again possible to build in a subdirectory.

### How Has This Been Tested?

Locally compiled user and kernel components in a subdirectory named `obj`.
Verify that `make dist`, `make install`, and `make rpms` all worked as intended.

```
mkdir obj
cd obj
../configure
make -s
```

Pending a full CI run to test all platforms.  My testing was done on CentOS 7.
Currently, the CI does not test subdirectory compilation but adding such a
builder would help us prevent this in the future.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
