### PR TITLE
Improve zdb -R (read block), -A (suppress ASSERTs), and -d (lookup by objset id)

### DIFF
--- a/include/sys/zio_compress.h
+++ b/include/sys/zio_compress.h
@@ -115,6 +115,8 @@ extern int zio_decompress_data(enum zio_compress c, abd_t *src, void *dst,
     size_t s_len, size_t d_len);
 extern int zio_decompress_data_buf(enum zio_compress c, void *src, void *dst,
     size_t s_len, size_t d_len);
+extern int zio_decompress_data_impl(enum zio_compress c, abd_t *src, void *dst,
+    size_t s_len, size_t d_len);
 
 #ifdef	__cplusplus
 }

--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -33,11 +33,20 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+#ifndef _KERNEL
+int aok;
+#endif
+
 static inline int
 libspl_assert(const char *buf, const char *file, const char *func, int line)
 {
 	fprintf(stderr, "%s\n", buf);
 	fprintf(stderr, "ASSERT at %s:%d:%s()", file, line, func);
+#ifndef _KERNEL
+	if (aok) {
+		return (0);
+	}
+#endif
 	abort();
 }
 
@@ -52,6 +61,12 @@ libspl_assertf(const char *file, const char *func, int line, char *format, ...)
 	fprintf(stderr, "\n");
 	fprintf(stderr, "ASSERT at %s:%d:%s()", file, line, func);
 	va_end(args);
+#ifndef _KERNEL
+	if (aok) {
+		return;
+	}
+#endif
+
 	abort();
 }
 

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -47,7 +47,6 @@
  * Emulation of kernel services in userland.
  */
 
-int aok;
 uint64_t physmem;
 vnode_t *rootdir = (vnode_t *)0xabcd1234;
 char hw_serial[HW_HOSTID_LEN];

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -63,7 +63,7 @@
 .Op Fl A
 .Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl U Ar cache
-.Ar poolname vdev Ns \&: Ns Ar offset Ns \&: Ns Ar size Ns Op : Ns Ar flags
+.Ar poolname vdev Ns \&: Ns Ar offset Ns \&: Ns Ar [<lsize>/]<psize> Ns Op : Ns Ar flags
 .Nm
 .Fl S
 .Op Fl AP
@@ -97,6 +97,11 @@ characters, it is interpreted as a pool name.
 The root dataset can be specified as
 .Ar pool Ns /
 .Pq pool name followed by a slash .
+As a special case, the 
+.Ar dataset 
+argument may contain the keyword
+.Qq Sy dataset
+followed by the numeric id of the dataset.
 .Pp
 When operating on an imported and active pool it is possible, though unlikely,
 that zdb may interpret inconsistent pool data and behave erratically.
@@ -228,7 +233,7 @@ This option can be combined with
 .Fl v
 for increasing verbosity.
 .It Xo
-.Fl R Ar poolname vdev Ns \&: Ns Ar offset Ns \&: Ns Ar size Ns Op : Ns Ar flags
+.Fl R Ar poolname vdev Ns \&: Ns Ar offset Ns \&: Ns Ar [<lsize>/]<psize> Ns Op : Ns Ar flags
 .Xc
 Read and display a block from the specified device.
 By default the block is displayed as a hex dump, but see the description of the
@@ -240,15 +245,17 @@ The block is specified in terms of a colon-separated tuple
 .Pq an integer vdev identifier
 .Ar offset
 .Pq the offset within the vdev
-.Ar size
-.Pq the size of the block to read
-and, optionally,
+.Ar lsize/psize
+.Pq the physical size, or logical size / physical size
+of the block to read and, optionally,
 .Ar flags
 .Pq a set of flags, described below .
 .Pp
 .Bl -tag -compact -width "b offset"
 .It Sy b Ar offset
 Print block pointer
+.It Sy c
+Calculate and display checksums
 .It Sy d
 Decompress the block. Set environment variable
 .Nm ZDB_NO_ZLE
@@ -261,6 +268,8 @@ Dump gang block header
 Dump indirect block
 .It Sy r
 Dump raw uninterpreted block data
+.It Sy v
+Verbose output for guessing compression algorithm
 .El
 .It Fl s
 Report statistics on

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -147,12 +147,20 @@ zio_decompress_data_buf(enum zio_compress c, void *src, void *dst,
 }
 
 int
-zio_decompress_data(enum zio_compress c, abd_t *src, void *dst,
+zio_decompress_data_impl(enum zio_compress c, abd_t *src, void *dst,
     size_t s_len, size_t d_len)
 {
 	void *tmp = abd_borrow_buf_copy(src, s_len);
 	int ret = zio_decompress_data_buf(c, tmp, dst, s_len, d_len);
 	abd_return_buf(src, tmp, s_len);
+	return (ret);
+}
+
+int
+zio_decompress_data(enum zio_compress c, abd_t *src, void *dst,
+    size_t s_len, size_t d_len)
+{
+	int ret = zio_decompress_data_impl(c, src, dst, s_len, d_len);
 
 	/*
 	 * Decompression shouldn't fail, because we've already verified


### PR DESCRIPTION
Improve zdb -R (read block) and -A (suppress ASSERTs).  Add the ability for-d to look up a dataset by its objset id.

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>

In zdb_read_block, implement the unfinished checksum flag.  Fix some problems with block display such as not failing gracefully when a block should be decompressed but the 'd' flag was not supplied.  Fix handling of multiple flags.

Implement the -A (aok) feature to ignore asserts.  Add the ability to express lsize and psize to limit the range of block sizes when guessing the decompression algorithm in zdb_read_block.

Implement the special keyword 'dataset' for -d so the user can supply an objset id in lieu of the dataset name.

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
Finish some features that were stubbed in.  Add a bit of helpful new functionality.

### How Has This Been Tested?
Exercised the new zdb code by using the zdb_read_block flags in different combinations.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
