### PR TITLE
Don't preload at or after final dirty txg

### DIFF
--- a/include/sys/metaslab.h
+++ b/include/sys/metaslab.h
@@ -64,7 +64,7 @@ uint64_t metaslab_allocated_space(metaslab_t *);
 
 void metaslab_sync(metaslab_t *, uint64_t);
 void metaslab_sync_done(metaslab_t *, uint64_t);
-void metaslab_sync_reassess(metaslab_group_t *);
+void metaslab_sync_reassess(metaslab_group_t *, uint64_t);
 uint64_t metaslab_largest_allocatable(metaslab_t *);
 
 /*

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3263,7 +3263,7 @@ vdev_sync_done(vdev_t *vd, uint64_t txg)
 		metaslab_sync_done(msp, txg);
 
 	if (reassess)
-		metaslab_sync_reassess(vd->vdev_mg);
+		metaslab_sync_reassess(vd->vdev_mg, txg);
 }
 
 void


### PR DESCRIPTION
### Motivation and Context
See Issue #9186

### Description
We prevent preloading at or after the final dirty txg

### How Has This Been Tested?
Passed the zfs-test suite once, needs a few more runs to verify that it fixes the issue (hoping that the automated PR test runs will help).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
