### PR TITLE
ZTS: harden xattr/cleanup.ksh

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2375,7 +2375,7 @@ function del_user #<logname> <basedir>
 	fi
 
 	if id $user > /dev/null 2>&1; then
-		log_must_retry "currently used" 5 userdel $user
+		log_must_retry "currently used" 6 userdel $user
 	fi
 
 	[[ -d $basedir/$user ]] && rm -fr $basedir/$user

--- a/tests/zfs-tests/tests/functional/xattr/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/cleanup.ksh
@@ -30,9 +30,6 @@
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/xattr/xattr_common.kshlib
 
-del_user $ZFS_USER
-del_group $ZFS_GROUP
-
 USES_NIS=$(cat $TEST_BASE_DIR/zfs-xattr-test-nis.txt)
 rm $TEST_BASE_DIR/zfs-xattr-test-nis.txt
 
@@ -41,4 +38,9 @@ then
     svcadm enable svc:/network/nis/client:default
 fi
 
-default_cleanup
+default_cleanup_noexit
+
+del_user $ZFS_USER
+del_group $ZFS_GROUP
+
+log_pass


### PR DESCRIPTION
### Motivation and Context

Improve the reliability of the test suite.  This failure mode has been
observed by the CI occasionally, though I've been unable to reproduce
it locally.

http://build.zfsonlinux.org/builders/Ubuntu%2016.04%20x86_64%20%28TEST%29/builds/8661/steps/shell_9/logs/log

### Description

When the `xattr/cleanup.ksh` script is unable to remove the test group
due to an active process then it will not call `default_cleanup`.  This
will result in a `zvol_ENOSPC/setup.ksh` failure when attempting to create
the `/mnt/testdir` directory which will already exist.

Resolve the issue by performing the default_cleanup before removing
the test user and group to ensure this step always happens.  Also
allow one more retry to further minimize the likelyhood of the
cleanup failing.

```
Test: /usr/share/zfs/zfs-tests/tests/functional/xattr/cleanup (run as root) [00:31] [FAIL]
22:54:51.24 userdel: user zxtr is currently used by process 5400
22:54:51.24 ERROR: userdel zxtr Retry in 1 seconds
22:54:52.25 userdel: user zxtr is currently used by process 5400
22:54:52.25 ERROR: userdel zxtr Retry in 2 seconds
22:54:54.26 userdel: user zxtr is currently used by process 5400
22:54:54.26 ERROR: userdel zxtr Retry in 4 seconds
22:54:58.27 userdel: user zxtr is currently used by process 5400
22:54:58.27 ERROR: userdel zxtr Retry in 8 seconds
22:55:06.29 userdel: user zxtr is currently used by process 5400
22:55:06.29 ERROR: userdel zxtr Retry in 16 seconds
22:55:22.30 userdel: user zxtr is currently used by process 5400
22:55:22.30 ERROR: userdel zxtr exited 8
22:55:22.31 groupdel: cannot remove the primary group of user 'zxtr'
22:55:22.31 ERROR: groupdel zfsgrp exited 8
```

### How Has This Been Tested?

Locally by running `./scripts/zfs-tests.sh -T xattr,zvol` to test the
relevant test groups.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
