### PR TITLE
Don't call dump_spill or arc_buf_destroy on unallocated arc_buf

### DIFF
--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -955,14 +955,14 @@ do_dump(dmu_send_cookie_t *dscp, struct send_range *range)
 			zb.zb_level = 0;
 			zb.zb_blkid = range->start_blkid;
 
-			if (!dscp->dsc_dso->dso_dryrun && arc_read(NULL, spa,
-			    bp, arc_getbuf_func, &abuf, ZIO_PRIORITY_ASYNC_READ,
-			    zioflags, &aflags, &zb) != 0)
-				return (SET_ERROR(EIO));
-
-			err = dump_spill(dscp, bp, zb.zb_object, abuf->b_data);
-			arc_buf_destroy(abuf, &abuf);
-			return (err);
+			if (!dscp->dsc_dso->dso_dryrun) {
+				if (arc_read(NULL, spa, bp, arc_getbuf_func, &abuf,
+				    ZIO_PRIORITY_ASYNC_READ, zioflags, &aflags, &zb) != 0)
+					return (SET_ERROR(EIO));
+				err = dump_spill(dscp, bp, zb.zb_object, abuf->b_data);
+				arc_buf_destroy(abuf, &abuf);
+				return (err);
+			}
 		}
 		if (send_do_embed(dscp, bp)) {
 			err = dump_write_embedded(dscp, range->object,


### PR DESCRIPTION
I don't recall when / how I initially hit this issue but it's self evident from the code that
in the `dso_dryrun != 0` case that we will call `dump_spill` and `arc_buf_destroy` on a pointer that contains whatever value happens to be at that stack location.

Signed-off-by: Matt Macy <mmacy@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
