### PR TITLE
Check for unlinked znodes after igrab()

### DIFF
--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -1095,7 +1095,8 @@ again:
 		ASSERT3U(zp->z_id, ==, obj_num);
 		/*
 		 * If zp->z_unlinked is set, the znode is already marked
-		 * for deletion and should not be discovered.
+		 * for deletion and should not be discovered. Check this
+		 * after checking igrab() due to fsetxattr() & O_TMPFILE.
 		 *
 		 * If igrab() returns NULL the VFS has independently
 		 * determined the inode should be evicted and has
@@ -1110,10 +1111,11 @@ again:
 		 * need to detect the active SA hold thereby informing
 		 * the VFS that this inode should not be evicted.
 		 */
-		if (zp->z_unlinked) {
-			err = SET_ERROR(ENOENT);
-		} else if (igrab(ZTOI(zp)) == NULL) {
-			err = SET_ERROR(EAGAIN);
+		if (igrab(ZTOI(zp)) == NULL) {
+			if (zp->z_unlinked)
+				err = SET_ERROR(ENOENT);
+			else
+				err = SET_ERROR(EAGAIN);
 		} else {
 			*zpp = zp;
 			err = 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The changes in commit `41e1aa2a` / PR#9583 introduced a regression on
`tmpfile_001_pos`: `fsetxattr()` on a `O_TMPFILE` file descriptor started
to fail with errno `ENODATA`:

```
    openat(AT_FDCWD, "/test", O_RDWR|O_TMPFILE, 0666) = 3
    <...>
    fsetxattr(3, "user.test", <...>, 64, 0) = -1 ENODATA (No data available)
```



### Description
<!--- Describe your changes in detail -->

The originally proposed change on PR#9583 is not susceptible to it,
so just move the code/if-checks around back in that way, to fix it.

Before that commit:

```
    $ cat /sys/module/zfs/version
    0.8.0-401_gcc1a1e17

    $ TESTDIR="/test" /usr/share/zfs/zfs-tests/tests/functional/tmpfile/tmpfile_001_pos ; echo $?
    Verify O_TMPFILE is working properly.
    0
```

After that commit:

```
    $ cat /sys/module/zfs/version
    0.8.0-402_g41e1aa2a

    $ TESTDIR="/test" /usr/share/zfs/zfs-tests/tests/functional/tmpfile/tmpfile_001_pos ; echo $?
    Verify O_TMPFILE is working properly.
    fsetxattr: No data available
    6
```

With this commit:

```
    $ cat /sys/module/zfs/version
    0.8.0-405_g...

    $ TESTDIR="/test" /usr/share/zfs/zfs-tests/tests/functional/tmpfile/tmpfile_001_pos ; echo $?
    Verify O_TMPFILE is working properly.
    0
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

The zfs test-suite (functional) has been run before/after commit `41e1aa2a` / PR#9583, and only `tmpfile_001_pos` had a consistent, repeatable regression.
The patch has been verified to fix it / make this particular test-case pass again.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
