### PR TITLE
keep more metaslabs loaded

### DIFF
--- a/include/sys/metaslab_impl.h
+++ b/include/sys/metaslab_impl.h
@@ -489,6 +489,7 @@ struct metaslab {
 	 */
 	hrtime_t	ms_load_time;	/* time last loaded */
 	hrtime_t	ms_unload_time;	/* time last unloaded */
+	hrtime_t	ms_selected_time; /* time last allocated from */
 
 	uint64_t	ms_alloc_txg;	/* last successful alloc (debug only) */
 	uint64_t	ms_max_size;	/* maximum allocatable size	*/

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -494,7 +494,7 @@ attempt to reduce unnecessary reloading. Note that both this many
 milliseconds and \fBmetaslab_unload_delay\fR txgs must pass before unloading
 will occur.
 .sp
-Default value: \fB60000\fR (ten minutes).
+Default value: \fB600000\fR (ten minutes).
 .RE
 
 .sp

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -398,7 +398,7 @@ the least recently used metaslab to prevent the system from clogging all of
 its memory with range trees. This tunable sets the percentage of total system
 memory that is the threshold.
 .sp
-Default value: \fB75 percent\fR
+Default value: \fB25 percent\fR
 .RE
 
 .sp
@@ -480,7 +480,7 @@ reduce unnecessary reloading. Note that both this many txgs and
 \fBmetaslab_unload_delay_ms\fR milliseconds must pass before unloading will
 occur.
 .sp
-Default value: \fB8\fR.
+Default value: \fB32\fR.
 .RE
 
 .sp
@@ -491,10 +491,10 @@ Default value: \fB8\fR.
 .RS 12n
 After a metaslab is used, we keep it loaded for this many milliseconds, to
 attempt to reduce unnecessary reloading. Note that both this many
-millisecondss and \fBmetaslab_unload_delay\fR txgs must pass before unloading
+milliseconds and \fBmetaslab_unload_delay\fR txgs must pass before unloading
 will occur.
 .sp
-Default value: \fB60000\fR (one minute).
+Default value: \fB60000\fR (ten minutes).
 .RE
 
 .sp

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -472,6 +472,34 @@ Use \fB1\fR for yes (default) and \fB0\fR for no.
 .sp
 .ne 2
 .na
+\fBmetaslab_unload_delay\fR (int)
+.ad
+.RS 12n
+After a metaslab is used, we keep it loaded for this many txgs, to attempt to
+reduce unnecessary reloading. Note that both this many txgs and
+\fBmetaslab_unload_delay_ms\fR milliseconds must pass before unloading will
+occur.
+.sp
+Default value: \fB8\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBmetaslab_unload_delay_ms\fR (int)
+.ad
+.RS 12n
+After a metaslab is used, we keep it loaded for this many milliseconds, to
+attempt to reduce unnecessary reloading. Note that both this many
+millisecondss and \fBmetaslab_unload_delay\fR txgs must pass before unloading
+will occur.
+.sp
+Default value: \fB60000\fR (one minute).
+.RE
+
+.sp
+.ne 2
+.na
 \fBsend_holes_without_birth_time\fR (int)
 .ad
 .RS 12n

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -202,15 +202,16 @@ int metaslab_load_pct = 50;
  * last allocation from it.  A metaslab can't be unloaded until at least
  * metaslab_unload_delay TXG's and metaslab_unload_delay_ms milliseconds
  * have elapsed.  However, zfs_metaslab_mem_limit may cause it to be
- * unloaded sooner.
+ * unloaded sooner.  These settings are intended to be generous -- to keep
+ * metaslabs loaded for a long time, reducing the rate of metaslab loading.
  */
-int metaslab_unload_delay = TXG_SIZE * 2;
-int metaslab_unload_delay_ms = 60000; /* one minute */
+int metaslab_unload_delay = 32;
+int metaslab_unload_delay_ms = 10 * 60 * 1000; /* ten minutes */
 
 /*
  * Max number of metaslabs per group to preload.
  */
-int metaslab_preload_limit = SPA_DVAS_PER_BP;
+int metaslab_preload_limit = 10;
 
 /*
  * Enable/disable preloading of metaslab.
@@ -274,6 +275,13 @@ uint64_t metaslab_trace_max_entries = 5000;
  * simultaneously.
  */
 int max_disabled_ms = 3;
+
+/*
+ * Maximum percentage of memory to use on storing loaded metaslabs. If loading
+ * a metaslab would take it over this percentage, the oldest selected metaslab
+ * is automatically unloaded.
+ */
+int zfs_metaslab_mem_limit = 25;
 
 /*
  * Time (in seconds) to respect ms_max_size when the metaslab is not loaded.

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -289,13 +289,6 @@ int zfs_metaslab_mem_limit = 25;
  */
 unsigned long zfs_metaslab_max_size_cache_sec = 3600; /* 1 hour */
 
-/*
- * Maximum percentage of memory to use on storing loaded metaslabs. If loading
- * a metaslab would take it over this percentage, the oldest selected metaslab
- * is automatically unloaded.
- */
-int zfs_metaslab_mem_limit = 75;
-
 static uint64_t metaslab_weight(metaslab_t *);
 static void metaslab_set_fragmentation(metaslab_t *);
 static void metaslab_free_impl(vdev_t *, uint64_t, uint64_t, boolean_t);
@@ -2589,7 +2582,6 @@ metaslab_space_weight(metaslab_t *msp)
 	uint64_t weight, space;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
-	ASSERT(!vd->vdev_removing);
 
 	/*
 	 * The baseline weight is the metaslab's free space.
@@ -2847,13 +2839,6 @@ metaslab_weight(metaslab_t *msp)
 	uint64_t weight;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
-
-	/*
-	 * If this vdev is in the process of being removed, there is nothing
-	 * for us to do here.
-	 */
-	if (vd->vdev_removing)
-		return (0);
 
 	metaslab_set_fragmentation(msp);
 

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -561,7 +561,7 @@ metaslab_class_evict_old(metaslab_class_t *mc, uint64_t txg)
 			if (txg >
 			    msp->ms_selected_txg + metaslab_unload_delay &&
 			    gethrtime() > msp->ms_selected_time +
-			    (uint64_t)metaslab_unload_delay_ms * 1000000ULL) {
+			    (uint64_t)MSEC2NSEC(metaslab_unload_delay_ms)) {
 				metaslab_evict(msp, txg);
 			} else {
 				/*

--- a/tests/zfs-tests/tests/functional/removal/removal_cancel.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_cancel.ksh
@@ -15,7 +15,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019 by Delphix. All rights reserved.
+# Copyright (c) 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib

--- a/tests/zfs-tests/tests/functional/removal/removal_cancel.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_cancel.ksh
@@ -43,7 +43,6 @@ function cleanup
 	# Reset tunable.
 	#
 	log_must set_tunable32 zfs_removal_suspend_progress 0
-	log_must set_tunable32 metaslab_unload_delay_ms 60000
 }
 log_onexit cleanup
 
@@ -66,9 +65,6 @@ log_must randwritecomp $SAMPLEFILE 12500
 # Add second device where all the data will be evacuated.
 #
 log_must zpool add -f $TESTPOOL $NOTREMOVEDISK
-
-# workaround for DLPX-63811
-log_must set_tunable32 metaslab_unload_delay_ms 0
 
 #
 # Start removal.

--- a/tests/zfs-tests/tests/functional/removal/removal_cancel.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_cancel.ksh
@@ -15,7 +15,7 @@
 #
 
 #
-# Copyright (c) 2018 by Delphix. All rights reserved.
+# Copyright (c) 2018, 2019 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -43,6 +43,7 @@ function cleanup
 	# Reset tunable.
 	#
 	log_must set_tunable32 zfs_removal_suspend_progress 0
+	log_must set_tunable32 metaslab_unload_delay_ms 60000
 }
 log_onexit cleanup
 
@@ -65,6 +66,9 @@ log_must randwritecomp $SAMPLEFILE 12500
 # Add second device where all the data will be evacuated.
 #
 log_must zpool add -f $TESTPOOL $NOTREMOVEDISK
+
+# workaround for DLPX-63811
+log_must set_tunable32 metaslab_unload_delay_ms 0
 
 #
 # Start removal.


### PR DESCRIPTION
### Motivation and Context
With the other metaslab changes loaded onto a system, we can significantly reduce the memory usage of each loaded metaslab and unload them on demand if there is memory pressure. However, none of those changes actually result in us keeping more metaslabs loaded. If we don't keep more metaslabs loaded, we will still have to wait for demand-loading to finish when no loaded metaslab can satisfy our allocation, which can cause ZIL performance issues. In addition, performance is traditionally measured by IOs per unit time, while unloading is currently done on a txg-count basis. Txgs can take a widely varying range of times, from tenths of a second to several seconds. This can result in confusing, hard to predict behavior.

### Description
This change simply adds a time-based component to metaslab unloading. A metaslab will remain loaded for one minute and 8 txgs (by default) after it was last used, unless it is evicted due to memory pressure.

### How Has This Been Tested?
zfs-test and zloop, and performance testing to verify no regressions.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
