### PR TITLE
Fix strdup signature conflict on other platforms

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -2863,7 +2863,7 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 	    zpool_prop_to_name(ZPOOL_PROP_VERSION)));
 	spa_close(spa, FTAG);
 
-	strfree(name);
+	kmem_strfree(name);
 	mutex_exit(&ztest_vdev_lock);
 }
 

--- a/include/os/linux/spl/sys/kmem.h
+++ b/include/os/linux/spl/sys/kmem.h
@@ -32,8 +32,8 @@
 extern int kmem_debugging(void);
 extern char *kmem_vasprintf(const char *fmt, va_list ap);
 extern char *kmem_asprintf(const char *fmt, ...);
-extern char *strdup(const char *str);
-extern void strfree(char *str);
+extern char *kmem_strdup(const char *str);
+extern void kmem_strfree(char *str);
 
 /*
  * Memory allocation interfaces

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -722,7 +722,8 @@ extern uint32_t zone_get_hostid(void *zonep);
 
 extern char *kmem_vasprintf(const char *fmt, va_list adx);
 extern char *kmem_asprintf(const char *fmt, ...);
-#define	strfree(str) kmem_free((str), strlen(str) + 1)
+#define	kmem_strfree(str) kmem_free((str), strlen(str) + 1)
+#define	kmem_strdup(s)  strdup(s)
 
 /*
  * Hostname information

--- a/module/icp/spi/kcf_spi.c
+++ b/module/icp/spi/kcf_spi.c
@@ -261,7 +261,7 @@ crypto_register_provider(crypto_provider_info_t *info,
 			prov_desc->pd_kstat->ks_update = kcf_prov_kstat_update;
 			kstat_install(prov_desc->pd_kstat);
 		}
-		strfree(ks_name);
+		kmem_strfree(ks_name);
 	}
 
 	if (prov_desc->pd_prov_type == CRYPTO_HW_PROVIDER)

--- a/module/os/linux/spl/spl-kmem.c
+++ b/module/os/linux/spl/spl-kmem.c
@@ -120,18 +120,18 @@ __strdup(const char *str, int flags)
 }
 
 char *
-strdup(const char *str)
+kmem_strdup(const char *str)
 {
 	return (__strdup(str, KM_SLEEP));
 }
-EXPORT_SYMBOL(strdup);
+EXPORT_SYMBOL(kmem_strdup);
 
 void
-strfree(char *str)
+kmem_strfree(char *str)
 {
 	kfree(str);
 }
-EXPORT_SYMBOL(strfree);
+EXPORT_SYMBOL(kmem_strfree);
 
 /*
  * General purpose unified implementation of kmem_alloc(). It is an

--- a/module/os/linux/spl/spl-kstat.c
+++ b/module/os/linux/spl/spl-kstat.c
@@ -631,7 +631,7 @@ kstat_detect_collision(kstat_proc_entry_t *kpep)
 	parent = kmem_asprintf("%s", kpep->kpe_module);
 
 	if ((cp = strrchr(parent, '/')) == NULL) {
-		strfree(parent);
+		kmem_strfree(parent);
 		return (0);
 	}
 
@@ -639,13 +639,13 @@ kstat_detect_collision(kstat_proc_entry_t *kpep)
 	if ((module = kstat_find_module(parent)) != NULL) {
 		list_for_each_entry(tmp, &module->ksm_kstat_list, kpe_list) {
 			if (strncmp(tmp->kpe_name, cp+1, KSTAT_STRLEN) == 0) {
-				strfree(parent);
+				kmem_strfree(parent);
 				return (EEXIST);
 			}
 		}
 	}
 
-	strfree(parent);
+	kmem_strfree(parent);
 	return (0);
 }
 

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -1038,7 +1038,7 @@ taskq_create(const char *name, int nthreads, pri_t pri,
 	spin_lock_init(&tq->tq_lock);
 	INIT_LIST_HEAD(&tq->tq_thread_list);
 	INIT_LIST_HEAD(&tq->tq_active_list);
-	tq->tq_name = strdup(name);
+	tq->tq_name = kmem_strdup(name);
 	tq->tq_nactive = 0;
 	tq->tq_nthreads = 0;
 	tq->tq_nspawn = 0;
@@ -1178,7 +1178,7 @@ taskq_destroy(taskq_t *tq)
 
 	spin_unlock_irqrestore(&tq->tq_lock, flags);
 
-	strfree(tq->tq_name);
+	kmem_strfree(tq->tq_name);
 	kmem_free(tq, sizeof (taskq_t));
 }
 EXPORT_SYMBOL(taskq_destroy);

--- a/module/os/linux/zfs/spa_stats.c
+++ b/module/os/linux/zfs/spa_stats.c
@@ -138,7 +138,7 @@ spa_read_history_init(spa_t *spa)
 	    spa_read_history_clear,
 	    offsetof(spa_read_history_t, srh_node));
 
-	strfree(module);
+	kmem_strfree(module);
 }
 
 static void
@@ -309,7 +309,7 @@ spa_txg_history_init(spa_t *spa)
 	    spa_txg_history_clear,
 	    offsetof(spa_txg_history_t, sth_node));
 
-	strfree(module);
+	kmem_strfree(module);
 }
 
 static void
@@ -529,7 +529,7 @@ spa_tx_assign_init(spa_t *spa)
 		ksp->ks_update = spa_tx_assign_update;
 		kstat_install(ksp);
 	}
-	strfree(name);
+	kmem_strfree(name);
 }
 
 static void
@@ -592,7 +592,7 @@ spa_io_history_init(spa_t *spa)
 		ksp->ks_update = spa_io_history_update;
 		kstat_install(ksp);
 	}
-	strfree(name);
+	kmem_strfree(name);
 }
 
 static void
@@ -675,7 +675,7 @@ spa_mmp_history_truncate(spa_history_list_t *shl, unsigned int size)
 	while (shl->size > size) {
 		smh = list_remove_head(&shl->procfs_list.pl_list);
 		if (smh->vdev_path)
-			strfree(smh->vdev_path);
+			kmem_strfree(smh->vdev_path);
 		kmem_free(smh, sizeof (spa_mmp_history_t));
 		shl->size--;
 	}
@@ -715,7 +715,7 @@ spa_mmp_history_init(spa_t *spa)
 	    spa_mmp_history_clear,
 	    offsetof(spa_mmp_history_t, smh_node));
 
-	strfree(module);
+	kmem_strfree(module);
 }
 
 static void
@@ -814,7 +814,7 @@ spa_mmp_history_add(spa_t *spa, uint64_t txg, uint64_t timestamp,
 	if (vd) {
 		smh->vdev_guid = vd->vdev_guid;
 		if (vd->vdev_path)
-			smh->vdev_path = strdup(vd->vdev_path);
+			smh->vdev_path = kmem_strdup(vd->vdev_path);
 	}
 	smh->vdev_label = label;
 	smh->mmp_node_id = mmp_node_id;
@@ -876,7 +876,7 @@ spa_state_init(spa_t *spa)
 		kstat_install(ksp);
 	}
 
-	strfree(name);
+	kmem_strfree(name);
 }
 
 static void
@@ -973,7 +973,7 @@ spa_iostats_init(spa_t *spa)
 		kstat_install(ksp);
 	}
 
-	strfree(name);
+	kmem_strfree(name);
 }
 
 static void

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -220,7 +220,7 @@ vdev_elevator_switch(vdev_t *v, char *elevator)
 
 	argv[2] = kmem_asprintf(SET_SCHEDULER_CMD, device, elevator);
 	error = call_usermodehelper(argv[0], argv, envp, UMH_NO_WAIT);
-	strfree(argv[2]);
+	kmem_strfree(argv[2]);
 #endif /* HAVE_ELEVATOR_CHANGE */
 	if (error) {
 		zfs_dbgmsg("Unable to set \"%s\" scheduler for %s (%s): %d",

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -137,8 +137,8 @@ zfsctl_snapshot_alloc(char *full_name, char *full_path, spa_t *spa,
 
 	se = kmem_zalloc(sizeof (zfs_snapentry_t), KM_SLEEP);
 
-	se->se_name = strdup(full_name);
-	se->se_path = strdup(full_path);
+	se->se_name = kmem_strdup(full_name);
+	se->se_path = kmem_strdup(full_path);
 	se->se_spa = spa;
 	se->se_objsetid = objsetid;
 	se->se_root_dentry = root_dentry;
@@ -157,8 +157,8 @@ static void
 zfsctl_snapshot_free(zfs_snapentry_t *se)
 {
 	zfs_refcount_destroy(&se->se_refcount);
-	strfree(se->se_name);
-	strfree(se->se_path);
+	kmem_strfree(se->se_name);
+	kmem_strfree(se->se_path);
 
 	kmem_free(se, sizeof (zfs_snapentry_t));
 }
@@ -311,8 +311,8 @@ zfsctl_snapshot_rename(char *old_snapname, char *new_snapname)
 		return (SET_ERROR(ENOENT));
 
 	zfsctl_snapshot_remove(se);
-	strfree(se->se_name);
-	se->se_name = strdup(new_snapname);
+	kmem_strfree(se->se_name);
+	se->se_name = kmem_strdup(new_snapname);
 	zfsctl_snapshot_add(se);
 	zfsctl_snapshot_rele(se);
 

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -111,7 +111,7 @@ zfsvfs_vfs_free(vfs_t *vfsp)
 {
 	if (vfsp != NULL) {
 		if (vfsp->vfs_mntpoint != NULL)
-			strfree(vfsp->vfs_mntpoint);
+			kmem_strfree(vfsp->vfs_mntpoint);
 
 		kmem_free(vfsp, sizeof (vfs_t));
 	}
@@ -222,7 +222,7 @@ zfsvfs_parse_options(char *mntopts, vfs_t **vfsp)
 		char *tmp_mntopts, *p, *t;
 		int token;
 
-		tmp_mntopts = t = strdup(mntopts);
+		tmp_mntopts = t = kmem_strdup(mntopts);
 		if (tmp_mntopts == NULL)
 			return (SET_ERROR(ENOMEM));
 
@@ -234,13 +234,13 @@ zfsvfs_parse_options(char *mntopts, vfs_t **vfsp)
 			token = match_token(p, zpl_tokens, args);
 			error = zfsvfs_parse_option(p, token, args, tmp_vfsp);
 			if (error) {
-				strfree(tmp_mntopts);
+				kmem_strfree(tmp_mntopts);
 				zfsvfs_vfs_free(tmp_vfsp);
 				return (error);
 			}
 		}
 
-		strfree(tmp_mntopts);
+		kmem_strfree(tmp_mntopts);
 	}
 
 	*vfsp = tmp_vfsp;

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -707,7 +707,7 @@ __zpl_xattr_user_get(struct inode *ip, const char *name,
 
 	xattr_name = kmem_asprintf("%s%s", XATTR_USER_PREFIX, name);
 	error = zpl_xattr_get(ip, xattr_name, value, size);
-	strfree(xattr_name);
+	kmem_strfree(xattr_name);
 
 	return (error);
 }
@@ -729,7 +729,7 @@ __zpl_xattr_user_set(struct inode *ip, const char *name,
 
 	xattr_name = kmem_asprintf("%s%s", XATTR_USER_PREFIX, name);
 	error = zpl_xattr_set(ip, xattr_name, value, size, flags);
-	strfree(xattr_name);
+	kmem_strfree(xattr_name);
 
 	return (error);
 }
@@ -776,7 +776,7 @@ __zpl_xattr_trusted_get(struct inode *ip, const char *name,
 #endif
 	xattr_name = kmem_asprintf("%s%s", XATTR_TRUSTED_PREFIX, name);
 	error = zpl_xattr_get(ip, xattr_name, value, size);
-	strfree(xattr_name);
+	kmem_strfree(xattr_name);
 
 	return (error);
 }
@@ -798,7 +798,7 @@ __zpl_xattr_trusted_set(struct inode *ip, const char *name,
 #endif
 	xattr_name = kmem_asprintf("%s%s", XATTR_TRUSTED_PREFIX, name);
 	error = zpl_xattr_set(ip, xattr_name, value, size, flags);
-	strfree(xattr_name);
+	kmem_strfree(xattr_name);
 
 	return (error);
 }
@@ -845,7 +845,7 @@ __zpl_xattr_security_get(struct inode *ip, const char *name,
 #endif
 	xattr_name = kmem_asprintf("%s%s", XATTR_SECURITY_PREFIX, name);
 	error = zpl_xattr_get(ip, xattr_name, value, size);
-	strfree(xattr_name);
+	kmem_strfree(xattr_name);
 
 	return (error);
 }
@@ -864,7 +864,7 @@ __zpl_xattr_security_set(struct inode *ip, const char *name,
 #endif
 	xattr_name = kmem_asprintf("%s%s", XATTR_SECURITY_PREFIX, name);
 	error = zpl_xattr_set(ip, xattr_name, value, size, flags);
-	strfree(xattr_name);
+	kmem_strfree(xattr_name);
 
 	return (error);
 }

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1404,7 +1404,7 @@ dmu_objset_snapshot_one(const char *fsname, const char *snapname)
 	nvlist_t *snaps = fnvlist_alloc();
 
 	fnvlist_add_boolean(snaps, longsnap);
-	strfree(longsnap);
+	kmem_strfree(longsnap);
 	err = dsl_dataset_snapshot(snaps, NULL, NULL);
 	fnvlist_free(snaps);
 	return (err);
@@ -2795,7 +2795,7 @@ dmu_objset_find_impl(spa_t *spa, const char *name,
 			err = dmu_objset_find_impl(spa, child,
 			    func, arg, flags);
 			dsl_pool_config_enter(dp, FTAG);
-			strfree(child);
+			kmem_strfree(child);
 			if (err != 0)
 				break;
 		}
@@ -2833,7 +2833,7 @@ dmu_objset_find_impl(spa_t *spa, const char *name,
 				dsl_pool_config_exit(dp, FTAG);
 				err = func(child, arg);
 				dsl_pool_config_enter(dp, FTAG);
-				strfree(child);
+				kmem_strfree(child);
 				if (err != 0)
 					break;
 			}

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -2435,7 +2435,7 @@ get_receive_resume_stats_impl(dsl_dataset_t *ds)
 		kmem_free(compressed, packed_size);
 		return (propval);
 	}
-	return (strdup(""));
+	return (kmem_strdup(""));
 }
 
 /*
@@ -2458,7 +2458,7 @@ get_child_receive_stats(dsl_dataset_t *ds)
 		dsl_dataset_rele(recv_ds, FTAG);
 		return (propval);
 	}
-	return (strdup(""));
+	return (kmem_strdup(""));
 }
 
 static void
@@ -2474,9 +2474,9 @@ get_receive_resume_stats(dsl_dataset_t *ds, nvlist_t *nv)
 			dsl_prop_nvlist_add_string(nv,
 			    ZFS_PROP_RECEIVE_RESUME_TOKEN, childval);
 		}
-		strfree(childval);
+		kmem_strfree(childval);
 	}
-	strfree(propval);
+	kmem_strfree(propval);
 }
 
 uint64_t

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -1200,7 +1200,7 @@ dsl_pool_user_hold_rele_impl(dsl_pool_t *dp, uint64_t dsobj,
 		error = zap_add(mos, zapobj, name, 8, 1, &now, tx);
 	else
 		error = zap_remove(mos, zapobj, name, tx);
-	strfree(name);
+	kmem_strfree(name);
 
 	return (error);
 }

--- a/module/zfs/dsl_prop.c
+++ b/module/zfs/dsl_prop.c
@@ -150,8 +150,8 @@ dsl_prop_get_dd(dsl_dir_t *dd, const char *propname,
 	if (err == ENOENT)
 		err = dodefault(prop, intsz, numints, buf);
 
-	strfree(inheritstr);
-	strfree(recvdstr);
+	kmem_strfree(inheritstr);
+	kmem_strfree(recvdstr);
 
 	return (err);
 }
@@ -190,7 +190,7 @@ dsl_prop_get_ds(dsl_dataset_t *ds, const char *propname,
 			char *inheritstr = kmem_asprintf("%s%s", propname,
 			    ZPROP_INHERIT_SUFFIX);
 			err = zap_contains(mos, zapobj, inheritstr);
-			strfree(inheritstr);
+			kmem_strfree(inheritstr);
 			if (err != 0 && err != ENOENT)
 				return (err);
 		}
@@ -201,7 +201,7 @@ dsl_prop_get_ds(dsl_dataset_t *ds, const char *propname,
 			    ZPROP_RECVD_SUFFIX);
 			err = zap_lookup(mos, zapobj, recvdstr,
 			    intsz, numints, buf);
-			strfree(recvdstr);
+			kmem_strfree(recvdstr);
 			if (err != ENOENT) {
 				if (setpoint != NULL && err == 0)
 					(void) strcpy(setpoint,
@@ -424,7 +424,7 @@ dsl_prop_predict(dsl_dir_t *dd, const char *propname,
 		panic("unexpected property source: %d", source);
 	}
 
-	strfree(recvdstr);
+	kmem_strfree(recvdstr);
 
 	if (err == ENOENT)
 		return (0);
@@ -752,8 +752,8 @@ dsl_prop_set_sync_impl(dsl_dataset_t *ds, const char *propname,
 		cmn_err(CE_PANIC, "unexpected property source: %d", source);
 	}
 
-	strfree(inheritstr);
-	strfree(recvdstr);
+	kmem_strfree(inheritstr);
+	kmem_strfree(recvdstr);
 
 	if (isint) {
 		VERIFY0(dsl_prop_get_int_ds(ds, propname, &intval));
@@ -1020,7 +1020,7 @@ dsl_prop_get_all_impl(objset_t *mos, uint64_t propobj,
 				valstr = kmem_asprintf("%s%s", propname,
 				    ZPROP_INHERIT_SUFFIX);
 				err = zap_contains(mos, propobj, valstr);
-				strfree(valstr);
+				kmem_strfree(valstr);
 				if (err == 0)
 					continue;
 				if (err != ENOENT)

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -406,7 +406,7 @@ dsl_dataset_user_release_check_one(dsl_dataset_user_release_arg_t *ddura,
 				    snapname, holdname);
 				fnvlist_add_int32(ddura->ddura_errlist, errtag,
 				    ENOENT);
-				strfree(errtag);
+				kmem_strfree(errtag);
 			}
 			continue;
 		}

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -533,7 +533,7 @@ log_internal(nvlist_t *nvl, const char *operation, spa_t *spa,
 
 	msg = kmem_vasprintf(fmt, adx);
 	fnvlist_add_string(nvl, ZPOOL_HIST_INT_STR, msg);
-	strfree(msg);
+	kmem_strfree(msg);
 
 	fnvlist_add_string(nvl, ZPOOL_HIST_INT_NAME, operation);
 	fnvlist_add_uint64(nvl, ZPOOL_HIST_TXG, tx->tx_txg);

--- a/module/zfs/zcp_get.c
+++ b/module/zfs/zcp_get.c
@@ -431,9 +431,9 @@ get_special_prop(lua_State *state, dsl_dataset_t *ds, const char *dsname,
 			if (strcmp(strval, "") == 0)
 				error = ENOENT;
 
-			strfree(childval);
+			kmem_strfree(childval);
 		}
-		strfree(token);
+		kmem_strfree(token);
 		break;
 	}
 	case ZFS_PROP_VOLSIZE:
@@ -661,7 +661,7 @@ get_userquota_prop(const char *prop_name)
  * prop type as well as the numeric group/user ids based on the string
  * following the '@' in the property name. On success, returns 0. On failure,
  * returns a non-zero error.
- * 'domain' must be free'd by caller using strfree()
+ * 'domain' must be free'd by caller using kmem_strfree()
  */
 static int
 parse_userquota_prop(const char *prop_name, zfs_userquota_prop_t *type,
@@ -688,7 +688,7 @@ parse_userquota_prop(const char *prop_name, zfs_userquota_prop_t *type,
 
 		(void) ddi_strtoll(cp, &end, 10, (longlong_t *)rid);
 		if (*end != '\0') {
-			strfree(domain_val);
+			kmem_strfree(domain_val);
 			return (EINVAL);
 		}
 	} else {
@@ -736,7 +736,7 @@ zcp_get_userquota_prop(lua_State *state, dsl_pool_t *dp,
 			}
 		}
 		if (domain != NULL)
-			strfree(domain);
+			kmem_strfree(domain);
 	}
 	dsl_dataset_rele(ds, FTAG);
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3493,7 +3493,7 @@ zfs_ioc_log_history(const char *unused, nvlist_t *innvl, nvlist_t *outnvl)
 		return (SET_ERROR(EINVAL));
 	(void) tsd_set(zfs_allow_log_key, NULL);
 	error = spa_open(poolname, &spa, FTAG);
