### PR TITLE
List log_spacemap feature in zpool-features.5 manual

### DIFF
--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -570,6 +570,28 @@ clones have been destroyed.
 .sp
 .ne 2
 .na
+\fBlog_spacemap\fR
+.ad
+.RS 4n
+.TS
+l l .
+GUID	com.delphix:log_spacemap
+READ\-ONLY COMPATIBLE	yes
+DEPENDENCIES	com.delphix:spacemap_v2
+.TE
+
+This feature improves performance for heavily-fragmented pools,
+especially when workloads are heavy in random-writes. It does so by
+logging all the metaslab changes on a single spacemap every TXG
+instead of scattering multiple writes to all the metaslab spacemaps.
+
+This feature becomes \fBactive\fR as soon as it is enabled and will never
+return to being \fBenabled\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBlz4_compress\fR
 .ad
 .RS 4n


### PR DESCRIPTION
Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>

### How Has This Been Tested?
`mandoc` output:
```
...
       livelist

           GUID                   com.delphix:livelist
           READ-ONLY COMPATIBLE   yes
           DEPENDENCIES           none
           This feature allows clones to be deleted faster than the
           traditional method when a large number of random/sparse writes have
           been made to the clone.  All blocks allocated and freed after a
           clone is created are tracked by the the clone's livelist which is
           referenced during the deletion of the clone.  The feature is
           activated when a clone is created and remains active until all
           clones have been destroyed.


       log_spacemap

           GUID                   com.delphix:log_spacemap
           READ-ONLY COMPATIBLE   yes
           DEPENDENCIES           com.delphix:spacemap_v2

           This feature improves performance for heavily-fragmented pools,
           especially when workloads are heavy in random-writes. It does so by
           logging all the metaslab changes on a single spacemap every TXG
           instead of scattering multiple writes to all the metaslab
           spacemaps.

           This feature becomes active as soon as it is enabled and will never
           return to being enabled.


       lz4_compress
....
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
