### PR TITLE
Improve "Unable to automount" error message

### DIFF
--- a/module/zfs/zfs_ctldir.c
+++ b/module/zfs/zfs_ctldir.c
@@ -30,6 +30,7 @@
  * Copyright (c) 2013 by Delphix. All rights reserved.
  * Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
  * Copyright (c) 2018 George Melikov. All Rights Reserved.
+ * Copyright (c) 2019 Datto, Inc. All rights reserved.
  */
 
 /*
@@ -1108,8 +1109,8 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 	if (error) {
 		if (!(error & MOUNT_BUSY << 8)) {
-			cmn_err(CE_WARN, "Unable to automount %s/%s: %d",
-			    full_path, full_name, error);
+			zfs_dbgmsg("Unable to automount %s error=%d",
+			    full_path, error);
 			error = SET_ERROR(EISDIR);
 		} else {
 			/*


### PR DESCRIPTION
Having the mountpoint and dataset name both in the message made it
confusing to read.

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>

### Motivation and Context
This message shows up frequently in our logs at Datto and we wanted to clean up the message a bit.

### Description
Reformatted the error message to just include the mount point.

### How Has This Been Tested?
Ran snapshot portion of zfstest.  To see the message:
```
umount /tank/fs1/.zfs/snapshot/snap1 &
zfs destroy tank/fs1@snap1
cd /tank/fs1/.zfs/snapshot/snap1 &
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).