### PR TITLE
maxinflight can overflow in spa_load_verify_cb()

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2229,7 +2229,8 @@ spa_load_verify_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 	if (!BP_IS_METADATA(bp) && !spa_load_verify_data)
 		return (0);
 
-	int maxinflight_bytes = arc_target_bytes() >> spa_load_verify_shift;
+	uint64_t maxinflight_bytes =
+	    arc_target_bytes() >> spa_load_verify_shift;
 	zio_t *rio = arg;
 	size_t size = BP_GET_PSIZE(bp);
 


### PR DESCRIPTION
When running on larger memory systems, we can overflow the value of
maxinflight. This can result in maxinflight having a value of 0 causing
the system to hang.

Signed-off-by: George Wilson <george.wilson@delphix.com>

This address issue [9214](https://github.com/zfsonlinux/zfs/issues/9214).