### PR TITLE
Test Compression Algorithm Selection Refactor

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -20,14 +20,13 @@
 #
 
 #
-# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
-# Use is subject to license terms.
-# Copyright (c) 2012, 2018 by Delphix. All rights reserved.
-# Copyright (c) 2017 by Tim Chase. All rights reserved.
-# Copyright (c) 2017 by Nexenta Systems, Inc. All rights reserved.
-# Copyright (c) 2017 Lawrence Livermore National Security, LLC.
-# Copyright (c) 2017 Datto Inc.
-# Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+# Copyright (c) 2009, Sun Microsystems Inc. All rights reserved.
+# Copyright (c) 2012, 2018, Delphix. All rights reserved.
+# Copyright (c) 2017, Tim Chase. All rights reserved.
+# Copyright (c) 2017, Nexenta Systems Inc. All rights reserved.
+# Copyright (c) 2017, Lawrence Livermore National Security LLC.
+# Copyright (c) 2017, Datto Inc. All rights reserved.
+# Copyright (c) 2017, Open-E Inc. All rights reserved.
 # Use is subject to license terms.
 #
 
@@ -2528,29 +2527,6 @@ function safe_to_destroy_pool { # $1 the pool name
 		log_note "Warning: it is not safe to destroy $1!"
 		return 1
 	fi
-}
-
-#
-# Get the available ZFS compression options
-# $1 option type zfs_set|zfs_compress
-#
-function get_compress_opts
-{
-	typeset COMPRESS_OPTS
-	typeset GZIP_OPTS="gzip gzip-1 gzip-2 gzip-3 gzip-4 gzip-5 \
-			gzip-6 gzip-7 gzip-8 gzip-9"
-
-	if [[ $1 == "zfs_compress" ]] ; then
-		COMPRESS_OPTS="on lzjb"
-	elif [[ $1 == "zfs_set" ]] ; then
-		COMPRESS_OPTS="on off lzjb"
-	fi
-	typeset valid_opts="$COMPRESS_OPTS"
-	zfs get 2>&1 | grep gzip >/dev/null 2>&1
-	if [[ $? -eq 0 ]]; then
-		valid_opts="$valid_opts $GZIP_OPTS"
-	fi
-	echo "$valid_opts"
 }
 
 #

--- a/tests/zfs-tests/include/properties.shlib
+++ b/tests/zfs-tests/include/properties.shlib
@@ -10,11 +10,10 @@
 #
 
 #
-# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2016, Delphix. All rights reserved.
 #
 
-typeset -a compress_prop_vals=('on' 'off' 'lzjb' 'gzip' 'gzip-1' 'gzip-2'
-    'gzip-3' 'gzip-4' 'gzip-5' 'gzip-6' 'gzip-7' 'gzip-8' 'gzip-9' 'zle' 'lz4')
+typeset -a compress_prop_vals=('off' 'lzjb' 'lz4' 'gzip' 'zle')
 typeset -a checksum_prop_vals=('on' 'off' 'fletcher2' 'fletcher4' 'sha256'
     'noparity' 'sha512' 'skein' 'edonr')
 typeset -a recsize_prop_vals=('512' '1024' '2048' '4096' '8192' '16384'
@@ -56,16 +55,6 @@ function get_rand_prop
 		retstr="${prop_array[$i]} $retstr"
 	done
 	echo $retstr
-}
-
-function get_rand_compress
-{
-	get_rand_prop compress_prop_vals $1 2
-}
-
-function get_rand_compress_any
-{
-	get_rand_prop compress_prop_vals $1 0
 }
 
 function get_rand_checksum

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/compression_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/compression_001_pos.ksh
@@ -26,6 +26,7 @@
 #
 
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/properties.shlib
 . $STF_SUITE/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
 
 #
@@ -41,7 +42,7 @@
 verify_runnable "both"
 
 set -A dataset "$TESTPOOL" "$TESTPOOL/$TESTFS" "$TESTPOOL/$TESTVOL"
-set -A values $(get_compress_opts zfs_set)
+set -A values "${compress_prop_vals[@]}"
 
 log_assert "Setting a valid compression on file system and volume, " \
 	"It should be successful."

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/property_alias_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/property_alias_001_pos.ksh
@@ -21,14 +21,12 @@
 #
 
 #
-# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2009, Sun Microsystems Inc. All rights reserved.
+# Copyright (c) 2016, 2017, Delphix. All rights reserved.
 # Use is subject to license terms.
 #
 
