### PR TITLE
Fix contrib/zcp/Makefile.am

### DIFF
--- a/contrib/zcp/Makefile.am
+++ b/contrib/zcp/Makefile.am
@@ -1,1 +1,1 @@
-+EXTRA_DIST = autosnap.lua
+EXTRA_DIST = autosnap.lua


### PR DESCRIPTION
### Motivation and Context

Resolve issue observed in one of the contrib makefiles.

### Description

Remove the stray leading + from the Makefile.  This was
preventing the autosnap.lua channel program from being
properly included by `make dist`.

### How Has This Been Tested?

Verified the `make dist` tarball now properly contains
the channel program.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
