### PR TITLE
zfs-mount-generator: Skip loading already loaded key

### DIFF
--- a/contrib/dracut/90zfs/mount-zfs.sh.in
+++ b/contrib/dracut/90zfs/mount-zfs.sh.in
@@ -62,11 +62,15 @@ if import_pool "${ZFS_POOL}" ; then
 		# if the root dataset has encryption enabled
 		ENCRYPTIONROOT="$(zfs get -H -o value encryptionroot "${ZFS_DATASET}")"
 		if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
-			# decrypt them
-			ask_for_password \
-				--tries 5 \
-				--prompt "Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
-				--cmd "zfs load-key '${ENCRYPTIONROOT}'"
+			KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
+			# if the key needs to be loaded
+			if [ "$KEYSTATUS" = "unavailable" ]; then
+				# decrypt them
+				ask_for_password \
+					--tries 5 \
+					--prompt "Encrypted ZFS password for ${ENCRYPTIONROOT}: " \
+					--cmd "zfs load-key '${ENCRYPTIONROOT}'"
+			fi
 		fi
 	fi
 	# Let us tell the initrd to run on shutdown.

--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -38,6 +38,9 @@ if [ "$(zpool list -H -o feature@encryption $(echo "${BOOTFS}" | awk -F\/ '{prin
     # if the root dataset has encryption enabled
     ENCRYPTIONROOT=$(zfs get -H -o value encryptionroot "${BOOTFS}")
     if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
+        KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
+        # continue only if the key needs to be loaded
+        [ "$KEYSTATUS" = "unavailable" ] || exit 0
         # decrypt them
         TRY_COUNT=5
         while [ $TRY_COUNT -gt 0 ]; do

--- a/contrib/initramfs/scripts/zfs.in
+++ b/contrib/initramfs/scripts/zfs.in
@@ -414,6 +414,9 @@ decrypt_fs()
 
 		# If root dataset is encrypted...
 		if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
+			KEYSTATUS="$(${ZFS} get -H -o value keystatus "${ENCRYPTIONROOT}")"
+			# Continue only if the key needs to be loaded
+			[ "$KEYSTATUS" = "unavailable" ] || return 0
 			TRY_COUNT=3
 			# Prompt with plymouth, if active
 			if [ -e /bin/plymouth ] && /bin/plymouth --ping 2>/dev/null; then

--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -182,6 +182,8 @@ process_line() {
         keyloadcmd="@sbindir@/zfs load-key '${dataset}'"
       elif [ "${p_keyloc}" = "prompt" ] ; then
         keyloadcmd="sh -c 'set -eu;"\
+"keystatus=\"\$\$(@sbindir@/zfs get -H -o value keystatus \"${dataset}\")\";"\
+"[ \"\$\$keystatus\" = \"unavailable\" ] || exit 0;"\
 "count=0;"\
 "while [ \$\$count -lt 3 ];do"\
 "  systemd-ask-password --id=\"zfs:${dataset}\""\


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Don't ask for the password / try to load the key
if the key for the `encryptionroot` is already loaded.
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves #9495.

### Description
<!--- Describe your changes in detail -->
Make the generated `zfs-load-key-<pool>.service` check if the `encryptionroot`'s `keystatus` is `available` (meaning that the key is loaded) and return success if it is.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
I've tested the change manually on top of 0.8.2 (in a fork with `libbe` and `beadm` ported from illumos; commit https://gitlab.com/linux-be/zfs/commits/85ef14c587e7cf358a8434ec31fa9ed2799247e7) on the Sabayon system from #9495.

1. After the initramfs has loaded the key for the root pool (`te`), `zfs-load-key-te.service` does not ask for the password and does not fail:

<details>
<summary>systemctl status zfs-load-key-te.service</summary>

```
# systemctl status zfs-load-key-te.service
● zfs-load-key-te.service - Load ZFS key for te
   Loaded: loaded (/etc/zfs/zfs-list.cache/te; generated)
   Active: active (exited) since Thu 2019-11-07 14:37:45 CET; 5min ago
     Docs: man:zfs-mount-generator(8)
 Main PID: 40379 (code=exited, status=0/SUCCESS)
    Tasks: 0 (limit: 4915)
   Memory: 0B
   CGroup: /system.slice/zfs-load-key-te.service

Nov 07 14:37:45 vozhx-te systemd[1]: Starting Load ZFS key for te...
Nov 07 14:37:45 vozhx-te systemd[1]: Started Load ZFS key for te.
```

</details>

2. With a file-based pool (`testpool`), the generated `zfs-load-key-testpool.service` does not ask for the passphrase when the key is already loaded, but does ask for one and loads the key when it is not loaded:

<details>
  <summary>results with a file-based pool</summary>

```
# truncate -s100M /tmp/testpool
# touch /etc/zfs/zfs-list.cache/testpool
# zpool create -O encryption=aes-256-gcm -O keyformat=passphrase testpool /tmp/testpool

Enter passphrase: 
Re-enter passphrase: 
# systemctl daemon-reload
# systemctl start zfs-load-key-testpool
# systemctl status zfs-load-key-testpool
● zfs-load-key-testpool.service - Load ZFS key for testpool
   Loaded: loaded (/etc/zfs/zfs-list.cache/testpool; generated)
   Active: active (exited) since Thu 2019-11-07 14:40:29 CET; 4s ago
     Docs: man:zfs-mount-generator(8)
  Process: 54248 ExecStart=/bin/sh -c set -eu;keystatus="$$(/sbin/zfs get -H -o value keystatus "testpool")";[ "$$keystatus" = "unavailable" ] || exit 0;count=0;while [ $$count -lt 3 ];do >
 Main PID: 54248 (code=exited, status=0/SUCCESS)

Nov 07 14:40:29 vozhx-te systemd[1]: Starting Load ZFS key for testpool...
Nov 07 14:40:29 vozhx-te systemd[1]: Started Load ZFS key for testpool.
# zfs unmount testpool
# zfs unload-key testpool
# systemctl start zfs-load-key-testpool
# systemctl restart zfs-load-key-testpool
Enter passphrase for testpool: ********
# systemctl status zfs-load-key-testpool
● zfs-load-key-testpool.service - Load ZFS key for testpool
   Loaded: loaded (/etc/zfs/zfs-list.cache/testpool; generated)
   Active: active (exited) since Thu 2019-11-07 14:40:55 CET; 3s ago
     Docs: man:zfs-mount-generator(8)
  Process: 54433 ExecStart=/bin/sh -c set -eu;keystatus="$$(/sbin/zfs get -H -o value keystatus "testpool")";[ "$$keystatus" = "unavailable" ] || exit 0;count=0;while [ $$count -lt 3 ];do >
 Main PID: 54433 (code=exited, status=0/SUCCESS)

Nov 07 14:40:51 vozhx-te systemd[1]: Starting Load ZFS key for testpool...
Nov 07 14:40:55 vozhx-te systemd[1]: Started Load ZFS key for testpool.
```

</details>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
