### PR TITLE
Fixes typo from #9681

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -23,4 +23,4 @@ comment:
   require_changes: yes		# only post when coverage changes
 
 ignore:
-  - "tests/*/**"		# Don't need Tests to cover themselves
+  - "tests/**/*"		# Don't need Tests to cover themselves


### PR DESCRIPTION
Fixes typo in #9681
Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

### Motivation and Context
Going from #9672 to #9681 I made a typo.
This removes that typo.

### Description
In #9672 I explored options for getting rid of the tests folder in codecov.
We moved to #9681 but I seem to have made a rather obvious typo.
The syntax is obviously: `$Folder/$RecursiveFolders/$RecursiveFiles`   
Which leads to:
`tests/**/*`

(Which was also the thing from the manual I wanted to copy)

It's just a typo fix.
has been tested before in #9672 and doesn't do jackshit when used in a PR.
But maybe after merging this magically works.

Anyway, it's just to get rid of the typo primarily.

### How Has This Been Tested?
It's just a typo fix


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
