### PR TITLE
ZTS: tst.terminate_by_signal increase test threshold

### DIFF
--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.terminate_by_signal.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.terminate_by_signal.ksh
@@ -91,7 +91,7 @@ log_note "$snap_count snapshots created by ZCP"
 
 if [ "$snap_count" -eq 0 ]; then
 	log_fail "Channel program failed to run."
-elif [ "$snap_count" -gt 50 ]; then
+elif [ "$snap_count" -gt 90 ]; then
 	log_fail "Too many snapshots after a cancel ($snap_count)."
 else
 	log_pass "Canceling a long-running channel program works."


### PR DESCRIPTION
### Motivation and Context

Resolve occasional ZTS failures reported by the CI.

http://build.zfsonlinux.org/builders/Amazon%202%20x86_64%20Release%20%28TEST%29/builds/7288
http://build.zfsonlinux.org/builders/Amazon%202%20x86_64%20Release%20%28TEST%29/builds/7458

### Description

The tst.terminate_by_signal test case may occasionally fail when
running in a less consistent virtual environment.  For all observed
failures the process was terminated correctly but it took longer than
expected resulting in too many snapshot being created.

To minimize the likelihood of this occurring increase the threshold
from 50 to 90 snapshots.  The larger limit will still verify that
the channel program was correctly terminated early.

### How Has This Been Tested?

Locally by running the relevant test case.  Manually verified that
the test case correctly fails for the right reason when the channel
program is allowed to create all of the snapshots.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).