### PR TITLE
Increase allowed 'special_small_blocks' maximum value

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1229,12 +1229,19 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 		}
 
 		case ZFS_PROP_SPECIAL_SMALL_BLOCKS:
+		{
+			int maxbs = SPA_OLD_MAXBLOCKSIZE;
+			char buf[64];
+
 			if (zpool_hdl != NULL) {
 				char state[64] = "";
 
+				maxbs = zpool_get_prop_int(zpool_hdl,
+				    ZPOOL_PROP_MAXBLOCKSIZE, NULL);
+
 				/*
 				 * Issue a warning but do not fail so that
-				 * tests for setable properties succeed.
+				 * tests for settable properties succeed.
 				 */
 				if (zpool_prop_get_feature(zpool_hdl,
 				    "feature@allocation_classes", state,
@@ -1247,15 +1254,17 @@ zfs_valid_proplist(libzfs_handle_t *hdl, zfs_type_t type, nvlist_t *nvl,
 			}
 			if (intval != 0 &&
 			    (intval < SPA_MINBLOCKSIZE ||
-			    intval > SPA_OLD_MAXBLOCKSIZE || !ISP2(intval))) {
+			    intval > maxbs || !ISP2(intval))) {
+				zfs_nicebytes(maxbs, buf, sizeof (buf));
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "invalid '%s=%d' property: must be zero or "
-				    "a power of 2 from 512B to 128K"), propname,
-				    intval);
+				    "a power of 2 from 512B to %s"), propname,
+				    intval, buf);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}
 			break;
+		}
 
 		case ZFS_PROP_MLSLABEL:
 		{

--- a/man/man8/zfsprops.8
+++ b/man/man8/zfsprops.8
@@ -1055,7 +1055,7 @@ This value represents the threshold block size for including small file
 blocks into the special allocation class. Blocks smaller than or equal to this
 value will be assigned to the special allocation class while greater blocks
 will be assigned to the regular class. Valid values are zero or a power of two
-from 512B up to 128K. The default size is 0 which means no small file blocks
+from 512B up to 1M. The default size is 0 which means no small file blocks
 will be allocated in the special class.
 .Pp
 Before setting this property, a special class vdev must be added to the

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -544,7 +544,7 @@ zfs_prop_init(void)
 	    ZFS_TYPE_FILESYSTEM, "512 to 1M, power of 2", "RECSIZE");
 	zprop_register_number(ZFS_PROP_SPECIAL_SMALL_BLOCKS,
 	    "special_small_blocks", 0, PROP_INHERIT, ZFS_TYPE_FILESYSTEM,
-	    "zero or 512 to 128K, power of 2", "SPECIAL_SMALL_BLOCKS");
+	    "zero or 512 to 1M, power of 2", "SPECIAL_SMALL_BLOCKS");
 
 	/* hidden properties */
 	zprop_register_hidden(ZFS_PROP_NUMCLONES, "numclones", PROP_TYPE_NUMBER,

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_011_neg.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_011_neg.ksh
@@ -21,6 +21,7 @@
 #
 # DESCRIPTION:
 #	Setting the special_small_blocks property to invalid values fails.
+#	Powers of two from 512 to 1M are allowed.
 #
 
 verify_runnable "global"
@@ -34,7 +35,7 @@ log_must disk_setup
 log_must zpool create $TESTPOOL raidz $ZPOOL_DISKS special mirror \
 	$CLASS_DISK0 $CLASS_DISK1
 
-for value in 256 1025 262144
+for value in 256 1025 2097152
 do
 	log_mustnot zfs set special_small_blocks=$value $TESTPOOL
 done


### PR DESCRIPTION
### Motivation and Context

Issue #9131.

### Description

There may be circumstances where it's desirable that all blocks
in a specified dataset be stored on the special device.  Relax
the artificial 128K limit and allow the special_small_blocks
property to be set up to 1M.  When blocks >1MB have been enabled
via the `zfs_max_recordsize` module option, this limit is increased
accordingly.

### How Has This Been Tested?

Verified that `zfs set special_small_blocks=1M` works correctly when
the allocation classes feature is enabled.  Additionally, verified the limit
can be increased up to 16M when `zfs_max_recordsize` in increased.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
