### PR TITLE
Prevent gcc -Werror=maybe-uninitialized warnings in spa_wait_common()

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -9465,7 +9465,7 @@ spa_wait_common(const char *pool, zpool_wait_activity_t activity,
 		error = spa_activity_in_progress(spa, activity, use_tag, tag,
 		    &in_progress);
 
-		if (!in_progress || spa->spa_waiters_cancel || error)
+		if (error || !in_progress || spa->spa_waiters_cancel)
 			break;
 
 		*waited = B_TRUE;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Build is failing on my Debian9 builder:

```
     CC [M]  module/zfs/spa.o
   module/zfs/spa.c: In function ‘spa_wait_common.part.31’:
   module/zfs/spa.c:9468:6: error: ‘in_progress’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
      if (!in_progress || spa->spa_waiters_cancel || error)
         ^
   cc1: all warnings being treated as errors
```

### Description
<!--- Describe your changes in detail -->
`in_progress` may be used uninitialized if we return `EINVAL` in `spa_vdev_initializing()`:

```
spa_wait_common()
  -> spa_activity_in_progress()
    -> spa_vdev_initializing() <- returns EINVAL, does not initialize "in_progress"
```
When this happens `error` is guaranteed to be `!= 0`; this change prevents access to the uninitialized `in_progress` thanks to short-circuit evaluation

```diff
diff --git a/module/zfs/spa.c b/module/zfs/spa.c
index 0f1a2a9eb..7e5c474eb 100644
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -9465,7 +9465,7 @@ spa_wait_common(const char *pool, zpool_wait_activity_t activity,
                error = spa_activity_in_progress(spa, activity, use_tag, tag,
                    &in_progress);
 
-               if (!in_progress || spa->spa_waiters_cancel || error)
+               if (error || !in_progress || spa->spa_waiters_cancel)
                        break;
 
                *waited = B_TRUE;
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Compiled on Debian9 builder (GCC 6.3.0)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
