### PR TITLE
Fix bp_embedded_type enum definition

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -407,9 +407,9 @@ _NOTE(CONSTCOND) } while (0)
 
 typedef enum bp_embedded_type {
 	BP_EMBEDDED_TYPE_DATA,
-	BP_EMBEDDED_TYPE_RESERVED, /* Reserved for an unintegrated feature. */
+	BP_EMBEDDED_TYPE_RESERVED, /* Reserved for Delphix byteswap feature. */
 	BP_EMBEDDED_TYPE_REDACTED,
-	NUM_BP_EMBEDDED_TYPES = BP_EMBEDDED_TYPE_RESERVED
+	NUM_BP_EMBEDDED_TYPES
 } bp_embedded_type_t;
 
 #define	BPE_NUM_WORDS 14

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -908,7 +908,7 @@ zfs_blkptr_verify(spa_t *spa, const blkptr_t *bp)
 	}
 
 	if (BP_IS_EMBEDDED(bp)) {
-		if (BPE_GET_ETYPE(bp) > NUM_BP_EMBEDDED_TYPES) {
+		if (BPE_GET_ETYPE(bp) >= NUM_BP_EMBEDDED_TYPES) {
 			zfs_panic_recover("blkptr at %p has invalid ETYPE %llu",
 			    bp, (longlong_t)BPE_GET_ETYPE(bp));
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the addition of BP_EMBEDDED_TYPE_REDACTED in 30af21b0 a couple of codepaths make wrong assumptions and could potentially result in errors.

```
(gdb) ptype bp_embedded_type_t
type = enum bp_embedded_type {BP_EMBEDDED_TYPE_DATA, BP_EMBEDDED_TYPE_RESERVED, BP_EMBEDDED_TYPE_REDACTED, NUM_BP_EMBEDDED_TYPES = 1}
(gdb) p/d BP_EMBEDDED_TYPE_REDACTED
$1 = 2
(gdb) 
```

With a bp (etype = `BP_EMBEDDED_TYPE_REDACTED`) we could panic in `zfs_blkptr_verify()`:
https://github.com/zfsonlinux/zfs/blob/30af21b02569ac192f52ce6e6511015f8a8d5729/module/zfs/zio.c#L910-L915

Also we would not be able to receive records with drr_etype = `BP_EMBEDDED_TYPE_REDACTED`:
https://github.com/zfsonlinux/zfs/blob/30af21b02569ac192f52ce6e6511015f8a8d5729/module/zfs/dmu_recv.c#L1849-L1850

And finally we will fail an assetion in `dmu_write_embedded()`:
https://github.com/zfsonlinux/zfs/blob/30af21b02569ac192f52ce6e6511015f8a8d5729/module/zfs/dmu.c#L1270-L1276

I'm not sure if `BP_EMBEDDED_TYPE_RESERVED` was supposed to be  `BP_EMBEDDED_TYPE_REDACTED` all along. I could not find any usage of `BP_SET_REDACTED()`, `dmu_buf_redact()` and `dmu_redact()` in the code.

### Description
<!--- Describe your changes in detail -->
Simply update `NUM_BP_EMBEDDED_TYPES` in `bp_embedded_type_t`

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Not tested, pushed as draft.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
