### PR TITLE
add regression test for "zpool list -p"

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -360,7 +360,7 @@ tags = ['functional', 'cli_root', 'zpool_export']
 
 [tests/functional/cli_root/zpool_get]
 tests = ['zpool_get_001_pos', 'zpool_get_002_pos', 'zpool_get_003_pos',
-    'zpool_get_004_neg']
+    'zpool_get_004_neg', 'zpool_get_005_pos']
 tags = ['functional', 'cli_root', 'zpool_get']
 
 [tests/functional/cli_root/zpool_history]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/Makefile.am
@@ -5,7 +5,8 @@ dist_pkgdata_SCRIPTS = \
 	zpool_get_001_pos.ksh \
 	zpool_get_002_pos.ksh \
 	zpool_get_003_pos.ksh \
-	zpool_get_004_neg.ksh
+	zpool_get_004_neg.ksh \
+	zpool_get_005_pos.ksh
 
 dist_pkgdata_DATA = \
-	zpool_get.cfg
+	zpool_get.cfg zpool_get_parsable.cfg

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_005_pos.ksh
@@ -1,4 +1,4 @@
-#!/usr/bin/ksh -p
+#!/bin/ksh -p
 #
 # CDDL HEADER START
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_005_pos.ksh
@@ -55,11 +55,12 @@ while [[ $i -lt "${#properties[@]}" ]]; do
 		log_fail "${properties[$i]} not seen in output"
 	fi
 
-	typeset v=$(grep "${properties[$i]}" /tmp/value.$$ | $AWK '{print $3}')
+	typeset v=$(grep "${properties[$i]}" /tmp/value.$$ | awk '{print $3}')
 
 	log_note "${properties[$i]} has a value of $v"
 
 	# Determine if this value is a valid number, result in return code
+	log_must test -n "$v"
 	expr $v + 0 >/dev/null 2>&1
 
 	# All properties must be positive integers in order to be

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_005_pos.ksh
@@ -1,0 +1,77 @@
+#!/usr/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2014 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_get/zpool_get_parsable.cfg
+
+#
+# DESCRIPTION:
+#
+# Zpool get returns parsable values for all known parsable properties
+#
+# STRATEGY:
+# 1. For all parsable properties, verify zpool get -p returns a parsable value
+#
+
+if ! is_global_zone ; then
+	TESTPOOL=${TESTPOOL%%/*}
+fi
+
+typeset -i i=0
+
+while [[ $i -lt "${#properties[@]}" ]]; do
+	log_note "Checking for parsable ${properties[$i]} property"
+	log_must eval "zpool get -p ${properties[$i]} $TESTPOOL >/tmp/value.$$"
+	grep "${properties[$i]}" /tmp/value.$$ >/dev/null 2>&1
+	if [[ $? -ne 0 ]]; then
+		log_fail "${properties[$i]} not seen in output"
+	fi
+
+	typeset v=$(grep "${properties[$i]}" /tmp/value.$$ | $AWK '{print $3}')
+
+	log_note "${properties[$i]} has a value of $v"
+
+	# Determine if this value is a valid number, result in return code
+	expr $v + 0 >/dev/null 2>&1
+
+	# All properties must be positive integers in order to be
+	# parsable (i.e. a return code of 0 or 1 from expr above).
+	# The only exception is "expandsize", which may be "-".
+	if [[ ! ($? -eq 0 || $? -eq 1 || \
+	    ("${properties[$i]}" = "expandsize" && "$v" = "-")) ]]; then
+		log_fail "${properties[$i]} is not parsable"
+	fi
+
+	i=$(( $i + 1 ))
+done
+
+rm /tmp/value.$$
+log_pass "Zpool get returns parsable values for all known parsable properties"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_parsable.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_parsable.cfg
@@ -1,0 +1,33 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013, 2014 by Delphix. All rights reserved.
+#
+
+# Set the expected properties of zpool
+typeset -a properties=("allocated" "capacity" "expandsize" "free" "freeing"
+    "leaked" "size")


### PR DESCRIPTION
Signed-off-by: Paul Dagnelie <pcd@delphix.com>

### Motivation and Context
Other than this test, `zpool list -p` is not well tested by any of the automated tests.

### Description
Add a test for `zpool list -p`

### How Has This Been Tested?
Ran the test on Linux

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
