### PR TITLE
Fix codecov ignore, wrong syntax

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -23,4 +23,4 @@ comment:
   require_changes: yes		# only post when coverage changes
 
 ignore:
-  - "tests/zfs-tests"		# Don't need Tests to cover themselves
+  - "tests/*/**"		# Don't need Tests to cover themselves


### PR DESCRIPTION
This changes codecov ignore to use the correct syntax for recursiveness

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>


### Motivation and Context and Description

The current codecov ignore syntax is not how it should be writen by codecov.
Fixed it, At least this is the right syntax now.


### How Has This Been Tested?
It does not seem I'm able to test this using a PR.
Codecov might prevent ignore changes inside a PR or there might be a mistake with codecov.

(if it doesn't work, ill take it up with codecov)

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
