### PR TITLE
Redacted Send/Receive causes zdb to dump core

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1939,7 +1939,7 @@ dump_bookmarks(objset_t *os, int verbosity)
 		char osname[ZFS_MAX_DATASET_NAME_LEN];
 		char buf[ZFS_MAX_DATASET_NAME_LEN];
 		dmu_objset_name(os, osname);
-		VERIFY0(snprintf(buf, sizeof (buf), "%s#%s", osname,
+		VERIFY3S(0, <=, snprintf(buf, sizeof (buf), "%s#%s", osname,
 		    attr.za_name));
 		(void) dump_bookmark(dp, buf, verbosity >= 5, verbosity >= 6);
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When used with verbosity >= 4 zdb fails an assertion in `dump_bookmarks()` because it expects `snprintf()` to retun 0 on success.

```
root@master:~# zdb -ddddddd testpool/fs
Dataset testpool/fs [ZPL], ID 74, cr_txg 6, 24K, 6 objects, rootbp DVA[0]=<0:d000:200> DVA[1]=<0:100d000:200> [L0 DMU objset] fletcher4 lz4 unencrypted LE contiguous unique double size=1000L/200P birth=6L/6P fill=6 cksum=c5e39e0f3:4800b5c0ac7:dab03d77ffcb:1cd8517b60f997

    Deadlist: 0 (0/0 comp)

    mintxg 0 -> obj 77: object 77, 0 blkptrs, 0

    mintxg 1 -> obj 77: object 77, 0 blkptrs, 0

snprintf(buf, sizeof (buf), "%s#%s", osname, attr.za_name) == 0 (0xe == 0)
ASSERT at zdb.c:1943:dump_bookmarks()Aborted (core dumped)
```

### Description
<!--- Describe your changes in detail -->
~~This was the only occurrence of `zdb` using `VERIFY0()` on `snprintf()` results, so i just removed it.~~

EDIT: gcc 7.3.1 20180303 does not like this (http://build.zfsonlinux.org/builders/Amazon%202%20x86_64%20%28BUILD%29/builds/12443/steps/shell_3/logs/make), change to `VERIFY3S()` instead.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Run patched `zdb` binary on local builder, successfully use `zdb -dddd testpool`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
