### PR TITLE
zvol_wait should ignore redacted zvols

### DIFF
--- a/cmd/zvol_wait/zvol_wait
+++ b/cmd/zvol_wait/zvol_wait
@@ -25,15 +25,19 @@ filter_out_deleted_zvols() {
 }
 
 list_zvols() {
-	zfs list -t volume -H -o name,volmode,receive_resume_token |
+	zfs list -t volume -H -o \
+		name,volmode,receive_resume_token,redact_snaps |
 		while read -r zvol_line; do
 		name=$(echo "$zvol_line" | awk '{print $1}')
 		volmode=$(echo "$zvol_line" | awk '{print $2}')
 		token=$(echo "$zvol_line" | awk '{print $3}')
+		redacted=$(echo "$zvol_line" | awk '{print $4}')
 		#
-		# /dev links are not created for zvols with volmode = "none".
+		# /dev links are not created for zvols with volmode = "none"
+		# or for redacted zvols.
 		#
 		[ "$volmode" = "none" ] && continue
+		[ "$redacted" = "-" ] || continue
 		#
 		# We also also ignore partially received zvols if it is
 		# not an incremental receive, as those won't even have a block


### PR DESCRIPTION
zvol_wait waits for zvol links to be created under /dev/zvol for each zvol.
Links are not created for redacted zvols so we should ignore those.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
Created a pool with redacted zvols and then tested that zvol_wait returns properly:
```
$ sudo zfs create -V 8G perfpool/zv
$ sudo zfs snapshot perfpool/zv@a
$ sudo zfs clone perfpool/zv@a perfpool/cl
$ sudo zfs snapshot perfpool/cl@b
$ sudo zfs redact perfpool/zv@a book perfpool/cl@b
$ sudo zfs send --redact book perfpool/zv@a | sudo zfs receive perfpool/rfs
$ ls /dev/zvol/perfpool/
$ zvol_wait
No zvols found, nothing to do.
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
