### PR TITLE
zvol_wait script should ignore partially received zvols

### DIFF
--- a/cmd/zvol_wait/zvol_wait
+++ b/cmd/zvol_wait/zvol_wait
@@ -25,11 +25,30 @@ filter_out_deleted_zvols() {
 }
 
 list_zvols() {
-	zfs list -t volume -H -o name,volmode | while read -r zvol_line; do
+	zfs list -t volume -H -o name,volmode,receive_resume_token |
+		while read -r zvol_line; do
 		name=$(echo "$zvol_line" | awk '{print $1}')
 		volmode=$(echo "$zvol_line" | awk '{print $2}')
+		token=$(echo "$zvol_line" | awk '{print $3}')
+		#
 		# /dev links are not created for zvols with volmode = "none".
-		[ "$volmode" = "none" ] || echo "$name"
+		#
+		[ "$volmode" = "none" ] && continue
+		#
+		# We also also ignore partially received zvols if it is
+		# not an incremental receive, as those won't even have a block
+		# device minor node created yet.
+		#
+		if [ "$token" != "-" ]; then
+			#
+			# Incremental receives create an invisible clone that
+			# is not automatically displayed by zfs list.
+			#
+			if ! zfs list "$name/%recv" >/dev/null 2>&1; then
+				continue
+			fi
+		fi
+		echo "$name"
 	done
 }
 


### PR DESCRIPTION
Partially received zvols won't have links in /dev/zvol.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `zfs-volume-wait` service is timing out when there are partially received zvols since they won't have links and `/dev/zvol` until the zfs receive has completed. As a matter of fact, I believe block device minor nodes won't even be created for them until then.

### Description
While a zfs receive is in-progress for a given zvol, it will have a resume token. However, if a zvol already existed before the receive, it should have a block device minor node and a /dev link. In such a case, the receive will be an incremental receive and there will be an invisible clone at `<zvol_name>/%recv` for the duration of the receive -- we can check if that dataset exists to determine whether or no the zvol should have a dev link.

### How Has This Been Tested?
 - Ran this on a system with partially received zvols, using both incremental and non-incremental partial receives, and made sure that it behaves as expected.
 - Delphix internal testing: [ab-pre-push](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2053/)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).