### PR TITLE
add callbacks to taskq create

### DIFF
--- a/include/spl/sys/taskq.h
+++ b/include/spl/sys/taskq.h
@@ -74,6 +74,7 @@ typedef enum tq_lock_role {
 
 typedef unsigned long taskqid_t;
 typedef void (task_func_t)(void *);
+typedef void (*taskq_callback_fn)(void *);
 
 typedef struct taskq {
 	spinlock_t		tq_lock;	/* protects taskq_t */
@@ -100,6 +101,8 @@ typedef struct taskq {
 	spl_wait_queue_head_t	tq_work_waitq;	/* new work waitq */
 	spl_wait_queue_head_t	tq_wait_waitq;	/* wait waitq */
 	tq_lock_role_t		tq_lock_class;	/* class when taking tq_lock */
+	taskq_callback_fn	tq_ctor;
+	taskq_callback_fn	tq_dtor;
 } taskq_t;
 
 typedef struct taskq_ent {
@@ -145,6 +148,8 @@ extern void taskq_dispatch_ent(taskq_t *, task_func_t, void *, uint_t,
 extern int taskq_empty_ent(taskq_ent_t *);
 extern void taskq_init_ent(taskq_ent_t *);
 extern taskq_t *taskq_create(const char *, int, pri_t, int, int, uint_t);
+extern taskq_t *taskq_create_with_callbacks(const char *, int, pri_t, int,
+    int, uint_t, taskq_callback_fn, taskq_callback_fn);
 extern void taskq_destroy(taskq_t *);
 extern void taskq_wait_id(taskq_t *, taskqid_t);
 extern void taskq_wait_outstanding(taskq_t *, taskqid_t);
@@ -152,8 +157,8 @@ extern void taskq_wait(taskq_t *);
 extern int taskq_cancel_id(taskq_t *, taskqid_t);
 extern int taskq_member(taskq_t *, kthread_t *);
 
-#define	taskq_create_proc(name, nthreads, pri, min, max, proc, flags) \
-    taskq_create(name, nthreads, pri, min, max, flags)
+#define	taskq_create_proc(name, nthreads, pri, min, max, proc, flags, c, d) \
+    taskq_create_with_callbacks(name, nthreads, pri, min, max, flags, c, d)
 #define	taskq_create_sysdc(name, nthreads, min, max, proc, dc, flags) \
     taskq_create(name, nthreads, maxclsyspri, min, max, flags)
 

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -437,6 +437,7 @@ typedef enum kmem_cbrc {
 
 typedef uintptr_t taskqid_t;
 typedef void (task_func_t)(void *);
+typedef void (*taskq_callback_fn)(void *);
 
 typedef struct taskq_ent {
 	struct taskq_ent	*tqent_next;
@@ -463,6 +464,8 @@ typedef struct taskq {
 	int		tq_maxalloc_wait;
 	taskq_ent_t	*tq_freelist;
 	taskq_ent_t	tq_task;
+	taskq_callback_fn	tq_ctor;
+	taskq_callback_fn	tq_dtor;
 } taskq_t;
 
 #define	TQENT_FLAG_PREALLOC	0x1	/* taskq_dispatch_ent used */
@@ -484,9 +487,11 @@ extern taskq_t *system_taskq;
 extern taskq_t *system_delay_taskq;
 
 extern taskq_t	*taskq_create(const char *, int, pri_t, int, int, uint_t);
-#define	taskq_create_proc(a, b, c, d, e, p, f) \
-	    (taskq_create(a, b, c, d, e, f))
-#define	taskq_create_sysdc(a, b, d, e, p, dc, f) \
+extern taskq_t *taskq_create_with_callbacks(const char *, int, pri_t, int, int,
+    uint_t, taskq_callback_fn, taskq_callback_fn);
+#define	taskq_create_proc(a, b, c, d, e, p, f, g, h)	\
+	(taskq_create_with_callbacks(a, b, c, d, e, f, g, h))
+#define	taskq_create_sysdc(a, b, d, e, p, dc, f)	\
 	    (taskq_create(a, b, maxclsyspri, d, e, f))
 extern taskqid_t taskq_dispatch(taskq_t *, task_func_t, void *, uint_t);
 extern taskqid_t taskq_dispatch_delay(taskq_t *, task_func_t, void *, uint_t,

--- a/lib/libzpool/taskq.c
+++ b/lib/libzpool/taskq.c
@@ -213,6 +213,9 @@ taskq_thread(void *arg)
 	taskq_ent_t *t;
 	boolean_t prealloc;
 
+	if (tq->tq_ctor != NULL)
+		tq->tq_ctor(tq);
+
 	mutex_enter(&tq->tq_lock);
 	while (tq->tq_flags & TASKQ_ACTIVE) {
 		if ((t = tq->tq_task.tqent_next) == &tq->tq_task) {
@@ -237,6 +240,17 @@ taskq_thread(void *arg)
 		if (!prealloc)
 			task_free(tq, t);
 	}
+
+	/*
+	 * This thread is on its way out, so just drop the lock temporarily
+	 * in order to call the shutdown callback.  This allows the callback
+	 * to look at the taskqueue, even just before it dies.
+	 */
+	mutex_exit(&tq->tq_lock);
+	if (tq->tq_dtor != NULL)
+		tq->tq_dtor(tq);
+	mutex_enter(&tq->tq_lock);
+
 	tq->tq_nthreads--;
 	cv_broadcast(&tq->tq_wait_cv);
 	mutex_exit(&tq->tq_lock);
@@ -245,8 +259,9 @@ taskq_thread(void *arg)
 
 /*ARGSUSED*/
 taskq_t *
-taskq_create(const char *name, int nthreads, pri_t pri,
-    int minalloc, int maxalloc, uint_t flags)
+taskq_create_with_callbacks(const char *name, int nthreads, pri_t pri,
+    int minalloc, int maxalloc, uint_t flags, taskq_callback_fn ctor,
+    taskq_callback_fn dtor)
 {
 	taskq_t *tq = kmem_zalloc(sizeof (taskq_t), KM_SLEEP);
 	int t;
@@ -279,6 +294,8 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 	tq->tq_task.tqent_prev = &tq->tq_task;
 	tq->tq_threadlist = kmem_alloc(nthreads * sizeof (kthread_t *),
 	    KM_SLEEP);
+	tq->tq_ctor = ctor;
+	tq->tq_dtor = dtor;
 
 	if (flags & TASKQ_PREPOPULATE) {
 		mutex_enter(&tq->tq_lock);
@@ -292,6 +309,15 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 		    taskq_thread, tq, 0, &p0, TS_RUN, pri)) != NULL);
 
 	return (tq);
+}
+
+/*ARGSUSED*/
+taskq_t *
+taskq_create(const char *name, int nthreads, pri_t pri,
+    int minalloc, int maxalloc, uint_t flags)
+{
+	return (taskq_create_with_callbacks(name, nthreads, pri, minalloc,
+	    maxalloc, flags, NULL, NULL));
 }
 
 void

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1025,7 +1025,7 @@ spa_taskqs_init(spa_t *spa, zio_type_t t, zio_taskq_type_t q)
 				pri++;
 
 			tq = taskq_create_proc(name, value, pri, 50,
-			    INT_MAX, spa->spa_proc, flags);
+			    INT_MAX, spa->spa_proc, flags, NULL, NULL);
 		}
 
 		tqs->stqs_taskq[i] = tq;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
adds callbacks to taskq_create to support async COW changes

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
