### PR TITLE
Workaround to avoid a race when /var/lib is a persistent dataset

### DIFF
--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -6,6 +6,7 @@ After=systemd-udev-settle.service
 After=zfs-import.target
 After=systemd-remount-fs.service
 Before=local-fs.target
+Before=systemd-random-seed.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
### Motivation and Context

There is a race when /var/lib is a separate dataset not under <pool>/ROOT/<root_dataset> between systemd-random-seed which creates/refresh a stamp file and zfs mount -a which will try to mount on /var/lib which isn't empty.

### Description

If /var/lib is a dataset not under <pool>/ROOT/<root_dataset>, as proposed in the ubuntu root on zfs upstream guide (https://github.com/zfsonlinux/zfs/wiki/Ubuntu-18.04-Root-on-ZFS), we end up with a race where some services, like systemd-random-seed are writing under /var/lib, while zfs-mount is called. zfs mount will then potentially fail because of /var/lib isn't empty and so, can't be mounted.
Order those 2 units for now (more may be needed) as we can't declare virtually a provide mount point to match "RequiresMountsFor=/var/lib/systemd/random-seed" from systemd-random-seed.service.
The optional generator for zfs 0.8 fixes it, but it's not enabled by default nor necessarily required.

Example:
- rpool/ROOT/ubuntu (mountpoint = /)
- rpool/var/ (mountpoint = /var)
- rpool/var/lib  (mountpoint = /var/lib)

Both zfs-mount.service and systemd-random-seed.service are starting After=systemd-remount-fs.service. zfs-mount.service should be done before local-fs.target while systemd-random-seed.service should finish before sysinit.target (which is a later target).
Ideally, we would have a way for zfs mount -a unit to declare all paths or move systemd-random-seed after local-fs.target.

The fix changes the unit ordering. I'm opened to any better option though if you can think of one.

### How Has This Been Tested?

This has been tested on ubuntu eoan (incoming 19.10) with the previous layout as descibed. The change is minimal and now the unit ordering is reproducible.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [] I have updated the documentation accordingly.
(No documentation to update AFAIK)
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
(No tests on that part)
- [X] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
