### PR TITLE
Update `zfs program` command usage

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -316,7 +316,8 @@
 .Op Fl t Ar instruction-limit
 .Op Fl m Ar memory-limit
 .Ar pool script
-.Op Ar arg1 No ...
+.Op --
+.Ar arg1 No ...
 .Nm
 .Cm load-key
 .Op Fl nr
@@ -4756,7 +4757,8 @@ Display the path's inode change time as the first column of output.
 .Op Fl t Ar instruction-limit
 .Op Fl m Ar memory-limit
 .Ar pool script
-.Op Ar arg1 No ...
+.Op --
+.Ar arg1 No ...
 .Xc
 Executes
 .Ar script


### PR DESCRIPTION
### Motivation and Context

Issue #9056.  Rather than try and force a particular non-portable
behavior for `getopt(3)` processing update the documentation to
require the `--` option parsing terminator.

### Description

Update the zfs(8) man page to clearly describe that arguments for
channel programs are to be listed after the `--` sentinel which
terminates argument processing.  This behavior is supported by
getopt on Linux, FreeBSD, and Illumos according to each platforms
respective man pages.

```
    zfs program [-jn] [-t instruction-limit] [-m memory-limit]
        pool script [--] arg1 ...
```

### How Has This Been Tested?

The `contrib/zcp/autosnap.lua` script works as intended on Linux when
the `--` is specified.  Untested on other platforms, but their respective
`getopt(3)` man pages describe this functionality as supported.

This is only an update to the documentation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).