### PR TITLE
Fix Plymouth passphrase prompt in initramfs script

### DIFF
--- a/contrib/initramfs/scripts/zfs.in
+++ b/contrib/initramfs/scripts/zfs.in
@@ -401,6 +401,13 @@ mount_fs()
 	return 0
 }
 
+# Loads a key for a ZFS native crypted filesystem via STDIN.
+loadkey_stdin()
+{
+	read -r KEY
+	echo "$KEY" | $ZFS load-key "$1"
+}
+
 # Unlock a ZFS native crypted filesystem.
 decrypt_fs()
 {
@@ -411,29 +418,29 @@ decrypt_fs()
 
 		# Determine dataset that holds key for root dataset
 		ENCRYPTIONROOT=$(${ZFS} get -H -o value encryptionroot "${fs}")
-		DECRYPT_CMD="${ZFS} load-key '${ENCRYPTIONROOT}'"
 
 		# If root dataset is encrypted...
 		if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
-
+			TRY_COUNT=3
 			# Prompt with plymouth, if active
 			if [ -e /bin/plymouth ] && /bin/plymouth --ping 2>/dev/null; then
-				plymouth ask-for-password --prompt "Encrypted ZFS password for ${ENCRYPTIONROOT}" \
-					--number-of-tries="3" \
-					--command="${DECRYPT_CMD}"
+				while [ $TRY_COUNT -gt 0 ]; do
+					plymouth ask-for-password --prompt "Encrypted ZFS password for ${ENCRYPTIONROOT}" | \
+						loadkey_stdin "${ENCRYPTIONROOT}" && break
+					TRY_COUNT=$((TRY_COUNT - 1))
+				done
 
 			# Prompt with systemd, if active 
 			elif [ -e /run/systemd/system ]; then
-				TRY_COUNT=3
 				while [ $TRY_COUNT -gt 0 ]; do
 					systemd-ask-password "Encrypted ZFS password for ${ENCRYPTIONROOT}" --no-tty | \
-						${DECRYPT_CMD} && break
+						loadkey_stdin "${ENCRYPTIONROOT}" && break
 					TRY_COUNT=$((TRY_COUNT - 1))
 				done
 
 			# Prompt with ZFS tty, otherwise
 			else
-				eval "${DECRYPT_CMD}"
+				$ZFS load-key "${ENCRYPTIONROOT}"
 			fi
 		fi
 	fi


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In issue #9193 I found that entering the ZFS encryption passphrase under Plymouth wasn't working because in the ZFS initrd script, Plymouth was calling zfs via `--command`, which wasn't passing through the filesystem argument to `zfs load-key` properly (it was passing through the single quotes around the filesystem name intended to handle spaces literally, which zfs load-key couldn't understand).

### Description
<!--- Describe your changes in detail -->

I have updated the script to have Plymouth and systemd pipe the key to `zfs load-key` instead, which removes the obstacle of Plymouth passing through arguments which contain spaces via `--command`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
I have tested this on my own desktop machine, updating the initramfs and rebooting upon each change to ensure the script continues working in a real environment.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
