### PR TITLE
Move platform dependent errno aliases

### DIFF
--- a/include/os/linux/spl/sys/errno.h
+++ b/include/os/linux/spl/sys/errno.h
@@ -44,4 +44,14 @@
 
 #define	ENOTSUP		EOPNOTSUPP
 
+/*
+ * We'll take the unused errnos, 'EBADE' and 'EBADR' (from the Convergent
+ * graveyard) to indicate checksum errors and fragmentation.
+ */
+#define	ECKSUM	EBADE
+#define	EFRAGS	EBADR
+
+/* Similar for ENOACTIVE */
+#define	ENOTACTIVE	ENOANO
+
 #endif	/* _SYS_ERRNO_H */

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -265,16 +265,6 @@ enum zio_wait_type {
 	ZIO_WAIT_TYPES
 };
 
-/*
- * We'll take the unused errnos, 'EBADE' and 'EBADR' (from the Convergent
- * graveyard) to indicate checksum errors and fragmentation.
- */
-#define	ECKSUM	EBADE
-#define	EFRAGS	EBADR
-
-/* Similar for ENOACTIVE */
-#define	ENOTACTIVE	ENOANO
-
 typedef void zio_done_func_t(zio_t *zio);
 
 extern int zio_dva_throttle_enabled;

--- a/lib/libspl/include/os/linux/sys/Makefile.am
+++ b/lib/libspl/include/os/linux/sys/Makefile.am
@@ -1,6 +1,7 @@
 libspldir = $(includedir)/libspl/sys
 libspl_HEADERS = \
 	$(top_srcdir)/lib/libspl/include/os/linux/sys/byteorder.h \
+	$(top_srcdir)/lib/libspl/include/os/linux/sys/errno.h \
 	$(top_srcdir)/lib/libspl/include/os/linux/sys/file.h \
 	$(top_srcdir)/lib/libspl/include/os/linux/sys/mnttab.h \
 	$(top_srcdir)/lib/libspl/include/os/linux/sys/mount.h \

--- a/lib/libspl/include/os/linux/sys/errno.h
+++ b/lib/libspl/include/os/linux/sys/errno.h
@@ -31,5 +31,16 @@
  */
 #ifndef _LIBSPL_SYS_ERRNO_H
 #define	_LIBSPL_SYS_ERRNO_H
+
 #include <errno.h>
+/*
+ * We'll take the unused errnos, 'EBADE' and 'EBADR' (from the Convergent
+ * graveyard) to indicate checksum errors and fragmentation.
+ */
+#define	ECKSUM	EBADE
+#define	EFRAGS	EBADR
+
+/* Similar for ENOACTIVE */
+#define	ENOTACTIVE	ENOANO
+
 #endif /* _LIBSPL_SYS_ERRNO_H */

--- a/lib/libspl/include/sys/Makefile.am
+++ b/lib/libspl/include/sys/Makefile.am
@@ -11,7 +11,6 @@ libspl_HEADERS = \
 	$(top_srcdir)/lib/libspl/include/sys/debug.h \
 	$(top_srcdir)/lib/libspl/include/sys/dkio.h \
 	$(top_srcdir)/lib/libspl/include/sys/dklabel.h \
-	$(top_srcdir)/lib/libspl/include/sys/errno.h \
 	$(top_srcdir)/lib/libspl/include/sys/feature_tests.h \
 	$(top_srcdir)/lib/libspl/include/sys/int_limits.h \
 	$(top_srcdir)/lib/libspl/include/sys/int_types.h \


### PR DESCRIPTION
EBADE, EBADR, and ENOANO do not exist on FreeBSD

The libspl errno.h is similarly platform dependent

Signed-off-by: Matt Macy <mmacy@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
