### PR TITLE
ICP: Fix null pointer dereference and use after free

### DIFF
--- a/module/icp/algs/modes/gcm.c
+++ b/module/icp/algs/modes/gcm.c
@@ -300,11 +300,13 @@ gcm_mode_decrypt_contiguous_blocks(gcm_ctx_t *ctx, char *data, size_t length,
 	if (length > 0) {
 		new_len = ctx->gcm_pt_buf_len + length;
 		new = vmem_alloc(new_len, ctx->gcm_kmflag);
+		if (new == NULL) {
+			vmem_free(ctx->gcm_pt_buf, ctx->gcm_pt_buf_len);
+			ctx->gcm_pt_buf = NULL;
+			return (CRYPTO_HOST_MEMORY);
+		}
 		bcopy(ctx->gcm_pt_buf, new, ctx->gcm_pt_buf_len);
 		vmem_free(ctx->gcm_pt_buf, ctx->gcm_pt_buf_len);
-		if (new == NULL)
-			return (CRYPTO_HOST_MEMORY);
-
 		ctx->gcm_pt_buf = new;
 		ctx->gcm_pt_buf_len = new_len;
 		bcopy(data, &ctx->gcm_pt_buf[ctx->gcm_processed_data_len],

--- a/module/icp/core/kcf_prov_lib.c
+++ b/module/icp/core/kcf_prov_lib.c
@@ -207,9 +207,12 @@ crypto_update_uio(void *ctx, crypto_data_t *input, crypto_data_t *output,
 		cur_len = MIN(uiop->uio_iov[vec_idx].iov_len -
 		    offset, length);
 
-		(cipher)(ctx, uiop->uio_iov[vec_idx].iov_base + offset,
+		int rv = (cipher)(ctx, uiop->uio_iov[vec_idx].iov_base + offset,
 		    cur_len, (input == output) ? NULL : output);
 
+		if (rv != CRYPTO_SUCCESS) {
+			return (rv);
+		}
 		length -= cur_len;
 		vec_idx++;
 		offset = 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bugfix.

### Description
In `gcm_mode_decrypt_contiguous_blocks()`, if `vmem_alloc()` fails, `bcopy()` is called with a null pointer destination and a length > 0. This results in undefined behavior. Further ctx->gcm_pt_buf is freed but not set to `NULL`, leading to a potential write after free and a double free due to missing return value handling in `crypto_update_uio()`. The code as is may write to `ctx->gcm_pt_buf` in [gcm_decrypt_final()](https://github.com/zfsonlinux/zfs/blob/51420321068e905445e625def28fadc7c3625e13/module/icp/algs/modes/gcm.c#L320) and may free `ctx->gcm_pt_buf` again in [aes_decrypt_atomic()](https://github.com/zfsonlinux/zfs/blob/51420321068e905445e625def28fadc7c3625e13/module/icp/io/aes.c#L1209).

The fix is to slightly rework error handling in `gcm_mode_decrypt_contiguous_blocks()` and check the return value in `crypto_update_uio()`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
As part of another branch this survived 6 hours of `zloop`. Currently `zloop` fails with unmodified master within one hour, so can't use `zloop` to test this PR, sorry.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
