### PR TITLE
initramfs fixes

### DIFF
--- a/contrib/initramfs/Makefile.am
+++ b/contrib/initramfs/Makefile.am
@@ -6,9 +6,14 @@ initrd_SCRIPTS = \
 SUBDIRS = hooks scripts
 
 EXTRA_DIST = \
+	$(top_srcdir)/etc/init.d/zfs \
+	$(top_srcdir)/etc/init.d/zfs-functions \
 	$(top_srcdir)/contrib/initramfs/conf.d/zfs \
 	$(top_srcdir)/contrib/initramfs/conf-hooks.d/zfs \
 	$(top_srcdir)/contrib/initramfs/README.initramfs.markdown
+
+$(top_srcdir)/etc/init.d/zfs $(top_srcdir)/etc/init.d/zfs-functions:
+	$(MAKE) -C $(top_srcdir)/etc/init.d zfs zfs-functions
 
 install-initrdSCRIPTS: $(EXTRA_DIST)
 	for d in conf.d conf-hooks.d scripts/local-top; do \
@@ -21,8 +26,9 @@ install-initrdSCRIPTS: $(EXTRA_DIST)
 		cp $(top_builddir)/contrib/initramfs/$$d/zfs \
 		    $(DESTDIR)$(initrddir)/$$d/; \
 	done
-	if [ -f $(top_builddir)/etc/init.d/zfs ]; then \
-		$(MKDIR_P) $(DESTDIR)$(DEFAULT_INITCONF_DIR); \
-		cp $(top_builddir)/etc/init.d/zfs \
-		    $(DESTDIR)$(DEFAULT_INITCONF_DIR)/; \
-	fi
+	$(MKDIR_P) $(DESTDIR)$(DEFAULT_INITCONF_DIR); \
+	cp $(top_builddir)/etc/init.d/zfs \
+	    $(DESTDIR)$(DEFAULT_INITCONF_DIR)/; \
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/zfs; \
+	cp $(top_builddir)/etc/init.d/zfs-functions \
+	    $(DESTDIR)$(sysconfdir)/zfs/

--- a/contrib/initramfs/hooks/zfs.in
+++ b/contrib/initramfs/hooks/zfs.in
@@ -4,16 +4,18 @@
 #
 
 # This hook installs udev rules for ZoL.
-PREREQ="zdev"
+PREREQ="udev"
 
 # These prerequisites are provided by the zfsutils package. The zdb utility is
 # not strictly required, but it can be useful at the initramfs recovery prompt.
 COPY_EXEC_LIST="@sbindir@/zdb @sbindir@/zpool @sbindir@/zfs"
 COPY_EXEC_LIST="$COPY_EXEC_LIST @mounthelperdir@/mount.zfs @udevdir@/vdev_id"
+COPY_EXEC_LIST="$COPY_EXEC_LIST @udevdir@/zvol_id"
 COPY_FILE_LIST="/etc/hostid @sysconfdir@/zfs/zpool.cache"
-COPY_FILE_LIST="$COPY_FILE_LIST @sysconfdir@/default/zfs"
+COPY_FILE_LIST="$COPY_FILE_LIST @DEFAULT_INITCONF_DIR@/zfs"
 COPY_FILE_LIST="$COPY_FILE_LIST @sysconfdir@/zfs/zfs-functions"
 COPY_FILE_LIST="$COPY_FILE_LIST @sysconfdir@/zfs/vdev_id.conf"
+COPY_FILE_LIST="$COPY_FILE_LIST @udevruledir@/60-zvol.rules"
 COPY_FILE_LIST="$COPY_FILE_LIST @udevruledir@/69-vdev.rules"
 
 # These prerequisites are provided by the base system.

--- a/etc/systemd/system/Makefile.am
+++ b/etc/systemd/system/Makefile.am
@@ -31,5 +31,9 @@ $(systemdunit_DATA) $(systemdpreset_DATA):%:%.in
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \
 		$< >'$@'
 
+install-data-hook:
+	$(MKDIR_P) "$(DESTDIR)$(systemdunitdir)"
+	ln -s /dev/null "$(DESTDIR)$(systemdunitdir)/zfs-import.service"
+
 distclean-local::
 	-$(RM) $(systemdunit_DATA) $(systemdpreset_DATA)

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -433,6 +433,14 @@ systemctl --system daemon-reload >/dev/null || true
 %{_udevdir}/vdev_id
 %{_udevdir}/zvol_id
 %{_udevdir}/rules.d/*
+%if ! 0%{?_systemd} || 0%{?_initramfs}
+# Files needed for sysvinit and initramfs-tools
+%{_sysconfdir}/%{name}/zfs-functions
+%config(noreplace) %{_initconfdir}/zfs
+%else
+%exclude %{_sysconfdir}/%{name}/zfs-functions
+%exclude %{_initconfdir}/zfs
+%endif
 %if 0%{?_systemd}
 %{_unitdir}/*
 %{_presetdir}/*
@@ -440,9 +448,10 @@ systemctl --system daemon-reload >/dev/null || true
 %{_systemdgeneratordir}/*
 %else
 %config(noreplace) %{_sysconfdir}/init.d/*
-%config(noreplace) %{_initconfdir}/zfs
 %endif
-%config(noreplace) %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/zed.d/*
+%config(noreplace) %{_sysconfdir}/%{name}/zpool.d/*
+%config(noreplace) %{_sysconfdir}/%{name}/vdev_id.conf.*.example
 %attr(440, root, root) %config(noreplace) %{_sysconfdir}/sudoers.d/*
 
 %files -n libzpool2


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #7904

Debian does not boot from zfs when using packages generated from the git repo because /etc/default/zfs and /etc/zfs/zfs-functions are missing, which both are used by the zfs initramfs script.

### Description
<!--- Describe your changes in detail -->

- Add the missing files above
- Prevent conflict of init.d/zfs-import (sysvinit) and zfs-import.target (systemd) by precautionary masking zfs-import.service
- fix the zfs initconfig location (debian: /etc/default) for distribs other than debian
- fix initramfs-tools' PREREQ parameter (zdev -> udev)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

- Tested on my debian server
- tested by @dreamcat4
- tested by @ReimuHakurei

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
