### PR TITLE
Implement ZPOOL_IMPORT_UDEV_TIMEOUT_MS

### DIFF
--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -53,6 +53,7 @@
 #include <libgen.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -181,17 +182,25 @@ zpool_open_func(void *arg)
 	if (rn->rn_labelpaths) {
 		char *path = NULL;
 		char *devid = NULL;
+		char *env = NULL;
 		rdsk_node_t *slice;
 		avl_index_t where;
+		int timeout;
 		int error;
 
 		if (label_paths(rn->rn_hdl, rn->rn_config, &path, &devid))
 			return;
 
+		env = getenv("ZPOOL_IMPORT_UDEV_TIMEOUT_MS");
+		if ((env == NULL) || sscanf(env, "%d", &timeout) != 1 ||
+		    timeout < 0) {
+			timeout = DISK_LABEL_WAIT;
+		}
+
 		/*
 		 * Allow devlinks to stabilize so all paths are available.
 		 */
-		zpool_label_disk_wait(rn->rn_name, DISK_LABEL_WAIT);
+		zpool_label_disk_wait(rn->rn_name, timeout);
 
 		if (path != NULL) {
 			slice = zutil_alloc(hdl, sizeof (rdsk_node_t));

--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -2813,6 +2813,12 @@ Similar to the
 option in
 .Nm zpool import .
 .El
+.Bl -tag -width "ZPOOL_IMPORT_UDEV_TIMEOUT_MS"
+.It Ev ZPOOL_IMPORT_UDEV_TIMEOUT_MS
+The maximum time in milliseconds that
+.Nm zpool import
+will wait for an expected device to be available.
+.El
 .Bl -tag -width "ZPOOL_VDEV_NAME_GUID"
 .It Ev ZPOOL_VDEV_NAME_GUID
 Cause


### PR DESCRIPTION
### Motivation and Context

Refreshed version of @ryao's original #9109 PR.  Documentation
updated and negative timeout values checked for.

### Description

Since 0.7.0, zpool import would unconditionally block on udev for 30
seconds. This introduced a regression in initramfs environments that
lack udev (particularly mdev based environments), yet use a zfs userland
tools intended for the system that had been built against udev. Gentoo's
genkernel is the main example, although custom user initramfs
environments would be similarly impacted unless special builds of the
ZFS userland utilities were done for them.  Such environments already
have their own mechanisms for blocking until device nodes are ready
(such as genkernel's scandelay parameter), so it is unnecessary for
zpool import to block on a non-existent udev until a timeout is reached
inside of them.

Rather than trying to intelligently determine whether udev is available
on the system to avoid unnecessarily blocking in such environments, it
seems best to just allow the environment to override the timeout.  I
propose that we add an environment variable called
ZPOOL_IMPORT_UDEV_TIMEOUT_MS. Setting it to 0 would restore the 0.6.x
behavior that was more desireable in mdev based initramfs environments.
This allows the system userland utilities to be reused when building
mdev-based initramfs archives.

### How Has This Been Tested?

Updated version has been compiled locally.  My understanding is the previous
version has been in use by Gentoo for some time.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).