### PR TITLE
ZTS: Use compatible arg order in tests

### DIFF
--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_004_pos.ksh
@@ -52,7 +52,7 @@ do
 	log_must zpool create $TESTPOOL $type $ZPOOL_DISKS \
 	    special $stype $sdisks
 
-	ac_value="$(zpool get all -H -o property,value | \
+	ac_value="$(zpool get -H -o property,value all | \
 	    egrep allocation_classes | nawk '{print $2}')"
 	if [ "$ac_value" = "active" ]; then
 		log_note "feature@allocation_classes is active"

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_005_pos.ksh
@@ -41,7 +41,7 @@ do
 	else
 		log_must zpool create $TESTPOOL $type $ZPOOL_DISKS
 	fi
-	ac_value="$(zpool get all -H -o property,value | \
+	ac_value="$(zpool get -H -o property,value all | \
 	    egrep allocation_classes  | awk '{print $2}')"
 	if [ "$ac_value" = "enabled" ]; then
 		log_note "feature@allocation_classes is enabled"
@@ -56,7 +56,7 @@ do
 		log_must zpool add $TESTPOOL special mirror \
 		    $CLASS_DISK0 $CLASS_DISK1
 	fi
-	ac_value="$(zpool get all -H -o property,value | \
+	ac_value="$(zpool get -H -o property,value all | \
 	    egrep allocation_classes | awk '{print $2}')"
 	if [ "$ac_value" = "active" ]; then
 		log_note "feature@allocation_classes is active"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json.ksh
@@ -95,10 +95,10 @@ typeset -i cnt=0
 typeset cmd
 for cmd in ${pos_cmds[@]}; do
 	log_must zfs program $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1
-	log_must zfs program $TESTPOOL -j $TESTZCP $TESTDS $cmd 2>&1
+	log_must zfs program -j $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1
 	# json.tool is needed to guarantee consistent ordering of fields
 	# sed is needed to trim trailing space in CentOS 6's json.tool output
-	OUTPUT=$(zfs program $TESTPOOL -j $TESTZCP $TESTDS $cmd 2>&1 | python -m json.tool | sed 's/[[:space:]]*$//')
+	OUTPUT=$(zfs program -j $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1 | python -m json.tool | sed 's/[[:space:]]*$//')
 	if [ "$OUTPUT" != "${pos_cmds_out[$cnt]}" ]; then
 		log_note "Got     :$OUTPUT"
 		log_note "Expected:${pos_cmds_out[$cnt]}"
@@ -120,9 +120,9 @@ For the property list, run: zfs set|get
 For the delegated permission list, run: zfs allow|unallow")
 cnt=0
 for cmd in ${neg_cmds[@]}; do
-	log_mustnot zfs program $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1
-	log_mustnot zfs program $TESTPOOL -j $TESTZCP $TESTDS $cmd 2>&1
-	OUTPUT=$(zfs program $TESTPOOL -j $TESTZCP $TESTDS $cmd 2>&1)
+	log_mustnot zfs program $cmd $TESTPOOL $TESTZCP $TESTDS 2>&1
+	log_mustnot zfs program -j $cmd $TESTPOOL $TESTZCP $TESTDS 2>&1
+	OUTPUT=$(zfs program -j $cmd $TESTPOOL $TESTZCP $TESTDS 2>&1)
 	if [ "$OUTPUT" != "${neg_cmds_out[$cnt]}" ]; then
 		log_note "Got     :$OUTPUT"
 		log_note "Expected:${neg_cmds_out[$cnt]}"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some implementations (BSD) of getopt() and getopt_long() want options before arguments.

### Description
<!--- Describe your changes in detail -->
Reorder arguments to zfs/zpool in tests to put all the options first.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
This has been tested by running the affected tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
