### PR TITLE
Satisfy shellcheck SC2086, split argument list

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -31,7 +31,7 @@ fi
 
 PROG=zfs-tests.sh
 VERBOSE="no"
-QUIET=
+QUIET=""
 CLEANUP="yes"
 CLEANUPALL="no"
 LOOPBACK="yes"
@@ -307,7 +307,7 @@ while getopts 'hvqxkfScn:d:s:r:?t:T:u:I:' OPTION; do
 		VERBOSE="yes"
 		;;
 	q)
-		QUIET="-q"
+		QUIET="yes"
 		;;
 	x)
 		CLEANUPALL="yes"
@@ -602,10 +602,17 @@ REPORT_FILE=$(mktemp -u -t zts-report.XXXX -p "$FILEDIR")
 #
 # Run all the tests as specified.
 #
-msg "${TEST_RUNNER} ${QUIET} -c ${RUNFILE} -T ${TAGS} -i ${STF_SUITE}" \
-    "-I ${ITERATIONS}"
-${TEST_RUNNER} ${QUIET} -c "${RUNFILE}" -T "${TAGS}" -i "${STF_SUITE}" \
-    -I "${ITERATIONS}" 2>&1 | tee "$RESULTS_FILE"
+msg "${TEST_RUNNER} ${QUIET:+-q}" \
+    "-c \"${RUNFILE}\"" \
+    "-T \"${TAGS}\"" \
+    "-i \"${STF_SUITE}\"" \
+    "-I \"${ITERATIONS}\""
+${TEST_RUNNER} ${QUIET:+-q} \
+    -c "${RUNFILE}" \
+    -T "${TAGS}" \
+    -i "${STF_SUITE}" \
+    -I "${ITERATIONS}" \
+    2>&1 | tee "$RESULTS_FILE"
 
 #
 # Analyze the results.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unquoted variables in argument lists are subject to splitting. In this particular case we can't quote the variable because it is an optional argument.

### Description
<!--- Describe your changes in detail -->
 Use the method suggested in the description of the check, instead: https://github.com/koalaman/shellcheck/wiki/SC2086
The technique is to use an unquoted variable with an alternate value.

Split the arguments for ${TEST_RUNNER} across multiple lines for
clarity. Also added quotes in the message to match the invoked command.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
