### PR TITLE
Add more refquota tests

### DIFF
--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -758,7 +758,8 @@ tags = ['functional', 'redundancy']
 
 [tests/functional/refquota]
 tests = ['refquota_001_pos', 'refquota_002_pos', 'refquota_003_pos',
-    'refquota_004_pos', 'refquota_005_pos', 'refquota_006_neg']
+    'refquota_004_pos', 'refquota_005_pos', 'refquota_006_neg',
+    'refquota_007_neg', 'refquota_008_neg']
 tags = ['functional', 'refquota']
 
 [tests/functional/refreserv]

--- a/tests/zfs-tests/tests/functional/refquota/Makefile.am
+++ b/tests/zfs-tests/tests/functional/refquota/Makefile.am
@@ -7,4 +7,6 @@ dist_pkgdata_SCRIPTS = \
 	refquota_003_pos.ksh \
 	refquota_004_pos.ksh \
 	refquota_005_pos.ksh \
-	refquota_006_neg.ksh
+	refquota_006_neg.ksh \
+	refquota_007_neg.ksh \
+	refquota_008_neg.ksh

--- a/tests/zfs-tests/tests/functional/refquota/refquota_007_neg.ksh
+++ b/tests/zfs-tests/tests/functional/refquota/refquota_007_neg.ksh
@@ -1,0 +1,61 @@
+#!/bin/ksh
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#       refquota limits the amount of space a dataset can consume,
+#       snapshot rollback should be limited by refquota.
+#
+# STRATEGY:
+#       1. Create a file in a filesystem
+#       2. Create a snapshot of the filesystem
+#       3. Remove the file
+#       4. Set a refquota of size half of the file
+#       5. Rollback the filesystem from the snapshot
+#       6. Rollback should fail
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must $ZFS destroy -rf $TESTPOOL/$TESTFS
+	log_must $ZFS create $TESTPOOL/$TESTFS
+	log_must $ZFS set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
+}
+
+log_onexit cleanup
+
+TESTFILE='testfile'
+FS=$TESTPOOL/$TESTFS
+
+mntpnt=$(get_prop mountpoint $FS)
+log_must mkfile 20M $mntpnt/$TESTFILE
+log_must zfs snapshot $FS@snap20M
+log_must rm $mntpnt/$TESTFILE
+
+log_must sync
+
+log_must zfs set refquota=10M $FS
+log_mustnot zfs rollback $FS@snap20M
+
+log_pass "The rollback to the snapshot was restricted by refquota."

--- a/tests/zfs-tests/tests/functional/refquota/refquota_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/refquota/refquota_008_neg.ksh
@@ -39,14 +39,18 @@
 
 verify_runnable "both"
 
+oldvalue=$(get_tunable spa_asize_inflation)
 function cleanup
 {
+	set_tunable32 spa_asize_inflation $oldvalue
         log_must zfs destroy -rf $TESTPOOL/$TESTFS
         log_must zfs create $TESTPOOL/$TESTFS
         log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 }
 
 log_onexit cleanup
+
+set_tunable32 spa_asize_inflation 2
 
 TESTFILE='testfile'
 FS=$TESTPOOL/$TESTFS
@@ -56,11 +60,11 @@ log_must zfs create $FS/$TESTSUBFS2
 mntpnt1=$(get_prop mountpoint $FS/$TESTSUBFS1)
 mntpnt2=$(get_prop mountpoint $FS/$TESTSUBFS2)
 
-log_must mkfile 800M $mntpnt1/$TESTFILE
-log_must zfs snapshot $FS/$TESTSUBFS1@snap800m
+log_must mkfile 200M $mntpnt1/$TESTFILE
+log_must zfs snapshot $FS/$TESTSUBFS1@snap200m
 
 log_must zfs set refquota=10M $FS/$TESTSUBFS2
-log_mustnot eval "zfs send $FS/$TESTSUBFS1@snap800m |" \
+log_mustnot eval "zfs send $FS/$TESTSUBFS1@snap200m |" \
         "zfs receive -F $FS/$TESTSUBFS2"
 
 log_pass "ZFS receive does not override refquota"

--- a/tests/zfs-tests/tests/functional/refquota/refquota_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/refquota/refquota_008_neg.ksh
@@ -1,0 +1,67 @@
+#!/bin/ksh
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#       refquota limits the amount of space a dataset can consume,
+#       This test verifies that zfs receive does not override
+#       refquota.
+#
+# STRATEGY:
+#       1. Create a sub-filesystem $TESTSUBFS1
+#       2. Create a file in the sub-filesystem $TESTSUBFS1
+#       3. Create a snapshot of the sub-filesystem $TESTSUBFS1
+#       4. Create another sub-filesystem $TESTSUBFS2
+#       5. Apply a refquota value to $TESTSUBFS2,
+#		half the sub-filesystem $TESTSUBFS1 file size
+#       6. Verify that zfs receive of the snapshot of $TESTSUBFS1
+#		fails due to refquota
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+        log_must zfs destroy -rf $TESTPOOL/$TESTFS
+        log_must zfs create $TESTPOOL/$TESTFS
+        log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
+}
+
+log_onexit cleanup
+
+TESTFILE='testfile'
+FS=$TESTPOOL/$TESTFS
+log_must zfs create $FS/$TESTSUBFS1
+log_must zfs create $FS/$TESTSUBFS2
+
+mntpnt1=$(get_prop mountpoint $FS/$TESTSUBFS1)
+mntpnt2=$(get_prop mountpoint $FS/$TESTSUBFS2)
+
+log_must mkfile 800M $mntpnt1/$TESTFILE
+log_must zfs snapshot $FS/$TESTSUBFS1@snap800m
+
+log_must zfs set refquota=10M $FS/$TESTSUBFS2
+log_mustnot eval "zfs send $FS/$TESTSUBFS1@snap800m |" \
+        "zfs receive -F $FS/$TESTSUBFS2"
+
+log_pass "ZFS receive does not override refquota"
+


### PR DESCRIPTION
Signed-off-by: Paul Dagnelie <pcd@delphix.com>

### Motivation and Context
It used to be possible for zfs receive (and other operations related to clone swap) to bypass refquotas. This can cause a number of issues, and there should be an automated test for it.

### Description
Added tests for rollback and receive not overriding refquota

### How Has This Been Tested?
Ran the refquota test suite.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
