### PR TITLE
pkg-utils python sitelib for SLES15

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -100,7 +100,7 @@
 %define __python_setuptools_pkg   python%{__python_pkg_version}-setuptools
 %endif
 %define __py_major_version        %(%{__python} -c "import sys; print(str(sys.version_info[0]))")
-%if 0%{?__py_major} >= 3
+%if 0%{?__py_major_version} >= 3
 %define __python_sitelib          %(%{__python} -Ic "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 %else
 %define __python_sitelib          %{python_sitelib}

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -87,17 +87,28 @@
 %define __python_pkg_version      2
 %define __python_cffi_pkg         python-cffi
 %define __python_setuptools_pkg   python-setuptools
+%define __python_sitelib          %{python_sitelib}
 %else
 %define __python                  /usr/bin/python3
 %define __python_pkg_version      3
 %define __python_cffi_pkg         python3-cffi
 %define __python_setuptools_pkg   python3-setuptools
+%if 0%{?suse_version} >= 1500
+%define __python_sitelib          %{python3_sitelib}
+%else
+%define __python_sitelib          %{python_sitelib}
+%endif
 %endif
 %else
 %define __python                  %{__use_python}
 %define __python_pkg_version      %{__use_python_pkg_version}
 %define __python_cffi_pkg         python%{__python_pkg_version}-cffi
 %define __python_setuptools_pkg   python%{__python_pkg_version}-setuptools
+%if 0%{?suse_version} >= 1500
+%define __python_sitelib          %{python%{__python_pkg_version}_sitelib}
+%else
+%define __python_sitelib          %{python_sitelib}
+%endif
 %endif
 
 # By default python-pyzfs is enabled, with the exception of
@@ -474,8 +485,8 @@ systemctl --system daemon-reload >/dev/null || true
 %doc contrib/pyzfs/README
 %doc contrib/pyzfs/LICENSE
 %defattr(-,root,root,-)
-%{python_sitelib}/libzfs_core/*
-%{python_sitelib}/pyzfs*
+%{__python_sitelib}/libzfs_core/*
+%{__python_sitelib}/pyzfs*
 %endif
 
 %if 0%{?_initramfs}

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -87,29 +87,25 @@
 %define __python_pkg_version      2
 %define __python_cffi_pkg         python-cffi
 %define __python_setuptools_pkg   python-setuptools
-%define __python_sitelib          %{python_sitelib}
 %else
 %define __python                  /usr/bin/python3
 %define __python_pkg_version      3
 %define __python_cffi_pkg         python3-cffi
 %define __python_setuptools_pkg   python3-setuptools
-%if 0%{?suse_version} >= 1500
-%define __python_sitelib          %{python3_sitelib}
-%else
-%define __python_sitelib          %{python_sitelib}
-%endif
 %endif
 %else
 %define __python                  %{__use_python}
 %define __python_pkg_version      %{__use_python_pkg_version}
 %define __python_cffi_pkg         python%{__python_pkg_version}-cffi
 %define __python_setuptools_pkg   python%{__python_pkg_version}-setuptools
-%if 0%{?suse_version} >= 1500
-%define __python_sitelib          %{python%{__python_pkg_version}_sitelib}
+%endif
+%define __py_major_version        %(%{__python} -c "import sys; print(str(sys.version_info[0]))")
+%if 0%{?__py_major} >= 3
+%define __python_sitelib          %(%{__python} -Ic "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 %else
 %define __python_sitelib          %{python_sitelib}
 %endif
-%endif
+
 
 # By default python-pyzfs is enabled, with the exception of
 # RHEL 6 which by default uses Python 2.6 which is too old.

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -99,13 +99,7 @@
 %define __python_cffi_pkg         python%{__python_pkg_version}-cffi
 %define __python_setuptools_pkg   python%{__python_pkg_version}-setuptools
 %endif
-%define __py_major_version        %(%{__python} -c "import sys; print(str(sys.version_info[0]))")
-%if 0%{?__py_major_version} >= 3
-%define __python_sitelib          %(%{__python} -Ic "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%else
-%define __python_sitelib          %{python_sitelib}
-%endif
-
+%define __python_sitelib          %(%{__python} -Esc "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 # By default python-pyzfs is enabled, with the exception of
 # RHEL 6 which by default uses Python 2.6 which is too old.


### PR DESCRIPTION
The name of python sitelib macro changed for openSuSE 15

Attempting to run make pkg-utils fails with errors expecting to find 

Processing files: python3-pyzfs-0.8.1-1.noarch
error: File not found: /tmp/.../usr/lib/python2.7/site-packages/libzfs_core/*
error: File not found: /tmp/.../usr/lib/python2.7/site-packages/pyzfs*
Executing(%doc): /bin/sh -e /tmp/zfs-build-shaun-3VGQcteZ/TMP/rpm-tmp.ONu8QE

This resolves the issue by updating the rpm macro python3_sitelib where required.

Signed-off-by: Shaun Tancheff <stancheff@cray.com>
