### PR TITLE
Remove zpl_revalidate

### DIFF
--- a/config/kernel-dentry-operations.m4
+++ b/config/kernel-dentry-operations.m4
@@ -150,29 +150,6 @@ AC_DEFUN([ZFS_AC_KERNEL_CONST_DENTRY_OPERATIONS], [
 	])
 ])
 
-dnl #
-dnl # 2.6.38 API change
-dnl # Added sb->s_d_op default dentry_operations member
-dnl #
-AC_DEFUN([ZFS_AC_KERNEL_SRC_S_D_OP], [
-	ZFS_LINUX_TEST_SRC([super_block_s_d_op], [
-		#include <linux/fs.h>
-	],[
-		struct super_block sb __attribute__ ((unused));
-		sb.s_d_op = NULL;
-	])
-])
-
-AC_DEFUN([ZFS_AC_KERNEL_S_D_OP], [
-	AC_MSG_CHECKING([whether super_block has s_d_op])
-	ZFS_LINUX_TEST_RESULT([super_block_s_d_op], [
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_S_D_OP, 1, [struct super_block has s_d_op])
-	], [
-		AC_MSG_RESULT(no)
-	])
-])
-
 AC_DEFUN([ZFS_AC_KERNEL_SRC_DENTRY], [
         ZFS_AC_KERNEL_SRC_D_MAKE_ROOT
         ZFS_AC_KERNEL_SRC_D_OBTAIN_ALIAS
@@ -180,7 +157,6 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_DENTRY], [
         ZFS_AC_KERNEL_SRC_D_SET_D_OP
         ZFS_AC_KERNEL_SRC_D_REVALIDATE_NAMEIDATA
         ZFS_AC_KERNEL_SRC_CONST_DENTRY_OPERATIONS
-        ZFS_AC_KERNEL_SRC_S_D_OP
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_DENTRY], [
@@ -190,5 +166,4 @@ AC_DEFUN([ZFS_AC_KERNEL_DENTRY], [
         ZFS_AC_KERNEL_D_SET_D_OP
         ZFS_AC_KERNEL_D_REVALIDATE_NAMEIDATA
         ZFS_AC_KERNEL_CONST_DENTRY_OPERATIONS
-        ZFS_AC_KERNEL_S_D_OP
 ])

--- a/include/os/linux/zfs/sys/zfs_vfsops.h
+++ b/include/os/linux/zfs/sys/zfs_vfsops.h
@@ -197,6 +197,7 @@ typedef struct zfid_long {
 extern int zfs_suspend_fs(zfsvfs_t *zfsvfs);
 extern int zfs_resume_fs(zfsvfs_t *zfsvfs, struct dsl_dataset *ds);
 extern int zfs_end_fs(zfsvfs_t *zfsvfs, struct dsl_dataset *ds);
+extern void zfs_exit_fs(zfsvfs_t *zfsvfs);
 extern int zfs_userspace_one(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,
     const char *domain, uint64_t rid, uint64_t *valuep);
 extern int zfs_userspace_many(zfsvfs_t *zfsvfs, zfs_userquota_prop_t type,

--- a/include/os/linux/zfs/sys/zfs_znode_impl.h
+++ b/include/os/linux/zfs/sys/zfs_znode_impl.h
@@ -84,6 +84,7 @@ do {								\
 /* Must be called before exiting the operation. */
 #define	ZFS_EXIT(zfsvfs)					\
 do {								\
+	zfs_exit_fs(zfsvfs);					\
 	rrm_exit(&(zfsvfs)->z_teardown_lock, FTAG);		\
 } while (0)
 #define	ZPL_EXIT(zfsvfs)	ZFS_EXIT(zfsvfs)

--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -45,7 +45,6 @@ extern const struct inode_operations zpl_inode_operations;
 extern const struct inode_operations zpl_dir_inode_operations;
 extern const struct inode_operations zpl_symlink_inode_operations;
 extern const struct inode_operations zpl_special_inode_operations;
-extern dentry_operations_t zpl_dentry_operations;
 
 /* zpl_file.c */
 extern ssize_t zpl_read_common(struct inode *ip, const char *buf,

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -70,9 +70,6 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 
 	spin_lock(&dentry->d_lock);
 	dentry->d_time = jiffies;
-#ifndef HAVE_S_D_OP
-	d_set_d_op(dentry, &zpl_dentry_operations);
-#endif /* HAVE_S_D_OP */
 	spin_unlock(&dentry->d_lock);
 
 	if (error) {
@@ -655,59 +652,6 @@ zpl_fallocate(struct inode *ip, int mode, loff_t offset, loff_t len)
 }
 #endif /* HAVE_INODE_FALLOCATE */
 
-static int
-#ifdef HAVE_D_REVALIDATE_NAMEIDATA
-zpl_revalidate(struct dentry *dentry, struct nameidata *nd)
-{
-	unsigned int flags = (nd ? nd->flags : 0);
-#else
-zpl_revalidate(struct dentry *dentry, unsigned int flags)
-{
-#endif /* HAVE_D_REVALIDATE_NAMEIDATA */
-	/* CSTYLED */
-	zfsvfs_t *zfsvfs = dentry->d_sb->s_fs_info;
-	int error;
-
-	if (flags & LOOKUP_RCU)
-		return (-ECHILD);
-
-	/*
-	 * Automounted snapshots rely on periodic dentry revalidation
-	 * to defer snapshots from being automatically unmounted.
-	 */
-	if (zfsvfs->z_issnap) {
-		if (time_after(jiffies, zfsvfs->z_snap_defer_time +
-		    MAX(zfs_expire_snapshot * HZ / 2, HZ))) {
-			zfsvfs->z_snap_defer_time = jiffies;
-			zfsctl_snapshot_unmount_delay(zfsvfs->z_os->os_spa,
-			    dmu_objset_id(zfsvfs->z_os), zfs_expire_snapshot);
-		}
-	}
-
-	/*
-	 * After a rollback negative dentries created before the rollback
-	 * time must be invalidated.  Otherwise they can obscure files which
-	 * are only present in the rolled back dataset.
-	 */
-	if (dentry->d_inode == NULL) {
-		spin_lock(&dentry->d_lock);
-		error = time_before(dentry->d_time, zfsvfs->z_rollback_time);
-		spin_unlock(&dentry->d_lock);
-
-		if (error)
-			return (0);
-	}
-
-	/*
-	 * The dentry may reference a stale inode if a mounted file system
-	 * was rolled back to a point in time where the object didn't exist.
-	 */
-	if (dentry->d_inode && ITOZ(dentry->d_inode)->z_is_stale)
-		return (0);
-
-	return (1);
-}
-
 const struct inode_operations zpl_inode_operations = {
 	.setattr	= zpl_setattr,
 	.getattr	= zpl_getattr,
@@ -819,8 +763,4 @@ const struct inode_operations zpl_special_inode_operations = {
 	.permission	= zpl_permission,
 #endif /* HAVE_GET_ACL | HAVE_CHECK_ACL | HAVE_PERMISSION */
 #endif /* CONFIG_FS_POSIX_ACL */
-};
-
-dentry_operations_t zpl_dentry_operations = {
-	.d_revalidate	= zpl_revalidate,
 };


### PR DESCRIPTION
This patch removes the need for zpl_revalidate altogether.

There were 3 main reasons why we used d_revalidate:

1. periodic automounted snapshots umount deferral
2. negative dentries created before snapshot rollback
3. stale inodes referenced by dentry cache after snapshot rollback

Periodic snapshots deferral solution introduces zfs_exit_fs function, which
is called as a part of ZFS_EXIT(zfsvfs_t) macro.

Negative dentries and stale inodes are solved by flushing the dcache for the
particular dataset on zfs_resume_fs call.

This patch also removes now unused HAVE_S_D_OP configure test.

Fixes zfsonlinux/zfs#8774

Signed-off-by: Pavel Snajdr <snajpa@snajpa.net>

### How Has This Been Tested?

Locally & together with PR #9414

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
