### PR TITLE
kmodtool: depmod path

### DIFF
--- a/scripts/kmodtool
+++ b/scripts/kmodtool
@@ -144,7 +144,13 @@ print_rpmtemplate_per_kmodpkg ()
 	local kernel_uname_r=${1}
 	local kernel_variant="${2:+-${2}}"
 
-    # first part
+	# Detect depmod install location
+	local depmod_path=/sbin/depmod
+	if [ ! -f ${depmod_path} ]; then
+		depmod_path=/usr/sbin/depmod
+	fi
+
+	# first part
 	cat <<EOF
 %package       -n kmod-${kmodname}-${kernel_uname_r}
 Summary:          ${kmodname} kernel module(s) for ${kernel_uname_r}
@@ -153,8 +159,14 @@ Provides:         kernel-modules-for-kernel = ${kernel_uname_r}
 Provides:         kmod-${kmodname}-uname-r = ${kernel_uname_r}
 Provides:         ${kmodname}-kmod = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires:         ${kmodname}-kmod-common >= %{?epoch:%{epoch}:}%{version}
-Requires(post):   ${prefix}/sbin/depmod
-Requires(postun): ${prefix}/sbin/depmod
+
+%if 0%{?rhel} == 6 || 0%{?centos} == 6
+Requires(post):   module-init-tools
+Requires(postun): module-init-tools
+%else
+Requires(post):   kmod
+Requires(postun): kmod
+%endif
 EOF
 
 	if [[ ${obsolete_name} ]]; then
@@ -170,17 +182,17 @@ BuildRequires:	  kernel-devel-uname-r = ${kernel_uname_r}
 %{?KmodsRequires:Requires: %{KmodsRequires}-uname-r = ${kernel_uname_r}}
 %{?KmodsRequires:BuildRequires: %{KmodsRequires}-uname-r = ${kernel_uname_r}}
 %post          -n kmod-${kmodname}-${kernel_uname_r}
-${prefix}/sbin/depmod -aeF /boot/System.map-${kernel_uname_r} ${kernel_uname_r} > /dev/null || :
+${prefix}${depmod_path} -aeF /boot/System.map-${kernel_uname_r} ${kernel_uname_r} > /dev/null || :
 %postun        -n kmod-${kmodname}-${kernel_uname_r}
-${prefix}/sbin/depmod  -aF /boot/System.map-${kernel_uname_r} ${kernel_uname_r} &> /dev/null || :
+${prefix}${depmod_path} -aF /boot/System.map-${kernel_uname_r} ${kernel_uname_r} &> /dev/null || :
 
 EOF
 	else
 	  cat <<EOF
 %post          -n kmod-${kmodname}-${kernel_uname_r}
-[[ "\$(uname -r)" == "${kernel_uname_r}"  ]] && ${prefix}/sbin/depmod -a > /dev/null || :
+[[ "\$(uname -r)" == "${kernel_uname_r}"  ]] && ${prefix}${depmod_path} -a > /dev/null || :
 %postun        -n kmod-${kmodname}-${kernel_uname_r}
-[[ "\$(uname -r)" == "${kernel_uname_r}"  ]] && ${prefix}/sbin/depmod -a > /dev/null || :
+[[ "\$(uname -r)" == "${kernel_uname_r}"  ]] && ${prefix}${depmod_path} -a > /dev/null || :
 
 EOF
 	fi


### PR DESCRIPTION
### Motivation and Context

Proposed alternative to #9293 to resolve #8724.

### Description

Determine the location of depmod on the system, either /sbin/depmod or
/usr/sbin/depmod.  Then use that path when generating the specfile.

Additionally, update the Requires lines to reference the package which
provides depmod rather than the binary itself.  For CentOS/RHEL 7+8
and all supported Fedora releases this is the kmod package, and for
CentOS/RHEL 6 it is the module-init-tools package.

### How Has This Been Tested?

Locally compiled, pending CI results.  Manually tested on RHEL 8.

<details open>
<summary>package install</summary>
<pre>
$ sudo dnf localinstall *.x86_64.rpm
Last metadata expiration check: 1:17:26 ago on Tue 10 Sep 2019 09:11:35 PM UTC.
Dependencies resolved.
=================================================================================================================================================
 Package                                                   Arch              Version                               Repository               Size
=================================================================================================================================================
Installing:
 kmod-zfs-4.18.0-80.11.1.el8_0.x86_64                      x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            1.2 M
 kmod-zfs-4.18.0-80.11.1.el8_0.x86_64-debuginfo            x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline             10 M
 kmod-zfs-devel                                            x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            350 k
 kmod-zfs-devel-4.18.0-80.11.1.el8_0.x86_64                x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline             30 k
 libnvpair1                                                x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline             37 k
 libnvpair1-debuginfo                                      x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline             87 k
 libuutil1                                                 x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline             31 k
 libuutil1-debuginfo                                       x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline             55 k
 libzfs2                                                   x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            213 k
 libzfs2-debuginfo                                         x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            493 k
 libzfs2-devel                                             x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            364 k
 libzpool2                                                 x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            885 k
 libzpool2-debuginfo                                       x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            2.2 M
 zfs                                                       x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            508 k
 zfs-debuginfo                                             x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            845 k
 zfs-debugsource                                           x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            2.0 M
 zfs-kmod-debugsource                                      x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            1.8 M
 zfs-test                                                  x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            3.1 M
 zfs-test-debuginfo                                        x86_64            0.8.0-265_g6c4e4ad69.el8              @commandline            275 k
</pre>
</details>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).