### PR TITLE
Fix initramfs install path again

### DIFF
--- a/contrib/initramfs/Makefile.am
+++ b/contrib/initramfs/Makefile.am
@@ -1,4 +1,4 @@
-initrddir = /usr/share/initramfs-tools
+initrddir = $(datarootdir)/initramfs-tools
 
 initrd_SCRIPTS = \
 	conf.d/zfs conf-hooks.d/zfs hooks/zfs scripts/zfs scripts/local-top/zfs

--- a/contrib/initramfs/hooks/Makefile.am
+++ b/contrib/initramfs/hooks/Makefile.am
@@ -1,4 +1,4 @@
-hooksdir = /usr/share/initramfs-tools/hooks
+hooksdir = $(datarootdir)/initramfs-tools/hooks
 
 hooks_SCRIPTS = \
 	zfs

--- a/contrib/initramfs/scripts/Makefile.am
+++ b/contrib/initramfs/scripts/Makefile.am
@@ -1,4 +1,4 @@
-scriptsdir = /usr/share/initramfs-tools/scripts
+scriptsdir = $(datarootdir)/initramfs-tools/scripts
 
 scripts_DATA = \
 	zfs

--- a/contrib/initramfs/scripts/local-top/Makefile.am
+++ b/contrib/initramfs/scripts/local-top/Makefile.am
@@ -1,3 +1,3 @@
-localtopdir = /usr/share/initramfs-tools/scripts/local-top
+localtopdir = $(datarootdir)/initramfs-tools/scripts/local-top
 
 EXTRA_DIST = zfs


### PR DESCRIPTION
Hard coding the install path of initramfs-tools broke install on NixOS.
This partly reverts a6c828 use $datarootdir again.

Signed-off-by: Michael Niewöhner <foss@mniewoehner.de>

Fixes https://github.com/zfsonlinux/zfs/pull/9161#issuecomment-529196847

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
