### PR TITLE
Implement -A (ignore ASSERTs) for zdb

### DIFF
--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -33,11 +33,18 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+#ifndef _KERNEL
+int aok;
+#endif
+
 static inline int
 libspl_assert(const char *buf, const char *file, const char *func, int line)
 {
 	fprintf(stderr, "%s\n", buf);
 	fprintf(stderr, "ASSERT at %s:%d:%s()", file, line, func);
+	if (aok) {
+		return (0);
+	}
 	abort();
 }
 
@@ -52,6 +59,9 @@ libspl_assertf(const char *file, const char *func, int line, char *format, ...)
 	fprintf(stderr, "\n");
 	fprintf(stderr, "ASSERT at %s:%d:%s()", file, line, func);
 	va_end(args);
+	if (aok) {
+		return;
+	}
 	abort();
 }
 

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -47,7 +47,6 @@
  * Emulation of kernel services in userland.
  */
 
-int aok;
 uint64_t physmem;
 char hw_serial[HW_HOSTID_LEN];
 struct utsname hw_utsname;


### PR DESCRIPTION
Implement -A (ignore ASSERTs) for zdb

The command line switch -A (ignore ASSERTs) has always been available in zdb but was never connected up to the correct global variable.

Signed-off-by: Paul Zuchowski <pzuchowski@datto.com>


### Motivation and Context
There are times when you need zdb to ignore asserts and keep dumping out whatever information it can get despite the ASSERT(s) failing.  It was always intended to be part of zdb but was incomplete.

### Description
Change the code so the global variable aok was correctly set, and that the ASSERT code would obey it.

### How Has This Been Tested?
Here is the test run I did.  There won't be a zfs test for this because the assert demonstrated here is going to be fixed.
\# zdb -R tank 0:2a856400:600:id
Found vdev: /root/file1
Trying 00600 -> 00800 (inherit)
ret == 0 (0x16 == 0)
ASSERT at ../../module/zfs/zio_compress.c:162:zio_decompress_data()
\# 
\# zdb -A -R tank 0:2a856400:600:id
DVA[0]=<0:2a850400:400> [L0 ZFS plain file] fletcher4 uncompressed unencrypted LE contiguous unique single size=400L/400P birth=277331L/277331P fill=1 cksum=4b20aef2a3:26cc1e35cd35:d2f34b21245fb:3595d44a25c6c4e
DVA[0]=<0:2a850800:400> [L0 ZFS plain file] fletcher4 uncompressed unencrypted LE contiguous unique single size=400L/400P birth=277331L/277331P fill=1 cksum=49959161
02:254bdc23fb93:ca43590452f0b:33a52770fdf8ed3
...
# 
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
