### PR TITLE
Make slog test setup more robust

### DIFF
--- a/tests/zfs-tests/tests/functional/slog/setup.ksh
+++ b/tests/zfs-tests/tests/functional/slog/setup.ksh
@@ -38,13 +38,4 @@ if ! verify_slog_support ; then
 	log_unsupported "This system doesn't support separate intent logs"
 fi
 
-if [[ -d $VDEV ]]; then
-	log_must rm -rf $VDIR
-fi
-if [[ -d $VDEV2 ]]; then
-	log_must rm -rf $VDIR2
-fi
-log_must mkdir -p $VDIR $VDIR2
-log_must truncate -s $MINVDEVSIZE $VDEV $SDEV $LDEV $VDEV2 $SDEV2 $LDEV2
-
 log_pass

--- a/tests/zfs-tests/tests/functional/slog/slog.kshlib
+++ b/tests/zfs-tests/tests/functional/slog/slog.kshlib
@@ -31,11 +31,20 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/slog/slog.cfg
 
+function setup
+{
+	log_must rm -rf $VDIR $VDIR2
+	log_must mkdir -p $VDIR $VDIR2
+	log_must truncate -s $MINVDEVSIZE $VDEV $SDEV $LDEV $VDEV2 $SDEV2 $LDEV2
+
+	return 0
+}
+
 function cleanup
 {
 	poolexists $TESTPOOL && destroy_pool $TESTPOOL
 	poolexists $TESTPOOL2 && destroy_pool $TESTPOOL2
-	rm -rf $TESTDIR
+	rm -rf $TESTDIR $VDIR $VDIR2
 }
 
 #

--- a/tests/zfs-tests/tests/functional/slog/slog_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_001_pos.ksh
@@ -45,6 +45,7 @@ verify_runnable "global"
 
 log_assert "Creating a pool with a log device succeeds."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_002_pos.ksh
@@ -46,6 +46,7 @@ verify_runnable "global"
 
 log_assert "Adding a log device to normal pool works."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_003_pos.ksh
@@ -46,6 +46,7 @@ verify_runnable "global"
 
 log_assert "Adding an extra log device works."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_004_pos.ksh
@@ -46,6 +46,7 @@ verify_runnable "global"
 
 log_assert "Attaching a log device passes."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_005_pos.ksh
@@ -46,6 +46,7 @@ verify_runnable "global"
 
 log_assert "Detaching a log device passes."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_006_pos.ksh
@@ -46,6 +46,7 @@ verify_runnable "global"
 
 log_assert "Replacing a log device passes."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_007_pos.ksh
@@ -48,6 +48,7 @@ verify_runnable "global"
 
 log_assert "Exporting and importing pool with log devices passes."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_008_neg.ksh
@@ -44,6 +44,7 @@ verify_runnable "global"
 
 log_assert "A raidz/raidz2 log is not supported."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_009_neg.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_009_neg.ksh
@@ -45,6 +45,7 @@ verify_runnable "global"
 
 log_assert "A raidz/raidz2 log can not be added to existed pool."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_010_neg.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_010_neg.ksh
@@ -46,6 +46,7 @@ verify_runnable "global"
 
 log_assert "Slog device can not be replaced with spare device."
 log_onexit cleanup
+log_must setup
 
 log_must zpool create $TESTPOOL $VDEV spare $SDEV log $LDEV
 sdev=$(random_get $SDEV)

--- a/tests/zfs-tests/tests/functional/slog/slog_011_neg.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_011_neg.ksh
@@ -46,6 +46,7 @@ verify_runnable "global"
 
 log_assert "Offline and online a log device passes."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_012_neg.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_012_neg.ksh
@@ -45,6 +45,7 @@ verify_runnable "global"
 
 log_assert "Pool can survive when one of mirror log device get corrupted."
 log_onexit cleanup
+log_must setup
 
 for type in "" "mirror" "raidz" "raidz2"
 do

--- a/tests/zfs-tests/tests/functional/slog/slog_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_013_pos.ksh
@@ -60,6 +60,7 @@ log_assert "Verify slog device can be disk, file, lofi device or any device " \
 	"that presents a block interface."
 verify_disk_count "$DISKS" 2
 log_onexit cleanup_testenv
+log_must setup
 
 dsk1=${DISKS%% *}
 log_must zpool create $TESTPOOL ${DISKS#$dsk1}

--- a/tests/zfs-tests/tests/functional/slog/slog_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_014_pos.ksh
@@ -44,6 +44,7 @@
 verify_runnable "global"
 
 log_assert "log device can survive when one of the pool device get corrupted."
+log_must setup
 
 for type in "mirror" "raidz" "raidz2"; do
 	for spare in "" "spare"; do

--- a/tests/zfs-tests/tests/functional/slog/slog_015_neg.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_015_neg.ksh
@@ -47,6 +47,7 @@ function cleanup
 
 ORIG_TIMEOUT=$(get_tunable zfs_commit_timeout_pct | tail -1 | awk '{print $NF}')
 log_onexit cleanup
+log_must setup
 
 for PCT in 0 1 2 4 8 16 32 64 128 256 512 1024; do
 	log_must set_tunable64 zfs_commit_timeout_pct $PCT

--- a/tests/zfs-tests/tests/functional/slog/slog_replay_fs.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_replay_fs.ksh
@@ -66,6 +66,7 @@ function cleanup_fs
 
 log_assert "Replay of intent log succeeds."
 log_onexit cleanup_fs
+log_must setup
 
 #
 # 1. Create an empty file system (TESTFS)

--- a/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_replay_volume.ksh
@@ -76,6 +76,7 @@ function cleanup_volume
 
 log_assert "Replay of intent log succeeds."
 log_onexit cleanup_volume
+log_must setup
 
 #
 # 1. Create an empty volume (TESTVOL), set sync=always, and format


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The slog tests fail when attempting to create pools using file vdevs that already exist from previous test runs.

### Description
<!--- Describe your changes in detail -->
Remove existing vdev files from previous runs in the setup for the slog tests.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Run the slog tests, abort in the middle of the run, run again.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).