### PR TITLE
WIP: zio_compress: remove compressratio threshold

### DIFF
--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -40,11 +40,6 @@
 unsigned long zio_decompress_fail_fraction = 0;
 
 /*
- * Common disk sector size.
- */
-short COMMON_SECTOR_SIZE = 4096;
-
-/*
  * Compression vectors.
  */
 zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS] = {
@@ -121,15 +116,14 @@ zio_compress_data(enum zio_compress c, abd_t *src, void *dst, size_t s_len)
 	if (c == ZIO_COMPRESS_EMPTY)
 		return (s_len);
 
-	/* Don't compress if it's less than common sector size */
-	d_len = MAX(0, s_len - COMMON_SECTOR_SIZE);
+	/* Don't threshold compressratio */
+	d_len = s_len;
 
 	/* No compression algorithms can read from ABDs directly */
 	void *tmp = abd_borrow_buf_copy(src, s_len);
 	c_len = ci->ci_compress(tmp, dst, s_len, d_len, ci->ci_level);
 	abd_return_buf(src, tmp, s_len);
 
-	/* block with recordsize <= COMMON_SECTOR_SIZE will always be raw */
 	if (c_len > d_len)
 		return (s_len);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
87.5% minimum compressratio is way to large, on 1TB with recordsize 16M such artifical limitation may lead to up to 125GB of wasted space in worst case (but you must be very, very unlucky). 

So i propose to remove compress threshold at all, previous variant didn't check for small blocks too, it will save you nearly 99% of compressratio on large recordsizes.

And I think if you enable slow compression on dataset you will prefer better compressratio over decompression absence for data nowadays.

So, pros:
- better compressratio
- better IO if decompress is faster than disks
- we're already compressing everything

Cons: 
- slower IO on decompress, if disks are faster than decompress for files with less than 12.5% compression
- if recordsizes==ashift, compression works without any space benefit (but it is not because of this PR)

There is another way - expose this parameter as module param, but I think it would not be useful.

### Description
<!--- Describe your changes in detail -->
Now default compression is lz4, which can stop
compression process by itself on incompressible data.
So we can check only for common sector size.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Generate 12% (just as needed to get into 87.5% threshold) compressible file with fio:
```
# cat fio.conf
[workload]
bs=128k
ioengine=libaio
iodepth=1
numjobs=1
direct=1
runtime=10
size=100m
filename=bigfile
rw=read
thread
unified_rw_reporting=1
group_reporting=1
buffer_compress_percentage=12
refill_buffers
buffer_pattern=0xdeadbeef
```
```
zfs set compression=lz4 rpool/test
```

version | recordsize | ashift | written | diff (from original)
--- | --- | --- | --- | ---
0.7.13 | 1M | 12  | 100M 
master_patched  | 1M | 12  |  88.8M   | ~11.2%

So there may be up to ~12.5% compression gain for hardly compressible files.

Tested manually in VM, didn't run actual system on this code yet.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
