### PR TITLE
ZTS: Fix some style nits in tests

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs/zfs_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs/zfs_002_pos.ksh
@@ -62,7 +62,7 @@ log_assert "With ZFS_ABORT set, all zfs commands can abort and generate a " \
     "core file."
 log_onexit cleanup
 
-#preparation work for testing
+# Preparation work for testing
 corepath=$TESTDIR/core
 if [[ -d $corepath ]]; then
 	rm -rf $corepath

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_006_pos.ksh
@@ -55,7 +55,7 @@ function get_estimate_size
 	typeset snapshot=$1
 	typeset option=$2
 	typeset base_snapshot=${3:-""}
-	if [[ -z $3 ]];then
+	if [[ -z $3 ]]; then
 		typeset total_size=$(zfs send $option $snapshot 2>&1 | tail -1)
 	else
 		typeset total_size=$(zfs send $option $base_snapshot $snapshot \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_unmount/zfs_unmount_008_neg.ksh
@@ -95,15 +95,14 @@ for arg in ${badargs[@]}; do
 	log_mustnot eval "zfs unmount $arg $fs >/dev/null 2>&1"
 done
 
-
-#Testing invalid datasets
+# Testing invalid datasets
 for ds in $snap $vol "blah"; do
 	for opt in "" "-f"; do
 		log_mustnot eval "zfs unmount $opt $ds >/dev/null 2>&1"
 	done
 done
 
-#Testing invalid mountpoint
+# Testing invalid mountpoint
 dir=foodir.$$
 file=foo.$$
 fs1=$TESTPOOL/fs.$$
@@ -119,20 +118,20 @@ for mpt in "./$dir" "./$file" "/tmp"; do
 done
 cd $curpath
 
-#Testing null argument and too many arguments
+# Testing null argument and too many arguments
 for opt in "" "-f"; do
 	log_mustnot eval "zfs unmount $opt >/dev/null 2>&1"
 	log_mustnot eval "zfs unmount $opt $fs $fs1 >/dev/null 2>&1"
 done
 
-#Testing already unmounted filesystem
+# Testing already unmounted filesystem
 log_must zfs unmount $fs1
 for opt in "" "-f"; do
 	log_mustnot eval "zfs unmount $opt $fs1 >/dev/null 2>&1"
 	log_mustnot eval "zfs unmount /tmp/$dir >/dev/null 2>&1"
 done
 
-#Testing legacy mounted filesystem
+# Testing legacy mounted filesystem
 log_must zfs set mountpoint=legacy $fs1
 if is_linux; then
 	log_must mount -t zfs $fs1 /tmp/$dir

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.shlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.shlib
@@ -45,7 +45,7 @@ function create_pool_test
 	typeset vdevs
 	eval "typeset -a diskarray=($3)"
 
-	for vdevs in "${diskarray[@]}";do
+	for vdevs in "${diskarray[@]}"; do
 		create_pool $pool $keywd $vdevs
 		log_must poolexists $pool
 		destroy_pool $pool

--- a/tests/zfs-tests/tests/functional/history/history_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_001_pos.ksh
@@ -115,7 +115,7 @@ import_dir=$TEST_BASE_DIR/import_dir.$$
 log_must mkdir $import_dir
 log_must cp $STF_SUITE/tests/functional/history/zfs-pool-v4.dat.Z $import_dir
 log_must uncompress $import_dir/zfs-pool-v4.dat.Z
-upgrade_pool=$(zpool import -d $import_dir | grep "pool:" | awk '{print $2}')
+upgrade_pool=$(zpool import -d $import_dir | awk '/pool:/ { print $2 }')
 log_must zpool import -d $import_dir $upgrade_pool
 run_and_verify -p "$upgrade_pool" "zpool upgrade $upgrade_pool"
 

--- a/tests/zfs-tests/tests/functional/history/history_common.kshlib
+++ b/tests/zfs-tests/tests/functional/history/history_common.kshlib
@@ -110,7 +110,7 @@ function verify_long
 	fi
 
 	typeset suffix=""
-	if [ is_linux ]; then
+	if is_linux; then
 		suffix=":linux"
 	fi
 

--- a/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
@@ -401,18 +401,17 @@ set -A local_val "off" "on" "off" \
 #
 # Add system specific values
 #
-
-if ! is_linux; then
+if is_linux; then
+	prop+=("acltype" "")
+	def_val+=("off")
+	local_val+=("off")
+else
 	prop+=("aclmode" "" \
 		"mountpoint" "")
 	def_val+=("discard" \
 		"")
 	local_val+=("groupmask" \
 		"$TESTDIR")
-else
-	prop+=("acltype" "")
-	def_val+=("off")
-	local_val+=("off")
 fi
 
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Upstreaming fixes from ZoF

### Description
<!--- Describe your changes in detail -->
Clean up a few style nits in the test suite. Not going for all of them, just the ones I spotted scrolling through our diff. Mostly whitespace changes, no functional changes intended.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
