### PR TITLE
ZTS: Clean up zfs_clone_010_pos

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_clone/zfs_clone_010_pos.ksh
@@ -143,7 +143,6 @@ datasets="$TESTPOOL/$TESTFS1 $TESTPOOL/$TESTFS1/$TESTFS2
 typeset -a d_clones
 typeset -a deferred_snaps
 typeset -i i
-i=1
 log_must setup_ds
 
 log_note "Verify zfs clone property for multiple clones"
@@ -157,19 +156,16 @@ for ds in $datasets; do
 	((i=i+1))
 done
 names=$(zfs list -rt all -o name $TESTPOOL)
-i=1
 log_must verify_clones 2 1
 
 log_must local_cleanup
 log_must setup_ds
 
 log_note "verify zfs deferred destroy on clones property"
-i=1
 names=$(zfs list -rt all -o name $TESTPOOL)
 for ds in $datasets; do
 	log_must zfs destroy -d $ds@snap
 	deferred_snaps=( "${deferred_snaps[@]}" "$ds@snap" )
-	((i=i+1))
 done
 log_must verify_clones 3 0
 
@@ -206,17 +202,14 @@ for ds in $datasets; do
 done
 names=$(zfs list -rt all -o name,clones $TESTPOOL)
 log_must verify_clones 3 1 $TESTCLONE
-i=1
 for ds in $datasets; do
 	log_must zfs promote $ds
-	((i=i+1))
 done
 log_must local_cleanup
 
 log_note "verify clone list truncated correctly"
-typeset -i j=200
-i=1
 fs=$TESTPOOL/$TESTFS1
+xs=""; for i in {1..200}; do xs+="x"; done
 if is_linux; then
 	ZFS_MAXPROPLEN=4096
 else
@@ -224,10 +217,8 @@ else
 fi
 log_must zfs create $fs
 log_must zfs snapshot $fs@snap
-while((i <= $(( ZFS_MAXPROPLEN/200+1 )))); do
-	log_must zfs clone $fs@snap $fs/$TESTCLONE$(python -c 'print "x" * 200').$i
-	((i=i+1))
-	((j=j+200))
+for (( i = 1; i <= (ZFS_MAXPROPLEN / 200 + 1); i++ )); do
+	log_must zfs clone ${fs}@snap ${fs}/${TESTCLONE}${xs}.${i}
 done
 clone_list=$(zfs list -o clones $fs@snap)
 char_count=$(echo "$clone_list" | tail -1 | wc | awk '{print $3}')


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On many systems, `python` is Python 3. zfs_clone_010_pos invokes `python -c 'print "x" * 200'`, which is not valid in Python 3.

### Description
<!--- Describe your changes in detail -->
Eliminate the Python, using built in shell constructs in its place.

While here, a few more potential improvements revealed themselves:

Remove a lot of unnecessary setting and incrementing of `i`.

Remove unused variable `j`.

Instead of generating the same string repeatedly inside a loop, generate it once outside of the loop.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
`./scripts/zfs-tests.sh -vxT zfs_clone`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
