### PR TITLE
Restore default pool config cache loading behaviour on FreeBSD

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -819,7 +819,11 @@ typedef struct zpool_load_policy {
  * The location of the pool configuration repository, shared between kernel and
  * userland.
  */
+#ifdef __FreeBSD__
+#define	ZPOOL_CACHE		"/boot/zfs/zpool.cache"
+#else
 #define	ZPOOL_CACHE		"/etc/zfs/zpool.cache"
+#endif
 
 /*
  * vdev states are ordered from least to most healthy.

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -846,7 +846,7 @@ extern kmutex_t spa_namespace_lock;
 #define	SPA_CONFIG_UPDATE_VDEVS	1
 
 extern void spa_write_cachefile(spa_t *, boolean_t, boolean_t);
-extern void spa_config_load(void);
+extern void spa_config_load(boolean_t);
 extern nvlist_t *spa_all_configs(uint64_t *);
 extern void spa_config_set(spa_t *spa, nvlist_t *config);
 extern nvlist_t *spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg,

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -74,7 +74,7 @@ int zfs_autoimport_disable = 1;
  * only populates the namespace.
  */
 void
-spa_config_load(void)
+spa_config_load(boolean_t boot)
 {
 	void *buf = NULL;
 	nvlist_t *nvlist, *child;
@@ -86,7 +86,7 @@ spa_config_load(void)
 	int err;
 
 #ifdef _KERNEL
-	if (zfs_autoimport_disable)
+	if (boot == B_FALSE && zfs_autoimport_disable)
 		return;
 #endif
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2278,7 +2278,7 @@ spa_name_compare(const void *a1, const void *a2)
 void
 spa_boot_init(void)
 {
-	spa_config_load();
+	spa_config_load(B_TRUE);
 }
 
 void
@@ -2333,7 +2333,7 @@ spa_init(spa_mode_t mode)
 	zfs_prop_init();
 	zpool_prop_init();
 	zpool_feature_init();
-	spa_config_load();
+	spa_config_load(B_FALSE);
 	l2arc_start();
 	scan_init();
 	qat_init();


### PR DESCRIPTION
Load pools present in the cachefile at boot time.
Preserving new tunable to not autoload when module is loaded manually.

Set the path to the zpool.cache file for FreeBSD

Signed-off-by: Allan Jude <allanjude@freebsd.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
