### PR TITLE
mistake in inherited dataset

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/receive-o-x_props_override.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/receive-o-x_props_override.ksh
@@ -299,10 +299,10 @@ log_must eval "zfs receive -e -o copies=3 -x atime "\
 	"-o '$userprop:orig'='newval' $dest < $streamfile_repl"
 log_must datasetexists $dest/2/3/4
 log_must eval "check_prop_source $dest/2 copies 3 local"
-log_must eval "check_prop_inherit $dest/2/3/4 copies $dest/2"
+log_must eval "check_prop_inherit $dest/2/3/4 copies $dest/2/3"
 log_must eval "check_prop_source $dest/2/3/4 atime on default"
 log_must eval "check_prop_source $dest/2 '$userprop:orig' 'newval' local"
-log_must eval "check_prop_inherit $dest/2/3/4 '$userprop:orig' $dest/2"
+log_must eval "check_prop_inherit $dest/2/3/4 '$userprop:orig' $dest/2/3"
 log_must zfs destroy -r -f $dest
 # Verify 'zfs recv -d'
 log_must zfs create $dest
@@ -311,10 +311,10 @@ log_must eval "zfs receive -d -o copies=3 -x atime "\
 	"-o '$userprop:orig'='newval' $dest < $streamfile_repl"
 log_must datasetexists $dest/$fs/1/2/3/4
 log_must eval "check_prop_source $dest/$fs/1/2 copies 3 local"
-log_must eval "check_prop_inherit $dest/$fs/1/2/3/4 copies $dest/$fs/1/2"
+log_must eval "check_prop_inherit $dest/$fs/1/2/3/4 copies $dest/$fs/1/2/3"
 log_must eval "check_prop_source $dest/$fs/1/2/3/4 atime on default"
 log_must eval "check_prop_source $dest/$fs/1/2 '$userprop:orig' 'newval' local"
-log_must eval "check_prop_inherit $dest/$fs/1/2/3/4 '$userprop:orig' $dest/$fs/1/2"
+log_must eval "check_prop_inherit $dest/$fs/1/2/3/4 '$userprop:orig' $dest/$fs/1/2/3"
 # We don't need to cleanup here
 
 log_pass "ZFS receive property override and exclude options passed."


### PR DESCRIPTION
Signed-off-by: Igor Kozhukhov <igor@dilos.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

mistake in inherited dataset in test receive-o-x_props_override.ksh

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).