### PR TITLE
Don't fail to apply umask for O_TMPFILE files

### DIFF
--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -213,6 +213,12 @@ zpl_tmpfile(struct inode *dir, struct dentry *dentry, umode_t mode)
 
 	crhold(cr);
 	vap = kmem_zalloc(sizeof (vattr_t), KM_SLEEP);
+	/*
+	 * The VFS does not apply the umask, therefore it is applied here
+	 * when POSIX ACLs are not enabled.
+	 */
+	if (!IS_POSIXACL(dir))
+		mode &= ~current_umask();
 	zpl_vap_init(vap, dir, mode, cr);
 
 	cookie = spl_fstrans_mark();

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -114,7 +114,8 @@ tests = ['snapshot_015_pos', 'snapshot_016_pos']
 tags = ['functional', 'snapshot']
 
 [tests/functional/tmpfile:Linux]
-tests = ['tmpfile_001_pos', 'tmpfile_002_pos', 'tmpfile_003_pos']
+tests = ['tmpfile_001_pos', 'tmpfile_002_pos', 'tmpfile_003_pos',
+    'tmpfile_stat_mode']
 tags = ['functional', 'tmpfile']
 
 [tests/functional/upgrade:Linux]

--- a/tests/zfs-tests/tests/functional/tmpfile/.gitignore
+++ b/tests/zfs-tests/tests/functional/tmpfile/.gitignore
@@ -2,3 +2,4 @@
 /tmpfile_001_pos
 /tmpfile_002_pos
 /tmpfile_003_pos
+/tmpfile_stat_mode

--- a/tests/zfs-tests/tests/functional/tmpfile/Makefile.am
+++ b/tests/zfs-tests/tests/functional/tmpfile/Makefile.am
@@ -8,7 +8,8 @@ dist_pkgdata_SCRIPTS = \
 
 pkgexecdir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/tmpfile
 
-pkgexec_PROGRAMS = tmpfile_test tmpfile_001_pos tmpfile_002_pos tmpfile_003_pos
+pkgexec_PROGRAMS = tmpfile_test tmpfile_001_pos tmpfile_002_pos \
+	tmpfile_003_pos tmpfile_stat_mode
 tmpfile_test_SOURCES= tmpfile_test.c
 tmpfile_001_pos_SOURCES = tmpfile_001_pos.c
 tmpfile_002_pos_SOURCES = tmpfile_002_pos.c

--- a/tests/zfs-tests/tests/functional/tmpfile/tmpfile_stat_mode.c
+++ b/tests/zfs-tests/tests/functional/tmpfile/tmpfile_stat_mode.c
@@ -1,0 +1,121 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2019 by Tomohiro Kusumi. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+/* backward compat in case it's not defined */
+#ifndef O_TMPFILE
+#define	O_TMPFILE	(020000000|O_DIRECTORY)
+#endif
+
+/*
+ * DESCRIPTION:
+ *	Verify stat(2) for O_TMPFILE file considers umask.
+ *
+ * STRATEGY:
+ *	1. open(2) with O_TMPFILE.
+ *	2. linkat(2).
+ *	3. fstat(2)/stat(2) and verify .st_mode value.
+ */
+
+static void
+test_stat_mode(mode_t mask)
+{
+	struct stat st, fst;
+	int i, fd;
+	char spath[1024], dpath[1024];
+	char *penv[] = {"TESTDIR", "TESTFILE0"};
+	mode_t masked = 0777 & ~mask;
+	mode_t mode;
+
+	/*
+	 * Get the environment variable values.
+	 */
+	for (i = 0; i < sizeof (penv) / sizeof (char *); i++) {
+		if ((penv[i] = getenv(penv[i])) == NULL) {
+			fprintf(stderr, "getenv(penv[%d])\n", i);
+			exit(1);
+		}
+	}
+
+	umask(mask);
+	fd = open(penv[0], O_RDWR|O_TMPFILE, 0777);
+	if (fd == -1) {
+		perror("open");
+		exit(2);
+	}
+
+	if (fstat(fd, &fst) == -1) {
+		perror("fstat");
+		close(fd);
+		exit(3);
+	}
+
+	snprintf(spath, sizeof (spath), "/proc/self/fd/%d", fd);
+	snprintf(dpath, sizeof (dpath), "%s/%s", penv[0], penv[1]);
+
+	unlink(dpath);
+	if (linkat(AT_FDCWD, spath, AT_FDCWD, dpath, AT_SYMLINK_FOLLOW) == -1) {
+		perror("linkat");
+		close(fd);
+		exit(4);
+	}
+	close(fd);
+
+	if (stat(dpath, &st) == -1) {
+		perror("stat");
+		exit(5);
+	}
+	unlink(dpath);
+
+	/* Verify fstat(2) result */
+	mode = fst.st_mode & 0777;
+	if (mode != masked) {
+		fprintf(stderr, "fstat(2) %o != %o\n", mode, masked);
+		exit(6);
+	}
+
+	/* Verify stat(2) result */
+	mode = st.st_mode & 0777;
+	if (mode != masked) {
+		fprintf(stderr, "stat(2) %o != %o\n", mode, masked);
+		exit(7);
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	fprintf(stdout, "Verify stat(2) for O_TMPFILE file considers umask.\n");
+
+	test_stat_mode(0022);
+	test_stat_mode(0077);
+
+	return (0);
+}


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#8997

### Description
<!--- Describe your changes in detail -->

Apply umask to `mode` which will eventually be applied to inode.
This is needed since VFS doesn't apply umask for O_TMPFILE files.

(Note that zpl_init_acl() applies `ip->i_mode &= ~current_umask();`
only when POSIX ACL is used.)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
With the code pasted in #8997.
```
# gcc -Wall -g ./tmpfile1.c
# zpool create p1 sdb
# cd /p1
# ~/a.out
current umask = 022
fstat(): in_mode=0777, resulting_mode=0100755
stat():  in_mode=0777, resulting_mode=0100755
current umask = 077
fstat(): in_mode=0777, resulting_mode=0100700
stat():  in_mode=0777, resulting_mode=0100700
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
