### PR TITLE
Remove zfs_vdev_elevator module option

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -3188,8 +3188,10 @@ Default value: \fB32,768\fR.
 \fBzfs_vdev_scheduler\fR (charp)
 .ad
 .RS 12n
-Set the Linux I/O scheduler on whole disk vdevs to this scheduler. Valid options
-are noop, cfq, bfq & deadline
+Set the Linux I/O scheduler on whole disk vdevs to this scheduler.  This
+option has been deprecated and will be removed in a future release.  The
+standard \fB/sys/block/<block>/queue/scheduler\fR interface should be used
+to set a block device scheduler.
 .sp
 Default value: \fBnoop\fR.
 .RE

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -930,7 +930,14 @@ param_set_vdev_scheduler(const char *val, zfs_kernel_param_t *kp)
 		mutex_exit(&spa_namespace_lock);
 	}
 
-	return (param_set_charp(val, kp));
+
+	int error = param_set_charp(val, kp);
+	if (error == 0) {
+		printk(KERN_INFO "The 'zfs_vdev_scheduler' module option "
+		    "will be removed in a future release.\n");
+	}
+
+	return (error);
 }
 
 vdev_ops_t vdev_disk_ops = {


### PR DESCRIPTION
### Motivation and Context

Issue #8664.  This PR proposes the removal of the `zfs_vdev_elevator`
module option for the following reasons:

1) complexity in supporting it; as observed in #8664 the current
  implementation may lead to unexpected consequences.
2) depending on the kernel version and block device driver, the
  available elevators can vary significantly; this makes it difficult
  to manage from within the `zfs.ko` since the available options
  cannot be easily queried (or set).
3) managing this from userspace is straight forward and more
  flexible, the initramfs scripts already do this and other scripts
  could be updated as appropriate.

Note: This PR entirely removes the module option.  However, we
may instead want to leave it in place but disable it and update the
documentation accordingly.  This would ensure that any systems
which are setting the module option are still able to load the kmod.

### Description

Originally the `zfs_vdev_elevator module` option was added as a
convenience so the requested elevator would be automatically set
on the underlying block devices.  At the time this was simple
because the kernel provided an API function which did exactly this.

This API was then removed in the Linux 4.12 kernel which prompted
us to add compatibly code to set the elevator via a usermodehelper.
While well intentioned this can result in a system hang if the
usermodehelper does not return.  This is because it may be called
with the spa config lock held as a writter.  For example via the
`zfs_ioc_pool_scan() -> spa_scan() -> spa_scan() -> vdev_reopen()`
call path.

Additionally, there's a reasonable argument that setting the elevator
is the responsibility of whatever software is being used to configure
the system.  Therefore, it's proposed that the zfs_vdev_elevator
be removed.

### How Has This Been Tested?

Locally compiled, all referenced to the module option we're remove
the source and documentation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
