### PR TITLE
Avoid some crashes when importing a pool with corrupt metadata

### DIFF
--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -282,10 +282,11 @@ vdev_mirror_map_init(zio_t *zio)
 		}
 
 		/*
-		 * If we do not trust the pool config, some DVAs might be
-		 * invalid or point to vdevs that do not exist. We skip them.
+		 * If the pool cannot be written to, then infer that some
+		 * DVAs might be invalid or point to vdevs that do not exist.
+		 * We skip them.
 		 */
-		if (!spa_trust_config(spa)) {
+		if (!spa_writeable(spa)) {
 			ASSERT3U(zio->io_type, ==, ZIO_TYPE_READ);
 			int j = 0;
 			for (int i = 0; i < c; i++) {
@@ -309,6 +310,13 @@ vdev_mirror_map_init(zio_t *zio)
 
 			mc->mc_vd = vdev_lookup_top(spa, DVA_GET_VDEV(&dva[c]));
 			mc->mc_offset = DVA_GET_OFFSET(&dva[c]);
+			if (mc->mc_vd == NULL) {
+				kmem_free(mm, vdev_mirror_map_size(
+				    mm->mm_children));
+				zio->io_vsd = NULL;
+				zio->io_error = ENXIO;
+				return (NULL);
+			}
 		}
 	} else {
 		/*


### PR DESCRIPTION
### Motivation and Context
- Skip invalid DVAs when importing pools in readonly mode (in addition to when the config is untrusted).
- Upon encountering a DVA with a null VDEV, fail gracefully instead of panicking with a NULL pointer dereference.

### How Has This Been Tested?
Start with a pool with corrupt metadata (in my case, a spacemap was corrupt).

    # echo 0 > /sys/module/zfs/parameters/spa_load_verify_metadata
    # bin/zpool import -o readonly=on -f zones

Before: kernel panic due to NULL pointer dereference.

After: no panic, and now I'm able to access (at least some of) the data on this pool.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
   - This being a risky recovery feature, I'm not sure it should be part of the help text / man page (similar to `-X`)
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
