### PR TITLE
Device removal of indirect vdev panics the kernel

### DIFF
--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
+ * Copyright (c) 2019, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -1962,6 +1963,9 @@ spa_vdev_remove_top_check(vdev_t *vd)
 	spa_t *spa = vd->vdev_spa;
 
 	if (vd != vd->vdev_top)
+		return (SET_ERROR(ENOTSUP));
+
+	if (!vdev_is_concrete(vd))
 		return (SET_ERROR(ENOTSUP));
 
 	if (!spa_feature_is_enabled(spa, SPA_FEATURE_DEVICE_REMOVAL))

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -794,7 +794,8 @@ tests = ['removal_all_vdev', 'removal_cancel', 'removal_check_space',
     'removal_with_remove', 'removal_with_scrub', 'removal_with_send',
     'removal_with_send_recv', 'removal_with_snapshot',
     'removal_with_write', 'removal_with_zdb', 'remove_expanded',
-    'remove_mirror', 'remove_mirror_sanity', 'remove_raidz']
+    'remove_mirror', 'remove_mirror_sanity', 'remove_raidz',
+    'remove_indirect']
 tags = ['functional', 'removal']
 
 [tests/functional/rename_dirs]

--- a/tests/zfs-tests/tests/functional/removal/Makefile.am
+++ b/tests/zfs-tests/tests/functional/removal/Makefile.am
@@ -29,7 +29,7 @@ dist_pkgdata_SCRIPTS = \
 	removal_with_send.ksh removal_with_send_recv.ksh \
 	removal_with_snapshot.ksh removal_with_write.ksh \
 	removal_with_zdb.ksh remove_mirror.ksh remove_mirror_sanity.ksh \
-	remove_raidz.ksh remove_expanded.ksh
+	remove_raidz.ksh remove_expanded.ksh remove_indirect.ksh
 
 dist_pkgdata_DATA = \
 	removal.kshlib

--- a/tests/zfs-tests/tests/functional/removal/remove_indirect.ksh
+++ b/tests/zfs-tests/tests/functional/removal/remove_indirect.ksh
@@ -1,0 +1,58 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2019, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+#
+# DESCRIPTION:
+# Device removal cannot remove non-concrete vdevs
+#
+# STRATEGY:
+# 1. Create a pool with removable devices
+# 2. Remove a top-level device
+# 3. Verify we can't remove the "indirect" vdev created by the first removal
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	destroy_pool $TESTPOOL
+	log_must rm -f $TEST_BASE_DIR/device-{1,2,3}
+}
+
+log_assert "Device removal should not be able to remove non-concrete vdevs"
+log_onexit cleanup
+
+# 1. Create a pool with removable devices
+truncate -s $MINVDEVSIZE $TEST_BASE_DIR/device-{1,2,3}
+zpool create $TESTPOOL $TEST_BASE_DIR/device-{1,2,3}
+
+# 2. Remove a top-level device
+log_must zpool remove $TESTPOOL $TEST_BASE_DIR/device-1
+log_must wait_for_removal $TESTPOOL
+
+# 3. Verify we can't remove the "indirect" vdev created by the first removal
+INDIRECT_VDEV=$(zpool list -v -g $TESTPOOL | awk '{if ($2 == "-") { print $1; exit} }')
+log_must test -n "$INDIRECT_VDEV"
+log_mustnot zpool remove $TESTPOOL $INDIRECT_VDEV
+
+log_pass "Device removal cannot remove non-concrete vdevs"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was trying to remove a vdev by its guid, picked wrong value from `zdb -P | grep guid` output (indirect vdev instead of file vdev):

```
root@linux:~# zdb -P
testpool:
    version: 5000
    name: 'testpool'
    state: 0
    txg: 32
    pool_guid: 17643256605659644812
    errata: 0
    hostname: 'linux'
    com.delphix:has_per_vdev_zaps
    vdev_children: 3
    vdev_tree:
        type: 'root'
        id: 0
        guid: 17643256605659644812
        create_txg: 4
        children[0]:
            type: 'indirect'
            id: 0
            guid: 15157881756569472318
            whole_disk: 0
            metaslab_array: 0
            metaslab_shift: 26
            ashift: 9
            asize: 1069023232
            is_log: 0
            com.delphix:indirect_object: 389
            com.delphix:indirect_births: 391
            create_txg: 4
            com.delphix:vdev_zap_top: 130
        children[1]:
            type: 'file'
            id: 1
            guid: 7707596351290300199
            path: '/var/tmp/2'
            metaslab_array: 143
            metaslab_shift: 26
            ashift: 9
            asize: 1069023232
            is_log: 0
            create_txg: 4
            com.delphix:vdev_zap_leaf: 131
            com.delphix:vdev_zap_top: 132
        children[2]:
            type: 'file'
            id: 2
            guid: 1989233471868155580
            path: '/var/tmp/3'
            metaslab_array: 135
            metaslab_shift: 26
            ashift: 9
            asize: 1069023232
            is_log: 0
            create_txg: 4
            com.delphix:vdev_zap_leaf: 133
            com.delphix:vdev_zap_top: 134
    features_for_read:
        com.delphix:hole_birth
        com.delphix:embedded_data
        com.delphix:device_removal
root@linux:~# zdb -P | grep guid
    pool_guid: 17643256605659644812
        guid: 17643256605659644812
            guid: 15157881756569472318
            guid: 7707596351290300199
            guid: 1989233471868155580
root@linux:~# 
root@linux:~# zpool remove testpool 15157881756569472318
[30933.313207] BUG: unable to handle kernel NULL pointer dereference at 00000000000000a8
[30933.317686] IP: [<ffffffffc030e004>] spa_vdev_remove_top_check+0xc4/0x440 [zfs]
[30933.321679] PGD 3653e067 PUD b822c067 PMD 0 
[30933.352991] Oops: 0000 [#1] SMP 
[30933.355106] Dumping ftrace buffer:
[30933.357215]    (ftrace buffer empty)
```

