### PR TITLE
lockdep false positive - move txg_kick() outside of ->dp_lock

### DIFF
--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -889,14 +889,14 @@ dsl_pool_need_dirty_delay(dsl_pool_t *dp)
 	    zfs_dirty_data_max * zfs_delay_min_dirty_percent / 100;
 	uint64_t dirty_min_bytes =
 	    zfs_dirty_data_max * zfs_dirty_data_sync_percent / 100;
-	boolean_t rv;
+	uint64_t dirty;
 
 	mutex_enter(&dp->dp_lock);
-	if (dp->dp_dirty_total > dirty_min_bytes)
-		txg_kick(dp);
-	rv = (dp->dp_dirty_total > delay_min_bytes);
+	dirty = dp->dp_dirty_total;
 	mutex_exit(&dp->dp_lock);
-	return (rv);
+	if (dirty > dirty_min_bytes)
+		txg_kick(dp);
+	return (dirty > delay_min_bytes);
 }
 
 void


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
This fixes the lockdep warning reported below by breaking a link
between ->tx_sync_lock and ->dp_lock.

This patch is orginally from Brian Behlendorf and slightly simplified
by me.

Signed-off-by: Jeff Dike <jdike@akamai.com>
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a lockdep false positive
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
======================================================

```
WARNING: possible circular locking dependency detected
4.19.55-4.19.2-debug-b494b4b34cd8ef26 #1 Tainted: G           O
------------------------------------------------------
ccid2/5165 is trying to acquire lock:
000000001e2f33d9 (&tx->tx_sync_lock){+.+.}, at: txg_kick+0x61/0x420 [zfs]
Jul 19 19:38:53 a198-18-40-5 kernel: [  227.508666]
but task is already holding lock:
00000000ca317575 (&dp->dp_lock){+.+.}, at: dsl_pool_need_dirty_delay+0x8b/0x3f0 [zfs]
which lock already depends on the new lock.
the existing dependency chain (in reverse order) is:
-> #3 (&dp->dp_lock){+.+.}:
       dsl_pool_dirty_space+0x70/0x2d0 [zfs]
       dbuf_dirty+0x778/0x31d0 [zfs]
       dmu_write_uio_dnode+0xfe/0x300 [zfs]
       dmu_write_uio_dbuf+0xa0/0x100 [zfs]
       zfs_write+0x18bd/0x1f70 [zfs]
       zpl_write_common_iovec+0x15e/0x380 [zfs]
       zpl_iter_write+0x1c6/0x2a0 [zfs]
       __vfs_write+0x3a2/0x5b0
       vfs_write+0x15d/0x460
       ksys_write+0xed/0x210
       do_syscall_64+0x9b/0x410
       do_syscall_64+0x9b/0x410
       entry_SYSCALL_64_after_hwframe+0x49/0xbe
-> #2 (&db->db_mtx){+.+.}:
       dmu_buf_will_dirty+0x6b/0x6c0 [zfs]
       bpobj_iterate_impl+0xbe6/0x1410 [zfs]
       spa_sync+0x1756/0x29b0 [zfs]
       txg_sync_thread+0x6d6/0x1370 [zfs]
       thread_generic_wrapper+0x1ff/0x2a0 [spl]
       kthread+0x2e7/0x3e0
       ret_from_fork+0x3a/0x50
-> #1 (&bpo->bpo_lock){+.+.}:
       bpobj_space+0x63/0x470 [zfs]
       dsl_scan_active+0x340/0x3d0 [zfs]
       txg_sync_thread+0x3f2/0x1370 [zfs]
       thread_generic_wrapper+0x1ff/0x2a0 [spl]
       kthread+0x2e7/0x3e0
       ret_from_fork+0x3a/0x50
-> #0 (&tx->tx_sync_lock){+.+.}:
       __mutex_lock+0xef/0x1380
       txg_kick+0x61/0x420 [zfs]
       dsl_pool_need_dirty_delay+0x1c7/0x3f0 [zfs]
       dmu_tx_assign+0x13b/0xe40 [zfs]
       zfs_write+0xb5e/0x1f70 [zfs]
       zpl_write_common_iovec+0x15e/0x380 [zfs]
       zpl_iter_write+0x1c6/0x2a0 [zfs]
       __vfs_write+0x3a2/0x5b0
       vfs_write+0x15d/0x460
       ksys_write+0xed/0x210
       do_int80_syscall_32+0xf1/0x470
       entry_INT80_compat+0x8a/0xa0
other info that might help us debug this:
us debug this:
Chain exists of:
  &tx->tx_sync_lock --> &db->db_mtx --> &dp->dp_lock
 Possible unsafe locking scenario:
       CPU0                    CPU1
       ----                    ----
  lock(&dp->dp_lock);
                               lock(&db->db_mtx);
                               lock(&dp->dp_lock);
  lock(&tx->tx_sync_lock);
 *** DEADLOCK ***
3 locks held by ccid2/5165:
 #0: 00000000e0fb8e9d (&f->f_pos_lock){+.+.}, at: __fdget_pos+0xb1/0xe0
 #1: 00000000ad27a3c1 (sb_writers#12){.+.+}, at: vfs_write+0x332/0x460
 #2: 00000000ca317575 (&dp->dp_lock){+.+.}, at: dsl_pool_need_dirty_delay+0x8b/0x3f0 [zfs]
stack backtrace:
CPU: 5 PID: 5165 Comm: ccid2 Tainted: G           O      4.19.55-4.19.2-debug-b494b4b34cd8ef26 #1
Hardware name: Dell Inc. PowerEdge R510/0W844P, BIOS 1.1.4 11/04/2009
Call Trace:
 dump_stack+0x91/0xeb
 print_circular_bug.isra.16+0x30b/0x5b0
 ? save_trace+0xd6/0x240
 __lock_acquire+0x41be/0x4f10
 ? ftrace_caller_op_ptr+0xe/0xe
 ? debug_show_all_locks+0x2d0/0x2d0
 ? debug_show_all_locks+0x2d0/0x2d0
 ? kernel_text_address+0x6d/0x100
 ? __save_stack_trace+0x73/0xd0
 ? quarantine_put+0xb0/0x150
 ? lock_acquire+0x153/0x330
 lock_acquire+0x153/0x330
 ? txg_kick+0x61/0x420 [zfs]
 ? lock_contended+0xd60/0xd60
 ? txg_kick+0x61/0x420 [zfs]
 __mutex_lock+0xef/0x1380
 ? txg_kick+0x61/0x420 [zfs __mutex_lock+0xef/0x1380
 ? txg_kick+0x61/0x420 [zfs]
 ? txg_kick+0x61/0x420 [zfs]
 ? __mutex_add_waiter+0x160/0x160
 ? sched_clock+0x5/0x10
 ? __mutex_add_waiter+0x160/0x160
 ? __cv_destroy+0x9e/0x180 [spl]
 ? cv_destroy_wakeup+0xc0/0xc0 [spl]
 ? __mutex_unlock_slowpath+0xf3/0x660
 ? zio_wait+0x419/0x660 [zfs]
 ? txg_kick+0x61/0x420 [zfs]
 txg_kick+0x61/0x420 [zfs]
 dsl_pool_need_dirty_delay+0x1c7/0x3f0 [zfs]
 dmu_tx_assign+0x13b/0xe40 [zfs]
 ? dmu_tx_count_write+0x42f/0x700 [zfs]
 zfs_write+0xb5e/0x1f70 [zfs]
 ? sched_clock_cpu+0x18/0x170
 ? mark_held_locks+0xca/0x120
 ? sched_clock+0x5/0x10
 ? zfs_close+0x1e0/0x1e0 [zfs]
 ? sched_clock+0x5/0x10
 ? sched_clock_cpu+0x18/0x170
 ? __lock_acquire+0xe3b/0x4f10
 ? sched_clock+0x5/0x10
 ? sched_clock_cpu+0x18/0x170
 zpl_write_common_iovec+0x15e/0x380 [zfs]
 ? __lock_acquire+0xe3b/0x4f10
 ? zpl_read_common_iovec+0x2b0/0x2b0 [zfs]
 zpl_iter_write+0x1c6/0x2a0 [zfs]
 __vfs_write+0x3a2/0x5b0
 ? __fdget_pos+0xb1/0xe0
 ? kernel_read+0x130/0x130
 ? __mutex_add_waiter+0x160/0x160
 ? lock_acquire+0x153/0x330
 ? lock_acquire+0x153/0x330
 ? rcu_read_lock_sched_held+0x117/0x130
 ? rcu_sync_lockdep_assert+0x76/0xb0
 ? __sb_start_write+0xf0/0x0x76/0xb0
 ? __sb_start_write+0xf0/0x260
 vfs_write+0x15d/0x460
 ksys_write+0xed/0x210
 ? __ia32_sys_read+0xb0/0xb0
 ? trace_hardirqs_on_thunk+0x1a/0x1c
 ? do_int80_syscall_32+0x17/0x470
 do_int80_syscall_32+0xf1/0x470
 entry_INT80_compat+0x8a/0xa0
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Soaked the patch over the weekend with our test suite.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
