### PR TITLE
Set "none" scheduler if available (initramfs)

### DIFF
--- a/contrib/initramfs/scripts/zfs.in
+++ b/contrib/initramfs/scripts/zfs.in
@@ -884,20 +884,27 @@ mountroot()
 		ZFS_RPOOL="${pool}"
 	fi
 
-	# Set elevator=noop on the root pool's vdevs' disks.  ZFS already
-	# does this for wholedisk vdevs (for all pools), so this is only
-	# important for partitions.
+	# Set the no-op scheduler on the disks containing the vdevs of
+	# the root pool. For single-queue devices, this scheduler is
+	# "noop", for multi-queue devices, it is "none".
+	# ZFS already does this for wholedisk vdevs (for all pools), so this
+	# is only important for partitions.
 	"${ZPOOL}" status -L "${ZFS_RPOOL}" 2> /dev/null |
 	    awk '/^\t / && !/(mirror|raidz)/ {
 	        dev=$1;
 	        sub(/[0-9]+$/, "", dev);
 	        print dev
 	    }' |
-	    while read i
+	while read -r i
 	do
-		if grep -sq noop /sys/block/$i/queue/scheduler
+		SCHEDULER=/sys/block/$i/queue/scheduler
+		if [ -e "${SCHEDULER}" ]
 		then
-			echo noop > "/sys/block/$i/queue/scheduler"
+			# Query to see what schedulers are available
+			case "$(cat "${SCHEDULER}")" in
+				*noop*) echo noop > "${SCHEDULER}" ;;
+				*none*) echo none > "${SCHEDULER}" ;;
+			esac
 		fi
 	done
 


### PR DESCRIPTION
Existing zfs initramfs script logic will attempt to set the 'noop' scheduler if it's available on the vdev block devices. Newer kernels have the similar 'none' scheduler on multiqueue devices; this change alters the initramfs script logic to also attempt to set this scheduler.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
