### PR TITLE
Fix automake program name transformations

### DIFF
--- a/cmd/arc_summary/Makefile.am
+++ b/cmd/arc_summary/Makefile.am
@@ -1,11 +1,17 @@
 EXTRA_DIST = arc_summary2 arc_summary3
 
+transform = $(program_transform_name)
+
 if USING_PYTHON_2
 dist_bin_SCRIPTS = arc_summary2
 install-exec-hook:
-	mv $(DESTDIR)$(bindir)/arc_summary2 $(DESTDIR)$(bindir)/arc_summary
+	before=$$(echo arc_summary2 | sed '$(transform)'); \
+	after=$$(echo arc_summary | sed '$(transform)'); \
+	mv "$(DESTDIR)$(bindir)/$$before" "$(DESTDIR)$(bindir)/$$after"
 else
 dist_bin_SCRIPTS = arc_summary3
 install-exec-hook:
-	mv $(DESTDIR)$(bindir)/arc_summary3 $(DESTDIR)$(bindir)/arc_summary
+	before=$$(echo arc_summary3 | sed '$(transform)'); \
+	after=$$(echo arc_summary | sed '$(transform)'); \
+	mv "$(DESTDIR)$(bindir)/$$before" "$(DESTDIR)$(bindir)/$$after"
 endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Automake can perform program name transformations at install time. However, arc_summary has its own name transformation taking place, which interferes with the automake transforms. The automake transforms must be taken into account in order to resolve the conflict.

### Description
<!--- Describe your changes in detail -->
The program name transform is a sed script available to make. The name of the arc_summary program must be transformed using this script in order to successfully rename it from arc_summary2 or arc_summary3 to arc_summary when program name transforms have been used.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
I have been building and testing ZFS on FreeBSD (and on Linux) with this change for a few months.
Try it at home with `./configure --program-suffix=foobar` and a standard `make && sudo make install DESTDIR=/tmp/suffixed`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
