### PR TITLE
Check b_freeze_cksum under ZFS_DEBUG_MODIFY conditional

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -1872,7 +1872,8 @@ arc_buf_try_copy_decompressed_data(arc_buf_t *buf)
 	 * There were no decompressed bufs, so there should not be a
 	 * checksum on the hdr either.
 	 */
-	EQUIV(!copied, hdr->b_l1hdr.b_freeze_cksum == NULL);
+	if (zfs_flags & ZFS_DEBUG_MODIFY)
+		EQUIV(!copied, hdr->b_l1hdr.b_freeze_cksum == NULL);
 
 	return (copied);
 }
@@ -2253,7 +2254,6 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 		 */
 		if (arc_buf_try_copy_decompressed_data(buf)) {
 			/* Skip byteswapping and checksumming (already done) */
-			ASSERT3P(hdr->b_l1hdr.b_freeze_cksum, !=, NULL);
 			return (0);
 		} else {
 			error = zio_decompress_data(HDR_GET_COMPRESS(hdr),


### PR DESCRIPTION
### Motivation and Context

Alternate fix for #8736. @ikozhukhov could you verify this change
resolves the issue on dilos as well.

### Description

The `b_freeze_cksum` field can only have data when `ZFS_DEBUG_MODIFY`
is set.  Therefore, the `EQUIV` check must be wrapped accordingly.
For the same reason the `ASSERT` in `arc_buf_fill()` is unsafe.
However, since it's largely redundant it has simply been removed.

### How Has This Been Tested?

Without this change applied, a debug build of ZFS (--enable_debug) with
the `zfs_flags`  `ZFS_DEBUG_MODIFY` bit clear would consistently fail when
running the `send_mixed_raw.ksh` test case.  With the patch applied, the
test case passes regardless of how `ZFS_DEBUG_MODIFY` is set.

Note: This issue went unnoticed since by default `ZFS_DEBUG_MODIFY` is enabled for all debug builds.  It must be explicitly cleared to reproduce the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
