### PR TITLE
[WIP] Pass arguments beginning with dash (-) to channel programs

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -7627,6 +7627,9 @@ zfs_do_channel_program(int argc, char **argv)
 	boolean_t sync_flag = B_TRUE, json_output = B_FALSE;
 	zpool_handle_t *zhp;
 
+	/* fix option scanning behavior so -args are passed to the channel program*/
+	putenv("POSIXLY_CORRECT=1");
+
 	/* check options */
 	while ((c = getopt(argc, argv, "nt:m:j")) != -1) {
 		switch (c) {

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.args_to_lua.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.args_to_lua.ksh
@@ -25,6 +25,6 @@ verify_runnable "global"
 
 log_assert "Passing arguments to lua programs should work correctly."
 
-log_must_program $TESTPOOL $ZCP_ROOT/lua_core/tst.args_to_lua.zcp foo bar
+log_must_program $TESTPOOL $ZCP_ROOT/lua_core/tst.args_to_lua.zcp -foo bar
 
 log_pass "Passing arguments to lua programs should work correctly."

--- a/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.args_to_lua.zcp
+++ b/tests/zfs-tests/tests/functional/channel_program/lua_core/tst.args_to_lua.zcp
@@ -19,7 +19,7 @@ arg = ...
 argv = arg["argv"]
 
 assert(#argv == 2)
-assert(argv[1] == "foo")
+assert(argv[1] == "-foo")
 assert(argv[2] == "bar")
 
 return


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
As documented in #9056, on Linux arguments beginning with `-` are not send to channel programs.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
Prefix getopt optstring with `+` to force the end of option scanning after the first nonoption as documented in `getopt(3)`.

<!--- Describe your changes in detail -->

### How Has This Been Tested?

`tst.args_to_lua` test has been modified to use arguments beginning with `-` to demonstrate the issue.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

This is a WIP first while I learn how the buildbot works and make sure the test demonstrates the bug before implementing the fix.