### PR TITLE
Fix-for-zfs-dracut-regression-#8913

### DIFF
--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -25,22 +25,23 @@ while true; do
 done
 
 # run this after import as zfs-import-cache/scan service is confirmed good
+# we do not overwrite the ${root} variable, but create a new one, BOOTFS, to hold the dataset
 if [ "${root}" = "zfs:AUTO" ] ; then
-    root="$(zpool list -H -o bootfs | awk '$1 != "-" {print; exit}')"
+    BOOTFS="$(zpool list -H -o bootfs | awk '$1 != "-" {print; exit}')"
 else
-    root="${root##zfs:}"
-    root="${root##ZFS=}"
+    BOOTFS="${root##zfs:}"
+    BOOTFS="${root##ZFS=}"
 fi
 
 # if pool encryption is active and the zfs command understands '-o encryption'
-if [ "$(zpool list -H -o feature@encryption $(echo "${root}" | awk -F\/ '{print $1}'))" = 'active' ]; then
+if [ "$(zpool list -H -o feature@encryption $(echo "${BOOTFS}" | awk -F\/ '{print $1}'))" = 'active' ]; then
     # if the root dataset has encryption enabled
-    ENCRYPTIONROOT=$(zfs get -H -o value encryptionroot "${root}")
+    ENCRYPTIONROOT=$(zfs get -H -o value encryptionroot "${BOOTFS}")
     if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
         # decrypt them
         TRY_COUNT=5
         while [ $TRY_COUNT -gt 0 ]; do
-            systemd-ask-password "Encrypted ZFS password for ${root}" --no-tty | zfs load-key "${ENCRYPTIONROOT}" && break
+            systemd-ask-password "Encrypted ZFS password for ${BOOTFS}" --no-tty | zfs load-key "${ENCRYPTIONROOT}" && break
             TRY_COUNT=$((TRY_COUNT - 1))
         done
     fi


### PR DESCRIPTION
Line 31 and 32 overwrote the ${root} variable which broke mount-zfs.sh

Signed-off-by: Dacian Reece-Stremtan <dacianstremtan@gmail.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
This fixes the issue #8913.  
We have create a new variable for the dataset instead of overwriting the ${root} variable in zfs-load-key.sh
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#8913
### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Create a new initramfs using dracut and restarted the computer.  This was done on two separate computers running Centos 7.7
<!--- Include details of your testing environment, and the tests you ran to -->
Centos 7.7, zfs 0.8.2
Rebuilt initramfs using dracut on the systems mentioned above. Restarted the system.  Instead of failing to start because the root was not mounted (using zfs root), now the computer started all the way.
<!--- see how your change affects other areas of the code, etc. -->
Fixes problem in mount-zfs.sh where the script is bypassed because the ${root} variable was overwritten in zfs-load-key.sh to hold only the dataset name and not the kernel line option for zfs root.
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
