### PR TITLE
Fix lockdep recursive locking false positive in dbuf_destroy

### DIFF
--- a/include/spl/sys/mutex.h
+++ b/include/spl/sys/mutex.h
@@ -127,6 +127,8 @@ spl_mutex_lockdep_on_maybe(kmutex_t *mp)			\
 })
 /* END CSTYLED */
 
+#define	NESTED_SINGLE 1
+
 #ifdef CONFIG_DEBUG_LOCK_ALLOC
 #define	mutex_enter_nested(mp, subclass)			\
 {								\

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -258,6 +258,8 @@ extern void mutex_enter(kmutex_t *mp);
 extern void mutex_exit(kmutex_t *mp);
 extern int mutex_tryenter(kmutex_t *mp);
 
+#define	NESTED_SINGLE 1
+#define	mutex_enter_nested(mp, class) mutex_enter(mp)
 /*
  * RW locks
  */

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2690,7 +2690,8 @@ dbuf_destroy(dmu_buf_impl_t *db)
 	if (db->db_blkid != DMU_BONUS_BLKID) {
 		boolean_t needlock = !MUTEX_HELD(&dn->dn_dbufs_mtx);
 		if (needlock)
-			mutex_enter(&dn->dn_dbufs_mtx);
+			mutex_enter_nested(&dn->dn_dbufs_mtx,
+			    NESTED_SINGLE);
 		avl_remove(&dn->dn_dbufs, db);
 		atomic_dec_32(&dn->dn_dbufs_count);
 		membar_producer();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->
lockdep reports a possible recursive lock in dbuf_destroy.

It is true that dbuf_destroy is acquiring the dn_dbufs_mtx
on one dnode while holding it on another dnode.  However,
it is impossible for these to be the same dnode because,
among other things,dbuf_destroy checks MUTEX_HELD before
acquiring the mutex.

This fix defines a class NESTED_SINGLE == 1 and changes
that lock to call mutex_enter_nested with a subclass of
NESTED_SINGLE.

In order to make the userspace code compile,
include/sys/zfs_context.h now defines mutex_enter_nested and
NESTED_SINGLE.

This is the lockdep report:

[  122.950921] ============================================
[  122.950921] WARNING: possible recursive locking detected
[  122.950921] 4.19.29-4.19.0-debug-d69edad5368c1166 #1 Tainted: G           O
[  122.950921] --------------------------------------------
[  122.950921] dbu_evict/1457 is trying to acquire lock:
[  122.950921] 0000000083e9cbcf (&dn->dn_dbufs_mtx){+.+.}, at: dbuf_destroy+0x3c0/0xdb0 [zfs]
[  122.950921]
               but task is already holding lock:
[  122.950921] 0000000055523987 (&dn->dn_dbufs_mtx){+.+.}, at: dnode_evict_dbufs+0x90/0x740 [zfs]
[  122.950921]
               other info that might help us debug this:
[  122.950921]  Possible unsafe locking scenario:

[  122.950921]        CPU0
[  122.950921]        ----
[  122.950921]   lock(&dn->dn_dbufs_mtx);
[  122.950921]   lock(&dn->dn_dbufs_mtx);
[  122.950921]
                *** DEADLOCK ***

[  122.950921]  May be due to missing lock nesting notation

[  122.950921] 1 lock held by dbu_evict/1457:
[  122.950921]  #0: 0000000055523987 (&dn->dn_dbufs_mtx){+.+.}, at: dnode_evict_dbufs+0x90/0x740 [zfs]
[  122.950921]
               stack backtrace:
[  122.950921] CPU: 0 PID: 1457 Comm: dbu_evict Tainted: G           O      4.19.29-4.19.0-debug-d69edad5368c1166 #1
[  122.950921] Hardware name: Supermicro H8SSL-I2/H8SSL-I2, BIOS 080011  03/13/2009
[  122.950921] Call Trace:
[  122.950921]  dump_stack+0x91/0xeb
[  122.950921]  __lock_acquire+0x2ca7/0x4f10
[  122.950921]  ? debug_show_all_locks+0x2d0/0x2d0
[  122.950921]  ? debug_show_all_locks+0x2d0/0x2d0
[  122.950921]  ? sched_clock_local+0xd8/0x130
[  122.950921]  ? sched_clock_cpu+0x133/0x170
[  122.950921]  ? arc_buf_destroy+0x21f/0x440 [zfs]
[  122.950921]  ? __lock_acquire+0xe3b/0x4f10
[  122.950921]  ? lock_acquire+0x153/0x330
[  122.950921]  lock_acquire+0x153/0x330
[  122.950921]  ? dbuf_destroy+0x3c0/0xdb0 [zfs]
[  122.950921]  ? dbuf_destroy+0x1e2/0xdb0 [zfs]
[  122.950921]  ? dbuf_destroy+0x3c0/0xdb0 [zfs]
[  122.950921]  __mutex_lock+0xef/0x1380
[  122.950921]  ? dbuf_destroy+0x3c0/0xdb0 [zfs]
[  122.950921]  ? dbuf_destroy+0x3c0/0xdb0 [zfs]
[  122.950921]  ? __mutex_add_waiter+0x160/0x160
[  122.950921]  ? sched_clock_cpu+0x133/0x170
[  122.950921]  ? __mutex_unlock_slowpath+0xf3/0x660
[  122.950921]  ? check_flags.part.23+0x480/0x480
[  122.950921]  ? zrl_add_impl+0x7e/0x380 [zfs]
[  122.950921]  ? dbuf_destroy+0x3c0/0xdb0 [zfs]
[  122.950921]  dbuf_destroy+0x3c0/0xdb0 [zfs]
[  122.950921]  dbuf_evict_one+0x1cc/0x3d0 [zfs]
[  122.950921]  dbuf_rele_and_unlock+0xb84/0xd60 [zfs]
[  122.950921]  ? dbuf_evict_one+0x3d0/0x3d0 [zfs]
[  122.950921]  ? dbuf_destroy+0x8c4/0xdb0 [zfs]
[  122.950921]  ? rcu_read_lock_sched_held+0xeb/0x120
[  122.950921]  ? kmem_cache_free+0x1b5/0x1f0
[  122.950921]  ? arc_space_return+0x7e/0x180 [zfs]
[  122.950921]  dnode_evict_dbufs+0x3a6/0x740 [zfs]
[  122.950921]  dmu_objset_evict+0x7a/0x500 [zfs]
[  122.950921]  dsl_dataset_evict_async+0x70/0x480 [zfs]
[  122.950921]  taskq_thread+0x979/0x1480 [spl]
[  122.950921]  ? taskq_thread_should_stop+0x200/0x200 [spl]
[  122.950921]  ? debug_show_all_locks+0x2d0/0x2d0
[  122.950921]  ? wake_up_q+0xf0/0xf0
[  122.950921]  ? sched_clock_local+0xd8/0x130
[  122.950921]  ? dsl_dataset_check_quota+0x8a0/0x8a0 [zfs]
[  122.950921]  ? __kthread_parkme+0xad/0x180
[  122.950921]  ? taskq_thread_should_stop+0x200/0x200 [spl]
[  122.950921]  kthread+0x2e7/0x3e0
[  122.950921]  ? kthread_park+0x120/0x120
[  122.950921]  ret_from_fork+0x27/0x50

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

The internal Akamai test suite which elicited this warning was rerun with no repeats and no regressions.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ x] All new and existing tests passed.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
 Signed-off-by: Jeff Dike <jdike@akamai.com>