### PR TITLE
Fix Intel QAT / ZFS compatibility on v4.7.1+ kernels

### DIFF
--- a/module/zfs/qat_compress.c
+++ b/module/zfs/qat_compress.c
@@ -547,7 +547,7 @@ qat_compress(qat_compress_dir_t dir, char *src, int src_len,
 }
 
 static int
-param_set_qat_compress(const char *val, struct kernel_param *kp)
+param_set_qat_compress(const char *val, zfs_kernel_param_t *kp)
 {
 	int ret;
 	int *pvalue = kp->arg;

--- a/module/zfs/qat_crypt.c
+++ b/module/zfs/qat_crypt.c
@@ -578,7 +578,7 @@ fail:
 }
 
 static int
-param_set_qat_encrypt(const char *val, struct kernel_param *kp)
+param_set_qat_encrypt(const char *val, zfs_kernel_param_t *kp)
 {
 	int ret;
 	int *pvalue = kp->arg;
@@ -600,7 +600,7 @@ param_set_qat_encrypt(const char *val, struct kernel_param *kp)
 }
 
 static int
-param_set_qat_checksum(const char *val, struct kernel_param *kp)
+param_set_qat_checksum(const char *val, zfs_kernel_param_t *kp)
 {
 	int ret;
 	int *pvalue = kp->arg;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #9268 

### Description
<!--- Describe your changes in detail -->
`module_param_call()` methods take a `const` parameter, use compat code added in https://github.com/zfsonlinux/zfs/commit/9cc1844a1dab9cb62743f1f31eca73fcc6aaf0c4 to fix the linked issue.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Compiled locally with patch applied and qat1.7.l.4.6.0-00025 tarball.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
