### PR TITLE
Sort log spacemap tunables in alphabetical order

### DIFF
--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -1283,6 +1283,43 @@ spa_ld_log_spacemaps(spa_t *spa)
 
 #if defined(_KERNEL)
 /* BEGIN CSTYLED */
+module_param(zfs_keep_log_spacemaps_at_export, int, 0644);
+MODULE_PARM_DESC(zfs_keep_log_spacemaps_at_export,
+    "Prevent the log spacemaps from being flushed and destroyed "
+    "during pool export/destroy");
+
+module_param(zfs_max_logsm_summary_length, ulong, 0644);
+MODULE_PARM_DESC(zfs_max_logsm_summary_length,
+    "Maximum number of rows allowed in the summary of "
+    "the spacemap log");
+
+module_param(zfs_max_log_walking, ulong, 0644);
+MODULE_PARM_DESC(zfs_max_log_walking,
+    "The number of past TXGs that the flushing algorithm of the log "
+    "spacemap feature uses to estimate incoming log blocks");
+
+module_param(zfs_min_metaslabs_to_flush, ulong, 0644);
+MODULE_PARM_DESC(zfs_min_metaslabs_to_flush,
+    "Minimum number of metaslabs to flush per dirty TXG");
+
+module_param(zfs_unflushed_log_block_pct, ulong, 0644);
+MODULE_PARM_DESC(zfs_unflushed_log_block_pct,
+    "Tunable used to determine the number of blocks that can be "
+    "used for the spacemap log, expressed as a percentage of the "
+    " total number of metaslabs in the pool (e.g. 400 means the "
+    " number of log blocks is capped at 4 times the number of "
+    "metaslabs)");
+
+module_param(zfs_unflushed_log_block_max, ulong, 0644);
+MODULE_PARM_DESC(zfs_unflushed_log_block_max,
+    "Hard limit (upper-bound) in the size of the space map log "
+    "in terms of blocks.");
+
+module_param(zfs_unflushed_log_block_min, ulong, 0644);
+MODULE_PARM_DESC(zfs_unflushed_log_block_min,
+    "Lower-bound limit for the maximum amount of blocks in "
+    "log spacemap.");
+
 module_param(zfs_unflushed_max_mem_amt, ulong, 0644);
 MODULE_PARM_DESC(zfs_unflushed_max_mem_amt,
     "Specific hard-limit in memory that ZFS allows to be used for "
@@ -1293,42 +1330,5 @@ MODULE_PARM_DESC(zfs_unflushed_max_mem_ppm,
     "Percentage of the overall system memory that ZFS allows to be "
     "used for unflushed changes (value is calculated over 1000000 for "
     "finer granularity");
-
-module_param(zfs_unflushed_log_block_max, ulong, 0644);
-MODULE_PARM_DESC(zfs_unflushed_log_block_max,
-    "Hard limit (upper-bound) in the size of the space map log "
-    "in terms of blocks.");
-
-module_param(zfs_unflushed_log_block_min, ulong, 0644);
-MODULE_PARM_DESC(zfs_unflushed_log_block_min,
-    "Lower-bound limit for the maximum amount of blocks allowed in "
-    "log spacemap (see zfs_unflushed_log_block_max)");
-
-module_param(zfs_unflushed_log_block_pct, ulong, 0644);
-MODULE_PARM_DESC(zfs_unflushed_log_block_pct,
-    "Tunable used to determine the number of blocks that can be "
-    "used for the spacemap log, expressed as a percentage of the "
-    " total number of metaslabs in the pool (e.g. 400 means the "
-    " number of log blocks is capped at 4 times the number of "
-    "metaslabs)");
-
-module_param(zfs_max_log_walking, ulong, 0644);
-MODULE_PARM_DESC(zfs_max_log_walking,
-    "The number of past TXGs that the flushing algorithm of the log "
-    "spacemap feature uses to estimate incoming log blocks");
-
-module_param(zfs_max_logsm_summary_length, ulong, 0644);
-MODULE_PARM_DESC(zfs_max_logsm_summary_length,
-    "Maximum number of rows allowed in the summary of "
-    "the spacemap log");
-
-module_param(zfs_min_metaslabs_to_flush, ulong, 0644);
-MODULE_PARM_DESC(zfs_min_metaslabs_to_flush,
-    "Minimum number of metaslabs to flush per dirty TXG");
-
-module_param(zfs_keep_log_spacemaps_at_export, int, 0644);
-MODULE_PARM_DESC(zfs_keep_log_spacemaps_at_export,
-    "Prevent the log spacemaps from being flushed and destroyed "
-    "during pool export/destroy");
 /* END CSTYLED */
 #endif


### PR DESCRIPTION
Beside the whole commit being a nit in reality it should
bring the diffs of the spa_log_spacemap.c source file
between ZoL and delphix/zfs to 0.

Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
