### PR TITLE
ZTS: Fix upgrade_readonly_pool

### DIFF
--- a/tests/zfs-tests/tests/functional/upgrade/upgrade_common.kshlib
+++ b/tests/zfs-tests/tests/functional/upgrade/upgrade_common.kshlib
@@ -34,8 +34,8 @@ export TMPDEV=$TEST_BASE_DIR/zpool_upgrade_test.dat
 
 function cleanup_upgrade
 {
-	datasetexists $TESTPOOL/fs1 && log_must zfs destroy $TESTPOOL/fs1
-	datasetexists $TESTPOOL/fs2 && log_must zfs destroy $TESTPOOL/fs2
-	datasetexists $TESTPOOL/fs3 && log_must zfs destroy $TESTPOOL/fs3
-	datasetexists $TESTPOOL && log_must zpool destroy $TESTPOOL
+	destroy_dataset "$TESTPOOL/fs1"
+	destroy_dataset "$TESTPOOL/fs2"
+	destroy_dataset "$TESTPOOL/fs3"
+	destroy_pool "$TESTPOOL"
 }


### PR DESCRIPTION
### Motivation and Context

http://build.zfsonlinux.org/builders/Debian%209%20x86_64%20%28TEST%29/builds/5528/steps/shell_9/logs/summary

### Description

Update cleanup_upgrade to use destroy_dataset and destroy_pool
when performing cleanup.  These wrappers retry if the pool is busy
preventing occasional failures like those observed when running
tests upgrade_readonly_pool.  For example:

    20:48:21.15 SUCCESS: test enabled == enabled
    20:48:21.15 User accounting upgrade is not executed on readonly pool
    20:48:21.15 NOTE: Performing local cleanup via log_onexit (cleanup_upgrade)
    20:48:21.19 cannot destroy 'testpool': pool is busy
    20:48:21.19 ERROR: zpool destroy testpool exited 1

### How Has This Been Tested?

Pending full CI run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).