### PR TITLE
Fix dracut Debian/Ubuntu packaging

### DIFF
--- a/config/deb.am
+++ b/config/deb.am
@@ -20,7 +20,7 @@ deb-kmod: deb-local rpm-kmod
 	arch=`$(RPM) -qp $${name}-kmod-$${version}.src.rpm --qf %{arch} | tail -1`; \
 	debarch=`$(DPKG) --print-architecture`; \
 	pkg1=kmod-$${name}*$${version}.$${arch}.rpm; \
-	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch $$pkg1; \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch $$pkg1 || exit 1; \
 	$(RM) $$pkg1
 
 
@@ -30,7 +30,7 @@ deb-dkms: deb-local rpm-dkms
 	arch=`$(RPM) -qp $${name}-dkms-$${version}.src.rpm --qf %{arch} | tail -1`; \
 	debarch=`$(DPKG) --print-architecture`; \
 	pkg1=$${name}-dkms-$${version}.$${arch}.rpm; \
-	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch $$pkg1; \
+	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch $$pkg1 || exit 1; \
 	$(RM) $$pkg1
 
 deb-utils: deb-local rpm-utils
@@ -45,7 +45,7 @@ deb-utils: deb-local rpm-utils
 	pkg5=libzpool2-$${version}.$${arch}.rpm; \
 	pkg6=libzfs2-devel-$${version}.$${arch}.rpm; \
 	pkg7=$${name}-test-$${version}.$${arch}.rpm; \
-	pkg8=$${name}-dracut-$${version}.$${arch}.rpm; \
+	pkg8=$${name}-dracut-$${version}.noarch.rpm; \
 	pkg9=$${name}-initramfs-$${version}.$${arch}.rpm; \
 	pkg10=`ls python*-pyzfs-$${version}* | tail -1`; \
 ## Arguments need to be passed to dh_shlibdeps. Alien provides no mechanism
@@ -63,7 +63,7 @@ deb-utils: deb-local rpm-utils
 	env PATH=$${path_prepend}:$${PATH} \
 	fakeroot $(ALIEN) --bump=0 --scripts --to-deb --target=$$debarch \
 	    $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \
-	    $$pkg8 $$pkg9 $$pkg10; \
+	    $$pkg8 $$pkg9 $$pkg10 || exit 1; \
 	$(RM) $${path_prepend}/dh_shlibdeps; \
 	rmdir $${path_prepend}; \
 	$(RM) $$pkg1 $$pkg2 $$pkg3 $$pkg4 $$pkg5 $$pkg6 $$pkg7 \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #8990 

~~I expected the Debian/Ubuntu builders to detect this kind of issue, this needs more debugging.~~

### Description
<!--- Describe your changes in detail -->
zfs-dracut package is "noarch" since ca4e5a785f844eaace4bf80cb70a3a02f1b587f6, `alien(1)` needs to know this to properly convert the dracut rpm.

To prevent future regression the make targets running alien to convert rpm->deb will now fail the build if they can't convert even a single file:

```
Putting child 0x5632c24cc770 (deb-utils) PID 12124 on the chain.
Live child 0x5632c24cc770 (deb-utils) PID 12124 
zfs_0.8.0-106_amd64.deb generated
libnvpair1_0.8.0-106_amd64.deb generated
libuutil1_0.8.0-106_amd64.deb generated
libzfs2_0.8.0-106_amd64.deb generated
libzpool2_0.8.0-106_amd64.deb generated
libzfs2-devel_0.8.0-106_amd64.deb generated
zfs-test_0.8.0-106_amd64.deb generated
zfs-dracut_0.8.0-106_amd64.deb generated
File "zfs-initramfs-0.8.0-106_gdf358db7c.x86_64.rpm" not found.
Reaping losing child 0x5632c24cc770 PID 12124 
Makefile:1381: recipe for target 'deb-utils' failed
make: *** [deb-utils] Error 1
Removing child 0x5632c24cc770 PID 12124 from chain.
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on my local Debian builder, also with --disable-pyzfs:

```
...
fakeroot alien --bump=0 --scripts --to-deb --target=$debarch \
    $pkg1 $pkg2 $pkg3 $pkg4 $pkg5 $pkg6 $pkg7 \
    $pkg8 $pkg9 $pkg10 || exit 1; \
rm -f ${path_prepend}/dh_shlibdeps; \
rmdir ${path_prepend}; \
rm -f $pkg1 $pkg2 $pkg3 $pkg4 $pkg5 $pkg6 $pkg7 \
    $pkg8 $pkg9 $pkg10;
Putting child 0x562259f28e00 (deb-utils) PID 15890 on the chain.
Live child 0x562259f28e00 (deb-utils) PID 15890 
ls: cannot access 'python*-pyzfs-0.8.0-112_g67af199fb*': No such file or directory
zfs_0.8.0-112_amd64.deb generated
libnvpair1_0.8.0-112_amd64.deb generated
libuutil1_0.8.0-112_amd64.deb generated
libzfs2_0.8.0-112_amd64.deb generated
libzpool2_0.8.0-112_amd64.deb generated
libzfs2-devel_0.8.0-112_amd64.deb generated
zfs-test_0.8.0-112_amd64.deb generated
zfs-dracut_0.8.0-112_amd64.deb generated
zfs-initramfs_0.8.0-112_amd64.deb generated
Reaping winning child 0x562259f28e00 PID 15890 
Removing child 0x562259f28e00 PID 15890 from chain.
Successfully remade target file 'deb-utils'.
root@linux:/usr/src/zfs# echo $?
0
root@linux:/usr/src/zfs# head config.log 
This file contains any messages produced by compilers while
running configure, to aid debugging if configure makes a mistake.

It was created by zfs configure 0.8.0, which was
generated by GNU Autoconf 2.69.  Invocation command line was

  $ ./configure --with-config=user --disable-pyzfs

## --------- ##
## Platform. ##
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
