### PR TITLE
Preliminary support for RV64G (RISC-V)

### DIFF
--- a/include/os/linux/spl/sys/isa_defs.h
+++ b/include/os/linux/spl/sys/isa_defs.h
@@ -192,10 +192,31 @@
  */
 #define	_ALIGNMENT_REQUIRED	1
 
+/*
+ * RISC-V arch specific defines
+ * only RV64G (including atomic) LP64 is supported yet
+ */
+#elif defined(__riscv) && defined(_LP64) && _LP64 && \
+	defined(__riscv_atomic) && __riscv_atomic
+
+#ifndef	__riscv__
+#define	__riscv__
+#endif
+
+#ifndef	__rv64g__
+#define	__rv64g__
+#endif
+
+#define	_LITTLE_ENDIAN
+
+#define	_SUNOS_VTOC_16
+
+#define	_ALIGNMENT_REQUIRED	1
+
 #else
 /*
  * Currently supported:
- * x86_64, i386, arm, powerpc, s390, sparc, and mips
+ * x86_64, i386, arm, powerpc, s390, sparc, mips, and RV64G
  */
 #error "Unsupported ISA type"
 #endif

--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -156,7 +156,7 @@ struct dk_map2  default_vtoc_map[NDKMAP] = {
 
 #if defined(i386) || defined(__amd64) || defined(__arm) || \
     defined(__powerpc) || defined(__sparc) || defined(__s390__) || \
-    defined(__mips__)
+    defined(__mips__) || defined(__rv64g__)
 	{	V_BOOT,		V_UNMNT	},		/* i - 8 */
 	{	V_ALTSCTR,	0	},		/* j - 9 */
 

--- a/lib/libspl/include/sys/isa_defs.h
+++ b/lib/libspl/include/sys/isa_defs.h
@@ -192,10 +192,29 @@ extern "C" {
 
 #define	_SUNOS_VTOC_16
 
+/*
+ * RISC-V arch specific defines
+ * only RV64G (including atomic) LP64 is supported yetxi
+ */
+#elif defined(__riscv) && defined(_LP64) && _LP64 && \
+	defined(__riscv_atomic) && __riscv_atomic
+
+#ifndef	__riscv__
+#define	__riscv__
+#endif
+
+#ifndef	__rv64g__
+#define	__rv64g__
+#endif
+
+#define	_LITTLE_ENDIAN
+
+#define	_SUNOS_VTOC_16
+
 #else
 /*
  * Currently supported:
- * x86_64, i386, arm, powerpc, s390, sparc, and mips
+ * x86_64, i386, arm, powerpc, s390, sparc, mips, and RV64G
  */
 #error "Unsupported ISA type"
 #endif

--- a/module/lua/ldo.c
+++ b/module/lua/ldo.c
@@ -63,6 +63,8 @@
 #define JMP_BUF_CNT	12
 #elif defined(__s390x__)
 #define JMP_BUF_CNT	18
+#elif defined(__riscv)
+#define JMP_BUF_CNT     64
 #else
 #define	JMP_BUF_CNT	1
 #endif

--- a/module/lua/setjmp/setjmp.S
+++ b/module/lua/setjmp/setjmp.S
@@ -14,4 +14,6 @@
 #include "setjmp_mips.S"
 #elif defined(__s390x__)
 #include "setjmp_s390x.S"
+#elif defined(__riscv)
+#include "setjmp_rv64g.S"
 #endif

--- a/module/lua/setjmp/setjmp_rv64g.S
+++ b/module/lua/setjmp/setjmp_rv64g.S
@@ -1,0 +1,91 @@
+/*-
+ * Copyright (c) 2015-2016 Ruslan Bukin <br@bsdpad.com>
+ * All rights reserved.
+ *
+ * Portions of this software were developed by SRI International and the
+ * University of Cambridge Computer Laboratory under DARPA/AFRL contract
+ * FA8750-10-C-0237 ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Portions of this software were developed by the University of Cambridge
+ * Computer Laboratory as part of the CTSRD Project, with support from the
+ * UK Higher Education Innovation Fund (HEIF).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#define ENTRY(sym)                                              \
+        .text; .globl sym; .type sym,@function; sym:
+#define END(sym) .size sym, . - sym
+
+
+ENTRY(setjmp)
+	/* Store the stack pointer */
+	sd	sp, (0 * 8)(a0)
+	addi	a0, a0, (1 * 8)
+
+	/* Store the general purpose registers and ra */
+	sd	s0, (0 * 8)(a0)
+	sd	s1, (1 * 8)(a0)
+	sd	s2, (2 * 8)(a0)
+	sd	s3, (3 * 8)(a0)
+	sd	s4, (4 * 8)(a0)
+	sd	s5, (5 * 8)(a0)
+	sd	s6, (6 * 8)(a0)
+	sd	s7, (7 * 8)(a0)
+	sd	s8, (8 * 8)(a0)
+	sd	s9, (9 * 8)(a0)
+	sd	s10, (10 * 8)(a0)
+	sd	s11, (11 * 8)(a0)
+	sd	ra, (12 * 8)(a0)
+	addi	a0, a0, (13 * 8)
+
+	/* Return value */
+	li	a0, 0
+	ret
+END(setjmp)
+
+ENTRY(longjmp)
+	/* Restore the stack pointer */
+	ld	t0, 0(a0)
+	mv	sp, t0
+	addi	a0, a0, (1 * 8)
+
+	/* Restore the general purpose registers and ra */
+	ld	s0, (0 * 8)(a0)
+	ld	s1, (1 * 8)(a0)
+	ld	s2, (2 * 8)(a0)
+	ld	s3, (3 * 8)(a0)
+	ld	s4, (4 * 8)(a0)
+	ld	s5, (5 * 8)(a0)
+	ld	s6, (6 * 8)(a0)
+	ld	s7, (7 * 8)(a0)
+	ld	s8, (8 * 8)(a0)
+	ld	s9, (9 * 8)(a0)
+	ld	s10, (10 * 8)(a0)
+	ld	s11, (11 * 8)(a0)
+	ld	ra, (12 * 8)(a0)
+	addi	a0, a0, (13 * 8)
+
+	/* Load the return value */
+	mv	a0, a1
+	ret
+END(longjmp)


### PR DESCRIPTION
This adds basic support for RISC-V, specifically RV64G.

Signed-off-by: Romain Dolbeau <romain.dolbeau@european-processor-initiative.eu>

### Motivation and Context

ZFS requires some arch-specific settings, which don't yet exist for [RISC-V](https://riscv.org/). This enable ZFS on RV64G, the 64-bits general-purpose variant of RISC-V, which is the variant supported by the distributions adding support for RISC-V.

### Description

This adds the required defines is the isa_defs file &, lua support. This does not include the changes to `module/os/linux/spl/spl-generic.c`  described below, as they are a temporary workaround.

### How Has This Been Tested?

This has been tested in Qemu, using a Fedora 32 kernel, using standard test like ztest or raidz_test, and by creating/using/testing/sharing a RAIDZ3 pool in the virtual machine & on the host. 

*warning*: currently, modules using per-cpu data (i.e. `DEFINE_PER_CPU` macro) do not load in Fedora and Debian, as they need to access symbols that are mapped out of range of a 32 bits displacement. This also affect other modules, as notified to the RISC-V Linux kernel maintainers: [openvswitch in Fedora](<http://lists.infradead.org/pipermail/linux-riscv/2019-October/007388.html>) or [scsi_mod in Debian](http://lists.infradead.org/pipermail/linux-riscv/2019-October/007413.html). This prevents the spl module, and therefore all of ZFS, to load. The current commit was tested with an additional patch to `module/os/linux/spl/spl-generic.c` to make the `spl_pseudo_entropy` array global instead of per-cpu, thus allowing the spl module to load.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ x] All new and existing tests passed.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
