### PR TITLE
etc/init.d/zfs-functions.in: remove arch warning 

### DIFF
--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -294,13 +294,6 @@ checksystem()
 	# Just make sure that /dev/zfs is created.
 	udev_trigger
 
-	if ! [ "$(uname -m)" = "x86_64" ]; then
-		echo "Warning: You're not running 64bit. Currently native zfs in";
-		echo "         Linux is only supported and tested on 64bit.";
-		# should we break here? People doing this should know what they
-		# do, thus i'm not breaking here.
-	fi
-
 	return 0
 }
 


### PR DESCRIPTION
Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
ZFS works and build-tested on those arches.
In fact it's even tested on arm and ppc, but those are 32bit arches.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Stop printing misleading warning on boot.
### Description
<!--- Describe your changes in detail -->
I extended the check to known-good `uname -m` values.
```diff
diff --git a/etc/init.d/zfs-functions.in b/etc/init.d/zfs-functions.in
index 490503e91..abc8617df 100644
--- a/etc/init.d/zfs-functions.in
+++ b/etc/init.d/zfs-functions.in
@@ -294,12 +294,17 @@ checksystem()
        # Just make sure that /dev/zfs is created.
        udev_trigger
 
-       if ! [ "$(uname -m)" = "x86_64" ]; then
-               echo "Warning: You're not running 64bit. Currently native zfs in";
-               echo "         Linux is only supported and tested on 64bit.";
-               # should we break here? People doing this should know what they
-               # do, thus i'm not breaking here.
-       fi
+       case "$(uname -m)" in
+               aarch64|ppc64|ppc64le|x86_64)
+                       ;;
+               *)
+                       # should we break here? People doing this should know
+                       # what they do, thus i'm not breaking here.     
+                       echo "Warning: You're not running supported arch."
+                       echo "         Currently native zfs on Linux is only"
+                       echo "         supported and tested on 64bit arches"
+                       ;;
+       esac
 
        return 0
 }
```
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
system boots, no longer prints a warning.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
