### PR TITLE
Remove inappropiate error message suggesting to apply '-r'

### DIFF
--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -119,8 +119,7 @@ zfs_validate_name(libzfs_handle_t *hdl, const char *path, int type,
 	if (type == ZFS_TYPE_SNAPSHOT && strchr(path, '@') == NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "missing '@' delimiter in snapshot name, "
-			    "did you mean to use -r?"));
+			    "missing '@' delimiter in snapshot name"));
 		return (0);
 	}
 
@@ -134,8 +133,7 @@ zfs_validate_name(libzfs_handle_t *hdl, const char *path, int type,
 	if (type == ZFS_TYPE_BOOKMARK && strchr(path, '#') == NULL) {
 		if (hdl != NULL)
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "missing '#' delimiter in bookmark name, "
-			    "did you mean to use -r?"));
+			    "missing '#' delimiter in bookmark name"));
 		return (0);
 	}
 


### PR DESCRIPTION
Remove inappropiate error message suggesting to use '-r'
    
Removes an incorrect error message from libzfs that suggests applying
'-r' when a zfs subcommand is called with a filesystem path while
expecting either a snapshot or bookmark path.

Signed-off-by: InsanePrawn <insane.prawny@gmail.com>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

Removes an additional error message suggesting to append '-r' to the zfs command in case zfs_validate_name expects **either** a bookmark **or** a snapshot and gets a snapshot/bookmark without the '@'/'#'.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


#8352 introduced more detailed error messages when handling dataset paths. Two of them recommend `-r` when it expects a snapshot/bookmark path but finds no '@'/'#' symbol. (`lib/libzfs/libzfs_dataset.c`, currently line 123).

```
$ sudo zfs clone yolopool/data yolopool/data
cannot open 'yolopool/data': missing '@' delimiter in snapshot name, did you mean to use -r?
$ sudo zfs diff yolopool/data
Badly formed snapshot name yolopool/data: missing '@' delimiter in snapshot name, did you mean to use -r?
```

This message seems to appear anywhere _either_ a snapshot or bookmark path is expected but a dataset path is provided by the user. Not all commands that handle snapshots support `-r` and i doubt we should be blindly recommending it even if they did ;)

In fact, after some staring at man pages and grepping through the repo, I was not able to identify a single case where the `-r` recommendation can come up and makes sense, although I'm not very familiar with the code base and could easily have missed something.
Either way, I suspect `zfs_validate_name` is not the right place to recommend command options. 🙃


### Description
<!--- Describe your changes in detail -->
Removed the `-r` suggestion, leaving the information about expecting a snapshot/bookmark but not finding the respective separator '@'/'#'.

```
$ sudo zfs diff yolopool/data
Badly formed snapshot name yolopool/data: missing '@' delimiter in snapshot name
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Compiled it on Debian Stretch, confirmed the new error messages match the expected result.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
