### PR TITLE
Suppress memleak warnings in rdwr_efi for cppcheck 1.86

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -399,8 +399,10 @@ efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
 	length = sizeof (struct dk_gpt) +
 	    sizeof (struct dk_part) * (nparts - 1);
 
-	if ((*vtoc = calloc(1, length)) == NULL)
+	if ((*vtoc = calloc(1, length)) == NULL) {
+		// cppcheck-suppress memleak
 		return (-1);
+	}
 
 	vptr = *vtoc;
 
@@ -419,6 +421,7 @@ efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
 
 	(void) uuid_generate((uchar_t *)&uuid);
 	UUID_LE_CONVERT(vptr->efi_disk_uguid, uuid);
+	// cppcheck-suppress memleak
 	return (0);
 }
 
@@ -436,9 +439,10 @@ efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
 	nparts = EFI_MIN_ARRAY_SIZE / sizeof (efi_gpe_t);
 	length = (int) sizeof (struct dk_gpt) +
 	    (int) sizeof (struct dk_part) * (nparts - 1);
-	if ((*vtoc = calloc(1, length)) == NULL)
+	if ((*vtoc = calloc(1, length)) == NULL) {
+		// cppcheck-suppress memleak
 		return (VT_ERROR);
-
+	}
 	(*vtoc)->efi_nparts = nparts;
 	rval = efi_read(fd, *vtoc);
 
@@ -451,6 +455,7 @@ efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
 		if ((tmp = realloc(*vtoc, length)) == NULL) {
 			free (*vtoc);
 			*vtoc = NULL;
+			// cppcheck-suppress memleak
 			return (VT_ERROR);
 		} else {
 			*vtoc = tmp;
@@ -466,7 +471,7 @@ efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
 		free (*vtoc);
 		*vtoc = NULL;
 	}
-
+	// cppcheck-suppress memleak
 	return (rval);
 }
 


### PR DESCRIPTION
Using the version of cppcheck on Ubuntu this triggers
the following memleak warnings:

[lib/libefi/rdwr_efi.c:403]: (error) Memory leak: vtoc
[lib/libefi/rdwr_efi.c:422]: (error) Memory leak: vtoc
[lib/libefi/rdwr_efi.c:440]: (error) Memory leak: vtoc
[lib/libefi/rdwr_efi.c:454]: (error) Memory leak: vtoc
[lib/libefi/rdwr_efi.c:470]: (error) Memory leak: vtoc

I'm not certain but this looks like this is a false
positive caused by the strange calling convention used.

Signed-off-by: Matt Macy <mmacy@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
