### PR TITLE
Document ZFS_DKMS_ENABLE_DEBUGINFO in userland configuration

### DIFF
--- a/etc/init.d/zfs.in
+++ b/etc/init.d/zfs.in
@@ -91,6 +91,10 @@ MOUNT_EXTRA_OPTIONS=""
 # Only applicable for Debian GNU/Linux {dkms,initramfs}.
 ZFS_DKMS_ENABLE_DEBUG='no'
 
+# Build kernel modules with the --enable-debuginfo switch?
+# Only applicable for Debian GNU/Linux {dkms,initramfs}.
+ZFS_DKMS_ENABLE_DEBUGINFO='no'
+
 # Keep debugging symbols in kernel modules?
 # Only applicable for Debian GNU/Linux {dkms,initramfs}.
 ZFS_DKMS_DISABLE_STRIP='no'


### PR DESCRIPTION
Document the `ZFS_DKMS_ENABLE_DEBUGINFO` option in the userland
configuration file, as done with the other `ZFS_DKMS_*` options.

It has been introduced with commit e45c1734a665 ("dkms: Enable
debuginfo option to be set with zfs sysconfig file") but isn't
mentioned anywhere other than the `dkms.conf` file (generated).

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The option to enable debuginfo in kernel modules built with DKMS
is not directly exposed to the user in the userland configuration file,
differently from other, existing options for similar purposes.

Even though a slightly more advanced user (who cares about debug
symbols, or has been asked to enable/build them) eventually can
figure out the `dkms.conf` file, this is certainly not too straighforward.

Since other, similar options are already in there, just add this one too.

### Description
<!--- Describe your changes in detail -->

This exposes the `ZFS_DKMS_ENABLE_DEBUGINFO` option
(consumed by `scripts/dkms.mkconf` to generate a `dkms.conf` file)
in the userland configuration file, similarly to other related options.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

This has been tested by checking for `.gnu_debuginfo` section in kernel modules
built with DKMS before/after enabling this option (plus option to disable stripping),
and confirming the debug symbol information matched the source code lines.
(please see `Testing` section below.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

### Testing

Before:

```
$ find /lib/modules/5.2.0-10-generic/updates/dkms/ -name '*.ko' \
  | while read ko; do \
    echo "* $ko"; \
    objdump -h $ko \
      | grep .debug_info || echo '  - No .debug_info sections'; \
    echo; \
  done

* /lib/modules/5.2.0-10-generic/updates/dkms/zunicode.ko
  - No .debug_info sections

* /lib/modules/5.2.0-10-generic/updates/dkms/zlua.ko
  - No .debug_info sections

* /lib/modules/5.2.0-10-generic/updates/dkms/zavl.ko
  - No .debug_info sections

* /lib/modules/5.2.0-10-generic/updates/dkms/zfs.ko
  - No .debug_info sections

* /lib/modules/5.2.0-10-generic/updates/dkms/znvpair.ko
  - No .debug_info sections

* /lib/modules/5.2.0-10-generic/updates/dkms/zcommon.ko
  - No .debug_info sections

* /lib/modules/5.2.0-10-generic/updates/dkms/icp.ko
  - No .debug_info sections

* /lib/modules/5.2.0-10-generic/updates/dkms/spl.ko
  - No .debug_info sections
```

After:

```
$ grep ^PACKAGE_CONFIG /usr/src/zfs-0.8.1/dkms.conf
PACKAGE_CONFIG="/etc/default/zfs"

$ sudo sed -i \
  -e '/^ZFS_DKMS_ENABLE_DEBUGINFO=/ s/no/yes/' \
  -e '/^ZFS_DKMS_DISABLE_STRIP=/    s/no/yes/' \ 
  /etc/default/zfs

$ sudo dkms remove zfs/0.8.1 -k 5.2.0-10-generic
$ sudo dkms build  zfs/0.8.1 -k 5.2.0-10-generic
...
checking whether debuginfo support will be forced... yes
...
DKMS: build completed.

$ sudo dkms install zfs/0.8.1 -k 5.2.0-10-generic

$ find /lib/modules/5.2.0-10-generic/updates/dkms/ -name '*.ko' \
  | while read ko; do \
    echo "* $ko"; \
    objdump -h $ko \
      | grep .debug_info || echo '  - No .debug_info sections'; \
    echo; \
  done

* /lib/modules/5.2.0-10-generic/updates/dkms/zunicode.ko
 16 .debug_info   0003afc9  0000000000000000  0000000000000000  0004e227  2**0

* /lib/modules/5.2.0-10-generic/updates/dkms/zlua.ko
 19 .debug_info   0029ccfe  0000000000000000  0000000000000000  0001bd50  2**0

* /lib/modules/5.2.0-10-generic/updates/dkms/zavl.ko
 18 .debug_info   0001097b  0000000000000000  0000000000000000  0000110a  2**0

* /lib/modules/5.2.0-10-generic/updates/dkms/zfs.ko
 26 .debug_info   01137c6d  0000000000000000  0000000000000000  0018af72  2**0

* /lib/modules/5.2.0-10-generic/updates/dkms/znvpair.ko
 17 .debug_info   0004c59c  0000000000000000  0000000000000000  00009de1  2**0

* /lib/modules/5.2.0-10-generic/updates/dkms/zcommon.ko
 23 .debug_info   001202d1  0000000000000000  0000000000000000  0000a6f3  2**0

* /lib/modules/5.2.0-10-generic/updates/dkms/icp.ko
 22 .debug_info   004013ec  0000000000000000  0000000000000000  00033940  2**0

* /lib/modules/5.2.0-10-generic/updates/dkms/spl.ko
 26 .debug_info   001462e2  0000000000000000  0000000000000000  000107e1  2**0

$ objdump -d /lib/modules/5.2.0-10-generic/updates/dkms/zfs.ko | grep -A18 '<zfs_zinactive>:' | tail -n1
  100edc:	e8 4f c2 ff ff       	callq  fd130 <zfs_znode_hold_enter>

$ addr2line -pifae /lib/modules/5.2.0-10-generic/updates/dkms/zfs.ko 0x100edc
0x0000000000100edc: zfs_zinactive at /var/lib/dkms/zfs/0.8.1/build/module/zfs/zfs_znode.c:1320

$ sed -n 1320p /usr/src/zfs-0.8.1/module/zfs/zfs_znode.c
	zh = zfs_znode_hold_enter(zfsvfs, z_id);
```