### PR TITLE
simd: use alloc_pages_node to force alignment

### DIFF
--- a/include/os/linux/kernel/linux/simd_x86.h
+++ b/include/os/linux/kernel/linux/simd_x86.h
@@ -135,6 +135,8 @@
  */
 #if defined(HAVE_KERNEL_FPU_INTERNAL)
 
+#include <linux/mm.h>
+
 extern union fpregs_state **zfs_kfpu_fpregs;
 
 /*
@@ -147,7 +149,8 @@ kfpu_fini(void)
 
 	for_each_possible_cpu(cpu) {
 		if (zfs_kfpu_fpregs[cpu] != NULL) {
-			kfree(zfs_kfpu_fpregs[cpu]);
+			free_pages((unsigned long)zfs_kfpu_fpregs[cpu],
+			    get_order(sizeof (union fpregs_state)));
 		}
 	}
 
@@ -157,20 +160,28 @@ kfpu_fini(void)
 static inline int
 kfpu_init(void)
 {
-	int cpu;
-
 	zfs_kfpu_fpregs = kzalloc(num_possible_cpus() *
 	    sizeof (union fpregs_state *), GFP_KERNEL);
 	if (zfs_kfpu_fpregs == NULL)
 		return (-ENOMEM);
 
+	/*
+	 * The fxsave and xsave operations require 16-/64-byte alignment of
+	 * the target memory. Since kmalloc() provides no alignment
+	 * guarantee instead use alloc_pages_node().
+	 */
+	unsigned int order = get_order(sizeof (union fpregs_state));
+	int cpu;
+
 	for_each_possible_cpu(cpu) {
-		zfs_kfpu_fpregs[cpu] = kmalloc_node(sizeof (union fpregs_state),
-		    GFP_KERNEL | __GFP_ZERO, cpu_to_node(cpu));
-		if (zfs_kfpu_fpregs[cpu] == NULL) {
+		struct page *page = alloc_pages_node(cpu_to_node(cpu),
+		    GFP_KERNEL | __GFP_ZERO, order);
+		if (page == NULL) {
 			kfpu_fini();
 			return (-ENOMEM);
 		}
+
+		zfs_kfpu_fpregs[cpu] = page_address(page);
 	}
 
 	return (0);


### PR DESCRIPTION
### Motivation and Context / Description
See #9608 - the SIMD/FPU code is currently broken because it relies on (wrong) assumptions about kernel memory allocation.

fxsave and xsave require the target address to be 16-/64-byte aligned.

kmalloc(_node) does not (yet) offer such fine-grained control over
alignement[0,1], even though it does "the right thing" most of the time
for power-of-2 sizes. unfortunately, alignment is completely off when
using certain debugging or hardening features/configs, such as KASAN,
slub_debug=Z or the not-yet-upstream SLAB_CANARY.

resort to (spl_)kmem_cache_alloc, which enables us to specify an
explicit alignment. CPU/NUMA-node locality is lost, since spl_kmem_cache
does not have kmem_cache_alloc_node support.

Fixes: #9608

0: https://lwn.net/Articles/787740/
1: https://lore.kernel.org/linux-block/20190826111627.7505-1-vbabka@suse.cz/

### How Has This Been Tested?
smoke-tested in VMs with regular, hardened and slub_debug kernels

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
