### PR TITLE
Dependency related additions to the systemd generator

### DIFF
--- a/cmd/zed/zed.d/history_event-zfs-list-cacher.sh.in
+++ b/cmd/zed/zed.d/history_event-zfs-list-cacher.sh.in
@@ -46,8 +46,13 @@ case "${ZEVENT_HISTORY_INTERNAL_NAME}" in
     set|inherit)
         # Only act if one of the tracked properties is altered.
         case "${ZEVENT_HISTORY_INTERNAL_STR%%=*}" in
-            canmount|mountpoint|atime|relatime|devices|exec| \
-                readonly|setuid|nbmand|encroot|keylocation) ;;
+            canmount|mountpoint|atime|relatime|devices|exec|readonly| \
+              setuid|nbmand|encroot|keylocation|org.openzfs.systemd:requires| \
+              org.openzfs.systemd:requires-mounts-for| \
+              org.openzfs.systemd:before|org.openzfs.systemd:after| \
+              org.openzfs.systemd:wanted-by|org.openzfs.systemd:required-by| \
+              org.openzfs.systemd:nofail|org.openzfs.systemd:ignore \
+            ) ;;
             *) exit 0 ;;
         esac
       ;;
@@ -61,8 +66,12 @@ esac
 zed_lock zfs-list
 trap abort_alter EXIT
 
-PROPS="name,mountpoint,canmount,atime,relatime,devices,exec,readonly"
-PROPS="${PROPS},setuid,nbmand,encroot,keylocation"
+PROPS="name,mountpoint,canmount,atime,relatime,devices,exec\
+,readonly,setuid,nbmand,encroot,keylocation\
+,org.openzfs.systemd:requires,org.openzfs.systemd:requires-mounts-for\
+,org.openzfs.systemd:before,org.openzfs.systemd:after\
+,org.openzfs.systemd:wanted-by,org.openzfs.systemd:required-by\
+,org.openzfs.systemd:nofail,org.openzfs.systemd:ignore"
 
 "${ZFS}" list -H -t filesystem -o $PROPS -r "${ZEVENT_POOL}" > "${FSLIST_TMP}"
 

