### PR TITLE
Test cancelling a removal in ZTS

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -769,7 +769,7 @@ tags = ['functional', 'refreserv']
 
 [tests/functional/removal]
 pre =
-tests = ['removal_all_vdev', 'removal_check_space',
+tests = ['removal_all_vdev', 'removal_cancel', 'removal_check_space',
     'removal_condense_export', 'removal_multiple_indirection',
     'removal_nopwrite', 'removal_remap_deadlists',
     'removal_resume_export', 'removal_sanity', 'removal_with_add',

--- a/tests/zfs-tests/tests/functional/removal/Makefile.am
+++ b/tests/zfs-tests/tests/functional/removal/Makefile.am
@@ -10,14 +10,15 @@
 #
 
 #
-# Copyright (c) 2014, 2015 by Delphix. All rights reserved.
+# Copyright (c) 2014, 2019 by Delphix. All rights reserved.
 #
 
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/removal
 
 dist_pkgdata_SCRIPTS = \
-	cleanup.ksh removal_all_vdev.ksh removal_check_space.ksh \
-	removal_condense_export.ksh removal_multiple_indirection.ksh \
+	cleanup.ksh removal_all_vdev.ksh removal_cancel.ksh \
+	removal_check_space.ksh removal_condense_export.ksh \
+	removal_multiple_indirection.ksh \
 	removal_nopwrite.ksh removal_remap_deadlists.ksh \
 	removal_reservation.ksh removal_resume_export.ksh \
 	removal_sanity.ksh removal_with_add.ksh removal_with_create_fs.ksh \

--- a/tests/zfs-tests/tests/functional/removal/removal_cancel.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_cancel.ksh
@@ -1,0 +1,99 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2018 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+#
+# DESCRIPTION:
+#
+# Ensure that cancelling a removal midway does not cause any
+# issues like cause a panic.
+#
+# STRATEGY:
+#
+# 1. Create a pool with one vdev and do some writes on it.
+# 2. Add a new vdev to the pool and start the removal of
+#    the first vdev.
+# 3. Cancel the removal after some segments have been copied
+#    over to the new vdev.
+# 4. Run zdb to ensure the on-disk state of the pool is ok.
+#
+
+function cleanup
+{
+	#
+	# Reset tunable.
+	#
+	log_must set_tunable32 zfs_removal_suspend_progress 0
+}
+log_onexit cleanup
+
+SAMPLEFILE=/$TESTDIR/00
+
+#
+# Create pool with one disk.
+#
+log_must default_setup_noexit "$REMOVEDISK"
+
+#
+# Create a file of size 1GB and then do some random writes.
+# Since randwritecomp does 8K writes we do 12500 writes
+# which means we write ~100MB to the vdev.
+#
+log_must mkfile -n 1g $SAMPLEFILE
+log_must randwritecomp $SAMPLEFILE 12500
+
+#
+# Add second device where all the data will be evacuated.
+#
+log_must zpool add -f $TESTPOOL $NOTREMOVEDISK
+
+#
+# Start removal.
+#
+log_must zpool remove $TESTPOOL $REMOVEDISK
+
+#
+# Sleep a bit and hopefully allow removal to copy some data.
+#
+log_must sleep 1
+
+#
+# Block removal.
+#
+log_must set_tunable32 zfs_removal_suspend_progress 1
+
+#
+# Only for debugging purposes in test logs.
+#
+log_must zpool status $TESTPOOL
+
+#
+# Cancel removal.
+#
+log_must zpool remove -s $TESTPOOL
+
+#
+# Verify on-disk state.
+#
+log_must zdb $TESTPOOL
+
+log_pass "Device removal thread cancelled successfully."


### PR DESCRIPTION
This patch adds a new test that sanity checks cancelling a removal.

Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>

### Description
A variation of this test has existed in DelphixOS for a while. It has helped detect bugs where there are faults in operations like forgetting to walk the `ms_freeing` or the `ms_unflushed_frees` trees from `svr_allocd_segs` when cancelling a removal. The variation that we had in DelphixOS was that instead of having `zfs_removal_suspend_progress` that just suspends removals right away (without potentially having done any copy whatsoever and thus having `svr_allocd_segs` empty to begin with) we had `zfs_remove_max_bytes_pause` which would pause removals AFTER having copied some data away from the removed device. `zfs_removal_suspend_progress` (ZoL) and `zfs_remove_max_bytes_pause` (DelphixOS) are in the same exact places in the source which makes me think that when upstreaming device removal to ZoL, people preferred the former over the latter. In any case, in order to "emulate"(/hack our way) `zfs_remove_max_bytes_pause`, we try to do enough writes in the device to be removed, so once the removal is issued we sleep for 1 second and then raise `zfs_removal_suspend_progress` to stop the removal mid-way.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
