### PR TITLE
Fix range_tree_add() input parameters.

### DIFF
--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -2011,6 +2011,7 @@ dnode_free_range(dnode_t *dn, uint64_t off, uint64_t len, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db;
 	uint64_t blkoff, blkid, nblks;
+	uint64_ ooff = off, olen = len;
 	int blksz, blkshift, head, tail;
 	int trunc = FALSE;
 	int epbs;
@@ -2220,8 +2221,8 @@ done:
 		dn->dn_free_ranges[txgoff] = range_tree_create(NULL,
 		    RANGE_SEG64, NULL, 0, 0);
 	}
-	range_tree_clear(dn->dn_free_ranges[txgoff], blkid, nblks);
-	range_tree_add(dn->dn_free_ranges[txgoff], blkid, nblks);
+	range_tree_clear(dn->dn_free_ranges[txgoff], ooff, olen);
+	range_tree_add(dn->dn_free_ranges[txgoff], ooff, olen);
 	}
 	dprintf_dnode(dn, "blkid=%llu nblks=%llu txg=%llu\n",
 	    blkid, nblks, tx->tx_txg);

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -2011,7 +2011,7 @@ dnode_free_range(dnode_t *dn, uint64_t off, uint64_t len, dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db;
 	uint64_t blkoff, blkid, nblks;
-	uint64_ ooff = off, olen = len;
+	uint64_t ooff = off, olen = len;
 	int blksz, blkshift, head, tail;
 	int trunc = FALSE;
 	int epbs;


### PR DESCRIPTION
#9552 describes the problem in detail.
In dnode_free_range(), we create dn_free_ranges, with new
implementation of range trees, we specify shift while
creating trees. In this case its zero. So, while doing
range_tree_add/clear(), it expects {offset,len} pair,
but current call provides {blkid, nblks}. This fix,
fixes this issue.

Signed-off-by: Rohan Puri <rohan.puri15@gmail.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
