### PR TITLE
zfs-functions.in: is_mounted() always returns 1

### DIFF
--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -373,10 +373,13 @@ read_mtab()
 
 in_mtab()
 {
-	local fs="$(echo "$1" | sed 's,/,_,g')"
+	local mntpnt="$1"
+	# Remove 'unwanted' characters.
+	mntpnt=$(printf '%b\n' "$mntpnt" | sed -e 's,/,,g' \
+	    -e 's,-,,g' -e 's,\.,,g' -e 's, ,,g')  
 	local var
 
-	var="$(eval echo MTAB_$fs)"
+	var="$(eval echo MTAB_$mntpnt)"
 	[ "$(eval echo "$""$var")" != "" ]
 	return "$?"
 }


### PR DESCRIPTION
`$fs` used with the wrong sed command where should be `$mntpnt` instead
to match a variable exported by `read_mtab()`

The fix is mostly to reuse the sed command found in `read_mtab()`

Signed-off-by: Alexey Smirnoff <fling@member.fsf.org>

<!--- Please fill out the following template, which will help other contributors review your Pull 
Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I need the working `in_mtab()` function
to be able to implement rw remount in `/etc/init.d/zfs-mount`

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).