### PR TITLE
Drop KMC_NOEMERGENCY

### DIFF
--- a/include/spl/sys/kmem_cache.h
+++ b/include/spl/sys/kmem_cache.h
@@ -45,7 +45,6 @@ enum {
 	KMC_BIT_VMEM		= 6,	/* Use vmem cache */
 	KMC_BIT_SLAB		= 7,	/* Use Linux slab cache */
 	KMC_BIT_OFFSLAB		= 8,	/* Objects not on slab */
-	KMC_BIT_NOEMERGENCY	= 9,	/* Disable emergency objects */
 	KMC_BIT_DEADLOCKED	= 14,	/* Deadlock detected */
 	KMC_BIT_GROWING		= 15,	/* Growing in progress */
 	KMC_BIT_REAPING		= 16,	/* Reaping in progress */
@@ -73,7 +72,6 @@ typedef enum kmem_cbrc {
 #define	KMC_VMEM		(1 << KMC_BIT_VMEM)
 #define	KMC_SLAB		(1 << KMC_BIT_SLAB)
 #define	KMC_OFFSLAB		(1 << KMC_BIT_OFFSLAB)
-#define	KMC_NOEMERGENCY		(1 << KMC_BIT_NOEMERGENCY)
 #define	KMC_DEADLOCKED		(1 << KMC_BIT_DEADLOCKED)
 #define	KMC_GROWING		(1 << KMC_BIT_GROWING)
 #define	KMC_REAPING		(1 << KMC_BIT_REAPING)

--- a/module/spl/spl-zlib.c
+++ b/module/spl/spl-zlib.c
@@ -202,7 +202,7 @@ spl_zlib_init(void)
 	zlib_workspace_cache = kmem_cache_create(
 	    "spl_zlib_workspace_cache",
 	    size, 0, NULL, NULL, NULL, NULL, NULL,
-	    KMC_VMEM | KMC_NOEMERGENCY);
+	    KMC_VMEM);
 	if (!zlib_workspace_cache)
 		return (1);
 


### PR DESCRIPTION
This is not implemented. If it were implemented, using it would risk
deadlocks on pre-3.18 kernels. Lets just drop it.

Signed-off-by: Richard Yao <ryao@gentoo.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is not implemented. If it were implemented, using it would risk deadlocks on pre-3.18 kernels.
### Description
<!--- Describe your changes in detail -->
Delete unnecessary definitions.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
No testing was done. Testing the removal of something unused is unnecessary beyond buildbot tests.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
