### PR TITLE
Add/generalize abstractions in arc_summary2

### DIFF
--- a/cmd/arc_summary/arc_summary2
+++ b/cmd/arc_summary/arc_summary2
@@ -54,6 +54,7 @@ import errno
 from subprocess import Popen, PIPE
 from decimal import Decimal as D
 
+
 show_tunable_descriptions = False
 alternate_tunable_layout = False
 
@@ -76,24 +77,19 @@ def get_Kstat():
     of the same name.
     """
 
-    def load_proc_kstats(fn, namespace):
+    def load_kstats(namespace):
         """Collect information on a specific subsystem of the ARC"""
 
-        kstats = [line.strip() for line in open(fn)]
-        del kstats[0:2]
-        for kstat in kstats:
-            kstat = kstat.strip()
-            name, _, value = kstat.split()
-            Kstat[namespace + name] = D(value)
+        kstat = 'kstat.zfs.misc.%s.%%s' % namespace
+        path = '/proc/spl/kstat/zfs/%s' % namespace
+        with open(path) as f:
+            entries = [line.strip().split() for line in f][2:] # Skip header
+        return [(kstat % name, D(value)) for name, _, value in entries]
 
     Kstat = {}
-    load_proc_kstats('/proc/spl/kstat/zfs/arcstats',
-                     'kstat.zfs.misc.arcstats.')
-    load_proc_kstats('/proc/spl/kstat/zfs/zfetchstats',
-                     'kstat.zfs.misc.zfetchstats.')
-    load_proc_kstats('/proc/spl/kstat/zfs/vdev_cache_stats',
-                     'kstat.zfs.misc.vdev_cache_stats.')
-
+    Kstat.update(load_kstats('arcstats'))
+    Kstat.update(load_kstats('zfetchstats'))
+    Kstat.update(load_kstats('vdev_cache_stats'))
     return Kstat
 
 
@@ -921,14 +917,19 @@ def _tunable_summary(Kstat):
     global show_tunable_descriptions
     global alternate_tunable_layout
 
-    names = os.listdir("/sys/module/zfs/parameters/")
+    def load_tunables():
+        basepath = '/sys/module/zfs/parameters'
+        tunables = {}
+        for name in os.listdir(basepath):
+            if not name:
+                continue
+            path = '%s/%s' % (basepath, name)
+            with open(path) as f:
+                value = f.read()
+            tunables[name] = value.strip()
+        return tunables
 
-    values = {}
-    for name in names:
-        with open("/sys/module/zfs/parameters/" + name) as f:
-            value = f.read()
-        values[name] = value.strip()
-
+    tunables = load_tunables()
     descriptions = {}
 
     if show_tunable_descriptions:
@@ -966,22 +967,17 @@ def _tunable_summary(Kstat):
             sys.stderr.write("Tunable descriptions will be disabled.\n")
 
     sys.stdout.write("ZFS Tunables:\n")
-    names.sort()
 
     if alternate_tunable_layout:
         fmt = "\t%s=%s\n"
     else:
         fmt = "\t%-50s%s\n"
 
-    for name in names:
-
-        if not name:
-            continue
-
+    for name in sorted(tunables.keys()):
         if show_tunable_descriptions and name in descriptions:
             sys.stdout.write("\t# %s\n" % descriptions[name])
 
-        sys.stdout.write(fmt % (name, values[name]))
+        sys.stdout.write(fmt % (name, tunables[name]))
 
 
 unSub = [


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Code for interfacing with procfs for kstats and tunables is Linux-specific. A more generic interface can be used for the abstraction of loading kstats, allowing other platforms to implement the function cleanly. In a similar vein, loading tunables can be abstracted away in order for other platforms to provide their own implementations of this function.

### Description
<!--- Describe your changes in detail -->
Hide the details of where kstats/tunables come from inside functions that can be implemented on any platform.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
`make flake8` and ZTS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
