### PR TITLE
Linux 5.3 compat: Makefile subdir-m no longer supported.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,14 @@ cscope.*
 *.log
 venv
 
+#
+# Module leftovers
+#
+/module/avl/zavl.mod
+/module/icp/icp.mod
+/module/lua/zlua.mod
+/module/nvpair/znvpair.mod
+/module/spl/spl.mod
+/module/unicode/zunicode.mod
+/module/zcommon/zcommon.mod
+/module/zfs/zfs.mod

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -1,11 +1,11 @@
-subdir-m += avl
-subdir-m += icp
-subdir-m += lua
-subdir-m += nvpair
-subdir-m += spl
-subdir-m += unicode
-subdir-m += zcommon
-subdir-m += zfs
+obj-m += avl/
+obj-m += icp/
+obj-m += lua/
+obj-m += nvpair/
+obj-m += spl/
+obj-m += unicode/
+obj-m += zcommon/
+obj-m += zfs/
 
 INSTALL_MOD_DIR ?= extra
 
@@ -60,13 +60,13 @@ modules_install:
 modules_uninstall:
 	@# Uninstall the kernel modules
 	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@
-	list='$(subdir-m)'; for subdir in $$list; do \
-		$(RM) -R $$kmoddir/$(INSTALL_MOD_DIR)/$$subdir; \
+	list='$(obj-m)'; for objdir in $$list; do \
+		$(RM) -R $$kmoddir/$(INSTALL_MOD_DIR)/$$objdir; \
 	done
 
 distdir:
-	list='$(subdir-m)'; for subdir in $$list; do \
-		(cd @top_srcdir@/module && find $$subdir \
+	list='$(obj-m)'; for objdir in $$list; do \
+		(cd @top_srcdir@/module && find $$objdir \
 		-name '*.c' -o -name '*.h' -o -name '*.S' | \
 		xargs cp --parents -t @abs_top_builddir@/module/$$distdir); \
 	done


### PR DESCRIPTION
Uses obj-m instead, due to kernel changes.

See [LKML](https://lkml.org/lkml/2019/8/6/335): [PATCH 3/3] kbuild: show hint if subdir-y/m is used to visit module Makefile

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
zfs fails to build on linux-5.3

### Description
Trivial change to the Makefile.in to replace subdir-m with obj-m as per the LKML thread.

### How Has This Been Tested?
"It works on my machine." zfs module successfully builds and loads on 5.3.0-rc4 with these changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
