### PR TITLE
New service that waits on zvol links to be created

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -5,4 +5,4 @@ if USING_PYTHON
 SUBDIRS += arcstat arc_summary dbufstat
 endif
 
-SUBDIRS += mount_zfs zed zvol_id
+SUBDIRS += mount_zfs zed zvol_id zvol_wait

--- a/cmd/zvol_wait/Makefile.am
+++ b/cmd/zvol_wait/Makefile.am
@@ -1,0 +1,1 @@
+dist_bin_SCRIPTS = zvol_wait

--- a/cmd/zvol_wait/zvol_wait
+++ b/cmd/zvol_wait/zvol_wait
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+count_zvols() {
+	if [ -z "$zvols" ]; then
+		echo 0
+	else
+		echo "$zvols" | wc -l
+	fi
+}
+
+filter_out_zvols_with_links() {
+	while read -r zvol; do
+		if [ ! -L "/dev/zvol/$zvol" ]; then
+			echo "$zvol"
+		fi
+	done
+}
+
+filter_out_deleted_zvols() {
+	while read -r zvol; do
+		if zfs list "$zvol" >/dev/null 2>&1; then
+			echo "$zvol"
+		fi
+	done
+}
+
+list_zvols() {
+	zfs list -t volume -H -o name,volmode | while read -r zvol_line; do
+		name=$(echo "$zvol_line" | awk '{print $1}')
+		volmode=$(echo "$zvol_line" | awk '{print $2}')
+		# /dev links are not created for zvols with volmode = "none".
+		[ "$volmode" = "none" ] || echo "$name"
+	done
+}
+
+zvols=$(list_zvols)
+zvols_count=$(count_zvols)
+if [ "$zvols_count" -eq 0 ]; then
+	echo "No zvols found, nothing to do."
+	exit 0
+fi
+
+echo "Testing $zvols_count zvol links"
+
+outer_loop=0
+while [ "$outer_loop" -lt 20 ]; do
+	outer_loop=$((outer_loop + 1))
+
+	old_zvols_count=$(count_zvols)
+
+	inner_loop=0
+	while [ "$inner_loop" -lt 30 ]; do
+		inner_loop=$((inner_loop + 1))
+
+		zvols="$(echo "$zvols" | filter_out_zvols_with_links)"
+
+		zvols_count=$(count_zvols)
+		if [ "$zvols_count" -eq 0 ]; then
+			echo "All zvol links are now present."
+			exit 0
+		fi
+		sleep 1
+	done
+
+	echo "Still waiting on $zvols_count zvol links ..."
+	#
+	# Although zvols should normally not be deleted at boot time,
+	# if that is the case then their links will be missing and
+	# we would stall.
+	#
+	if [ "$old_zvols_count" -eq "$zvols_count" ]; then
+		echo "No progress since last loop."
+		echo "Checking if any zvols were deleted."
+
+		zvols=$(echo "$zvols" | filter_out_deleted_zvols)
+		zvols_count=$(count_zvols)
+
+		if [ "$old_zvols_count" -ne "$zvols_count" ]; then
+			echo "$((old_zvols_count - zvols_count)) zvol(s) deleted."
+		fi
+
+		if [ "$zvols_count" -ne 0 ]; then
+			echo "Remaining zvols:"
+			echo "$zvols"
+		else
+			echo "All zvol links are now present."
+			exit 0
+		fi
+	fi
+done
+
+echo "Timed out waiting on zvol links"
+exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,7 @@ AC_CONFIG_FILES([
 	cmd/zed/zed.d/Makefile
 	cmd/raidz_test/Makefile
 	cmd/zgenhostid/Makefile
+	cmd/zvol_wait/Makefile
 	contrib/Makefile
 	contrib/bash_completion.d/Makefile
 	contrib/dracut/Makefile

--- a/etc/systemd/system/50-zfs.preset.in
+++ b/etc/systemd/system/50-zfs.preset.in
@@ -5,4 +5,5 @@ enable zfs-import.target
 enable zfs-mount.service
 enable zfs-share.service
 enable zfs-zed.service
+enable zfs-volume-wait.service
 enable zfs.target

--- a/etc/systemd/system/Makefile.am
+++ b/etc/systemd/system/Makefile.am
@@ -7,7 +7,9 @@ systemdunit_DATA = \
 	zfs-import-scan.service \
 	zfs-mount.service \
 	zfs-share.service \
+	zfs-volume-wait.service \
 	zfs-import.target \
+	zfs-volumes.target \
 	zfs.target
 
 EXTRA_DIST = \
@@ -17,6 +19,8 @@ EXTRA_DIST = \
 	$(top_srcdir)/etc/systemd/system/zfs-mount.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-share.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-import.target.in \
+	$(top_srcdir)/etc/systemd/system/zfs-volume-wait.service.in \
+	$(top_srcdir)/etc/systemd/system/zfs-volumes.target.in \
 	$(top_srcdir)/etc/systemd/system/zfs.target.in \
 	$(top_srcdir)/etc/systemd/system/50-zfs.preset.in
 

--- a/etc/systemd/system/zfs-volume-wait.service.in
+++ b/etc/systemd/system/zfs-volume-wait.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=Wait for ZFS Volume (zvol) links in /dev
+DefaultDependencies=no
+After=systemd-udev-settle.service
+After=zfs-import.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=@bindir@/zvol_wait
+
+[Install]
+WantedBy=zfs-volumes.target

--- a/etc/systemd/system/zfs-volumes.target.in
+++ b/etc/systemd/system/zfs-volumes.target.in
@@ -1,0 +1,7 @@
+[Unit]
+Description=ZFS volumes are ready
+After=zfs-volume-wait.service
+Requires=zfs-volume-wait.service
+
+[Install]
+WantedBy=zfs.target

--- a/man/man1/Makefile.am
+++ b/man/man1/Makefile.am
@@ -1,4 +1,4 @@
-dist_man_MANS = zhack.1 ztest.1 raidz_test.1
+dist_man_MANS = zhack.1 ztest.1 raidz_test.1 zvol_wait.1
 EXTRA_DIST = cstyle.1
 
 install-data-local:

--- a/man/man1/zvol_wait.1
+++ b/man/man1/zvol_wait.1
@@ -1,0 +1,21 @@
+.Dd July 5, 2019
+.Dt ZVOL_WAIT 1 SMM
+.Os Linux
+.Sh NAME
+.Nm zvol_wait
+.Nd Wait for ZFS volume links in
+.Em /dev
+to be created.
+.Sh SYNOPSIS
+.Nm
+.Sh DESCRIPTION
+When a ZFS pool is imported, ZFS will register each ZFS volume
+(zvol) as a disk device with the system. As the disks are registered,
+.Xr \fBudev 7\fR
+will asynchronously create symlinks under
+.Em /dev/zvol
+using the zvol's name.
+.Nm
+will wait for all those symlinks to be created before returning.
+.Sh SEE ALSO
+.Xr \fBudev 7\fR

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -322,7 +322,7 @@ image which is ZFS aware.
 
 %if 0%{?_systemd}
     %define systemd --enable-systemd --with-systemdunitdir=%{_unitdir} --with-systemdpresetdir=%{_presetdir} --with-systemdmodulesloaddir=%{_modulesloaddir} --with-systemdgeneratordir=%{_systemdgeneratordir} --disable-sysvinit
-    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target
+    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target zfs-volume-wait.service zfs-volumes.target
 %else
     %define systemd --enable-sysvinit --disable-systemd
 %endif
@@ -419,6 +419,7 @@ systemctl --system daemon-reload >/dev/null || true
 %{_sbindir}/*
 %{_bindir}/raidz_test
 %{_bindir}/zgenhostid
+%{_bindir}/zvol_wait
 # Optional Python 2/3 scripts
 %{_bindir}/arc_summary
 %{_bindir}/arcstat


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

This creates a new service, `zfs-volume.service`. When this service becomes active, it ensures that all the zvols of imported pools are ready to use and their symlinks are created under `/dev`. Note that this service doesn't actually do any modifications to the system, it only waits for resources to be ready before returning. Any service that performs operations on zvols at boot time would want to add this service as a dependency.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
The `rtslib-fb-targetctl` service that comes with the `python-rtslib-fb` package provides a userland interface to the LIO framework, which can serve iSCSI LUNs from block devices on the system. ZFS volumes (zvols) can be used as backing block devices. However, there is currently no guarantee that the zvols are ready when that service runs at boot time. If that is the case, then `rtslib-fb-targetctl` will fail to create LUNs from those zvols. The new `zfs-volume` service can be added as a dependency to `rtslib-fb-targetctl` to avoid such situations.

### Description
<!--- Describe your changes in detail -->
The original Delphix review is here: https://github.com/delphix/zfs/pull/56.
The idea is to list all the zvols and then wait for their links under `/dev` to be created.

### How Has This Been Tested?
- See https://github.com/delphix/zfs/pull/56 for original testing.
- Made sure that the `rtslib-fb-targetctl` service doesn't report any errors at boot because of unexisting zvol links after adding a dependency on zfs-volume.service.
- Tested the new script converted to POSIX sh:
1. Reduced the inner loop iterations to test that logic better:
```
Jun 28 22:11:57 localhost systemd[1]: Starting Wait for ZFS Volume (zvol) /dev links...
Jun 28 22:12:03 localhost zvol-wait[4899]: Testing 1003 zvol links
Jun 28 22:12:04 localhost zvol-wait[4899]: Still waiting on 120 zvol links ...
Jun 28 22:12:04 localhost zvol-wait[4899]: All zvol links are now present.
Jun 28 22:12:04 localhost systemd[1]: Started Wait for ZFS Volume (zvol) /dev links.
```
2. Simulated a zvol deletion while the service is running with additional test code:
```
-- Logs begin at Wed 2019-06-19 14:49:06 UTC, end at Fri 2019-06-28 22:19:04 UTC. --
Jun 28 22:17:59 localhost systemd[1]: Starting Wait for ZFS Volume (zvol) /dev links...
Jun 28 22:18:07 pzakha-lx-4.dcenter zvol-wait[3998]: Testing 1003 zvol links
Jun 28 22:18:07 pzakha-lx-4.dcenter zvol-wait[3998]: TEST CODE: delete domain0/VOLS/zvol333
Jun 28 22:18:13 pzakha-lx-4.dcenter zvol-wait[3998]: Still waiting on 1 zvol links ...
Jun 28 22:18:18 pzakha-lx-4.dcenter zvol-wait[3998]: Still waiting on 1 zvol links ...
Jun 28 22:18:18 pzakha-lx-4.dcenter zvol-wait[3998]: No progress since last loop.
Jun 28 22:18:18 pzakha-lx-4.dcenter zvol-wait[3998]: Checking if any zvols were deleted.
Jun 28 22:18:18 pzakha-lx-4.dcenter zvol-wait[3998]: 1 zvol(s) deleted.
Jun 28 22:18:18 pzakha-lx-4.dcenter zvol-wait[3998]: All zvol links are now present.
Jun 28 22:18:18 pzakha-lx-4.dcenter systemd[1]: Started Wait for ZFS Volume (zvol) /dev links.
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
