### PR TITLE
module/Makefile.in: don't run xargs if empty

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -115,5 +115,5 @@ distdir:
 	list='$(obj-m)'; for objdir in $$list; do \
 		(cd @top_srcdir@/module && find $$objdir \
 		-name '*.c' -o -name '*.h' -o -name '*.S' | \
-		xargs cp --parents -t @abs_top_builddir@/module/$$distdir); \
+		xargs -r cp --parents -t @abs_top_builddir@/module/$$distdir); \
 	done


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If stdin is empty - don't run xargs command,
otherwise we can get `cp: missing file operand`
error (reproducer triggers on `spl` dir).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Reproducer - 'make -j 2 pkg-utils deb-kmod'
```
list='avl/ icp/ lua/ nvpair/ spl/ os/linux/spl/ unicode/ zcommon/ zfs/ os/linux/zfs/'; for objdir in $list; do \
	(cd ../module && find $objdir \
	-name '*.c' -o -name '*.h' -o -name '*.S' | \
	xargs cp --parents -t /home/travis/build/gmelikov/zfs/module/$distdir); \
done

cp: missing file operand
```

Don't reproduce after this patch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