-	strfree(poolname);
+	kmem_strfree(poolname);
 	if (error != 0)
 		return (error);
 
@@ -4152,7 +4152,7 @@ recursive_unmount(const char *fsname, void *arg)
 
 	fullname = kmem_asprintf("%s@%s", fsname, snapname);
 	zfs_unmount_snap(fullname);
-	strfree(fullname);
+	kmem_strfree(fullname);
 
 	return (0);
 }
@@ -4688,7 +4688,7 @@ zfs_allow_log_destroy(void *arg)
 	char *poolname = arg;
 
 	if (poolname != NULL)
-		strfree(poolname);
+		kmem_strfree(poolname);
 }
 
 #ifdef	DEBUG
@@ -5907,8 +5907,8 @@ zfs_ioc_tmp_snapshot(zfs_cmd_t *zc)
 	if (error == 0)
 		(void) strlcpy(zc->zc_value, snap_name,
 		    sizeof (zc->zc_value));
-	strfree(snap_name);
-	strfree(hold_name);
+	kmem_strfree(snap_name);
+	kmem_strfree(hold_name);
 	zfs_onexit_fd_rele(zc->zc_cleanup_fd);
 	return (error);
 }
@@ -7335,7 +7335,7 @@ zfsdev_ioctl_common(uint_t vecnum, unsigned long arg)
 		goto out;
 
 	/* legacy ioctls can modify zc_name */
