### PR TITLE
Fix `zpool create -o <property>` error message

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -724,8 +724,6 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			break;
 
 		default:
-			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "property '%s'(%d) not defined"), propname, prop);
 			break;
 		}
 	}


### PR DESCRIPTION
### Motivation and Context

Issue #9550 

### Description

When `zpool create -o <property>` is run without root permissions
and the pool property requested is not specifically enumerated in
zpool_valid_proplist().  Then an incorrect error message referring
to an invalid property is printed rather than the expected permission
denied error.

Specifing a pool property at create time should be handled the same
way as filesystem properties in zfs_valid_proplist().  There should
not be default zfs_error_aux() set for properties which are not
listed.

### How Has This Been Tested?

Locally using the provided test case, without this PR applied we
print a misleading error message with an incorrect diagnosis of
the issue.

```
$ zpool create -f -o autotrim=on temp /tmp/poolfile
cannot create 'temp': property 'autotrim'(31) not defined
```

With it applied we print the real issue.

```
$ zpool create -f -o autotrim=on temp /tmp/poolfile
cannot create 'temp': permission denied
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
