### PR TITLE
Disable unused pathname::pn_path* (unneeded in Linux)

### DIFF
--- a/include/sys/pathname.h
+++ b/include/sys/pathname.h
@@ -54,8 +54,10 @@ extern "C" {
  */
 typedef struct pathname {
 	char	*pn_buf;		/* underlying storage */
+#if 0 /* unused in ZoL */
 	char	*pn_path;		/* remaining pathname */
 	size_t	pn_pathlen;		/* remaining length */
+#endif
 	size_t	pn_bufsize;		/* total size of pn_buf */
 } pathname_t;
 

--- a/module/zfs/pathname.c
+++ b/module/zfs/pathname.c
@@ -71,9 +71,12 @@ pn_alloc(struct pathname *pnp)
 void
 pn_alloc_sz(struct pathname *pnp, size_t sz)
 {
-	pnp->pn_path = pnp->pn_buf = kmem_alloc(sz, KM_SLEEP);
-	pnp->pn_pathlen = 0;
+	pnp->pn_buf = kmem_alloc(sz, KM_SLEEP);
 	pnp->pn_bufsize = sz;
+#if 0 /* unused in ZoL */
+	pnp->pn_path = pnp->pn_buf;
+	pnp->pn_pathlen = 0;
+#endif
 }
 
 /*
@@ -84,6 +87,10 @@ pn_free(struct pathname *pnp)
 {
 	/* pn_bufsize is usually MAXPATHLEN, but may not be */
 	kmem_free(pnp->pn_buf, pnp->pn_bufsize);
-	pnp->pn_path = pnp->pn_buf = NULL;
-	pnp->pn_pathlen = pnp->pn_bufsize = 0;
+	pnp->pn_buf = NULL;
+	pnp->pn_bufsize = 0;
+#if 0 /* unused in ZoL */
+	pnp->pn_path = NULL;
+	pnp->pn_pathlen = 0;
+#endif
 }


### PR DESCRIPTION




<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
`struct pathname` is originally from Solaris VFS, and it has been used
in ZoL to merely call VOP from Linux VFS interface without API change,
therefore `pathname::pn_path*` are unused and unneeded. Technically,
`struct pathname` is a wrapper for C string in ZoL.

Saves stack a bit on lookup and unlink.

(#if0'd members instead of removing since comments refer to them.)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
