### PR TITLE
ZTS: Fix /usr/bin/env: 'python2': No such file or directory

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -96,6 +96,7 @@ export SYSTEM_FILES='arp
     ps
     pwd
     python
+    python2
     python3
     quotaon
     readlink


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recently i lost the ability to run the ZTS on my "golden" builder image (Debian9):

```
root@linux:~# head config.log 
This file contains any messages produced by compilers while
running configure, to aid debugging if configure makes a mistake.

It was created by zfs configure 0.8.0, which was
generated by GNU Autoconf 2.69.  Invocation command line was

  $ ./configure --prefix=/usr --sysconfdir=/etc --libdir=/lib64 --enable-debug --with-python=2.7

## --------- ##
## Platform. ##
root@linux:~# sudo -u nobody -s /usr/share/zfs/zfs-tests.sh -d /var/tmp -v -T removal 

--- Configuration ---
Runfile:         /usr/share/zfs/runfiles/linux.run
STF_TOOLS:       /usr/share/zfs/test-runner
STF_SUITE:       /usr/share/zfs/zfs-tests
STF_PATH:        /var/tmp/constrained_path.aZwC
FILEDIR:         /var/tmp
FILES:           /var/tmp/file-vdev0 /var/tmp/file-vdev1 /var/tmp/file-vdev2
LOOPBACKS:       /dev/loop0 /dev/loop1 /dev/loop2 
DISKS:           loop0 loop1 loop2
NUM_DISKS:       3
FILESIZE:        4G
ITERATIONS:      1
TAGS:            removal
STACK_TRACER:    no
Keep pool(s):    rpool
Missing util(s): arc_summary3 mmap_libaio arp bc fio umask wait 

/usr/share/zfs/test-runner/bin/test-runner.py  -c "/usr/share/zfs/runfiles/linux.run" -T "removal" -i "/usr/share/zfs/zfs-tests" -I "1"
/usr/bin/env: 'python2': No such file or directory
/usr/bin/env: 'python2': No such file or directory
root@linux:~# 
```

### Description
<!--- Describe your changes in detail -->
Since 4f342e45 `env(1)` must be able to find a "python2" executable in the "constrained path" on systems configured with `--with-python=2.x` otherwise the ZFS Test Suite won't be able to use Python scripts.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on Debian9 with the following configuration:

```./configure --prefix=/usr --sysconfdir=/etc --libdir=/lib64 --enable-debug --with-python=2.7```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
