### PR TITLE
Fix pool creation with feature@allocation_classes disabled

### DIFF
--- a/include/zfs_comutil.h
+++ b/include/zfs_comutil.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 extern boolean_t zfs_allocatable_devs(nvlist_t *);
+extern boolean_t zfs_special_devs(nvlist_t *);
 extern void zpool_get_load_policy(nvlist_t *, zpool_load_policy_t *);
 
 extern int zfs_zpl_version_map(int spa_version);

--- a/module/zcommon/zfs_comutil.c
+++ b/module/zcommon/zfs_comutil.c
@@ -64,6 +64,33 @@ zfs_allocatable_devs(nvlist_t *nv)
 	return (B_FALSE);
 }
 
+/*
+ * Are there special vdevs?
+ */
+boolean_t
+zfs_special_devs(nvlist_t *nv)
+{
+	char *bias;
+	uint_t c;
+	nvlist_t **child;
+	uint_t children;
+
+	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN,
+	    &child, &children) != 0) {
+		return (B_FALSE);
+	}
+	for (c = 0; c < children; c++) {
+		if (nvlist_lookup_string(child[c], ZPOOL_CONFIG_ALLOCATION_BIAS,
+		    &bias) == 0) {
+			if (strcmp(bias, VDEV_ALLOC_BIAS_SPECIAL) == 0 ||
+			    strcmp(bias, VDEV_ALLOC_BIAS_DEDUP) == 0) {
+				return (B_TRUE);
+			}
+		}
+	}
+	return (B_FALSE);
+}
+
 void
 zpool_get_load_policy(nvlist_t *nvl, zpool_load_policy_t *zlpp)
 {
@@ -223,6 +250,7 @@ zfs_dataset_name_hidden(const char *name)
 
 #if defined(_KERNEL)
 EXPORT_SYMBOL(zfs_allocatable_devs);
+EXPORT_SYMBOL(zfs_special_devs);
 EXPORT_SYMBOL(zpool_get_load_policy);
 EXPORT_SYMBOL(zfs_zpl_version_map);
 EXPORT_SYMBOL(zfs_spa_version_map);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -5620,6 +5620,7 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	uint64_t version, obj;
 	boolean_t has_features;
 	boolean_t has_encryption;
+	boolean_t has_allocclass;
 	spa_feature_t feat;
 	char *feat_name;
 	char *poolname;
@@ -5664,6 +5665,7 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 
 	has_features = B_FALSE;
 	has_encryption = B_FALSE;
+	has_allocclass = B_FALSE;
 	for (nvpair_t *elem = nvlist_next_nvpair(props, NULL);
 	    elem != NULL; elem = nvlist_next_nvpair(props, elem)) {
 		if (zpool_prop_feature(nvpair_name(elem))) {
@@ -5673,6 +5675,8 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 			VERIFY0(zfeature_lookup_name(feat_name, &feat));
 			if (feat == SPA_FEATURE_ENCRYPTION)
 				has_encryption = B_TRUE;
+			if (feat == SPA_FEATURE_ALLOCATION_CLASSES)
+				has_allocclass = B_TRUE;
 		}
 	}
 
@@ -5685,6 +5689,12 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 			mutex_exit(&spa_namespace_lock);
 			return (error);
 		}
