### PR TITLE
CodeCov Tweaks

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,7 +4,8 @@ codecov:
     after_n_builds: 2		# user and kernel
 
 coverage:
-  precision: 2			# 2 digits of precision
+  precision: 0			# 0 decimals of precision
+  round: nearest        # Round to nearest precision point
   range: "50...90"		# red -> yellow -> green
 
   status:
@@ -20,3 +21,6 @@ comment:
   layout: "reach, diff, flags, footer"
   behavior: once		# update if exists; post new; skip if deleted
   require_changes: yes		# only post when coverage changes
+
+ignore:
+  - "tests/zfs-tests"		# Don't need Tests to cover themselves


### PR DESCRIPTION
Codecov has been hit-or-mis for a time now

It seems to have 2 flaws:
- Tests are actually taken into account when comparing coverage
- There is a random variance in coverage leading in the 0.0-0.4 range.


### Motivation, Context and Description
- As far as I know there is no plan to write tests to cover tests, so this folder could just as well be excluded.
- Precision has been limited to whole percents only, but will round to nearest. This means 0.0-0.49 will round to zero (no change) and 0.51 will round to 1%. 

This might also lead to a more realistic and stable codecov report.

### How Has This Been Tested?
Automated tests for as far as thats even possible

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
