### PR TITLE
zdb -R should be able to display checksums

### DIFF
--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -249,6 +249,8 @@ and, optionally,
 .Bl -tag -compact -width "b offset"
 .It Sy b Ar offset
 Print block pointer
+.It Sy c
+Calculate and display checksums
 .It Sy d
 Decompress the block. Set environment variable
 .Nm ZDB_NO_ZLE

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -95,7 +95,7 @@ tags = ['functional', 'clean_mirror']
 
 [tests/functional/cli_root/zdb]
 tests = ['zdb_001_neg', 'zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos',
-    'zdb_005_pos', 'zdb_006_pos']
+    'zdb_005_pos', 'zdb_006_pos', 'zdb_checksum']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zdb']

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
@@ -5,4 +5,5 @@ dist_pkgdata_SCRIPTS = \
 	zdb_003_pos.ksh \
 	zdb_004_pos.ksh \
 	zdb_005_pos.ksh \
-	zdb_006_pos.ksh
+	zdb_006_pos.ksh \
+	zdb_checksum.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_checksum.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_checksum.ksh
@@ -1,0 +1,64 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Datto, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb -c will display the same checksum as -ddddddbbbbbb
+#
+# Strategy:
+# 1. Create a pool
+# 2. Write some data to a file
+# 3. Run zdb -ddddddbbbbbb against the file
+# 4. Record the checksum and DVA of L0 block 0
+# 5. Run zdb -R with :c flag and match the checksum
+
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_assert "Verify zdb -R generates the correct checksum."
+log_onexit cleanup
+init_data=$TESTDIR/file1
+write_count=8
+blksize=131072
+verify_runnable "global"
+verify_disk_count "$DISKS" 2
+
+default_mirror_setup_noexit $DISKS
+file_write -o create -w -f $init_data -b $blksize -c $write_count
+
+# get object number of file
+listing=$(ls -i $init_data)
+set -A array $listing
+obj=${array[0]}
+log_note "file $init_data has object number $obj"
+
+output=$(zdb -ddddddbbbbbb $TESTPOOL/$TESTFS $obj 2> /dev/null \
+    |grep -m 1 "L0 DVA" |head -n1)
+dva=$(grep -oP 'DVA\[0\]=<\K.*?(?=>)' <<< "$output")
+log_note "block 0 of $init_data has a DVA of $dva"
+cksum_expected=$(grep -oP '(?<=cksum=)[ A-Za-z0-9:]*' <<< "$output")
+log_note "expecting cksum $cksum_expected"
+output=$(zdb -R $TESTPOOL $dva:c 2> /dev/null)
+result=$(grep $cksum_expected <<< "$output")
+(( $? != 0 )) && log_fail "zdb -R failed to print the correct checksum"
+
+log_pass "zdb -R generates the correct checksum"


### PR DESCRIPTION
Add display of checksums to zdb -R

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>

The function zdb_read_block (zdb -R) was always intended to have a :c flag which would read the DVA and length supplied by the user, and display the checksum.  Since we don't know which checksum goes with the data, we should calculate and display them all.

### Motivation and Context
The block comment for zdb_read_block tells us this was an intended feature that never got implemented.

### Description
For each checksum in the table, read in the data at the supplied DVA:length, calculate the checksum, and display it.  Update the man page and create a zfs test for the new feature.

### How Has This Been Tested?
Manually and also with new zfs test that obtains the checksum from zdb -ddddddbbbbbb and compares it the zdb -R <pool> dva:length:c.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
