### PR TITLE
Fix small btree-related errors

### DIFF
--- a/include/sys/range_tree.h
+++ b/include/sys/range_tree.h
@@ -126,11 +126,11 @@ rs_get_start_raw(const range_seg_t *rs, const range_tree_t *rt)
 	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
 	case RANGE_SEG32:
-		return (((range_seg32_t *)rs)->rs_start);
+		return (((const range_seg32_t *)rs)->rs_start);
 	case RANGE_SEG64:
-		return (((range_seg64_t *)rs)->rs_start);
+		return (((const range_seg64_t *)rs)->rs_start);
 	case RANGE_SEG_GAP:
-		return (((range_seg_gap_t *)rs)->rs_start);
+		return (((const range_seg_gap_t *)rs)->rs_start);
 	default:
 		VERIFY(0);
 		return (0);
@@ -143,11 +143,11 @@ rs_get_end_raw(const range_seg_t *rs, const range_tree_t *rt)
 	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
 	case RANGE_SEG32:
-		return (((range_seg32_t *)rs)->rs_end);
+		return (((const range_seg32_t *)rs)->rs_end);
 	case RANGE_SEG64:
-		return (((range_seg64_t *)rs)->rs_end);
+		return (((const range_seg64_t *)rs)->rs_end);
 	case RANGE_SEG_GAP:
-		return (((range_seg_gap_t *)rs)->rs_end);
+		return (((const range_seg_gap_t *)rs)->rs_end);
 	default:
 		VERIFY(0);
 		return (0);

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -1244,7 +1244,7 @@ dsl_scan_should_clear(dsl_scan_t *scn)
 		if (queue != NULL) {
 			/* # extents in exts_by_size = # in exts_by_addr */
 			mused += zfs_btree_numnodes(&queue->q_exts_by_size) *
-			    sizeof (range_seg_t) + queue->q_sio_memused;
+			    sizeof (range_seg_gap_t) + queue->q_sio_memused;
 		}
 		mutex_exit(&tvd->vdev_scan_io_queue_lock);
 	}


### PR DESCRIPTION
Signed-off-by: Paul Dagnelie <pcd@delphix.com>

### Motivation and Context
As pointed out on Slack, this call of sizeof on void is both confusing and incorrect. In addition, clang complains about casting away the const of the range seg in the get_raw functions.

### Description
We get the sizeof the appropriate type, and don't cast away const.

### How Has This Been Tested?
Verified compilation

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
