### PR TITLE
RHEL8: Require depmod path based on local path

### DIFF
--- a/scripts/kmodtool
+++ b/scripts/kmodtool
@@ -144,6 +144,12 @@ print_rpmtemplate_per_kmodpkg ()
 	local kernel_uname_r=${1}
 	local kernel_variant="${2:+-${2}}"
 
+	# With RHEL 8, depmod moved from /sbin to /usr/sbin
+	local depmod_path=/sbin/depmod
+	if [ ! -f ${depmod_path} ]; then
+		depmod_path=/usr/sbin/depmod
+	fi
+
     # first part
 	cat <<EOF
 %package       -n kmod-${kmodname}-${kernel_uname_r}
@@ -153,8 +159,8 @@ Provides:         kernel-modules-for-kernel = ${kernel_uname_r}
 Provides:         kmod-${kmodname}-uname-r = ${kernel_uname_r}
 Provides:         ${kmodname}-kmod = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires:         ${kmodname}-kmod-common >= %{?epoch:%{epoch}:}%{version}
-Requires(post):   ${prefix}/sbin/depmod
-Requires(postun): ${prefix}/sbin/depmod
+Requires(post):   ${prefix}${depmod_path}
+Requires(postun): ${prefix}${depmod_path}
 EOF
 
 	if [[ ${obsolete_name} ]]; then


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
RHEL8 moved depmod from /sbin/depmod to /usr/sbin/depmod.  The specfile
for builds targeting RHEL8 must use the correct path for the Requires
line.

See #8724 

### Description
<!--- Describe your changes in detail -->
Assume that if the builder is targeting a RHEL8 derived system, they are
building on one.  Use the local path to depmod to indicate which path
should be used.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
local builds on rhel 7 and rhel 8

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