-	saved_poolname = strdup(zc->zc_name);
+	saved_poolname = kmem_strdup(zc->zc_name);
 	if (saved_poolname == NULL) {
 		error = SET_ERROR(ENOMEM);
 		goto out;
@@ -7420,11 +7420,11 @@ out:
 	if (error == 0 && vec->zvec_allow_log) {
 		char *s = tsd_get(zfs_allow_log_key);
 		if (s != NULL)
-			strfree(s);
+			kmem_strfree(s);
 		(void) tsd_set(zfs_allow_log_key, saved_poolname);
 	} else {
 		if (saved_poolname != NULL)
-			strfree(saved_poolname);
+			kmem_strfree(saved_poolname);
 	}
 
 	kmem_free(zc, sizeof (zfs_cmd_t));

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1009,7 +1009,7 @@ zvol_create_snap_minor_cb(const char *dsname, void *arg)
 		    "%s is not a snapshot name\n", dsname);
 	} else {
 		minors_job_t *job;
-		char *n = strdup(dsname);
+		char *n = kmem_strdup(dsname);
 		if (n == NULL)
 			return (0);
 
@@ -1051,7 +1051,7 @@ zvol_create_minors_cb(const char *dsname, void *arg)
 	 */
 	if (strchr(dsname, '@') == 0) {
 		minors_job_t *job;
-		char *n = strdup(dsname);
+		char *n = kmem_strdup(dsname);
 		if (n == NULL)
 			return (0);
 
@@ -1152,7 +1152,7 @@ zvol_create_minors_impl(const char *name)
 		list_remove(&minors_list, job);
 		if (!job->error)
 			ops->zv_create_minor(job->name);
-		strfree(job->name);
+		kmem_strfree(job->name);
 		kmem_free(job, sizeof (minors_job_t));
 	}
 
@@ -1305,7 +1305,7 @@ zvol_rename_minors_impl(const char *oldname, const char *newname)
 			    zv->zv_name[oldnamelen],
 			    zv->zv_name + oldnamelen + 1);
 			ops->zv_rename_minor(zv, name);
-			strfree(name);
+			kmem_strfree(name);
 		}
 
 		mutex_exit(&zv->zv_state_lock);


### PR DESCRIPTION
In the FreeBSD kernel the strdup signature is:

```
char	*strdup(const char *__restrict, struct malloc_type *);
```

It's unfortunate that the developers have chosen to change the signature of
libc functions - but it's what I have to deal with.

Signed-off-by: Matt Macy <mmacy@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
