### PR TITLE
Factor out non-portable vnode_t usage

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -1069,7 +1069,7 @@ void dmu_traverse_objset(objset_t *os, uint64_t txg_start,
     dmu_traverse_cb_t cb, void *arg);
 
 int dmu_diff(const char *tosnap_name, const char *fromsnap_name,
-    struct vnode *vp, offset_t *offp);
+    file_t *fp, offset_t *offp);
 
 /* CRC64 table */
 #define	ZFS_CRC64_POLY	0xC96C5795D7870F42ULL	/* ECMA-182, reflected form */

--- a/include/sys/dmu_impl.h
+++ b/include/sys/dmu_impl.h
@@ -251,6 +251,15 @@ typedef struct dmu_sendstatus {
 	uint64_t dss_blocks; /* blocks visited during the sending process */
 } dmu_sendstatus_t;
 
+typedef struct dmu_diffarg {
+	file_t *da_fp;		/* file to which we are reporting */
+	offset_t *da_offp;
+	int da_err;			/* error that stopped diff search */
+	dmu_diff_record_t da_ddr;
+} dmu_diffarg_t;
+
+int dmu_send_write(file_t *fp, char *buf, int len, ssize_t *resid);
+int dmu_write_record(dmu_diffarg_t *da);
 void dmu_object_zapify(objset_t *, uint64_t, dmu_object_type_t, dmu_tx_t *);
 void dmu_object_free_zapified(objset_t *, uint64_t, dmu_tx_t *);
 int dmu_buf_hold_noread(objset_t *, uint64_t, uint64_t,

--- a/include/sys/dmu_recv.h
+++ b/include/sys/dmu_recv.h
@@ -62,7 +62,7 @@ typedef struct dmu_recv_cookie {
 	nvlist_t *drc_begin_nvl;
 
 	objset_t *drc_os;
-	vnode_t *drc_vp; /* The vnode to read the stream from */
+	file_t *drc_fp; /* The file to read the stream from */
 	uint64_t drc_voff; /* The current offset in the stream */
 	uint64_t drc_bytes_read;
 	/*
@@ -82,10 +82,13 @@ typedef struct dmu_recv_cookie {
 int dmu_recv_begin(char *tofs, char *tosnap, dmu_replay_record_t *drr_begin,
     boolean_t force, boolean_t resumable, nvlist_t *localprops,
     nvlist_t *hidden_args, char *origin, dmu_recv_cookie_t *drc,
-    vnode_t *vp, offset_t *voffp);
+    file_t *fp, offset_t *voffp);
 int dmu_recv_stream(dmu_recv_cookie_t *drc, int cleanup_fd,
     uint64_t *action_handlep, offset_t *voffp);
 int dmu_recv_end(dmu_recv_cookie_t *drc, void *owner);
 boolean_t dmu_objset_is_receiving(objset_t *os);
+int dmu_restore_bytes(dmu_recv_cookie_t *drc, void *buf, int len,
+    ssize_t *resid);
+
 
 #endif /* _DMU_RECV_H */

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -528,6 +528,10 @@ typedef struct vnode {
 	int		v_dump_fd;
 } vnode_t;
 
+typedef struct file {
+	vnode_t *f_vnode;
+} file_t;
+
 extern char *vn_dumpdir;
 #define	AV_SCANSTAMP_SZ	32		/* length of anti-virus scanstamp */
 

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -56,6 +56,7 @@ KERNEL_C = \
 	ddt.c \
 	ddt_zap.c \
 	dmu.c \
+	dmu_os.c \
 	dmu_diff.c \
 	dmu_object.c \
 	dmu_objset.c \

--- a/module/os/linux/zfs/Makefile.in
+++ b/module/os/linux/zfs/Makefile.in
@@ -10,6 +10,7 @@ endif
 ccflags-y += -I@abs_top_srcdir@/module/os/linux/zfs
 
 $(MODULE)-objs += ../os/linux/zfs/abd.o
+$(MODULE)-objs += ../os/linux/zfs/dmu_os.o
 $(MODULE)-objs += ../os/linux/zfs/policy.o
 $(MODULE)-objs += ../os/linux/zfs/trace.o
 $(MODULE)-objs += ../os/linux/zfs/qat.o

--- a/module/os/linux/zfs/dmu_os.c
+++ b/module/os/linux/zfs/dmu_os.c
@@ -1,0 +1,78 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2019, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+ */
+
+#include <sys/dmu.h>
+#include <sys/dmu_impl.h>
+#include <sys/dmu_recv.h>
+#include <sys/dmu_tx.h>
+#include <sys/dbuf.h>
+#include <sys/dnode.h>
+#include <sys/zfs_context.h>
+#include <sys/dmu_objset.h>
+#include <sys/dmu_traverse.h>
+#include <sys/dsl_dataset.h>
+#include <sys/dsl_dir.h>
+#include <sys/dsl_pool.h>
+#include <sys/dsl_synctask.h>
+#include <sys/zfs_ioctl.h>
+#include <sys/zap.h>
+#include <sys/zio_checksum.h>
+#include <sys/zfs_znode.h>
+
+int
+dmu_write_record(dmu_diffarg_t *da)
+{
+	ssize_t resid; /* have to get resid to get detailed errno */
+
+	if (da->da_ddr.ddr_type == DDR_NONE) {
+		da->da_err = 0;
+		return (0);
+	}
+
+	da->da_err = vn_rdwr(UIO_WRITE, da->da_fp->f_vnode,
+	    (caddr_t)&da->da_ddr,
+	    sizeof (da->da_ddr), 0, UIO_SYSSPACE, FAPPEND,
+	    RLIM64_INFINITY, CRED(), &resid);
+	*da->da_offp += sizeof (da->da_ddr);
+	return (da->da_err);
+}
+
+int
+dmu_send_write(file_t *fp, char *buf, int len, ssize_t *resid)
+{
+	return (vn_rdwr(UIO_WRITE, fp->f_vnode, buf, len, 0, UIO_SYSSPACE,
+	    FAPPEND, RLIM64_INFINITY, CRED(), resid));
+}
+
+int
+dmu_restore_bytes(dmu_recv_cookie_t *drc, void *buf, int len,
+    ssize_t *resid)
+{
+	return (vn_rdwr(UIO_READ, drc->drc_fp->f_vnode,
+	    (char *)buf, len,
+	    drc->drc_voff, UIO_SYSSPACE, FAPPEND,
+	    RLIM64_INFINITY, CRED(), resid));
+}

--- a/module/zfs/dmu_diff.c
+++ b/module/zfs/dmu_diff.c
@@ -41,37 +41,13 @@
 #include <sys/zio_checksum.h>
 #include <sys/zfs_znode.h>
 
-struct diffarg {
-	struct vnode *da_vp;		/* file to which we are reporting */
-	offset_t *da_offp;
-	int da_err;			/* error that stopped diff search */
-	dmu_diff_record_t da_ddr;
-};
-
 static int
-write_record(struct diffarg *da)
-{
-	ssize_t resid; /* have to get resid to get detailed errno */
-
-	if (da->da_ddr.ddr_type == DDR_NONE) {
-		da->da_err = 0;
-		return (0);
-	}
-
-	da->da_err = vn_rdwr(UIO_WRITE, da->da_vp, (caddr_t)&da->da_ddr,
-	    sizeof (da->da_ddr), 0, UIO_SYSSPACE, FAPPEND,
-	    RLIM64_INFINITY, CRED(), &resid);
-	*da->da_offp += sizeof (da->da_ddr);
-	return (da->da_err);
-}
-
-static int
-report_free_dnode_range(struct diffarg *da, uint64_t first, uint64_t last)
+report_free_dnode_range(dmu_diffarg_t *da, uint64_t first, uint64_t last)
 {
 	ASSERT(first <= last);
 	if (da->da_ddr.ddr_type != DDR_FREE ||
 	    first != da->da_ddr.ddr_last + 1) {
-		if (write_record(da) != 0)
+		if (dmu_write_record(da) != 0)
 			return (da->da_err);
 		da->da_ddr.ddr_type = DDR_FREE;
 		da->da_ddr.ddr_first = first;
@@ -83,7 +59,7 @@ report_free_dnode_range(struct diffarg *da, uint64_t first, uint64_t last)
 }
 
 static int
-report_dnode(struct diffarg *da, uint64_t object, dnode_phys_t *dnp)
+report_dnode(dmu_diffarg_t *da, uint64_t object, dnode_phys_t *dnp)
 {
 	ASSERT(dnp != NULL);
 	if (dnp->dn_type == DMU_OT_NONE)
@@ -91,7 +67,7 @@ report_dnode(struct diffarg *da, uint64_t object, dnode_phys_t *dnp)
 
 	if (da->da_ddr.ddr_type != DDR_INUSE ||
 	    object != da->da_ddr.ddr_last + 1) {
-		if (write_record(da) != 0)
+		if (dmu_write_record(da) != 0)
 			return (da->da_err);
 		da->da_ddr.ddr_type = DDR_INUSE;
 		da->da_ddr.ddr_first = da->da_ddr.ddr_last = object;
@@ -110,7 +86,7 @@ static int
 diff_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
     const zbookmark_phys_t *zb, const dnode_phys_t *dnp, void *arg)
 {
-	struct diffarg *da = arg;
+	dmu_diffarg_t *da = arg;
 	int err = 0;
 
 	if (issig(JUSTLOOKING) && issig(FORREAL))
@@ -162,9 +138,9 @@ diff_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 
 int
 dmu_diff(const char *tosnap_name, const char *fromsnap_name,
-    struct vnode *vp, offset_t *offp)
+    file_t *fp, offset_t *offp)
 {
-	struct diffarg da;
+	dmu_diffarg_t da;
 	dsl_dataset_t *fromsnap;
 	dsl_dataset_t *tosnap;
 	dsl_pool_t *dp;
@@ -205,7 +181,7 @@ dmu_diff(const char *tosnap_name, const char *fromsnap_name,
 	dsl_dataset_long_hold(tosnap, FTAG);
 	dsl_pool_rele(dp, FTAG);
 
-	da.da_vp = vp;
+	da.da_fp = fp;
 	da.da_offp = offp;
 	da.da_ddr.ddr_type = DDR_NONE;
 	da.da_ddr.ddr_first = da.da_ddr.ddr_last = 0;
@@ -227,7 +203,7 @@ dmu_diff(const char *tosnap_name, const char *fromsnap_name,
 		da.da_err = error;
 	} else {
 		/* we set the da.da_err we return as side-effect */
-		(void) write_record(&da);
+		(void) dmu_write_record(&da);
 	}
 
 	dsl_dataset_long_rele(tosnap, FTAG);


### PR DESCRIPTION
On FreeBSD file offset state is maintained in struct file. A given
vnode can be referenced from many different struct file *. As a
consequence, FreeBSD's SPL doesn't support vn_rdwr with the FAPPEND
flag.

This change replaces the non-portable vnode_t with the portable
file_t in the common code.

Signed-off-by: Matt Macy <mmacy@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