-#
-# Copyright (c) 2016, 2017 by Delphix. All rights reserved.
-#
-
+. $STF_SUITE/include/properties.shlib
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
 
@@ -106,7 +104,7 @@ for ds in $pool $fs $vol; do
 			done
 			;;
 		compression|compress )
-			for val in $(get_compress_opts zfs_set); do
+			for val in "${compress_prop_vals[@]}"; do
 				set_and_check $ds ${rw_prop[i]} $val ${chk_prop[i]}
 			done
 			;;

--- a/tests/zfs-tests/tests/functional/compression/compress_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/compression/compress_001_pos.ksh
@@ -21,12 +21,9 @@
 #
 
 #
-# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2007, Sun Microsystems Inc. All rights reserved.
+# Copyright (c) 2013, 2016, Delphix. All rights reserved.
 # Use is subject to license terms.
-#
-
-#
-# Copyright (c) 2013, 2016 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib

--- a/tests/zfs-tests/tests/functional/compression/compress_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/compression/compress_003_pos.ksh
@@ -21,14 +21,14 @@
 #
 
 #
-# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2007, Sun Microsystems Inc. All rights reserved.
+# Copyright (c) 2013, 2016, Delphix. All rights reserved.
+# Copyright (c) 2019, Kjeld Schouten-Lebbing. All rights reserved.
 # Use is subject to license terms.
 #
 
-#
-# Copyright (c) 2013, 2016 by Delphix. All rights reserved.
-#
 
+. $STF_SUITE/include/properties.shlib
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -62,7 +62,7 @@ typeset -i offset=0
 
 for propname in "compression" "compress"
 do
-	for value in $(get_compress_opts zfs_compress)
+	for value in "${compress_prop_vals[@]:1}"
 	do
 		log_must zfs set $propname=$value $fs
 		if [[ $value == "gzip-6" ]]; then

--- a/tests/zfs-tests/tests/functional/compression/compress_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/compression/compress_004_pos.ksh
@@ -21,14 +21,13 @@
 #
 
 #
-# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2007, Sun Microsystems Inc. All rights reserved.
+# Copyright (c) 2013, 2016, Delphix. All rights reserved.
+# Copyright (c) 2019, Kjeld Schouten-Lebbing. All Rights Reserved.
 # Use is subject to license terms.
 #
 
-#
-# Copyright (c) 2013, 2016 by Delphix. All rights reserved.
-#
-
+. $STF_SUITE/include/properties.shlib
 . $STF_SUITE/include/libtest.shlib
 
 #
@@ -94,7 +93,7 @@ typeset -i blknum=0
 
 for propname in "compression" "compress"
 do
-	for value in $(get_compress_opts zfs_compress)
+	for value in "${compress_prop_vals[@]:1}"
 	do
 		log_must zfs set compression=$value $fs
 		real_val=$(get_prop $propname $fs)

--- a/tests/zfs-tests/tests/functional/nopwrite/nopwrite_varying_compression.ksh
+++ b/tests/zfs-tests/tests/functional/nopwrite/nopwrite_varying_compression.ksh
@@ -12,11 +12,12 @@
 #
 
 #
-# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2016, Delphix. All rights reserved.
+# Copyright (c) 2019, Kjeld Schouten-Lebbing. All Rights Reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/include/properties.shlib
+. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/nopwrite/nopwrite.shlib
 
 #
@@ -51,8 +52,8 @@ log_must zfs set checksum=sha256 $origin
 dd if=/dev/urandom of=$TESTDIR/file bs=1024k count=$MEGS conv=notrunc \
     >/dev/null 2>&1 || log_fail "initial dd failed."
 
-# Verify nop_write for 4 random compression algorithms
-for i in $(get_rand_compress 4); do
+# Verify nop_write for all compression algorithms except "off"
+for i in "${compress_prop_vals[@]:1}"; do
 	zfs snapshot $origin@a || log_fail "zfs snap failed"
 	log_must zfs clone -o compress=$i $origin@a $origin/clone
 	dd if=/$TESTDIR/file of=/$TESTDIR/clone/file bs=1024k count=$MEGS \

--- a/tests/zfs-tests/tests/functional/rsend/rsend_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_012_pos.ksh
@@ -21,14 +21,13 @@
 #
 
 #
-# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2009, Sun Microsystems Inc. All rights reserved.
+# Copyright (c) 2013, 2016, Delphix. All rights reserved.
 # Use is subject to license terms.
 #
 
 #
-# Copyright (c) 2013, 2016 by Delphix. All rights reserved.
-#
-
+. $STF_SUITE/include/properties.shlib
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
 
 #
@@ -121,9 +120,7 @@ for fs in "$POOL" "$POOL/pclone" "$POOL/$FS" "$POOL/$FS/fs1" \
 	rand_set_prop $fs acltype "off" "noacl" "posixacl"
 	rand_set_prop $fs atime "on" "off"
 	rand_set_prop $fs checksum "on" "off" "fletcher2" "fletcher4" "sha256"
-	rand_set_prop $fs compression "on" "off" "lzjb" "gzip" \
-		"gzip-1" "gzip-2" "gzip-3" "gzip-4" "gzip-5" "gzip-6"   \
-		"gzip-7" "gzip-8" "gzip-9"
+	rand_set_prop $fs compression "${compress_prop_vals[@]}"
 	rand_set_prop $fs copies "1" "2" "3"
 	rand_set_prop $fs devices "on" "off"
 	rand_set_prop $fs exec "on" "off"
@@ -138,9 +135,7 @@ done
 
 for vol in "$POOL/vol" "$POOL/$FS/vol" ; do
 	rand_set_prop $vol checksum "on" "off" "fletcher2" "fletcher4" "sha256"
-	rand_set_prop $vol compression "on" "off" "lzjb" "gzip" \
-		"gzip-1" "gzip-2" "gzip-3" "gzip-4" "gzip-5" "gzip-6"   \
-		"gzip-7" "gzip-8" "gzip-9"
+	rand_set_prop $vol compression "${compress_prop_vals[@]}"
 	rand_set_prop $vol readonly "on" "off"
 	rand_set_prop $vol copies "1" "2" "3"
 	rand_set_prop $vol user:prop "aaa" "bbb" "23421" "()-+?"

--- a/tests/zfs-tests/tests/functional/rsend/send-c_recv_lz4_disabled.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_recv_lz4_disabled.ksh
@@ -12,10 +12,11 @@
 #
 
 #
-# Copyright (c) 2015 by Delphix. All rights reserved.
+# Copyright (c) 2015, Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
+. $STF_SUITE/include/properties.shlib
 
 #
 # Description:
@@ -34,7 +35,6 @@ verify_runnable "both"
 
 log_assert "Verify compressed streams are rejected if incompatible."
 
-typeset compress_types="off gzip lz4"
 typeset send_ds=$POOL2/testds
 typeset recv_ds=$POOL3/testds
 
@@ -49,7 +49,7 @@ log_onexit cleanup
 datasetexists $POOL3 && log_must zpool destroy $POOL3
 log_must zpool create -d $POOL3 $DISK3
 
-for compress in $compress_types; do
+for compress in "${compress_prop_vals[@]}"; do
 	datasetexists $send_ds && log_must_busy zfs destroy -r $send_ds
 	datasetexists $recv_ds && log_must_busy zfs destroy -r $recv_ds
 

--- a/tests/zfs-tests/tests/functional/rsend/send-c_stream_size_estimate.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_stream_size_estimate.ksh
@@ -12,10 +12,11 @@
 #
 
 #
-# Copyright (c) 2015 by Delphix. All rights reserved.
+# Copyright (c) 2015, Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
+. $STF_SUITE/include/properties.shlib
 
 #
 # Description:
@@ -28,7 +29,6 @@
 #
 
 verify_runnable "both"
-typeset compress_types="off gzip lz4"
 typeset send_ds="$POOL2/testfs"
 typeset send_vol="$POOL2/vol"
 typeset send_voldev="$ZVOL_DEVDIR/$POOL2/vol"
@@ -55,7 +55,7 @@ log_onexit cleanup_pool $POOL2
 
 write_compressible $BACKDIR ${megs}m
 
-for compress in $compress_types; do
+for compress in "${compress_prop_vals[@]}"; do
 	datasetexists $send_ds && log_must_busy zfs destroy -r $send_ds
 	datasetexists $send_vol && log_must_busy zfs destroy -r $send_vol
 	log_must zfs create -o compress=$compress $send_ds

--- a/tests/zfs-tests/tests/functional/rsend/send-c_verify_ratio.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_verify_ratio.ksh
@@ -12,7 +12,8 @@
 #
 
 #