+	}
+	if (!has_allocclass && zfs_special_devs(nvroot)) {
+		spa_deactivate(spa);
+		spa_remove(spa);
+		mutex_exit(&spa_namespace_lock);
+		return (ENOTSUP);
 	}
 
 	if (has_features || nvlist_lookup_uint64(props,

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_001_pos.ksh
@@ -20,7 +20,8 @@
 
 #
 # DESCRIPTION:
-#	Creating a pool with a special device succeeds.
+#	Creating a pool with a special device succeeds, but only if
+#	"feature@allocation_classes" is enabled.
 #
 
 verify_runnable "global"
@@ -31,6 +32,9 @@ log_assert $claim
 log_onexit cleanup
 
 log_must disk_setup
+for type in special dedup; do
+	log_mustnot zpool create -d $TESTPOOL $CLASS_DISK0 $type $CLASS_DISK1
+done
 log_must zpool create $TESTPOOL raidz $ZPOOL_DISKS special mirror \
     $CLASS_DISK0 $CLASS_DISK1
 log_must display_status "$TESTPOOL"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #9427 

### Description
<!--- Describe your changes in detail -->
When "feature@allocation_classes" is not enabled on the pool no vdev with "special" or "dedup" allocation type should be allowed to exist in the vdev tree.

Without this change creating a pool with a special vdev and "feature@allocation_classes" disabled results in the following failure:

```
VERIFY(spa_feature_is_enabled(spa, SPA_FEATURE_ALLOCATION_CLASSES)) failed
PANIC at spa_misc.c:1555:spa_activate_allocation_classes()
Showing stack for process 4329
CPU: 0 PID: 4329 Comm: txg_sync Tainted: P           O    4.9.0-3-amd64 #1 Debian 4.9.30-2+deb9u5
Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
 0000000000000000 ffffffffb75285b4 ffffffffc08d8480 ffffc23401bb7ac8
 ffffffffc056b125 0000000000000008 579a0c3000000028 ffffc23401bb7ad8
 ffffc23401bb7a78 7328594649524556 75746165665f6170 6e655f73695f6572
Call Trace:
 [<ffffffffb75285b4>] ? dump_stack+0x5c/0x78
 [<ffffffffc056b125>] ? spl_panic+0xc5/0x100 [spl]
 [<ffffffffc07b16e8>] ? zap_add_impl+0xb8/0x280 [zfs]
 [<ffffffffc07b819d>] ? feature_get_refcount+0x4d/0x90 [zfs]
 [<ffffffffc07710c3>] ? spa_activate_allocation_classes+0x53/0x60 [zfs]
 [<ffffffffc077de49>] ? vdev_construct_zaps+0x189/0x240 [zfs]
 [<ffffffffc077dd2a>] ? vdev_construct_zaps+0x6a/0x240 [zfs]
 [<ffffffffc075c10d>] ? spa_sync_config_object+0xad/0x480 [zfs]
 [<ffffffffc056d43b>] ? spl_kmem_cache_alloc+0xab/0xc10 [spl]
 [<ffffffffb72ac985>] ? set_next_entity+0xb5/0x1a0
 [<ffffffffb73df0b6>] ? kmem_cache_alloc_node_trace+0x156/0x5a0
 [<ffffffffb780390e>] ? mutex_lock+0xe/0x30
 [<ffffffffc056bbd3>] ? spl_kmem_zalloc+0xc3/0x140 [spl]
 [<ffffffffb780390e>] ? mutex_lock+0xe/0x30
 [<ffffffffb72e2d3b>] ? lock_timer_base+0x7b/0xa0
 [<ffffffffc076f5e0>] ? spa_suspend_async_destroy+0x50/0x50 [zfs]
 [<ffffffffb72e2bca>] ? __internal_add_timer+0x1a/0x50
 [<ffffffffb72e5346>] ? add_timer+0x126/0x200
 [<ffffffffc076f5e0>] ? spa_suspend_async_destroy+0x50/0x50 [zfs]
 [<ffffffffc0789384>] ? vdev_indirect_should_condense+0x84/0x2b0 [zfs]
 [<ffffffffc075cfa9>] ? spa_sync+0x859/0x1800 [zfs]
 [<ffffffffc077a7f9>] ? vdev_get_stats_ex_impl+0xe9/0x2b0 [zfs]
 [<ffffffffb780390e>] ? mutex_lock+0xe/0x30
 [<ffffffffb780390e>] ? mutex_lock+0xe/0x30
 [<ffffffffc0773a4e>] ? spa_txg_history_init_io+0xfe/0x110 [zfs]
 [<ffffffffc0778a13>] ? txg_sync_thread+0x303/0x5a0 [zfs]
 [<ffffffffc0778710>] ? txg_thread_wait+0xd0/0xd0 [zfs]
 [<ffffffffc0573e10>] ? __thread_exit+0x20/0x20 [spl]
 [<ffffffffc0573e86>] ? thread_generic_wrapper+0x76/0xb0 [spl]
 [<ffffffffb72965d7>] ? kthread+0xd7/0xf0
 [<ffffffffb7296500>] ? kthread_park+0x60/0x60
 [<ffffffffb78065f5>] ? ret_from_fork+0x25/0x30
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Run "alloc_class" on Debian builder with patch applied.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
