### PR TITLE
Modify sharenfs=on default behavior

### DIFF
--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -387,9 +387,10 @@ get_linux_shareopts(const char *shareopts, char **plinux_opts)
 
 	*plinux_opts = NULL;
 
-	/* default options for Solaris shares */
+	/* no_subtree_check - Default as of nfs-utils v1.1.0 */
 	(void) add_linux_shareopt(plinux_opts, "no_subtree_check", NULL);
-	(void) add_linux_shareopt(plinux_opts, "no_root_squash", NULL);
+
+	/* mountpoint - Restrict exports to ZFS mountpoints */
 	(void) add_linux_shareopt(plinux_opts, "mountpoint", NULL);
 
 	rc = foreach_nfs_shareopt(shareopts, get_linux_shareopts_cb,

--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -1992,7 +1992,7 @@ If the property is set to
 .Sy on ,
 the dataset is shared using the default options:
 .Pp
-.Em sec=sys,rw,crossmnt,no_subtree_check,no_root_squash
+.Em sec=sys,rw,crossmnt,no_subtree_check
 .Pp
 See
 .Xr exports 5


### PR DESCRIPTION
### Motivation and Context

Issue #9397

### Description

While it may sometimes be convenient to export an NFS filesystem with
`no_root_squash` it should not be the default behavior.  Align the
default behavior with the Linux NFS server defaults.  To restore
the previous behavior use 'zfs set sharenfs="no_root_squash,..."'.

### How Has This Been Tested?

Minimal.  Manual testing required to verify the default behavior is as
expected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).