### PR TITLE
dracut/zfs-load-key.sh: properly remove prefixes

### DIFF
--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -30,7 +30,7 @@ if [ "${root}" = "zfs:AUTO" ] ; then
     BOOTFS="$(zpool list -H -o bootfs | awk '$1 != "-" {print; exit}')"
 else
     BOOTFS="${root##zfs:}"
-    BOOTFS="${root##ZFS=}"
+    BOOTFS="${BOOTFS##ZFS=}"
 fi
 
 # if pool encryption is active and the zfs command understands '-o encryption'


### PR DESCRIPTION
### Motivation and Context
If the `root` is passed to the kernel like this: `root=zfs:zroot/sys/def`, then on boot, you'll receive a message like this:

     cannot open pool 'zfs:zroot'

Then the encryption key prompt will not show up, making the system unbootable (if you use encryption).

### How Has This Been Tested?
Booted my machine with it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
