### PR TITLE
Fixes for spurious failures of resilver_restart_001 test

### DIFF
--- a/tests/zfs-tests/tests/functional/resilver/resilver_restart_001.ksh
+++ b/tests/zfs-tests/tests/functional/resilver/resilver_restart_001.ksh
@@ -45,14 +45,16 @@
 
 function cleanup
 {
-	echo $ORIG_RESILVER_MIN_TIME > $ZFS_PARAMS/zfs_resilver_min_time_ms
-	echo $ORIG_SCAN_SUSPEND_PROGRESS > $ZFS_PARAMS/zfs_scan_suspend_progress
+	log_must set_tunable32 zfs_resilver_min_time_ms $ORIG_RESILVER_MIN_TIME
+	log_must set_tunable32 zfs_scan_suspend_progress \
+	    $ORIG_SCAN_SUSPEND_PROGRESS
+	log_must set_tunable32 zfs_zevent_len_max $ORIG_ZFS_ZEVENT_LEN_MAX
 	log_must zinject -c all
 	destroy_pool $TESTPOOL
 	rm -f ${VDEV_FILES[@]} $SPARE_VDEV_FILE
 }
 
-# Count resilver events in zpool and number of deferred rsilvers on vdevs
+# count resilver events in zpool and number of deferred rsilvers on vdevs
 function verify_restarts # <msg> <cnt> <defer>
 {
 	msg=$1
@@ -85,9 +87,9 @@ function verify_restarts # <msg> <cnt> <defer>
 
 log_assert "Check for unnecessary resilver restarts"
 
-ZFS_PARAMS=/sys/module/zfs/parameters
-ORIG_RESILVER_MIN_TIME=$(cat $ZFS_PARAMS/zfs_resilver_min_time_ms)
-ORIG_SCAN_SUSPEND_PROGRESS=$(cat $ZFS_PARAMS/zfs_scan_suspend_progress)
+ORIG_RESILVER_MIN_TIME=$(get_tunable zfs_resilver_min_time_ms)
+ORIG_SCAN_SUSPEND_PROGRESS=$(get_tunable zfs_scan_suspend_progress)
+ORIG_ZFS_ZEVENT_LEN_MAX=$(get_tunable zfs_zevent_len_max)
 
 set -A RESTARTS -- '1' '2' '2' '2'
 set -A VDEVS -- '' '' '' ''
@@ -98,12 +100,15 @@ VDEV_REPLACE="${VDEV_FILES[1]} $SPARE_VDEV_FILE"
 
 log_onexit cleanup
 
+# ensure that enough events will be saved
+log_must set_tunable32 zfs_zevent_len_max 512
+
 log_must truncate -s $VDEV_FILE_SIZE ${VDEV_FILES[@]} $SPARE_VDEV_FILE
 
 log_must zpool create -f -o feature@resilver_defer=disabled $TESTPOOL \
     raidz ${VDEV_FILES[@]}
 
-# Create 4 filesystems
+# create 4 filesystems
 for fs in fs{0..3}
 do
 	log_must zfs create -o primarycache=none -o recordsize=1k $TESTPOOL/$fs
@@ -118,7 +123,7 @@ do
 done
 wait
 
-# Test without and with deferred resilve feature enabled
+# test without and with deferred resilve feature enabled
 for test in "without" "with"
 do
 	log_note "Testing $test deferred resilvers"
@@ -135,11 +140,11 @@ do
 	log_must zpool events -c
 
 	# limit scanning time
-	echo 50 > $ZFS_PARAMS/zfs_resilver_min_time_ms
+	log_must set_tunable32 zfs_resilver_min_time_ms 50
 
 	# initiate a resilver and suspend the scan as soon as possible
 	log_must zpool replace $TESTPOOL $VDEV_REPLACE
-	echo 1 > $ZFS_PARAMS/zfs_scan_suspend_progress
+	log_must set_tunable32 zfs_scan_suspend_progress 1
 
 	# there should only be 1 resilver start
 	verify_restarts '' "${RESTARTS[0]}" "${VDEVS[0]}"
@@ -163,8 +168,8 @@ do
 	verify_restarts ' after zinject' "${RESTARTS[2]}" "${VDEVS[2]}"
 
 	# unsuspend resilver
-	echo 0 > $ZFS_PARAMS/zfs_scan_suspend_progress
-	echo 3000 > $ZFS_PARAMS/zfs_resilver_min_time_ms
+	log_must set_tunable32 zfs_scan_suspend_progress 0
+	log_must set_tunable32 zfs_resilver_min_time_ms 3000
 
 	# wait for resilver to finish
 	for iter in {0..59}
@@ -176,6 +181,7 @@ do
 	    log_fail "resilver timed out"
 
 	# wait for a few txg's to see if a resilver happens
+	log_must zpool sync $TESTPOOL
 	log_must zpool sync $TESTPOOL
 
 	# there should now be 2 resilver starts


### PR DESCRIPTION
Signed-off-by: John Poduska <jpoduska@datto.com>
Closes #9677

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
This PR fixes spurious failures to a new test introduced by zfsonlinux#9588, as reported in zfsonlinux#9677.

### Description
The resilver restart test was reported as failing about 2% of the time.

Issues found:
- The event log wasn't large enough, so resilver events were missing
- One 'zpool sync' wasn't enough for resilver to start after zinject
- Comment capitalization inconsistencies were fixed as well

### How Has This Been Tested?
The test has been run by itself over one thousand times without failure.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
