### PR TITLE
Race between zfs-share and zfs-mount services

### DIFF
--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -5,6 +5,7 @@ After=nfs-server.service nfs-kernel-server.service
 After=smb.service
 Before=rpc-statd-notify.service
 Wants=zfs-mount.service
+After=zfs-mount.service
 PartOf=nfs-server.service nfs-kernel-server.service
 PartOf=smb.service
 


### PR DESCRIPTION
When a system boots the zfs-mount.service and the
zfs-share.service can start simultaneously. What may be
unclear is that sharing a filesystem will first mount
the filesystem if it's not already mounted. This means
that both service can race to mount the same fileystem.
This race can result in a SEGFAULT or EBUSY conditions.

This change explicitly defines the start ordering between the
two services such that the zfs-mount.service is solely
responsible for mounting filesystems eliminating the race
between "zfs mount -a" and "zfs share -a" commands.

Signed-off-by: George Wilson <george.wilson@delphix.com>