### PR TITLE
Remove duplicate and random algorithms from tests

### DIFF
--- a/tests/zfs-tests/include/properties.shlib
+++ b/tests/zfs-tests/include/properties.shlib
@@ -13,8 +13,7 @@
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 #
 
-typeset -a compress_prop_vals=('on' 'off' 'lzjb' 'gzip' 'gzip-1' 'gzip-2'
-    'gzip-3' 'gzip-4' 'gzip-5' 'gzip-6' 'gzip-7' 'gzip-8' 'gzip-9' 'zle' 'lz4')
+typeset -a compress_prop_vals=('off' 'lzjb' 'gzip' 'zle' 'lz4')
 typeset -a checksum_prop_vals=('on' 'off' 'fletcher2' 'fletcher4' 'sha256'
     'noparity' 'sha512' 'skein' 'edonr')
 typeset -a recsize_prop_vals=('512' '1024' '2048' '4096' '8192' '16384'
@@ -60,7 +59,7 @@ function get_rand_prop
 
 function get_rand_compress
 {
-	get_rand_prop compress_prop_vals $1 2
+	get_rand_prop compress_prop_vals $1 1
 }
 
 function get_rand_compress_any

--- a/tests/zfs-tests/tests/functional/rsend/rsend_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_012_pos.ksh
@@ -138,9 +138,7 @@ done
 
 for vol in "$POOL/vol" "$POOL/$FS/vol" ; do
 	rand_set_prop $vol checksum "on" "off" "fletcher2" "fletcher4" "sha256"
-	rand_set_prop $vol compression "on" "off" "lzjb" "gzip" \
-		"gzip-1" "gzip-2" "gzip-3" "gzip-4" "gzip-5" "gzip-6"   \
-		"gzip-7" "gzip-8" "gzip-9"
+	rand_set_prop $vol compression "off" "lzjb" "gzip" "lz4"
 	rand_set_prop $vol readonly "on" "off"
 	rand_set_prop $vol copies "1" "2" "3"
 	rand_set_prop $vol user:prop "aaa" "bbb" "23421" "()-+?"

--- a/tests/zfs-tests/tests/functional/rsend/send-c_verify_ratio.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_verify_ratio.ksh
@@ -37,7 +37,7 @@ log_onexit cleanup_pool $POOL2
 typeset sendfs=$POOL2/$FS
 typeset megs=128
 
-for prop in $(get_rand_compress_any 6); do
+for prop in 'off' 'lzjb' 'gzip' 'zle' 'lz4'; do
 	for compressible in 'yes' 'no'; do
 		log_must zfs create -o compress=$prop $sendfs
 


### PR DESCRIPTION
This is a spinoff from #8941 seperating general, unrelated, test changes from the zstd PR.

TL:DR: 
- Random tests (`send-c_verify_ratio`) lead to inpredicatble results
- Duplicate algorithms lead to duplicate execution of tests
- Combined the effects are even worse and lead to false positives

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

### Motivation and Context
During my work on investigating the compression test suite for #8941 a few things became appearant:
`send-c_verify_ratio` used randomly selected compression algorithms.  Those algorithms differ widely in performance and for the majority consist of different levels of gzip. This lead to difficulty comparing performance of tests over multiple runs. This also lead to situations where tests ended with a false-positive (pass) result, due to algorithms being skipped.

During my research into this there seemed to be 2 versions of multi-compression test suits:
1. Randomly selected from a pool listing all different levels of algorithms
2. Fixed selective non-random selection of algorithms

The 2 tests using version 1, both suffered from the same problems. (listed above) This wouldn't be that bad, but it gets worse when new algorithms get added with multiple levels.

### Description
This change removes duplicate algorithms from all compression tests (and leaves just 1 of each kind), including the random compression pool.

It also removed the random draw of algorithms from `send-c_verify_ratio`, to make sure results are repeatable. This also removes one whole loop of the test and thus improves performance.

### Is * taken into account?
The following is taken into account:
- There is a seperate test for testing aliasses, those should work regardless
- If many more algorithms get added, possibly in the future in some places random selection might be needed, but still should only list one level each to prevent limiting the chances of drawing a non-level based algorithm like lz4
- If seperate levels work totally differently, a seperate test for that algorithm would be a cleaner solution than adding all levels everywhere.

### How Has This Been Tested?
i've been debating and testing multiple versions/levels of these changes for about a week now. After I came up with them due to (unrelated) issues in  #8941

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
