### PR TITLE
Add support for externally compressed data

### DIFF
--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -55,6 +55,7 @@ extern "C" {
 #define	DB_RF_NEVERWAIT		(1 << 4)
 #define	DB_RF_CACHED		(1 << 5)
 #define	DB_RF_NO_DECRYPT	(1 << 6)
+#define	DB_RF_NO_DECOMPRESS	(1 << 7)
 
 /*
  * The simplified state transition diagram for dbufs looks like:
@@ -317,8 +318,13 @@ int dbuf_spill_set_blksz(dmu_buf_t *db, uint64_t blksz, dmu_tx_t *tx);
 void dbuf_rm_spill(struct dnode *dn, dmu_tx_t *tx);
 
 dmu_buf_impl_t *dbuf_hold(struct dnode *dn, uint64_t blkid, void *tag);
+dmu_buf_impl_t *dbuf_hold_db(dnode_t *dn, int level, uint64_t blkid,
+    int dbflag, void *tag);
 dmu_buf_impl_t *dbuf_hold_level(struct dnode *dn, int level, uint64_t blkid,
     void *tag);
+int dbuf_hold_db_impl(struct dnode *dn, uint8_t level, uint64_t blkid,
+    boolean_t fail_sparse, boolean_t fail_uncached, int dbflag,
+    void *tag, dmu_buf_impl_t **dbp);
 int dbuf_hold_impl(struct dnode *dn, uint8_t level, uint64_t blkid,
     boolean_t fail_sparse, boolean_t fail_uncached,
     void *tag, dmu_buf_impl_t **dbp);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -528,6 +528,8 @@ void dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp,
  * Returns ENOENT, EIO, or 0.
  */
 int dmu_bonus_hold(objset_t *os, uint64_t object, void *tag, dmu_buf_t **dbp);
+int dmu_bonus_hold_compressed(objset_t *os, uint64_t object, void *tag,
+    dmu_buf_t **dbp);
 int dmu_bonus_hold_by_dnode(dnode_t *dn, void *tag, dmu_buf_t **dbp,
     uint32_t flags);
 int dmu_bonus_max(void);
@@ -600,6 +602,9 @@ uint64_t dmu_buf_user_refcount(dmu_buf_t *db);
 int dmu_buf_hold_array_by_bonus(dmu_buf_t *db, uint64_t offset,
     uint64_t length, boolean_t read, void *tag,
     int *numbufsp, dmu_buf_t ***dbpp);
+int dmu_buf_hold_array_by_bonus_compressed(dmu_buf_t *db, uint64_t offset,
+    uint64_t length, boolean_t read, void *tag,
+    int *numbufsp, dmu_buf_t ***dbpp, enum zio_compress **comp);
 void dmu_buf_rele_array(dmu_buf_t **, int numbufs, void *tag);
 
 typedef void dmu_buf_evict_func_t(void *user_ptr);
@@ -771,6 +776,8 @@ void dmu_buf_set_crypt_params(dmu_buf_t *db_fake, boolean_t byteorder,
 
 dmu_tx_t *dmu_tx_create(objset_t *os);
 void dmu_tx_hold_write(dmu_tx_t *tx, uint64_t object, uint64_t off, int len);
+void dmu_tx_hold_write_db(dmu_tx_t *tx, uint64_t object, int dbflag,
+    uint64_t off, int len);
 void dmu_tx_hold_write_by_dnode(dmu_tx_t *tx, dnode_t *dn, uint64_t off,
     int len);
 void dmu_tx_hold_free(dmu_tx_t *tx, uint64_t object, uint64_t off,
@@ -833,8 +840,9 @@ int dmu_free_long_object(objset_t *os, uint64_t object);
  * nonrecoverable I/O error.
  */
 #define	DMU_READ_PREFETCH	0 /* prefetch */
-#define	DMU_READ_NO_PREFETCH	1 /* don't prefetch */
-#define	DMU_READ_NO_DECRYPT	2 /* don't decrypt */
+#define	DMU_READ_NO_PREFETCH	(1 << 0) /* don't prefetch */
+#define	DMU_READ_NO_DECRYPT	(1 << 1) /* don't decrypt */
+#define	DMU_READ_NO_DECOMPRESS	(1 << 2) /* don't decompress */
 int dmu_read(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	void *buf, uint32_t flags);
 int dmu_read_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size, void *buf,
@@ -858,6 +866,8 @@ int dmu_write_uio_dnode(dnode_t *dn, struct uio *uio, uint64_t size,
 	dmu_tx_t *tx);
 #endif
 struct arc_buf *dmu_request_arcbuf(dmu_buf_t *handle, int size);
+struct arc_buf *dmu_request_compressed_arcbuf(dmu_buf_t *handle, int psize,
+    int lsize, enum zio_compress compression_type);
 void dmu_return_arcbuf(struct arc_buf *buf);
 int dmu_assign_arcbuf_by_dnode(dnode_t *dn, uint64_t offset,
     struct arc_buf *buf, dmu_tx_t *tx);
@@ -866,6 +876,8 @@ int dmu_assign_arcbuf_by_dbuf(dmu_buf_t *handle, uint64_t offset,
 #define	dmu_assign_arcbuf	dmu_assign_arcbuf_by_dbuf
 void dmu_copy_from_buf(objset_t *os, uint64_t object, uint64_t offset,
     dmu_buf_t *handle, dmu_tx_t *tx);
+void dmu_assign_compressed_arcbuf(dmu_buf_t *handle, uint64_t offset,
+    uint64_t psize, struct arc_buf *buf, dmu_tx_t *tx);
 #ifdef HAVE_UIO_ZEROCOPY
 int dmu_xuio_init(struct xuio *uio, int niov);
 void dmu_xuio_fini(struct xuio *uio);

--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -411,8 +411,12 @@ void dnode_rm_spill(dnode_t *dn, dmu_tx_t *tx);
 
 int dnode_hold(struct objset *dd, uint64_t object,
     void *ref, dnode_t **dnp);
+int dnode_hold_db(struct objset *dd, uint64_t object, int dbflag,
+    void *ref, dnode_t **dnp);
 int dnode_hold_impl(struct objset *dd, uint64_t object, int flag, int dn_slots,
     void *ref, dnode_t **dnp);
+int dnode_hold_db_impl(struct objset *dd, uint64_t object, int dnflag,
+    int dbflag, int dn_slots, void *ref, dnode_t **dnp);
 boolean_t dnode_add_ref(dnode_t *dn, void *ref);
 void dnode_rele(dnode_t *dn, void *ref);
 void dnode_rele_and_unlock(dnode_t *dn, void *tag, boolean_t evicting);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -995,6 +995,7 @@ extern void spa_claim_notify(zio_t *zio);
 extern void spa_deadman(void *);
 
 /* Accessor functions */
+extern int spa_get_min_ashift(spa_t *spa);
 extern boolean_t spa_shutting_down(spa_t *spa);
 extern struct dsl_pool *spa_get_dsl(spa_t *spa);
 extern boolean_t spa_is_initializing(spa_t *spa);

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5540,6 +5540,11 @@ arc_read(zio_t *pio, spa_t *spa, const blkptr_t *bp,
 	ASSERT(!BP_IS_REDACTED(bp));
 
 top:
+	if (*arc_flags & ARC_FLAG_COMPRESSED_ARC) {
+		zio_flags |= ZIO_FLAG_RAW;
+		compressed_read = TRUE;
+	}
+
 	if (!embedded_bp) {
 		/*
 		 * Embedded BP's have no DVA and require no I/O to "read".

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1438,6 +1438,10 @@ dbuf_read_impl(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags,
 
 	if ((flags & DB_RF_NO_DECRYPT) && BP_IS_PROTECTED(db->db_blkptr))
 		zio_flags |= ZIO_FLAG_RAW;
+
+	if (flags & DB_RF_NO_DECOMPRESS)
+		zio_flags |= ZIO_FLAG_RAW_COMPRESS;
+
 	/*
 	 * The zio layer will copy the provided blkptr later, but we need to
 	 * do this now so that we can release the parent's rwlock. We have to
@@ -1571,6 +1575,7 @@ dbuf_read(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags)
 		 */
 		if (err == 0 && db->db_buf != NULL &&
 		    (flags & DB_RF_NO_DECRYPT) == 0 &&
+		    (flags & DB_RF_NO_DECOMPRESS) == 0 &&
 		    (arc_is_encrypted(db->db_buf) ||
 		    arc_is_unauthenticated(db->db_buf) ||
 		    arc_get_compression(db->db_buf) != ZIO_COMPRESS_OFF)) {
@@ -2728,7 +2733,7 @@ dbuf_destroy(dmu_buf_impl_t *db)
 __attribute__((always_inline))
 static inline int
 dbuf_findbp(dnode_t *dn, int level, uint64_t blkid, int fail_sparse,
-    dmu_buf_impl_t **parentp, blkptr_t **bpp)
+    dmu_buf_impl_t **parentp, int dbflag, blkptr_t **bpp)
 {
 	*parentp = NULL;
 	*bpp = NULL;
@@ -2783,13 +2788,14 @@ dbuf_findbp(dnode_t *dn, int level, uint64_t blkid, int fail_sparse,
 		/* this block is referenced from an indirect block */
 		int err;
 
-		err = dbuf_hold_impl(dn, level + 1,
-		    blkid >> epbs, fail_sparse, FALSE, NULL, parentp);
+		err = dbuf_hold_db_impl(dn, level + 1,
+		    blkid >> epbs, fail_sparse, FALSE, dbflag, NULL, parentp);
 
 		if (err)
 			return (err);
 		err = dbuf_read(*parentp, NULL,
-		    (DB_RF_HAVESTRUCT | DB_RF_NOPREFETCH | DB_RF_CANFAIL));
+		    (DB_RF_HAVESTRUCT | DB_RF_NOPREFETCH | DB_RF_CANFAIL |
+		    dbflag));
 		if (err) {
 			dbuf_rele(*parentp, NULL);
 			*parentp = NULL;
@@ -2917,7 +2923,7 @@ dbuf_dnode_findbp(dnode_t *dn, uint64_t level, uint64_t blkid,
 	int err = 0;
 	ASSERT(RW_LOCK_HELD(&dn->dn_struct_rwlock));
 
-	err = dbuf_findbp(dn, level, blkid, B_FALSE, &dbp, &bp2);
+	err = dbuf_findbp(dn, level, blkid, B_FALSE, &dbp, 0, &bp2);
 	if (err == 0) {
 		*bp = *bp2;
 		if (dbp != NULL)
@@ -2961,8 +2967,9 @@ dbuf_issue_final_prefetch(dbuf_prefetch_arg_t *dpa, blkptr_t *bp)
 	    dpa->dpa_aflags | ARC_FLAG_NOWAIT | ARC_FLAG_PREFETCH;
 
 	/* dnodes are always read as raw and then converted later */
-	if (BP_GET_TYPE(bp) == DMU_OT_DNODE && BP_IS_PROTECTED(bp) &&
-	    dpa->dpa_curlevel == 0)
+	if ((BP_GET_TYPE(bp) == DMU_OT_DNODE && BP_IS_PROTECTED(bp) &&
+	    dpa->dpa_curlevel == 0) ||
+	    (aflags & ARC_FLAG_COMPRESSED_ARC) != 0)
 		zio_flags |= ZIO_FLAG_RAW;
 
 	ASSERT3U(dpa->dpa_curlevel, ==, BP_GET_LEVEL(bp));
@@ -3245,13 +3252,9 @@ dbuf_hold_copy(dnode_t *dn, dmu_buf_impl_t *db)
 	rw_exit(&db->db_rwlock);
 }
 
-/*
- * Returns with db_holds incremented, and db_mtx not held.
- * Note: dn_struct_rwlock must be held.
- */
 int
-dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
-    boolean_t fail_sparse, boolean_t fail_uncached,
+dbuf_hold_db_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
+    boolean_t fail_sparse, boolean_t fail_uncached, int dbflag,
     void *tag, dmu_buf_impl_t **dbp)
 {
 	dmu_buf_impl_t *db, *parent = NULL;
@@ -3280,7 +3283,8 @@ dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
 			return (SET_ERROR(ENOENT));
 
 		ASSERT3P(parent, ==, NULL);
-		err = dbuf_findbp(dn, level, blkid, fail_sparse, &parent, &bp);
+		err = dbuf_findbp(dn, level, blkid, fail_sparse, &parent,
+		    dbflag, &bp);
 		if (fail_sparse) {
 			if (err == 0 && bp && BP_IS_HOLE(bp))
 				err = SET_ERROR(ENOENT);
@@ -3356,6 +3360,19 @@ dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
 	return (0);
 }
 
+/*
+ * Returns with db_holds incremented, and db_mtx not held.
+ * Note: dn_struct_rwlock must be held.
+ */
+int
+dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
+    boolean_t fail_sparse, boolean_t fail_uncached,
+    void *tag, dmu_buf_impl_t **dbp)
+{
+	return dbuf_hold_db_impl(dn, level, blkid, fail_sparse, fail_uncached,
+	    0, tag, dbp);
+}
+
 dmu_buf_impl_t *
 dbuf_hold(dnode_t *dn, uint64_t blkid, void *tag)
 {
@@ -3368,6 +3385,17 @@ dbuf_hold_level(dnode_t *dn, int level, uint64_t blkid, void *tag)
 	dmu_buf_impl_t *db;
 	int err = dbuf_hold_impl(dn, level, blkid, FALSE, FALSE, tag, &db);
 	return (err ? NULL : db);
+}
+
+dmu_buf_impl_t *
+dbuf_hold_db(dnode_t *dn, int level, uint64_t blkid, int dbflag, void *tag)
+{
+	dmu_buf_impl_t *db;
+
+	int error = dbuf_hold_db_impl(dn, level, blkid, FALSE, FALSE, dbflag,
+	    tag, &db);
+
+	return (error ? NULL : db);
 }
 
 void
@@ -4694,6 +4722,7 @@ EXPORT_SYMBOL(dbuf_assign_arcbuf);
 EXPORT_SYMBOL(dbuf_prefetch);
 EXPORT_SYMBOL(dbuf_hold_impl);
 EXPORT_SYMBOL(dbuf_hold);
+EXPORT_SYMBOL(dbuf_hold_db);
 EXPORT_SYMBOL(dbuf_hold_level);
 EXPORT_SYMBOL(dbuf_create_bonus);
 EXPORT_SYMBOL(dbuf_spill_set_blksz);

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1249,38 +1249,9 @@ dnode_buf_evict_async(void *dbu)
 	    dnc->dnc_count * sizeof (dnode_handle_t));
 }
 
-/*
- * When the DNODE_MUST_BE_FREE flag is set, the "slots" parameter is used
- * to ensure the hole at the specified object offset is large enough to
- * hold the dnode being created. The slots parameter is also used to ensure
- * a dnode does not span multiple dnode blocks. In both of these cases, if
- * a failure occurs, ENOSPC is returned. Keep in mind, these failure cases
- * are only possible when using DNODE_MUST_BE_FREE.
- *
- * If the DNODE_MUST_BE_ALLOCATED flag is set, "slots" must be 0.
- * dnode_hold_impl() will check if the requested dnode is already consumed
- * as an extra dnode slot by an large dnode, in which case it returns
- * ENOENT.
- *
- * If the DNODE_DRY_RUN flag is set, we don't actually hold the dnode, just
- * return whether the hold would succeed or not. tag and dnp should set to
- * NULL in this case.
- *
- * errors:
- * EINVAL - Invalid object number or flags.
- * ENOSPC - Hole too small to fulfill "slots" request (DNODE_MUST_BE_FREE)
- * EEXIST - Refers to an allocated dnode (DNODE_MUST_BE_FREE)
- *        - Refers to a freeing dnode (DNODE_MUST_BE_FREE)
- *        - Refers to an interior dnode slot (DNODE_MUST_BE_ALLOCATED)
- * ENOENT - The requested dnode is not allocated (DNODE_MUST_BE_ALLOCATED)
- *        - The requested dnode is being freed (DNODE_MUST_BE_ALLOCATED)
- * EIO    - I/O error when reading the meta dnode dbuf.
- *
- * succeeds even for free dnodes.
- */
 int
-dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
-    void *tag, dnode_t **dnp)
+dnode_hold_db_impl(objset_t *os, uint64_t object, int flag, int dbflag,
+    int slots, void *tag, dnode_t **dnp)
 {
 	int epb, idx, err;
 	int drop_struct_lock = FALSE;
@@ -1346,7 +1317,7 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 	}
 
 	blk = dbuf_whichblock(mdn, 0, object * sizeof (dnode_phys_t));
-	db = dbuf_hold(mdn, blk, FTAG);
+	db = dbuf_hold_db(mdn, 0, blk, dbflag, FTAG);
 	if (drop_struct_lock)
 		rw_exit(&mdn->dn_struct_rwlock);
 	if (db == NULL) {
@@ -1358,7 +1329,7 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 	 * We do not need to decrypt to read the dnode so it doesn't matter
 	 * if we get the encrypted or decrypted version.
 	 */
-	err = dbuf_read(db, NULL, DB_RF_CANFAIL | DB_RF_NO_DECRYPT);
+	err = dbuf_read(db, NULL, DB_RF_CANFAIL | DB_RF_NO_DECRYPT | dbflag);
 	if (err) {
 		DNODE_STAT_BUMP(dnode_hold_dbuf_read);
 		dbuf_rele(db, FTAG);
@@ -1569,6 +1540,41 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 }
 
 /*
+ * When the DNODE_MUST_BE_FREE flag is set, the "slots" parameter is used
+ * to ensure the hole at the specified object offset is large enough to
+ * hold the dnode being created. The slots parameter is also used to ensure
+ * a dnode does not span multiple dnode blocks. In both of these cases, if
+ * a failure occurs, ENOSPC is returned. Keep in mind, these failure cases
+ * are only possible when using DNODE_MUST_BE_FREE.
+ *
+ * If the DNODE_MUST_BE_ALLOCATED flag is set, "slots" must be 0.
+ * dnode_hold_impl() will check if the requested dnode is already consumed
+ * as an extra dnode slot by an large dnode, in which case it returns
+ * ENOENT.
+ *
+ * If the DNODE_DRY_RUN flag is set, we don't actually hold the dnode, just
+ * return whether the hold would succeed or not. tag and dnp should set to
+ * NULL in this case.
+ *
+ * errors:
+ * EINVAL - Invalid object number or flags.
+ * ENOSPC - Hole too small to fulfill "slots" request (DNODE_MUST_BE_FREE)
+ * EEXIST - Refers to an allocated dnode (DNODE_MUST_BE_FREE)
+ *        - Refers to a freeing dnode (DNODE_MUST_BE_FREE)
+ *        - Refers to an interior dnode slot (DNODE_MUST_BE_ALLOCATED)
+ * ENOENT - The requested dnode is not allocated (DNODE_MUST_BE_ALLOCATED)
+ *        - The requested dnode is being freed (DNODE_MUST_BE_ALLOCATED)
+ * EIO    - I/O error when reading the meta dnode dbuf.
+ *
+ * succeeds even for free dnodes.
+ */
+int dnode_hold_impl(struct objset *dd, uint64_t object, int flag, int dn_slots,
+    void *ref, dnode_t **dnp)
+{
+	return (dnode_hold_db_impl(dd, object, flag, 0, dn_slots, ref, dnp));
+}
+
+/*
  * Return held dnode if the object is allocated, NULL if not.
  */
 int
@@ -1576,6 +1582,17 @@ dnode_hold(objset_t *os, uint64_t object, void *tag, dnode_t **dnp)
 {
 	return (dnode_hold_impl(os, object, DNODE_MUST_BE_ALLOCATED, 0, tag,
 	    dnp));
+}
+
+/*
+ * Return held dnode if the object is allocated, NULL if not.
+ */
+int
+dnode_hold_db(objset_t *os, uint64_t object, int dbflag, void *tag,
+    dnode_t **dnp)
+{
+	return (dnode_hold_db_impl(os, object, DNODE_MUST_BE_ALLOCATED, dbflag,
+	    0, tag, dnp));
 }
 
 /*

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1590,6 +1590,12 @@ spa_activate_allocation_classes(spa_t *spa, dmu_tx_t *tx)
  * ==========================================================================
  */
 
+int
+spa_get_min_ashift(spa_t *spa)
+{
+	return (spa->spa_min_ashift);
+}
+
 boolean_t
 spa_shutting_down(spa_t *spa)
 {


### PR DESCRIPTION
Nearly one year ago I submitted pull request https://github.com/zfsonlinux/zfs/pull/8143/ which added the write path for externally compressed data. There was some discussion and I got a lot of feedback. After finishing my bachelor thesis, I continued working on this which is part of my master project (one of the courses during my master's degree). Since January I refactored a lot of things and also implemented the feedback you gave us.

I hope these changes satisfy all requirements and are soon added to ZFS. However I'm always happy about feedback.

### Motivation
Just as a revision/reminder: Lustre compresses data and should be able to efficiently write it to ZFS. ZFS should then *not* compress it again and should also not store gaps between those pre-compressed data blocks from Lustre. Therefore ZFS needs to know that the data is compressed in order to write it to disk using a raw I/O operation. When reading the data, it should stay compressed and should be returned to Lustre in that state.

This approach increases the logical network throughput, saves CPU cycles in ZFS, space in the ARC and of course space on disk. Not having this approach would also save space on disk but does not have any positive effect on the network, CPU and ARC. Because network throughput and especially disk space is valuable in HPC (high performance computing), these changes help a Lustre based computer network to be more efficient.

The feedback for this PR (s. comments above this one), showed that the changes should be compatible to the existing features ZFS offers. My initial PR was not backward compatible but this should be fully compatible to ZFS (also to older versions).

### Description
I added a new write- and read-path to ZFS for the externally compressed data. This describes the things I implemented and things I changed since https://github.com/zfsonlinux/zfs/pull/8143/.

#### Code: Write path
There are two possible ways Lustre writes something: via ARC-buffers for full blocks (which are compressed by Lustre) and `dmu_write` for non-full blocks. Currently the `dmu_write` way is unchanged (and therefore writes uncompressed data), because there are a lot of code changes that need to be made in ZFS to also write pre-compressed data here. Therefore we focused on the ARC-buffer way to write data:

Instead of using `ZIO_COMPRESS_EXTERNAL`, Lustre now only uses ZFS supported compression algorithms. Also the new code path makes use of raw I/O operations as @behlendorf suggested.

The ARC buf requested by Lustre contains a known and valid compression algorithm, which leads to a raw I/O in `arc_write` because `ZIO_FLAG_RAW_COMPRESS` is set there.

Because the ARC can contain compressed data and the data Lustre writes is already compressed, we save space because ZFS does not decompress this data. Of course this does not apply when the compression in the ARC is disabled.

#### Code: Read path
This code path stayed mainly unchanged but the `dmu_buf_hold_array_by_bonus_compressed` now also determines the used compression algorithm per block. As far as I know, compression can be different between blocks. I just use `BP_GET_COMPRESS` on each block to determine the used algorithm.

Because we now store the correct compression algorithm of a block, ZFS is able to decompress the pre-compressed data written by Lustre. I tested this by using the already existing `dmu_buf_hold_array_by_dnode` function which decompresses the data correctly.

### ztest
I also adjusted the test I wrote. It now allocates a larger amount of data, compresses it, writes it, reads it, decompresses it and checks if the data is equal to the original.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
