### PR TITLE
ZTS: Fix zpool_status_-s

### DIFF
--- a/tests/zfs-tests/tests/functional/fault/scrub_after_resilver.ksh
+++ b/tests/zfs-tests/tests/functional/fault/scrub_after_resilver.ksh
@@ -42,6 +42,7 @@ function cleanup
 	# Restore our zed.rc
 	log_must zed_rc_restore $zedrc_backup
 	default_cleanup_noexit
+	log_must zpool labelclear -f $DISK1
 }
 
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/fault/zpool_status_-s.ksh
+++ b/tests/zfs-tests/tests/functional/fault/zpool_status_-s.ksh
@@ -41,14 +41,14 @@ DISK=${DISKS%% *}
 
 verify_runnable "both"
 
-log_must zpool create $TESTPOOL mirror ${DISKS}
+default_mirror_setup_noexit $DISKS
 
 function cleanup
 {
 	log_must zinject -c all
 	log_must set_tunable64 zio_slow_io_ms $OLD_SLOW_IO
 	log_must set_tunable64 zfs_slow_io_events_per_second $OLD_SLOW_IO_EVENTS
-	log_must destroy_pool $TESTPOOL
+	default_cleanup_noexit
 }
 
 log_onexit cleanup


### PR DESCRIPTION
### Motivation and Context

Observed ZTS failures of `zpool_status_-s` test case.

### Description

After commit 5e74ac51 which split and reordered the run files the
zpool_status_-s test began failing.  The new ordering placed
the test after a previous test which used `zpool replace` to replace
a disk but did not clear its label.  This resulted the next test,
zpool_status_-s, failing because of the potentially active
pool being detected on the replaced vdev.

    /dev/loop0 is part of potentially active pool 'testpool'

Use the default_mirror_setup_noexit() and default_cleanup_noexit()
functions to create the pool in zpool_status_-s.  They use the -f
flag by default.

In the scrub_after_resilver test clear wipe the label during cleanup
to prevent a failure in case the tests are reordered again.

### How Has This Been Tested?

Manually ran the test cases to verify the failure no longer occurs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
