### PR TITLE
zfs send does not handle invalid input gracefully

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -4338,7 +4338,11 @@ zfs_do_send(int argc, char **argv)
 		return (1);
 	}
 
-	cp = strchr(argv[0], '@');
+	if ((cp = strchr(argv[0], '@')) == NULL) {
+		(void) fprintf(stderr, gettext("Error: "
+		    "Unsupported flag with filesystem or bookmark.\n"));
+		return (1);
+	}
 	*cp = '\0';
 	toname = cp + 1;
 	zhp = zfs_open(g_zfs, argv[0], ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -2422,6 +2422,10 @@ zfs_send(zfs_handle_t *zhp, const char *fromsnap, const char *tosnap,
 		}
 		zfs_handle_t *tosnap = zfs_open(zhp->zfs_hdl,
 		    full_tosnap_name, ZFS_TYPE_SNAPSHOT);
+		if (tosnap == NULL) {
+			err = -1;
+			goto err_out;
+		}
 		err = send_prelim_records(tosnap, fromsnap, outfd,
 		    flags->replicate || flags->props || flags->holds,
 		    flags->replicate, flags->verbosity > 0, flags->dryrun,
@@ -2707,6 +2711,8 @@ zfs_send_one(zfs_handle_t *zhp, const char *from, int fd, sendflags_t *flags,
 	if (from != NULL && strchr(from, '@')) {
 		zfs_handle_t *from_zhp = zfs_open(hdl, from,
 		    ZFS_TYPE_DATASET);
+		if (from_zhp == NULL)
+			return (-1);
 		if (!snapshot_is_before(from_zhp, zhp)) {
 			zfs_close(from_zhp);
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On master `zfs send` can crash when provided with invalid inputs:

```
root@linux:/usr/src/zfs# zfs send -R $POOLNAME/fs3 > /dev/null
Segmentation fault (core dumped)
root@linux:/usr/src/zfs# gdb -q zfs /var/crash/zfs.30818
Reading symbols from zfs...done.
[New LWP 30818]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `zfs send -R testpool/fs3'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00005557b743c545 in zfs_do_send (argc=1, argv=0x5557b8083f08) at zfs_main.c:4340
4340		*cp = '\0';
(gdb) bt
#0  0x00005557b743c545 in zfs_do_send (argc=1, argv=0x5557b8083f08) at zfs_main.c:4340
#1  0x00005557b74347a8 in main (argc=4, argv=<optimized out>) at zfs_main.c:8260
(gdb) list 
4335			    "cannot be sent redacted.\n"));
4336			return (1);
4337		}
4338	
4339		cp = strchr(argv[0], '@');
4340		*cp = '\0';
4341		toname = cp + 1;
4342		zhp = zfs_open(g_zfs, argv[0], ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);
4343		if (zhp == NULL)
4344			return (1);
(gdb) p cp
$1 = 0x0
(gdb) p argv[0]
$2 = 0x5557b8083c60 "testpool/fs3"
(gdb) 
```

### Description
<!--- Describe your changes in detail -->
This change attempts to add more checks to the affected code paths.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Run "zfs_send" test group on a local builder.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
