### PR TITLE
ZTS: Clean up do_vol_test in zfs_copies tests

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_copies/zfs_copies.kshlib
@@ -50,19 +50,6 @@ function cmp_prop
 }
 
 #
-# Get the value of property used via zfs list
-# $1, the dataset name
-#
-function get_used_prop
-{
-	typeset ds=$1
-	typeset used
-
-	used=`zfs list -H -p -o used $ds`
-	echo $used
-}
-
-#
 # Check the used space is charged correctly
 # $1, the number of used space
 # $2, the expected common factor between the used space and the file space
@@ -85,64 +72,72 @@ function check_used
 
 #
 # test ncopies on volume
-# $1  test type zfs|ufs, default zfs
+# $1  test type zfs|ufs|ext2
 # $2  copies
-# $3  mntp for ufs test
+# $3  mntp for ufs|ext2 test
 function do_vol_test
 {
 	typeset type=$1
-	typeset copy=$2
+	typeset copies=$2
 	typeset mntp=$3
 
 	vol=$TESTPOOL/$TESTVOL1
 	vol_b_path=$ZVOL_DEVDIR/$TESTPOOL/$TESTVOL1
 	vol_r_path=$ZVOL_RDEVDIR/$TESTPOOL/$TESTVOL1
 
-	log_must zfs create -V $VOLSIZE -o copies=$copy $vol
+	log_must zfs create -V $VOLSIZE -o copies=$copies $vol
 	log_must zfs set refreservation=none $vol
 	block_device_wait
 
-	if [[ $type == "ufs" ]]; then
-		log_must echo y | newfs $vol_r_path >/dev/null 2>&1
-		log_must mount -F ufs -o rw $vol_b_path $mntp
-	elif [[ $type == "ext2" ]]; then
-		log_must echo y | newfs $vol_r_path >/dev/null 2>&1
+	case "$type" in
+	"ext2")
+		log_must eval "echo y | newfs $vol_r_path >/dev/null 2>&1"
 		log_must mount -o rw $vol_b_path $mntp
-	else
+		;;
+	"ufs")
+		if is_linux; then
+			log_unsupported "ufs test not implemented for linux"
+		fi
+		log_must eval "newfs $vol_r_path >/dev/null 2>&1"
+		log_must mount $vol_b_path $mntp
+		;;
+	"zfs")
 		log_must zpool create $TESTPOOL1 $vol_b_path
 		log_must zfs create $TESTPOOL1/$TESTFS1
-	fi
+		;;
+	*)
+		log_unsupported "$type test not implemented"
+		;;
+	esac
 
-	((nfilesize = copy * ${FILESIZE%m}))
-	pre_used=$(get_used_prop $vol)
+	((nfilesize = copies * ${FILESIZE%m}))
+	pre_used=$(get_prop used $vol)
 	((target_size = pre_used + nfilesize))
 
-	if [[ $type == "ufs" ]]; then
-		log_must mkfile $FILESIZE $mntp/$FILE
-	elif [[ $type == "ext2" ]]; then
-		log_must mkfile $FILESIZE $mntp/$FILE
-	else
+	if [[ $type == "zfs" ]]; then
 		log_must mkfile $FILESIZE /$TESTPOOL1/$TESTFS1/$FILE
+	else
+		log_must mkfile $FILESIZE $mntp/$FILE
 	fi
 
-	post_used=$(get_used_prop $vol)
-	while ((post_used < target_size)) ; do
+	post_used=$(get_prop used $vol)
+	((retries = 0))
+	while ((post_used < target_size && retries++ < 42)); do
 		sleep 1
-		post_used=$(get_used_prop $vol)
+		post_used=$(get_prop used $vol)
 	done
 
 	((used = post_used - pre_used))
 	if ((used < nfilesize)); then
 		log_fail "The space is not charged correctly while setting" \
-		    "copies as $copy"
+		    "copies as $copies ($used < $nfilesize)" \
+		    "pre=${pre_used} post=${post_used}"
 	fi
 
-	if [[ $type == "ufs" ]]; then
-		umount $mntp
-	elif [[ $type == "ext2" ]]; then
-		umount $mntp
-	else
+	if [[ $type == "zfs" ]]; then
 		log_must zpool destroy $TESTPOOL1
+	else
+		log_must umount $mntp
 	fi
 
 	log_must zfs destroy $vol


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This test was stuck in an infinite loop, which caused me to stare at the code for quite a while to figure out why.

### Description
<!--- Describe your changes in detail -->
Get rid of the `get_used_prop` function. `get_prop used` works fine.

Fix the comment describing the function parameters. The type does not have a default, and mntp is also used for ext2.

Rename the variable for the number of copies from `copy` to `copies`.

Use a `case` statement to match the type parameter, order the cases alphabetically, and add a little sanity checking for good measure.

Use eval to make sure the output of commands is silenced rather than the log messages when redirecting output to /dev/null.

Simplify cases where zfs requires special behavior.

Don't allow the test to loop forever in the event space usage does not change. Bail out of the loop and fail after an arbitrary number of iterations.

Add more information to the log message when the test fails, to help debugging.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
`./scripts/zfs-tests.sh -vxT zfs_copies` on Debian 10.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
