### PR TITLE
ZTS: Fix pool_clear_001_pos and slog_014_pos.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
@@ -175,7 +175,7 @@ function do_testing #<clear type> <vdevs>
 	esac
 	dd if=/dev/zero of=$fbase.$i seek=512 bs=1024 count=$wcount conv=notrunc \
 			> /dev/null 2>&1
-	log_must sync
+	log_must zpool sync
 	log_must zpool scrub -w $TESTPOOL1
 
 	check_err $TESTPOOL1 && \
@@ -192,6 +192,7 @@ function do_testing #<clear type> <vdevs>
 		    log_fail "'zpool clear' fails to clear error for pool $TESTPOOL1."
 	fi
 
+	log_must zpool wait -t scrub $TESTPOOL1
 	log_must zpool destroy $TESTPOOL1
 }
 

--- a/tests/zfs-tests/tests/functional/slog/slog_014_pos.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_014_pos.ksh
@@ -83,6 +83,9 @@ for type in "mirror" "raidz" "raidz2"; do
 		fi
 
 		log_must zpool online $TESTPOOL $VDIR/a
+		log_must zpool sync $TESTPOOL
+		log_must zpool wait -t resilver $TESTPOOL
+		log_must zpool wait -t scrub $TESTPOOL
 		log_must zpool destroy -f $TESTPOOL
 	done
 done


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

tests are failed time to time with long works in non-stop loop.

```
tests/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_001_pos.ksh
tests/zfs-tests/tests/functional/slog/slog_014_pos.ksh
```

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).