### PR TITLE
ZTS: Fix vdev_zaps_005_pos on CentOS 6

### DIFF
--- a/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_005_pos.ksh
@@ -41,6 +41,7 @@ orig_top=$(get_top_vd_zap $DISK $conf)
 orig_leaf=$(get_leaf_vd_zap $DISK $conf)
 assert_zap_common $TESTPOOL $DISK "top" $orig_top
 assert_zap_common $TESTPOOL $DISK "leaf" $orig_leaf
+log_must zpool sync
 
 # Export the pool.
 log_must zpool export $TESTPOOL


### PR DESCRIPTION
### Motivation and Context

Resolve `vdev_zaps_005_pos` test failure when running on CentOS 6.
Observed by the CI.

### Description

The ancient version of blkid (v2.17.2) used in CentOS 6 will not
detect the newly created pool unless it has been written to.
Force a pool sync so `zpool import` will detect the newly created
pool.

### How Has This Been Tested?

Locally in a CentOS 6 VM.

```
$ ./scripts/zfs-tests.sh -t tests/functional/vdev_zaps/vdev_zaps_005_pos
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/vdev_zaps/setup (run as root) [00:00] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/vdev_zaps/vdev_zaps_005_pos (run as root) [00:07] [PASS]
Test: /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/vdev_zaps/cleanup (run as root) [00:00] [PASS]

Results Summary
PASS	   3

Running Time:	00:00:08
Percent passed:	100.0%
Log directory:	/var/tmp/test_results/20190821T141509

Tests with results other than PASS that are expected:

Tests with result of PASS that are unexpected:

Tests with results other than PASS that are unexpected:
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
