### PR TITLE
Fix zfs-dkms .deb package warning in prerm script

### DIFF
--- a/rpm/generic/zfs-dkms.spec.in
+++ b/rpm/generic/zfs-dkms.spec.in
@@ -73,7 +73,7 @@ exit 1
 
 %preun
 # Are we doing an upgrade?
-if [ $1 -ne 0 ] ; then
+if [ "$1" = "1" -o "$1" = "upgrade" ] ; then
 	# Yes we are.  Are we upgrading to a new ZFS version?
 	NEWEST_VER=$(dkms status zfs | sed 's/,//g' | sort -r -V | awk '/installed/{print $2; exit}')
 	if [ "$NEWEST_VER" != "%{version}" ] ; then


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Debian zfs-dkms package generated by alien doesn't call the prerm script (rpm's %preun) with an integer as first parameter, which results in the following warning when the package is uninstalled:

```
root@linux:~# apt-get remove -y zfs-dkms
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages will be REMOVED:
  zfs-dkms
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
1 not fully installed or removed.
After this operation, 34.7 MB disk space will be freed.
Removing zfs-dkms (0.8.0-233) ...
/var/lib/dpkg/info/zfs-dkms.prerm: line 3: [: remove: integer expression expected
```

### Description
<!--- Describe your changes in detail -->
Modify the if-condition to avoid the warning. This is basically the same change proposed in https://github.com/zfsonlinux/zfs/commit/4e3de24b61b9116f0138d22ec687d0a759b29967.

preun/prerm docs:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html#summary-of-ways-maintainer-scripts-are-called

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
I usually build kmod packages for my systems, i tested this on a throwaway builder just to confirm the warning is not printed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
