### PR TITLE
copy-builtin: SPL must be in Kbuild first (again)

### DIFF
--- a/copy-builtin
+++ b/copy-builtin
@@ -12,9 +12,16 @@ usage()
 KERNEL_DIR="$(readlink --canonicalize-existing "$1")"
 
 MODULES=()
+
+# When integrated in to a monolithic kernel the spl module must appear
+# first.  This ensures its module initialization function is run before
+# any of the other module initialization functions which depend on it.
+MODULES+="spl"
+
 for MODULE_DIR in module/* module/os/linux/*
 do
 	[ -d "$MODULE_DIR" ] || continue
+	[ "spl" = "${MODULE_DIR##*/}" ] && continue
 	[ "os" = "${MODULE_DIR#*/}" ] && continue
 	MODULES+=("${MODULE_DIR#*/}")
 done


### PR DESCRIPTION
### Motivation and Context

#9302.

### Description

Commit bced7e3 accidentally reintroduced issue #7595 which was
previously addressed by 517d247.  Reapply the original fix to
resolve the issue and include a comment to make it clear the
ordering is important.

note: As part of the source tree refactoring we should strongly consider
merging all of the kmods by license type so there are only a couple.
Then explicitly enumerate them in `copy-builtin` to simplify the script.

### How Has This Been Tested?

Pending results from the kernel CI bot.  Manual testing requested in
issue ##9302 to verify the change resolves the issue.

@mattmacy can you please review this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zxfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
