### PR TITLE
ZTS: Move tmpfile tests to linux.run

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -836,10 +836,6 @@ tags = ['functional', 'suid']
 tests = ['threadsappend_001_pos']
 tags = ['functional', 'threadsappend']
 
-[tests/functional/tmpfile]
-tests = ['tmpfile_001_pos', 'tmpfile_002_pos', 'tmpfile_003_pos']
-tags = ['functional', 'tmpfile']
-
 [tests/functional/trim]
 tests = ['autotrim_integrity', 'autotrim_config', 'autotrim_trim_integrity',
     'trim_integrity', 'trim_config']

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -101,6 +101,10 @@ tags = ['functional', 'rsend']
 tests = ['snapshot_015_pos', 'snapshot_016_pos']
 tags = ['functional', 'snapshot']
 
+[tests/functional/tmpfile:Linux]
+tests = ['tmpfile_001_pos', 'tmpfile_002_pos', 'tmpfile_003_pos']
+tags = ['functional', 'tmpfile']
+
 [tests/functional/upgrade:Linux]
 tests = ['upgrade_projectquota_001_pos']
 tags = ['functional', 'upgrade']

--- a/tests/zfs-tests/tests/functional/Makefile.am
+++ b/tests/zfs-tests/tests/functional/Makefile.am
@@ -70,7 +70,6 @@ SUBDIRS = \
 	sparse \
 	suid \
 	threadsappend \
-	tmpfile \
 	trim \
 	truncate \
 	upgrade \
@@ -80,3 +79,8 @@ SUBDIRS = \
 	write_dirs \
 	xattr \
 	zvol
+
+if BUILD_LINUX
+SUBDIRS += \
+	tmpfile
+endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
O_TMPFILE is not available on FreeBSD.

### Description
<!--- Describe your changes in detail -->
Only build and run the tmpfile tests on Linux.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
