### PR TITLE
ZTS: Use decimal values when setting tunables

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_condense_and_disable.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_condense_and_disable.ksh
@@ -58,9 +58,9 @@ function test_condense
 {
 	# set the max livelist entries to a small value to more easily
 	# trigger a condense
-	set_tunable64 zfs_livelist_max_entries 0x14
+	set_tunable64 zfs_livelist_max_entries 20
 	# set a small percent shared threshold so the livelist is not disabled
-	set_tunable32 zfs_livelist_min_percent_shared 0xa
+	set_tunable32 zfs_livelist_min_percent_shared 10
 	clone_dataset $TESTFS1 snap $TESTCLONE
 
 	# sync between each write to make sure a new entry is created
@@ -86,7 +86,7 @@ function test_condense
 function test_deactivated
 {
 	# Threshold set to 50 percent
-	set_tunable32 zfs_livelist_min_percent_shared 0x32
+	set_tunable32 zfs_livelist_min_percent_shared 50
 	clone_dataset $TESTFS1 snap $TESTCLONE
 
 	log_must mkfile 5m /$TESTPOOL/$TESTCLONE/$TESTFILE0
@@ -97,7 +97,7 @@ function test_deactivated
 	log_must zfs destroy -R $TESTPOOL/$TESTCLONE
 
 	# Threshold set to 20 percent
-	set_tunable32 zfs_livelist_min_percent_shared 0x14
+	set_tunable32 zfs_livelist_min_percent_shared 20
 	clone_dataset $TESTFS1 snap $TESTCLONE
 
 	log_must mkfile 5m /$TESTPOOL/$TESTCLONE/$TESTFILE0

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_condense_races.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_clone_livelist_condense_races.ksh
@@ -98,7 +98,7 @@ log_must zpool sync $TESTPOOL
 log_must zfs snapshot $TESTPOOL/$TESTFS1@snap
 
 # Reduce livelist size to trigger condense more easily
-set_tunable64 zfs_livelist_max_entries 0x14
+set_tunable64 zfs_livelist_max_entries 20
 
 # Test cancellation path in the zthr
 set_tunable32 zfs_livelist_condense_zthr_pause 1

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_clone_livelist.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_clone_livelist.ksh
@@ -128,7 +128,7 @@ log_must mkfile 20m /$TESTPOOL/$TESTFS1/atestfile
 log_must zfs snapshot $TESTPOOL/$TESTFS1@snap
 
 # set a small livelist entry size to more easily test multiple entry livelists
-set_tunable64 zfs_livelist_max_entries 0x14
+set_tunable64 zfs_livelist_max_entries 20
 
 test_one_empty
 test_one

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_dev_removal_condense.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_dev_removal_condense.ksh
@@ -45,7 +45,7 @@ function cleanup
 log_onexit cleanup
 
 ORIGINAL_MAX=$(get_tunable zfs_livelist_max_entries)
-set_tunable64 zfs_livelist_max_entries 0x14
+set_tunable64 zfs_livelist_max_entries 20
 
 VIRTUAL_DISK1=/var/tmp/disk1
 VIRTUAL_DISK2=/var/tmp/disk2


### PR DESCRIPTION
### Motivation and Context

Failures observed when running these test cases on a non-Linux
platform using `mdb`.

### Description

The mdb_set_uint32 function requires that the values passed in be
decimal.  This was overlooked initially because the matching Linux
function accepts both decimal and hexadecimal values.

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Signed-off-by: Igor Kozhukhov <igor@dilos.org>
Issue #9125

### How Has This Been Tested?

Tested on DilOS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