--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -60,6 +60,7 @@ process_line() {
   IFS="$(printf '\t')"
   # protect against special characters in, e.g., mountpoints
   set -f
+  # shellcheck disable=SC2086
   set -- $1
   dataset="${1}"
   p_mountpoint="${2}"
@@ -87,17 +88,19 @@ process_line() {
         pathdep="RequiresMountsFor='${p_keyloc#file://}'"
         keyloadcmd="@sbindir@/zfs load-key '${dataset}'"
       elif [ "${p_keyloc}" = "prompt" ] ; then
-        keyloadcmd="/bin/sh -c 'set -eu;"\
-"keystatus=\"\$\$(@sbindir@/zfs get -H -o value keystatus \"${dataset}\")\";"\
-"[ \"\$\$keystatus\" = \"unavailable\" ] || exit 0;"\
-"count=0;"\
-"while [ \$\$count -lt 3 ];do"\
-"  systemd-ask-password --id=\"zfs:${dataset}\""\
-"    \"Enter passphrase for ${dataset}:\"|"\
-"    @sbindir@/zfs load-key \"${dataset}\" && exit 0;"\
-"  count=\$\$((count + 1));"\
-"done;"\
-"exit 1'"
+        keyloadcmd="\
+/bin/sh -c '\
+set -eu;\
+keystatus=\"\$\$(@sbindir@/zfs get -H -o value keystatus \"${dataset}\")\";\
+[ \"\$\$keystatus\" = \"unavailable\" ] || exit 0;\
+count=0;\
+while [ \$\$count -lt 3 ];do\
+  systemd-ask-password --id=\"zfs:${dataset}\"\
+    \"Enter passphrase for ${dataset}:\"|\
+    @sbindir@/zfs load-key \"${dataset}\" && exit 0;\
+  count=\$\$((count + 1));\
+done;\
+exit 1'"
       else
         printf 'zfs-mount-generator: (%s) invalid keylocation\n' \
           "${dataset}" >/dev/kmsg

--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -2,6 +2,7 @@
 
 # zfs-mount-generator - generates systemd mount units for zfs
 # Copyright (c) 2017 Antonio Russo <antonio.e.russo@gmail.com>
+# Copyright (c) 2020 InsanePrawn <insane.prawny@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -33,6 +34,35 @@ do_fail() {
   exit 1
 }
 
+# test if $1 is in space-separated list $2
+is_known() {
+  query="$1"
+  IFS=' '
+  # protect against special characters
+  set -f
+  for element in $2 ; do
+    if [ "$query" = "$element" ] ; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# create dependency on unit file $1
+# of type $2, i.e. "wants" or "requires"
+# in the target units from space-separated list $3
+create_dependencies() {
+  unitfile="$1"
+  suffix="$2"
+  # protect against special characters
+  set -f
+  for target in $3 ; do
+    target_dir="${dest_norm}/${target}.${suffix}/"
+    mkdir -p "${target_dir}"
+    ln -s "../${unitfile}" "${target_dir}"
+  done
+}
+
 # see systemd.generator
 if [ $# -eq 0 ] ; then
   dest_norm="/tmp"
@@ -42,11 +72,6 @@ else
   do_fail "zero or three arguments required"
 fi
 
-# For ZFSs marked "auto", a dependency is created for local-fs.target. To
-# avoid regressions, this dependency is reduced to "wants" rather than
-# "requires". **THIS MAY CHANGE**
-req_dir="${dest_norm}/local-fs.target.wants/"
-mkdir -p "${req_dir}"
 
 # All needed information about each ZFS is available from
 # zfs list -H -t filesystem -o <properties>
@@ -74,18 +99,58 @@ process_line() {
   p_nbmand="${10}"
   p_encroot="${11}"
   p_keyloc="${12}"
+  p_systemd_requires="${13}"
+  p_systemd_requiresmountsfor="${14}"
+  p_systemd_before="${15}"
+  p_systemd_after="${16}"
+  p_systemd_wantedby="${17}"
+  p_systemd_requiredby="${18}"
+  p_systemd_nofail="${19}"
+  p_systemd_ignore="${20}"
 
   # Minimal pre-requisites to mount a ZFS dataset
+  # By ordering before zfs-mount.service, we avoid race conditions.
+  after="zfs-import.target"
+  before="zfs-mount.service"
   wants="zfs-import.target"
+  requires=""
+  requiredmounts=""
+  wantedby=""
+  requiredby=""
+  noauto="off"
+
+  if [ -n "${p_systemd_after}" ] && \
+      [ "${p_systemd_after}" != "-" ] ; then
+    after="${p_systemd_after} ${after}"
+  fi
+
+  if [ -n "${p_systemd_before}" ] && \
+      [ "${p_systemd_before}" != "-" ] ; then
+    before="${p_systemd_before} ${before}"
+  fi
+
+  if [ -n "${p_systemd_requires}" ] && \
+      [ "${p_systemd_requires}" != "-" ] ; then
+    requires="Requires=${p_systemd_requires}"
+  fi
+
+  if [ -n "${p_systemd_requiresmountsfor}" ] && \
+      [ "${p_systemd_requiresmountsfor}" != "-" ] ; then
+    requiredmounts="RequiresMountsFor=${p_systemd_requiresmountsfor}"
+  fi
 
   # Handle encryption
   if [ -n "${p_encroot}" ] &&
       [ "${p_encroot}" != "-" ] ; then
     keyloadunit="zfs-load-key-$(systemd-escape "${p_encroot}").service"
     if [ "${p_encroot}" = "${dataset}" ] ; then
-        pathdep=""
+      keymountdep=""
       if [ "${p_keyloc%%://*}" = "file" ] ; then
-        pathdep="RequiresMountsFor='${p_keyloc#file://}'"
+        if [ -n "${requiredmounts}" ] ; then
+          keymountdep="${requiredmounts} '${p_keyloc#file://}'"
+        else
+          keymountdep="RequiresMountsFor='${p_keyloc#file://}'"
+        fi
         keyloadcmd="@sbindir@/zfs load-key '${dataset}'"
       elif [ "${p_keyloc}" = "prompt" ] ; then
         keyloadcmd="\
@@ -121,8 +186,10 @@ SourcePath=${cachefile}
 Documentation=man:zfs-mount-generator(8)
 DefaultDependencies=no
 Wants=${wants}
-After=${wants}
-${pathdep}
+After=${after}
+Before=${before}
+${requires}
+${keymountdep}
 
 [Service]
 Type=oneshot
@@ -130,23 +197,35 @@ RemainAfterExit=yes
 ExecStart=${keyloadcmd}
 ExecStop=@sbindir@/zfs unload-key '${dataset}'"   > "${dest_norm}/${keyloadunit}"
     fi
-    # Update the dependencies for the mount file to require the
+    # Update the dependencies for the mount file to want the
     # key-loading unit.
     wants="${wants} ${keyloadunit}"
+    after="${after} ${keyloadunit}"
   fi
 
   # Prepare the .mount unit
+
+  # skip generation of the mount unit if org.openzfs.systemd:ignore is "on"
+  if [ -n "${p_systemd_ignore}" ] ; then
+    if [ "${p_systemd_ignore}" = "on" ] ; then
+      return
+    elif [ "${p_systemd_ignore}" = "-" ] \
+      || [ "${p_systemd_ignore}" = "off" ] ; then
+      : # This is OK
+    else
+      do_fail "invalid org.openzfs.systemd:ignore for ${dataset}"
+    fi
+  fi
 
   # Check for canmount=off .
   if [ "${p_canmount}" = "off" ] ; then
     return
   elif [ "${p_canmount}" = "noauto" ] ; then
-    # Don't let a noauto marked mountpoint block an "auto" marked mountpoint
-    return
+    noauto="on"
   elif [ "${p_canmount}" = "on" ] ; then
     : # This is OK
   else
-    do_fail "invalid canmount"
+    do_fail "invalid canmount for ${dataset}"
   fi
 
   # Check for legacy and blank mountpoints.
@@ -155,7 +234,7 @@ ExecStop=@sbindir@/zfs unload-key '${dataset}'"   > "${dest_norm}/${keyloadunit}
   elif [ "${p_mountpoint}" = "none" ] ; then
     return
   elif [ "${p_mountpoint%"${p_mountpoint#?}"}" != "/" ] ; then
-    do_fail "invalid mountpoint $*"
+    do_fail "invalid mountpoint for ${dataset}"
   fi
 
   # Escape the mountpoint per systemd policy.
@@ -233,15 +312,91 @@ ExecStop=@sbindir@/zfs unload-key '${dataset}'"   > "${dest_norm}/${keyloadunit}
       "${dataset}" >/dev/kmsg
   fi
 
-  # If the mountpoint has already been created, give it precedence.
+  if [ -n "${p_systemd_wantedby}" ] && \
+      [ "${p_systemd_wantedby}" != "-" ] ; then
+    noauto="on"
+    if [ "${p_systemd_wantedby}" = "none" ] ; then
+      wantedby=""
+    else
+      wantedby="${p_systemd_wantedby}"
+      before="${before} ${wantedby}"
+    fi
+  fi
+
+  if [ -n "${p_systemd_requiredby}" ] && \
+      [ "${p_systemd_requiredby}" != "-" ] ; then
+    noauto="on"
+    if [ "${p_systemd_requiredby}" = "none" ] ; then
+      requiredby=""
+    else
+      requiredby="${p_systemd_requiredby}"
+      before="${before} ${requiredby}"
+    fi
+  fi
+
+  # For datasets with canmount=on, a dependency is created for
+  # local-fs.target by default. To avoid regressions, this dependency
+  # is reduced to "wants" rather than "requires" when nofail is not "off".
+  # **THIS MAY CHANGE**
+  # noauto=on disables this behavior completely.
+  if [ "${noauto}" != "on" ] ; then
+    if [ "${p_systemd_nofail}" = "off" ] ; then
+      requiredby="local-fs.target"
+      before="${before} local-fs.target"
+    else
+      wantedby="local-fs.target"
+      if [ "${p_systemd_nofail}" != "on" ] ; then
+        before="${before} local-fs.target"
+      fi
+    fi
+  fi
+
+  # Handle existing files:
+  # 1.  We never overwrite existing files, although we may delete
+  #     files if we're sure they were created by us. (see 5.)
+  # 2.  We handle files differently based on canmount. Units with canmount=on
+  #     always have precedence over noauto. This is enforced by the sort pipe
+  #     in the loop around this function.
+  #     It is important to use $p_canmount and not $noauto here, since we
+  #     sort by canmount while other properties also modify $noauto, e.g.
+  #     org.openzfs.systemd:wanted-by.
+  # 3.  If no unit file exists for a noauto dataset, we create one.
+  #     Additionally, we use $noauto_files to track the unit file names
+  #     (which are the systemd-escaped mountpoints) of all (exclusively)
+  #     noauto datasets that had a file created.
+  # 4.  If the file to be created is found in the tracking variable,
+  #     we do NOT create it.
+  # 5.  If a file exists for a noauto dataset, we check whether the file
+  #     name is in the variable. If it is, we have multiple noauto datasets
+  #     for the same mountpoint. In such cases, we remove the file for safety.
+  #     To avoid further noauto datasets creating a file for this path again,
+  #     we leave the file name in the tracking variable.
   if [ -e "${dest_norm}/${mountfile}" ] ; then
-    printf 'zfs-mount-generator: %s already exists\n' "${mountfile}" \
-      >/dev/kmsg
+    if is_known "$mountfile" "$noauto_files" ; then
+      # if it's in $noauto_files, we must be noauto too. See 2.
+      printf 'zfs-mount-generator: removing duplicate noauto %s\n' \
+        "${mountfile}" >/dev/kmsg
+      # See 5.
+      rm "${dest_norm}/${mountfile}"
+    else
+      # don't log for canmount=noauto
+      if [  "${p_canmount}" = "on" ] ; then
+        printf 'zfs-mount-generator: %s already exists. Skipping.\n' \
+          "${mountfile}" >/dev/kmsg
+      fi
+    fi
+    # file exists; Skip current dataset.
     return
+  else
+    if is_known "${mountfile}" "${noauto_files}" ; then
+      # See 4.
+      return
+    elif [ "${p_canmount}" = "noauto" ] ; then
+      noauto_files="${mountfile} ${noauto_files}"
+    fi
   fi
 
   # Create the .mount unit file.
-  # By ordering before zfs-mount.service, we avoid race conditions.
   #
   # (Do not use `<<EOF`-style here-documents for this, see warning above)
   #
@@ -251,9 +406,12 @@ ExecStop=@sbindir@/zfs unload-key '${dataset}'"   > "${dest_norm}/${keyloadunit}
 [Unit]
 SourcePath=${cachefile}
 Documentation=man:zfs-mount-generator(8)
-Before=local-fs.target zfs-mount.service
-After=${wants}
+
+Before=${before}
+After=${after}
 Wants=${wants}
+${requires}
+${requiredmounts}
 
 [Mount]
 Where=${p_mountpoint}
@@ -261,13 +419,20 @@ What=${dataset}
 Type=zfs
 Options=defaults${opts},zfsutil" > "${dest_norm}/${mountfile}"
 
-  # Finally, create the appropriate dependency
-  ln -s "../${mountfile}" "${req_dir}"
+  # Finally, create the appropriate dependencies
+  create_dependencies "${mountfile}" "wants" "$wantedby"
+  create_dependencies "${mountfile}" "requires" "$requiredby"
+
 }
 
-# Feed each line into process_line
 for cachefile in "${FSLIST}/"* ; do
-  while read -r fs ; do
-    process_line "${fs}"
-  done < "${cachefile}"
+  # Sort cachefile's lines by canmount, "on" before "noauto"
+  # and feed each line into process_line
+  sort -t "$(printf '\t')" -k 3 -r "${cachefile}" | \
+  ( # subshell is necessary for `sort|while read` and $noauto_files
+    noauto_files=""
+    while read -r fs ; do
+      process_line "${fs}"
+    done
+  )
 done

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -89,6 +89,7 @@ EXTRA_DIST = \
 
 $(nodist_man_MANS): %: %.in
 	-$(SED) -e 's,@zfsexecdir\@,$(zfsexecdir),g' \
+		-e 's,@systemdgeneratordir\@,$(systemdgeneratordir),g' \
 		-e 's,@runstatedir\@,$(runstatedir),g' \
 		-e 's,@sysconfdir\@,$(sysconfdir),g' \
 		$< >'$@'

--- a/man/man8/zfs-mount-generator.8.in
+++ b/man/man8/zfs-mount-generator.8.in
@@ -1,8 +1,33 @@
-.TH "ZFS\-MOUNT\-GENERATOR" "8" "ZFS" "zfs-mount-generator" "\""
+.\"
+.\" Copyright 2018 Antonio Russo <antonio.e.russo@gmail.com>
+.\" Copyright 2019 Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
+.\" Copyright 2020 InsanePrawn <insane.prawny@gmail.com>
+.\"
+.\" Permission is hereby granted, free of charge, to any person obtaining
+.\" a copy of this software and associated documentation files (the
+.\" "Software"), to deal in the Software without restriction, including
+.\" without limitation the rights to use, copy, modify, merge, publish,
+.\" distribute, sublicense, and/or sell copies of the Software, and to
+.\" permit persons to whom the Software is furnished to do so, subject to
+.\" the following conditions:
+.\"
+.\" The above copyright notice and this permission notice shall be
+.\" included in all copies or substantial portions of the Software.
+.\"
+.\" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+.\" EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+.\" MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+.\" NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+.\" LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+.\" OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+.\" WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+.TH "ZFS\-MOUNT\-GENERATOR" "8" "2020-01-19" "ZFS" "zfs-mount-generator" "\""
+
 .SH "NAME"
 zfs\-mount\-generator \- generates systemd mount units for ZFS
 .SH SYNOPSIS
-.B /lib/systemd/system-generators/zfs\-mount\-generator
+.B @systemdgeneratordir@/zfs\-mount\-generator
 .sp
 .SH DESCRIPTION
 zfs\-mount\-generator implements the \fBGenerators Specification\fP
@@ -11,22 +36,50 @@ of
 and is called during early boot to generate
 .BR systemd.mount (5)
 units for automatically mounted datasets. Mount ordering and dependencies
-are created for all tracked pools (see below). If a dataset has
-.BR canmount=on
-and
-.BR mountpoint
-set, the
-.BR auto
-mount option will be set, and a dependency for
-.BR local-fs.target
-on the mount will be created.
+are created for all tracked pools (see below).
 
-Because zfs pools may not be available very early in the boot process,
-information on ZFS mountpoints must be stored separately. The output
-of the command
+.SS ENCRYPTION KEYS
+If the dataset is an encryption root, a service that loads the associated key (either from file or through a
+.BR systemd\-ask\-password (1)
+prompt) will be created. This service
+. BR RequiresMountsFor
+the path of the key (if file-based) and also copies the mount unit's
+.BR After ,
+.BR Before
+and
+.BR Requires .
+All mount units of encrypted datasets add the key\-load service for their encryption root to their
+.BR Wants
+and
+.BR After .
+The service will not be
+.BR Want ed
+or
+.BR Require d
+by
+.BR local-fs.target
+directly, and so will only be started manually or as a dependency of a started mount unit.
+
+.SS UNIT ORDERING AND DEPENDENCIES
+mount unit's
+.BR Before
+\->
+key\-load service (if any)
+\->
+mount unit
+\->
+mount unit's
+.BR After
+
+It is worth nothing that when a mount unit is activated, it activates all available mount units for parent paths to its mountpoint, i.e. activating the mount unit for /tmp/foo/1/2/3 automatically activates all available mount units for /tmp, /tmp/foo, /tmp/foo/1, and /tmp/foo/1/2. This is true for any combination of mount units from any sources, not just ZFS.
+
+.SS CACHE FILE
+Because ZFS pools may not be available very early in the boot process,
+information on ZFS mountpoints must be stored separately. The output of the command
 .PP
 .RS 4
-zfs list -H -o name,mountpoint,canmount,atime,relatime,devices,exec,readonly,setuid,nbmand,encroot,keylocation
+zfs list -H -o name,mountpoint,canmount,atime,relatime,devices,exec,readonly,setuid,nbmand,encroot,keylocation,org.openzfs.systemd:requires,org.openzfs.systemd:requires-mounts-for,org.openzfs.systemd:before,org.openzfs.systemd:after,org.openzfs.systemd:wanted-by,org.openzfs.systemd:required-by,org.openzfs.systemd:nofail,org.openzfs.systemd:ignore
+
 .RE
 .PP
 for datasets that should be mounted by systemd, should be kept
@@ -45,6 +98,98 @@ history_event-zfs-list-cacher.sh .
 .RE
 .PP
 .sp
+.SS PROPERTIES
+The behavior of the generator script can be influenced by the following dataset properties:
+.sp
+.TP 4
+.BR canmount = on | off | noauto
+If a dataset has
+.BR mountpoint
+set and
+.BR canmount
+is not
+.BR off ,
+a mount unit will be generated.
+Additionally, if
+.BR canmount
+is
+.BR on ,
+.BR local-fs.target
+will gain a dependency on the mount unit.
+
+This behavior is equal to the
+.BR auto
+and
+.BR noauto
+legacy mount options, see
+.BR systemd.mount (5).
+
+Encryption roots always generate a key-load service, even for
+.BR canmount=off .
+.TP 4
+.BR org.openzfs.systemd:requires\-mounts\-for = \fIpath\fR...
+Space\-separated list of mountpoints to require to be mounted for this mount unit
+.TP 4
+.BR org.openzfs.systemd:before = \fIunit\fR...
+The mount unit and associated key\-load service will be ordered before this space\-separated list of units.
+.TP 4
+.BR org.openzfs.systemd:after = \fIunit\fR...
+The mount unit and associated key\-load service will be ordered after this space\-separated list of units.
+.TP 4
+.BR org.openzfs.systemd:wanted\-by = \fIunit\fR...
+Space-separated list of units that will gain a
+.BR Wants
+dependency on this mount unit.
+Setting this property implies
+.BR noauto .
+.TP 4
+.BR org.openzfs.systemd:required\-by = \fIunit\fR...
+Space-separated list of units that will gain a
+.BR Requires
+dependency on this mount unit.
+Setting this property implies
+.BR noauto .
+.TP 4
+.BR org.openzfs.systemd:nofail = unset | on | off
+Toggles between a
+.BR Wants
+and
+.BR Requires
+type of dependency between the mount unit and
+.BR local-fs.target ,
+if
+.BR noauto
+isn't set or implied.
+
+.BR on :
+Mount will be
+.BR WantedBy
+local-fs.target
+
+.BR off :
+Mount will be
+.BR Before
+and
+.BR RequiredBy
+local-fs.target
+
+.BR unset :
+Mount will be
+.BR Before
+and
+.BR WantedBy
+local-fs.target
+.TP 4
+.BR org.openzfs.systemd:ignore = on | off
+If set to
+.BR on ,
+do not generate a mount unit for this dataset.
+
+.RE
+See also
+.BR systemd.mount (5)
+
+.PP
 .SH EXAMPLE
 To begin, enable tracking for the pool:
 .PP
@@ -63,7 +208,9 @@ systemctl enable zfs-zed.service
 systemctl restart zfs-zed.service
 .RE
 .PP
-Force the running of the ZEDLET by setting canmount=on for at least one dataset in the pool:
+Force the running of the ZEDLET by setting a monitored property, e.g.
+.BR canmount ,
+for at least one dataset in the pool:
 .PP
 .RS 4
 zfs set canmount=on
@@ -71,6 +218,24 @@ zfs set canmount=on
 .RE
 .PP
 This forces an update to the stale cache file.
+
+To test the generator output, run
+.PP
+.RS 4
+@systemdgeneratordir@/zfs-mount-generator /tmp/zfs-mount-generator . .
+.RE
+.PP
+This will generate units and dependencies in
+.I /tmp/zfs-mount-generator
+for you to inspect them. The second and third argument are ignored.
+
+If you're satisfied with the generated units, instruct systemd to re-run all generators:
+.PP
+.RS 4
+systemctl daemon-reload
+.RE
+.PP
+
 .sp
 .SH SEE ALSO
 .BR zfs (5)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Needs some detail work, e.g. default values for the config vars.

As discovered in #9611, there is still some potentially desirable behaviours that the systemd generator does or does not show:
- Don't blindly symlink all generated mount units into local-fs.target.wants/
- create .mount units for datasets with canmount=noauto
 
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Don't blindly symlink all generated mount units into local-fs.target.wants/
Admins might not want the default behaviour of systemd mounting **every** canmount=on dataset with a valid mount point during boot (e.g. to utilize .automount units). Added code to disable the symlinking based on a variable, leaving it enabled by default (same as old behaviour)
- create .mount units for datasets with canmount=noauto
Added code to conditionally create .mount units for datasets with canmount=noauto, disabled by default (same as old behaviour)
Caveats: Currently no default values for those config strings. Might want to discuss whether to check for 'yes' or 'no' for every variable to achieve the best possible default behaviour.

### Description
<!--- Describe your changes in detail -->
- read the config from /etc/default/zfs (first commit):
Looking for feedback! Is this the right file to store this config? Currently just sourcing it as a shell script, anything nicer? Config variable names - I think at least `ZFS_SYSTEMD_NOAUTO_UNITS` needs a rename. Suggestions?
- Don't blindly symlink all generated mount units into local-fs.target.wants/
Skip symlinking altogether if config var is set. Currently **always** skips symlink creation for canmount=noauto datasets. Seems sane to me.
- create .mount units for datasets with canmount=noauto
I've left the creation of these units disabled by default, as they would get pulled in by mount units of descending paths (which can come from outside ZFS!).
This seems like the right thing to do in *most* situations, but I'd rather have a switch to control this rather than having to change pool configs or layouts to accommodate the generator, especially since this would be a breaking change.

from `man systemd.mount`:

```man
   Implicit Dependencies
       The following dependencies are implicitly added:

       •   If a mount unit is beneath another mount unit in the file system hierarchy, both a requirement dependency and an ordering dependency between both units are created
           automatically.
```


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Very manually on my Debian 9 server. The variables seem to function correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
