### PR TITLE
fix comments on zfs_bookmark_phys

### DIFF
--- a/include/sys/dsl_bookmark.h
+++ b/include/sys/dsl_bookmark.h
@@ -36,9 +36,11 @@ typedef struct zfs_bookmark_phys {
 	uint64_t zbm_creation_txg;	/* birth transaction group */
 	uint64_t zbm_creation_time;	/* bookmark creation time */
 
-	/* the following fields are reserved for redacted send / recv */
+	/* fields used for redacted send / recv */
 	uint64_t zbm_redaction_obj;	/* redaction list object */
 	uint64_t zbm_flags;		/* ZBM_FLAG_* */
+
+	/* fields used for bookmark written size */
 	uint64_t zbm_referenced_bytes_refd;
 	uint64_t zbm_compressed_bytes_refd;
 	uint64_t zbm_uncompressed_bytes_refd;


### PR DESCRIPTION
Signed-off-by: Paul Dagnelie <pcd@delphix.com>

### Motivation and Context
Since redacted send/recv was integrated, these comments are out of date.

### Description
I updated the comments.

### How Has This Been Tested?
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
