### PR TITLE
Change zed.service to zfs-zed.service in man page (fixed)

### DIFF
--- a/man/man8/zfs-mount-generator.8.in
+++ b/man/man8/zfs-mount-generator.8.in
@@ -58,9 +58,9 @@ Then, enable the tracking ZEDLET:
 .RS 4
 ln -s "@zfsexecdir@/zed.d/history_event-zfs-list-cacher.sh" "@sysconfdir@/zfs/zed.d"
 
-systemctl enable zed.service
+systemctl enable zfs-zed.service
 
-systemctl restart zed.service
+systemctl restart zfs-zed.service
 .RE
 .PP
 Force the running of the ZEDLET by setting canmount=on for at least one dataset in the pool:


### PR DESCRIPTION
Fixed style issues from #9563 by @gjedeer (that can be closed now).
Should comply to code-standards now.

zed.service does not exist
replaced with correct service name in man.

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>


### Motivation and Context
The manual advices to use "zed.service" this ends in an error according to #9563
```
# systemctl enable zed.service
Failed to enable unit: Refusing to operate on linked unit file zed.service
```
- New PR because previous author didn't want to follow the contribution guidelines.
- No legal issues as it's just changing 2 words in the in-application documentation + permission by original author, so no protected work has been violated by copying the changes in a new PR.

### Description
This PR corrects the manual to list the correct service name

### How Has This Been Tested?
It's changing a word in a manual. 'nuf said.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