```
Thread 180 received signal SIGSEGV, Segmentation fault.
0xffffffffc030e004 in spa_vdev_remove_top_check (vd=0xffff880139ca4000) at /usr/src/zfs/module/zfs/vdev_removal.c:1972
1972		metaslab_class_t *mc = vd->vdev_mg->mg_class;
(gdb) bt
#0  0xffffffffc030e004 in spa_vdev_remove_top_check (vd=0xffff880139ca4000) at /usr/src/zfs/module/zfs/vdev_removal.c:1972
#1  0xffffffffc030e3ad in spa_vdev_remove_top (vd=0xffff880139ca4000, txg=0xffff8800b8993d88) at /usr/src/zfs/module/zfs/vdev_removal.c:2073
#2  0xffffffffc030e6c5 in spa_vdev_remove (spa=0xffff8800b8630000, guid=15157881756569472318, unspare=<optimized out>) at /usr/src/zfs/module/zfs/vdev_removal.c:2226
#3  0xffffffffc0331a38 in zfs_ioc_vdev_remove (zc=0xffff8800b8e90000) at /usr/src/zfs/module/zfs/zfs_ioctl.c:1939
#4  0xffffffffc033d6a5 in zfsdev_ioctl (filp=<optimized out>, cmd=<optimized out>, arg=<optimized out>) at /usr/src/zfs/module/zfs/zfs_ioctl.c:7502
#5  0xffffffff81202d74 in vfs_ioctl (arg=<optimized out>, cmd=<optimized out>, filp=<optimized out>) at fs/ioctl.c:43
#6  do_vfs_ioctl (filp=0xffff8800ba86f100, fd=<optimized out>, cmd=<optimized out>, arg=140725645557792) at fs/ioctl.c:607
#7  0xffffffff81202fc9 in SYSC_ioctl (arg=<optimized out>, cmd=<optimized out>, fd=<optimized out>) at fs/ioctl.c:622
#8  SyS_ioctl (fd=3, cmd=23052, arg=140725645557792) at fs/ioctl.c:613
#9  0xffffffff818096f6 in entry_SYSCALL_64 () at arch/x86/entry/entry_64.S:185
#10 0x00007f4c82c5a678 in ?? ()
#11 0x0000000000040000 in ?? ()
#12 0x0000000000041000 in ?? ()
#13 0x00007f4c840cb010 in ?? ()
#14 0x0000000000040010 in ?? ()
#15 0x00007f4c82c5a620 in ?? ()
#16 0x0000000000000246 in irq_stack_union ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
(gdb) p *vd->vdev_ops
$2 = {vdev_op_open = 0xffffffffc02f0d00 <vdev_indirect_open>, vdev_op_close = 0xffffffffc02f0cf0 <vdev_indirect_close>, vdev_op_asize = 0xffffffffc02e3690 <vdev_default_asize>, 
  vdev_op_io_start = 0xffffffffc02f4610 <vdev_indirect_io_start>, vdev_op_io_done = 0xffffffffc02f3450 <vdev_indirect_io_done>, vdev_op_state_change = 0x0 <irq_stack_union>, 
  vdev_op_need_resilver = 0x0 <irq_stack_union>, vdev_op_hold = 0x0 <irq_stack_union>, vdev_op_rele = 0x0 <irq_stack_union>, vdev_op_remap = 0xffffffffc02f3fa0 <vdev_indirect_remap>, 
  vdev_op_xlate = 0x0 <irq_stack_union>, vdev_op_type = "indirect\000\000\000\000\000\000\000", vdev_op_leaf = B_FALSE}
(gdb) p vd->vdev_guid
$3 = 15157881756569472318
(gdb) p vd->vdev_mg
$4 = (metaslab_group_t *) 0x0 <irq_stack_union>
(gdb) p vd->vdev_mg->mg_class
Cannot access memory at address 0xa8
(gdb) 
```

### Description
<!--- Describe your changes in detail -->
This change prevents `zpool removal` for indirect (and other non-concrete) vdevs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Reproducer added as ZTS test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