-# Copyright (c) 2015 by Delphix. All rights reserved.
+# Copyright (c) 2015, Delphix. All rights reserved.
+# Copyright (c) 2019, Kjeld Schouten-Lebbing. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
@@ -37,7 +38,7 @@ log_onexit cleanup_pool $POOL2
 typeset sendfs=$POOL2/$FS
 typeset megs=128
 
-for prop in $(get_rand_compress_any 6); do
+for prop in "${compress_prop_vals[@]}"; do
 	for compressible in 'yes' 'no'; do
 		log_must zfs create -o compress=$prop $sendfs
 

--- a/tests/zfs-tests/tests/functional/rsend/send_realloc_encrypted_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_realloc_encrypted_files.ksh
@@ -12,9 +12,11 @@
 #
 
 #
-# Copyright (c) 2019 by Lawrence Livermore National Security, LLC.
+# Copyright (c) 2019, Lawrence Livermore National Security LLC.
+# Use is subject to license terms.
 #
 
+. $STF_SUITE/include/properties.shlib
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
 
@@ -78,7 +80,7 @@ for i in {1..$passes}; do
 	# Randomly modify several dataset properties in order to generate
 	# more interesting incremental send streams.
 	rand_set_prop $POOL/fs checksum "off" "fletcher4" "sha256"
-	rand_set_prop $POOL/fs compression "off" "lzjb" "gzip" "lz4"
+	rand_set_prop $POOL/fs compression "${compress_prop_vals[@]}"
 	rand_set_prop $POOL/fs recordsize "32K" "128K"
 	rand_set_prop $POOL/fs dnodesize "legacy" "auto" "4k"
 	rand_set_prop $POOL/fs xattr "on" "sa"


### PR DESCRIPTION
This PR is based on my previous work in #9626 trying to find a more standardised way to select compression algorithms for the test suit.

TL:DR: 
- Removes duplicate algorithms from compression tests
- Refactors compression algorithm selection for tests to use one uniform format

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

### Motivation and Context
During my work on investigating the compression test suite for #8941 a few things became appearant:
1. There are a multitude of different ways/arrays/variables containing compression algorithms for tests
2. Already some algorithms seem to have skipped over certain tests because of this
3. Listing multiple (gzip) levels leads to duplicate and decreases the chance of other algorithms being choosen
4. The decreased chance for different algorithms increases a lot when other "level based" algorithms get added
5. Listing aliasses of algorithms leads to duplicate tests
6. Somehow someone had the idea to use a function to simply pass array values to a for loop.

### Description

This PR refactors it all.

- The only compression algorithm list left is the one inside `properties.shlib`
- It removes all seperate levels from the compression algorithms list for tests, except one (the default)
- It removes the `on` alias for the selection of tests, in favor of `lz4` to prevent mistakes switching default algorithm
- It removes random algorithm selection, if the new array is just 1 or 2 longer than the previous amount of random draws
- It removes the function onder `libtest.shlib` that was used to pass compresion algorithms (now directly uses the array in `properties.shlib` instead)
- As a consequence, all tests now use the right set of algorithms
- Also cleans the copyright notices a bit, layout was not always the best

**One list to use them and in compression store them**

### Is * taken into account aka FAQ?
Q: Can't test failure of different levels slip past now? 
_A: Mostly levels are similair enough to the default to be found out just by using the default. If that's not the case a seperate test testing the different levels one time is more efficient than doing so for all tests._

Q: Can't test failure of aliasses slip past now?
_A: Aliasses already have their own tests script or (in case of `on`) still get used a few times directly. So failures shouldn't slip past._

Q: Don't we need more randomised selection again when more compression algorithms get added?
_A: If the amount of algorithms in the list increases byond 8 or 9, 1 or 2 extra random draws might be needed. Considering the current number and the (slow) speed of new algorithms being added, this will suffice for quite a while_

Q: Doesn't adding the same complete selection of algorithms increase test runtime?
_A: In scenario's where some compression algorithms where left out and no randomisation is used, it might take a little longer. However the same subset of algorithms should already have been used and, by decreasing the amount of gzip-based algorithms in the selection, in general less performance intensive tests are being used. Net it will stay about the same or a little faster, but in general the test will be more repeatable and comparable.

### How Has This Been Tested?
I manually checked if all tests actually used the algorithms referenced and they do.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
