### PR TITLE
Don't do activity check importing pools without MMP magic

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2953,9 +2953,10 @@ spa_activity_check_required(spa_t *spa, uberblock_t *ub, nvlist_t *label,
 		return (B_FALSE);
 
 	/*
-	 * Skip the activity check when the MMP feature is disabled.
+	 * Skip the activity check when the MMP feature is not present or is
+	 * disabled.
 	 */
-	if (ub->ub_mmp_magic == MMP_MAGIC && ub->ub_mmp_delay == 0)
+	if (ub->ub_mmp_magic != MMP_MAGIC || ub->ub_mmp_delay == 0)
 		return (B_FALSE);
 
 	/*
@@ -3496,8 +3497,7 @@ spa_ld_select_uberblock(spa_t *spa, spa_import_type_t type)
 	activity_check = spa_activity_check_required(spa, ub, label,
 	    spa->spa_config);
 	if (activity_check) {
-		if (ub->ub_mmp_magic == MMP_MAGIC && ub->ub_mmp_delay &&
-		    spa_get_hostid(spa) == 0) {
+		if (spa_get_hostid(spa) == 0) {
 			nvlist_free(label);
 			fnvlist_add_uint64(spa->spa_load_info,
 			    ZPOOL_CONFIG_MMP_STATE, MMP_STATE_NO_HOSTID);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`spa_activity_check_required()` determines if an activity check should be performed for multi-mount protection. It mistakenly can return the wrong result for pools that do not have the necessary MMP magic. This can cause pools that were not created by ZoL to undergo an activity check, which must time out.

Some of the conditions checked in `spa_activity_check_required()` are then unnecessarily checked again when setting up to do the activity check.

### Description
<!--- Describe your changes in detail -->
Fix the checks in `spa_activity_check_required()`. Remove the redundant checks.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
This change has been applied in ZoF for a while.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
