### PR TITLE
set send_realloc_files.ksh to use properties.shlib

### DIFF
--- a/tests/zfs-tests/tests/functional/rsend/send_realloc_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_realloc_files.ksh
@@ -15,6 +15,7 @@
 # Copyright (c) 2019 by Lawrence Livermore National Security, LLC.
 #
 
+. $STF_SUITE/include/properties.shlib
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
 
@@ -71,7 +72,7 @@ for i in {1..$passes}; do
 	# Randomly modify several dataset properties in order to generate
 	# more interesting incremental send streams.
 	rand_set_prop $POOL/fs checksum "off" "fletcher4" "sha256"
-	rand_set_prop $POOL/fs compression "off" "lzjb" "gzip" "lz4"
+	rand_set_prop $POOL/fs compression "${compress_prop_vals[@]}"
 	rand_set_prop $POOL/fs recordsize "32K" "128K"
 	rand_set_prop $POOL/fs dnodesize "legacy" "auto" "4k"
 	rand_set_prop $POOL/fs xattr "on" "sa"


### PR DESCRIPTION
This sets send_realloc_files.ksh to use properties.shlib
(like the other compression related tests)

It was missing from #9645

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

### Motivation and Context
I don't know how I missed it, but I missed this file while doing PR #9645
This does however make pretty clear how easy it was to forget references in the previous way compression algorithms where referenced in tests.

### Description
So I just applied the same basics as  #9645 to send_realloc_files.ksh


### How Has This Been Tested?
Automatic testing

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
