### PR TITLE
Eliminate Linux specific inode usage from common code

### DIFF
--- a/include/os/linux/zfs/sys/zfs_dir.h
+++ b/include/os/linux/zfs/sys/zfs_dir.h
@@ -55,7 +55,7 @@ extern void zfs_dirent_unlock(zfs_dirlock_t *);
 extern int zfs_link_create(zfs_dirlock_t *, znode_t *, dmu_tx_t *, int);
 extern int zfs_link_destroy(zfs_dirlock_t *, znode_t *, dmu_tx_t *, int,
     boolean_t *);
-extern int zfs_dirlook(znode_t *, char *, struct inode **, int, int *,
+extern int zfs_dirlook(znode_t *, char *, znode_t **, int, int *,
     pathname_t *);
 extern void zfs_mknode(znode_t *, vattr_t *, dmu_tx_t *, cred_t *,
     uint_t, znode_t **, zfs_acl_ids_t *);
@@ -66,8 +66,8 @@ extern void zfs_unlinked_add(znode_t *, dmu_tx_t *);
 extern void zfs_unlinked_drain(zfsvfs_t *zfsvfs);
 extern void zfs_unlinked_drain_stop_wait(zfsvfs_t *zfsvfs);
 extern int zfs_sticky_remove_access(znode_t *, znode_t *, cred_t *cr);
-extern int zfs_get_xattrdir(znode_t *, struct inode **, cred_t *, int);
-extern int zfs_make_xattrdir(znode_t *, vattr_t *, struct inode **, cred_t *);
+extern int zfs_get_xattrdir(znode_t *, znode_t **, cred_t *, int);
+extern int zfs_make_xattrdir(znode_t *, vattr_t *, znode_t **, cred_t *);
 
 #ifdef	__cplusplus
 }

--- a/include/os/linux/zfs/sys/zfs_vnops.h
+++ b/include/os/linux/zfs/sys/zfs_vnops.h
@@ -44,36 +44,36 @@ extern int zfs_holey(struct inode *ip, int cmd, loff_t *off);
 extern int zfs_read(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr);
 extern int zfs_write(struct inode *ip, uio_t *uio, int ioflag, cred_t *cr);
 extern int zfs_access(struct inode *ip, int mode, int flag, cred_t *cr);
-extern int zfs_lookup(struct inode *dip, char *nm, struct inode **ipp,
+extern int zfs_lookup(znode_t *dzp, char *nm, znode_t **zpp,
     int flags, cred_t *cr, int *direntflags, pathname_t *realpnp);
-extern int zfs_create(struct inode *dip, char *name, vattr_t *vap, int excl,
+extern int zfs_create(znode_t *dzp, char *name, vattr_t *vap, int excl,
+    int mode, znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp);
+extern int zfs_tmpfile(struct inode *dip, vattr_t *vapzfs, int excl,
     int mode, struct inode **ipp, cred_t *cr, int flag, vsecattr_t *vsecp);
-extern int zfs_tmpfile(struct inode *dip, vattr_t *vap, int excl,
-    int mode, struct inode **ipp, cred_t *cr, int flag, vsecattr_t *vsecp);
-extern int zfs_remove(struct inode *dip, char *name, cred_t *cr, int flags);
-extern int zfs_mkdir(struct inode *dip, char *dirname, vattr_t *vap,
-    struct inode **ipp, cred_t *cr, int flags, vsecattr_t *vsecp);
-extern int zfs_rmdir(struct inode *dip, char *name, struct inode *cwd,
+extern int zfs_remove(znode_t *dzp, char *name, cred_t *cr, int flags);
+extern int zfs_mkdir(znode_t *dzp, char *dirname, vattr_t *vap,
+    znode_t **zpp, cred_t *cr, int flags, vsecattr_t *vsecp);
+extern int zfs_rmdir(znode_t *dzp, char *name, znode_t *cwd,
     cred_t *cr, int flags);
 extern int zfs_readdir(struct inode *ip, zpl_dir_context_t *ctx, cred_t *cr);
-extern int zfs_fsync(struct inode *ip, int syncflag, cred_t *cr);
+extern int zfs_fsync(znode_t *zp, int syncflag, cred_t *cr);
 extern int zfs_getattr(struct inode *ip, vattr_t *vap, int flag, cred_t *cr);
 extern int zfs_getattr_fast(struct inode *ip, struct kstat *sp);
-extern int zfs_setattr(struct inode *ip, vattr_t *vap, int flag, cred_t *cr);
-extern int zfs_rename(struct inode *sdip, char *snm, struct inode *tdip,
+extern int zfs_setattr(znode_t *zp, vattr_t *vap, int flag, cred_t *cr);
+extern int zfs_rename(znode_t *sdzp, char *snm, znode_t *tdzp,
     char *tnm, cred_t *cr, int flags);
-extern int zfs_symlink(struct inode *dip, char *name, vattr_t *vap,
-    char *link, struct inode **ipp, cred_t *cr, int flags);
+extern int zfs_symlink(znode_t *dzp, char *name, vattr_t *vap,
+    char *link, znode_t **zpp, cred_t *cr, int flags);
 extern int zfs_readlink(struct inode *ip, uio_t *uio, cred_t *cr);
-extern int zfs_link(struct inode *tdip, struct inode *sip,
+extern int zfs_link(znode_t *tdzp, znode_t *szp,
     char *name, cred_t *cr, int flags);
 extern void zfs_inactive(struct inode *ip);
-extern int zfs_space(struct inode *ip, int cmd, flock64_t *bfp, int flag,
+extern int zfs_space(znode_t *zp, int cmd, flock64_t *bfp, int flag,
     offset_t offset, cred_t *cr);
 extern int zfs_fid(struct inode *ip, fid_t *fidp);
 extern int zfs_getsecattr(struct inode *ip, vsecattr_t *vsecp, int flag,
     cred_t *cr);
-extern int zfs_setsecattr(struct inode *ip, vsecattr_t *vsecp, int flag,
+extern int zfs_setsecattr(znode_t *zp, vsecattr_t *vsecp, int flag,
     cred_t *cr);
 extern int zfs_getpage(struct inode *ip, struct page *pl[], int nr_pages);
 extern int zfs_putpage(struct inode *ip, struct page *pp,
@@ -81,7 +81,7 @@ extern int zfs_putpage(struct inode *ip, struct page *pp,
 extern int zfs_dirty_inode(struct inode *ip, int flags);
 extern int zfs_map(struct inode *ip, offset_t off, caddr_t *addrp,
     size_t len, unsigned long vm_flags);
-extern void zfs_iput_async(struct inode *ip);
+extern void zfs_zrele_async(znode_t *zp);
 
 #ifdef	__cplusplus
 }

--- a/include/os/linux/zfs/sys/zfs_znode_impl.h
+++ b/include/os/linux/zfs/sys/zfs_znode_impl.h
@@ -69,6 +69,9 @@ extern "C" {
 #define	Z_ISLNK(type) S_ISLNK(type)
 #define	Z_ISDEV(type)	(S_ISCHR(type) || S_ISBLK(type) || S_ISFIFO(type))
 
+#define	zhold(zp)	igrab(ZTOI((zp)))
+#define	zrele(zp)	iput(ZTOI((zp)))
+
 /* Called on entry to each ZFS inode and vfs operation. */
 #define	ZFS_ENTER_ERROR(zfsvfs, error)				\
 do {								\

--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -96,7 +96,7 @@ typedef struct dsl_pool {
 	struct dsl_dir *dp_leak_dir;
 	struct dsl_dataset *dp_origin_snap;
 	uint64_t dp_root_dir_obj;
-	struct taskq *dp_iput_taskq;
+	struct taskq *dp_zrele_taskq;
 	struct taskq *dp_unlinked_drain_taskq;
 
 	/* No lock needed - sync context only */
@@ -177,7 +177,7 @@ void dsl_pool_config_exit(dsl_pool_t *dp, void *tag);
 boolean_t dsl_pool_config_held(dsl_pool_t *dp);
 boolean_t dsl_pool_config_held_writer(dsl_pool_t *dp);
 
-taskq_t *dsl_pool_iput_taskq(dsl_pool_t *dp);
+taskq_t *dsl_pool_zrele_taskq(dsl_pool_t *dp);
 taskq_t *dsl_pool_unlinked_drain_taskq(dsl_pool_t *dp);
 
 int dsl_pool_user_hold(dsl_pool_t *dp, uint64_t dsobj,

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -2540,14 +2540,14 @@ zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk, cred_t *cr)
 	if ((error = zfs_zaccess_common(check_zp, mode, &working_mode,
 	    &check_privs, skipaclchk, cr)) == 0) {
 		if (is_attr)
-			iput(ZTOI(xzp));
+			zrele(xzp);
 		return (secpolicy_vnode_access2(cr, ZTOI(zp), owner,
 		    needed_bits, needed_bits));
 	}
 
 	if (error && !check_privs) {
 		if (is_attr)
-			iput(ZTOI(xzp));
+			zrele(xzp);
 		return (error);
 	}
 
@@ -2609,7 +2609,7 @@ zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk, cred_t *cr)
 	}
 
 	if (is_attr)
-		iput(ZTOI(xzp));
+		zrele(xzp);
 
 	return (error);
 }

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1185,7 +1185,7 @@ zfsctl_shares_lookup(struct inode *dip, char *name, struct inode **ipp,
     int flags, cred_t *cr, int *direntflags, pathname_t *realpnp)
 {
 	zfsvfs_t *zfsvfs = ITOZSB(dip);
-	struct inode *ip;
+	znode_t *zp;
 	znode_t *dzp;
 	int error;
 
@@ -1197,8 +1197,8 @@ zfsctl_shares_lookup(struct inode *dip, char *name, struct inode **ipp,
 	}
 
 	if ((error = zfs_zget(zfsvfs, zfsvfs->z_shares_dir, &dzp)) == 0) {
-		error = zfs_lookup(ZTOI(dzp), name, &ip, 0, cr, NULL, NULL);
-		iput(ZTOI(dzp));
+		error = zfs_lookup(dzp, name, &zp, 0, cr, NULL, NULL);
+		zrele(dzp);
 	}
 
 	ZFS_EXIT(zfsvfs);

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -27,9 +27,9 @@
  *   Brian Behlendorf <behlendorf1@llnl.gov>
  */
 
+#include <sys/zfs_znode.h>
 #include <sys/zfs_vfsops.h>
 #include <sys/zfs_vnops.h>
-#include <sys/zfs_znode.h>
 #include <sys/zfs_ctldir.h>
 #include <sys/zpl.h>
 

--- a/module/os/linux/zfs/zpl_export.c
+++ b/module/os/linux/zfs/zpl_export.c
@@ -24,8 +24,8 @@
  */
 
 
-#include <sys/zfs_vnops.h>
 #include <sys/zfs_znode.h>
+#include <sys/zfs_vnops.h>
 #include <sys/zfs_ctldir.h>
 #include <sys/zpl.h>
 
@@ -110,12 +110,12 @@ zpl_get_parent(struct dentry *child)
 {
 	cred_t *cr = CRED();
 	fstrans_cookie_t cookie;
-	struct inode *ip;
+	znode_t *zp;
 	int error;
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_lookup(child->d_inode, "..", &ip, 0, cr, NULL, NULL);
+	error = -zfs_lookup(ITOZ(child->d_inode), "..", &zp, 0, cr, NULL, NULL);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 	ASSERT3S(error, <=, 0);
@@ -123,7 +123,7 @@ zpl_get_parent(struct dentry *child)
 	if (error)
 		return (ERR_PTR(error));
 
-	return (d_obtain_alias(ip));
+	return (d_obtain_alias(ZTOI(zp)));
 }
 
 static int
@@ -138,7 +138,7 @@ zpl_commit_metadata(struct inode *inode)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_fsync(inode, 0, cr);
+	error = -zfs_fsync(ITOZ(inode), 0, cr);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 	ASSERT3S(error, <=, 0);

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -29,9 +29,9 @@
 #endif
 #include <sys/file.h>
 #include <sys/dmu_objset.h>
+#include <sys/zfs_znode.h>
 #include <sys/zfs_vfsops.h>
 #include <sys/zfs_vnops.h>
-#include <sys/zfs_znode.h>
 #include <sys/zfs_project.h>
 
 
@@ -125,7 +125,7 @@ zpl_fsync(struct file *filp, int datasync)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_fsync(inode, datasync, cr);
+	error = -zfs_fsync(ITOZ(inode), datasync, cr);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 	ASSERT3S(error, <=, 0);
@@ -163,7 +163,7 @@ zpl_fsync(struct file *filp, loff_t start, loff_t end, int datasync)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_fsync(inode, datasync, cr);
+	error = -zfs_fsync(ITOZ(inode), datasync, cr);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 	ASSERT3S(error, <=, 0);
@@ -757,7 +757,7 @@ zpl_fallocate_common(struct inode *ip, int mode, loff_t offset, loff_t len)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_space(ip, F_FREESP, &bf, O_RDWR, offset, cr);
+	error = -zfs_space(ITOZ(ip), F_FREESP, &bf, O_RDWR, offset, cr);
 	spl_fstrans_unmark(cookie);
 	spl_inode_unlock(ip);
 
@@ -886,7 +886,7 @@ zpl_ioctl_setflags(struct file *filp, void __user *arg)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	err = -zfs_setattr(ip, (vattr_t *)&xva, 0, cr);
+	err = -zfs_setattr(ITOZ(ip), (vattr_t *)&xva, 0, cr);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 
@@ -934,7 +934,7 @@ zpl_ioctl_setxattr(struct file *filp, void __user *arg)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	err = -zfs_setattr(ip, (vattr_t *)&xva, 0, cr);
+	err = -zfs_setattr(ITOZ(ip), (vattr_t *)&xva, 0, cr);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -39,6 +39,7 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 {
 	cred_t *cr = CRED();
 	struct inode *ip;
+	znode_t *zp;
 	int error;
 	fstrans_cookie_t cookie;
 	pathname_t *ppn = NULL;
@@ -59,7 +60,8 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 		ppn = &pn;
 	}
 
-	error = -zfs_lookup(dir, dname(dentry), &ip, zfs_flags, cr, NULL, ppn);
+	error = -zfs_lookup(ITOZ(dir), dname(dentry), &zp,
+	    zfs_flags, cr, NULL, ppn);
 	spl_fstrans_unmark(cookie);
 	ASSERT3S(error, <=, 0);
 	crfree(cr);
@@ -85,6 +87,7 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 		else
 			return (ERR_PTR(error));
 	}
+	ip = ZTOI(zp);
 
 	/*
 	 * If we are case insensitive, call the correct function
@@ -128,7 +131,7 @@ static int
 zpl_create(struct inode *dir, struct dentry *dentry, umode_t mode, bool flag)
 {
 	cred_t *cr = CRED();
-	struct inode *ip;
+	znode_t *zp;
 	vattr_t *vap;
 	int error;
 	fstrans_cookie_t cookie;
@@ -138,16 +141,17 @@ zpl_create(struct inode *dir, struct dentry *dentry, umode_t mode, bool flag)
 	zpl_vap_init(vap, dir, mode, cr);
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_create(dir, dname(dentry), vap, 0, mode, &ip, cr, 0, NULL);
+	error = -zfs_create(ITOZ(dir), dname(dentry), vap, 0,
+	    mode, &zp, cr, 0, NULL);
 	if (error == 0) {
-		d_instantiate(dentry, ip);
+		d_instantiate(dentry, ZTOI(zp));
 
-		error = zpl_xattr_security_init(ip, dir, &dentry->d_name);
+		error = zpl_xattr_security_init(ZTOI(zp), dir, &dentry->d_name);
 		if (error == 0)
-			error = zpl_init_acl(ip, dir);
+			error = zpl_init_acl(ZTOI(zp), dir);
 
 		if (error)
-			(void) zfs_remove(dir, dname(dentry), cr, 0);
+			(void) zfs_remove(ITOZ(dir), dname(dentry), cr, 0);
 	}
 
 	spl_fstrans_unmark(cookie);
@@ -163,7 +167,7 @@ zpl_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
     dev_t rdev)
 {
 	cred_t *cr = CRED();
-	struct inode *ip;
+	znode_t *zp;
 	vattr_t *vap;
 	int error;
 	fstrans_cookie_t cookie;
@@ -181,16 +185,17 @@ zpl_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
 	vap->va_rdev = rdev;
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_create(dir, dname(dentry), vap, 0, mode, &ip, cr, 0, NULL);
+	error = -zfs_create(ITOZ(dir), dname(dentry), vap, 0,
+	    mode, &zp, cr, 0, NULL);
 	if (error == 0) {
-		d_instantiate(dentry, ip);
+		d_instantiate(dentry, ZTOI(zp));
 
-		error = zpl_xattr_security_init(ip, dir, &dentry->d_name);
+		error = zpl_xattr_security_init(ZTOI(zp), dir, &dentry->d_name);
 		if (error == 0)
-			error = zpl_init_acl(ip, dir);
+			error = zpl_init_acl(ZTOI(zp), dir);
 
 		if (error)
-			(void) zfs_remove(dir, dname(dentry), cr, 0);
+			(void) zfs_remove(ITOZ(dir), dname(dentry), cr, 0);
 	}
 
 	spl_fstrans_unmark(cookie);
@@ -250,7 +255,7 @@ zpl_unlink(struct inode *dir, struct dentry *dentry)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_remove(dir, dname(dentry), cr, 0);
+	error = -zfs_remove(ITOZ(dir), dname(dentry), cr, 0);
 
 	/*
 	 * For a CI FS we must invalidate the dentry to prevent the
@@ -271,7 +276,7 @@ zpl_mkdir(struct inode *dir, struct dentry *dentry, umode_t mode)
 {
 	cred_t *cr = CRED();
 	vattr_t *vap;
-	struct inode *ip;
+	znode_t *zp;
 	int error;
 	fstrans_cookie_t cookie;
 
@@ -280,16 +285,16 @@ zpl_mkdir(struct inode *dir, struct dentry *dentry, umode_t mode)
 	zpl_vap_init(vap, dir, mode | S_IFDIR, cr);
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_mkdir(dir, dname(dentry), vap, &ip, cr, 0, NULL);
+	error = -zfs_mkdir(ITOZ(dir), dname(dentry), vap, &zp, cr, 0, NULL);
 	if (error == 0) {
-		d_instantiate(dentry, ip);
+		d_instantiate(dentry, ZTOI(zp));
 
-		error = zpl_xattr_security_init(ip, dir, &dentry->d_name);
+		error = zpl_xattr_security_init(ZTOI(zp), dir, &dentry->d_name);
 		if (error == 0)
-			error = zpl_init_acl(ip, dir);
+			error = zpl_init_acl(ZTOI(zp), dir);
 
 		if (error)
-			(void) zfs_rmdir(dir, dname(dentry), NULL, cr, 0);
+			(void) zfs_rmdir(ITOZ(dir), dname(dentry), NULL, cr, 0);
 	}
 
 	spl_fstrans_unmark(cookie);
@@ -310,7 +315,7 @@ zpl_rmdir(struct inode *dir, struct dentry *dentry)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_rmdir(dir, dname(dentry), NULL, cr, 0);
+	error = -zfs_rmdir(ITOZ(dir), dname(dentry), NULL, cr, 0);
 
 	/*
 	 * For a CI FS we must invalidate the dentry to prevent the
@@ -377,7 +382,7 @@ zpl_setattr(struct dentry *dentry, struct iattr *ia)
 	}
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_setattr(ip, vap, 0, cr);
+	error = -zfs_setattr(ITOZ(ip), vap, 0, cr);
 	if (!error && (ia->ia_valid & ATTR_MODE))
 		error = zpl_chmod_acl(ip);
 
@@ -403,7 +408,8 @@ zpl_rename2(struct inode *sdip, struct dentry *sdentry,
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	error = -zfs_rename(sdip, dname(sdentry), tdip, dname(tdentry), cr, 0);
+	error = -zfs_rename(ITOZ(sdip), dname(sdentry), ITOZ(tdip),
+	    dname(tdentry), cr, 0);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 	ASSERT3S(error, <=, 0);
@@ -425,7 +431,7 @@ zpl_symlink(struct inode *dir, struct dentry *dentry, const char *name)
 {
 	cred_t *cr = CRED();
 	vattr_t *vap;
-	struct inode *ip;
+	znode_t *zp;
 	int error;
 	fstrans_cookie_t cookie;
 
@@ -434,13 +440,14 @@ zpl_symlink(struct inode *dir, struct dentry *dentry, const char *name)
 	zpl_vap_init(vap, dir, S_IFLNK | S_IRWXUGO, cr);
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_symlink(dir, dname(dentry), vap, (char *)name, &ip, cr, 0);
+	error = -zfs_symlink(ITOZ(dir), dname(dentry), vap,
+	    (char *)name, &zp, cr, 0);
 	if (error == 0) {
-		d_instantiate(dentry, ip);
+		d_instantiate(dentry, ZTOI(zp));
 
-		error = zpl_xattr_security_init(ip, dir, &dentry->d_name);
+		error = zpl_xattr_security_init(ZTOI(zp), dir, &dentry->d_name);
 		if (error)
-			(void) zfs_remove(dir, dname(dentry), cr, 0);
+			(void) zfs_remove(ITOZ(dir), dname(dentry), cr, 0);
 	}
 
 	spl_fstrans_unmark(cookie);
@@ -587,7 +594,7 @@ zpl_link(struct dentry *old_dentry, struct inode *dir, struct dentry *dentry)
 	igrab(ip); /* Use ihold() if available */
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_link(dir, ip, dname(dentry), cr, 0);
+	error = -zfs_link(ITOZ(dir), ITOZ(ip), dname(dentry), cr, 0);
 	if (error) {
 		iput(ip);
 		goto out;

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -23,9 +23,9 @@
  */
 
 
+#include <sys/zfs_znode.h>
 #include <sys/zfs_vfsops.h>
 #include <sys/zfs_vnops.h>
-#include <sys/zfs_znode.h>
 #include <sys/zfs_ctldir.h>
 #include <sys/zpl.h>
 

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -220,7 +220,7 @@ dsl_pool_open_impl(spa_t *spa, uint64_t txg)
 	mutex_init(&dp->dp_lock, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&dp->dp_spaceavail_cv, NULL, CV_DEFAULT, NULL);
 
-	dp->dp_iput_taskq = taskq_create("z_iput", max_ncpus, defclsyspri,
+	dp->dp_zrele_taskq = taskq_create("z_zrele", max_ncpus, defclsyspri,
 	    max_ncpus * 8, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 	dp->dp_unlinked_drain_taskq = taskq_create("z_unlinked_drain",
 	    max_ncpus, defclsyspri, max_ncpus, INT_MAX,
@@ -416,7 +416,7 @@ dsl_pool_close(dsl_pool_t *dp)
 	mutex_destroy(&dp->dp_lock);
 	cv_destroy(&dp->dp_spaceavail_cv);
 	taskq_destroy(dp->dp_unlinked_drain_taskq);
-	taskq_destroy(dp->dp_iput_taskq);
+	taskq_destroy(dp->dp_zrele_taskq);
 	if (dp->dp_blkstats != NULL) {
 		mutex_destroy(&dp->dp_blkstats->zab_lock);
 		vmem_free(dp->dp_blkstats, sizeof (zfs_all_blkstats_t));
@@ -1102,9 +1102,9 @@ dsl_pool_create_origin(dsl_pool_t *dp, dmu_tx_t *tx)
 }
 
 taskq_t *
-dsl_pool_iput_taskq(dsl_pool_t *dp)
+dsl_pool_zrele_taskq(dsl_pool_t *dp)
 {
-	return (dp->dp_iput_taskq);
+	return (dp->dp_zrele_taskq);
 }
 
 taskq_t *

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -231,7 +231,8 @@ zfs_xattr_owner_unlinked(znode_t *zp)
 {
 	int unlinked = 0;
 	znode_t *dzp;
-	igrab(ZTOI(zp));
+
+	zhold(zp);
 	/*
 	 * if zp is XATTR node, keep walking up via z_xattr_parent until we
 	 * get the owner
@@ -242,11 +243,11 @@ zfs_xattr_owner_unlinked(znode_t *zp)
 			unlinked = 1;
 			break;
 		}
-		iput(ZTOI(zp));
+		zrele(zp);
 		zp = dzp;
 		unlinked = zp->z_unlinked;
 	}
-	iput(ZTOI(zp));
+	zrele(zp);
 	return (unlinked);
 }
 

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -280,7 +280,7 @@ zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 	char *name = NULL;		/* location determined later */
 	lr_create_t *lr = (lr_create_t *)lracl;
 	znode_t *dzp;
-	struct inode *ip = NULL;
+	znode_t *zp;
 	xvattr_t xva;
 	int vflg = 0;
 	vsecattr_t vsec = { 0 };
@@ -371,8 +371,8 @@ zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 			    lr->lr_uid, lr->lr_gid);
 		}
 
-		error = zfs_create(ZTOI(dzp), name, &xva.xva_vattr,
-		    0, 0, &ip, kcred, vflg, &vsec);
+		error = zfs_create(dzp, name, &xva.xva_vattr,
+		    0, 0, &zp, kcred, vflg, &vsec);
 		break;
 	case TX_MKDIR_ACL:
 		aclstart = (caddr_t)(lracl + 1);
@@ -401,18 +401,18 @@ zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 			    (void *)&name, lracl->lr_fuidcnt, lracl->lr_domcnt,
 			    lr->lr_uid, lr->lr_gid);
 		}
-		error = zfs_mkdir(ZTOI(dzp), name, &xva.xva_vattr,
-		    &ip, kcred, vflg, &vsec);
+		error = zfs_mkdir(dzp, name, &xva.xva_vattr,
+		    &zp, kcred, vflg, &vsec);
 		break;
 	default:
 		error = SET_ERROR(ENOTSUP);
 	}
 
 bail:
-	if (error == 0 && ip != NULL)
-		iput(ip);
+	if (error == 0 && zp != NULL)
+		zrele(zp);
 
-	iput(ZTOI(dzp));
+	zrele(dzp);
 
 	if (zfsvfs->z_fuid_replay)
 		zfs_fuid_info_free(zfsvfs->z_fuid_replay);
@@ -429,7 +429,7 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 	char *name = NULL;		/* location determined later */
 	char *link;			/* symlink content follows name */
 	znode_t *dzp;
-	struct inode *ip = NULL;
+	znode_t *zp = NULL;
 	xvattr_t xva;
 	int vflg = 0;
 	size_t lrsize = sizeof (lr_create_t);
@@ -509,8 +509,8 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 		if (name == NULL)
 			name = (char *)start;
 
-		error = zfs_create(ZTOI(dzp), name, &xva.xva_vattr,
-		    0, 0, &ip, kcred, vflg, NULL);
+		error = zfs_create(dzp, name, &xva.xva_vattr,
+		    0, 0, &zp, kcred, vflg, NULL);
 		break;
 	case TX_MKDIR_ATTR:
 		lrattr = (lr_attr_t *)(caddr_t)(lr + 1);
@@ -527,27 +527,27 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 		if (name == NULL)
 			name = (char *)(lr + 1);
 
-		error = zfs_mkdir(ZTOI(dzp), name, &xva.xva_vattr,
-		    &ip, kcred, vflg, NULL);
+		error = zfs_mkdir(dzp, name, &xva.xva_vattr,
+		    &zp, kcred, vflg, NULL);
 		break;
 	case TX_MKXATTR:
-		error = zfs_make_xattrdir(dzp, &xva.xva_vattr, &ip, kcred);
+		error = zfs_make_xattrdir(dzp, &xva.xva_vattr, &zp, kcred);
 		break;
 	case TX_SYMLINK:
 		name = (char *)(lr + 1);
 		link = name + strlen(name) + 1;
-		error = zfs_symlink(ZTOI(dzp), name, &xva.xva_vattr,
-		    link, &ip, kcred, vflg);
+		error = zfs_symlink(dzp, name, &xva.xva_vattr,
+		    link, &zp, kcred, vflg);
 		break;
 	default:
 		error = SET_ERROR(ENOTSUP);
 	}
 
 out:
-	if (error == 0 && ip != NULL)
-		iput(ip);
+	if (error == 0 && zp != NULL)
+		zrele(zp);
 
-	iput(ZTOI(dzp));
+	zrele(dzp);
 
 	if (zfsvfs->z_fuid_replay)
 		zfs_fuid_info_free(zfsvfs->z_fuid_replay);
@@ -576,16 +576,16 @@ zfs_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 
 	switch ((int)lr->lr_common.lrc_txtype) {
 	case TX_REMOVE:
-		error = zfs_remove(ZTOI(dzp), name, kcred, vflg);
+		error = zfs_remove(dzp, name, kcred, vflg);
 		break;
 	case TX_RMDIR:
-		error = zfs_rmdir(ZTOI(dzp), name, NULL, kcred, vflg);
+		error = zfs_rmdir(dzp, name, NULL, kcred, vflg);
 		break;
 	default:
 		error = SET_ERROR(ENOTSUP);
 	}
 
-	iput(ZTOI(dzp));
+	zrele(dzp);
 
 	return (error);
 }
@@ -607,17 +607,17 @@ zfs_replay_link(void *arg1, void *arg2, boolean_t byteswap)
 		return (error);
 
 	if ((error = zfs_zget(zfsvfs, lr->lr_link_obj, &zp)) != 0) {
-		iput(ZTOI(dzp));
+		zrele(dzp);
 		return (error);
 	}
 
 	if (lr->lr_common.lrc_txtype & TX_CI)
 		vflg |= FIGNORECASE;
 
-	error = zfs_link(ZTOI(dzp), ZTOI(zp), name, kcred, vflg);
+	error = zfs_link(dzp, zp, name, kcred, vflg);
 
-	iput(ZTOI(zp));
-	iput(ZTOI(dzp));
+	zrele(zp);
+	zrele(dzp);
 
 	return (error);
 }
@@ -640,17 +640,17 @@ zfs_replay_rename(void *arg1, void *arg2, boolean_t byteswap)
 		return (error);
 
 	if ((error = zfs_zget(zfsvfs, lr->lr_tdoid, &tdzp)) != 0) {
-		iput(ZTOI(sdzp));
+		zrele(sdzp);
 		return (error);
 	}
 
 	if (lr->lr_common.lrc_txtype & TX_CI)
 		vflg |= FIGNORECASE;
 
-	error = zfs_rename(ZTOI(sdzp), sname, ZTOI(tdzp), tname, kcred, vflg);
+	error = zfs_rename(sdzp, sname, tdzp, tname, kcred, vflg);
 
-	iput(ZTOI(tdzp));
-	iput(ZTOI(sdzp));
+	zrele(tdzp);
+	zrele(sdzp);
 
 	return (error);
 }
@@ -714,7 +714,7 @@ zfs_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	else if (written < length)
 		error = SET_ERROR(EIO); /* short write */
 
-	iput(ZTOI(zp));
+	zrele(zp);
 	zfsvfs->z_replay_eof = 0;	/* safety */
 
 	return (error);
@@ -750,7 +750,7 @@ top:
 		dmu_tx_hold_sa(tx, zp->z_sa_hdl, B_FALSE);
 		error = dmu_tx_assign(tx, TXG_WAIT);
 		if (error) {
-			iput(ZTOI(zp));
+			zrele(zp);
 			if (error == ERESTART) {
 				dmu_tx_wait(tx);
 				dmu_tx_abort(tx);
@@ -768,7 +768,7 @@ top:
 		dmu_tx_commit(tx);
 	}
 
-	iput(ZTOI(zp));
+	zrele(zp);
 
 	return (error);
 }
@@ -794,10 +794,10 @@ zfs_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 	fl.l_start = lr->lr_offset;
 	fl.l_len = lr->lr_length;
 
-	error = zfs_space(ZTOI(zp), F_FREESP, &fl, O_RDWR | O_LARGEFILE,
+	error = zfs_space(zp, F_FREESP, &fl, O_RDWR | O_LARGEFILE,
 	    lr->lr_offset, kcred);
 
-	iput(ZTOI(zp));
+	zrele(zp);
 
 	return (error);
 }
@@ -849,11 +849,11 @@ zfs_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 	zfsvfs->z_fuid_replay = zfs_replay_fuid_domain(start, &start,
 	    lr->lr_uid, lr->lr_gid);
 
-	error = zfs_setattr(ZTOI(zp), vap, 0, kcred);
+	error = zfs_setattr(zp, vap, 0, kcred);
 
 	zfs_fuid_info_free(zfsvfs->z_fuid_replay);
 	zfsvfs->z_fuid_replay = NULL;
-	iput(ZTOI(zp));
+	zrele(zp);
 
 	return (error);
 }
@@ -883,9 +883,9 @@ zfs_replay_acl_v0(void *arg1, void *arg2, boolean_t byteswap)
 	vsa.vsa_aclflags = 0;
 	vsa.vsa_aclentp = ace;
 
-	error = zfs_setsecattr(ZTOI(zp), &vsa, 0, kcred);
+	error = zfs_setsecattr(zp, &vsa, 0, kcred);
 
-	iput(ZTOI(zp));
+	zrele(zp);
 
 	return (error);
 }
@@ -943,13 +943,13 @@ zfs_replay_acl(void *arg1, void *arg2, boolean_t byteswap)
 		    lr->lr_fuidcnt, lr->lr_domcnt, 0, 0);
 	}
 
-	error = zfs_setsecattr(ZTOI(zp), &vsa, 0, kcred);
+	error = zfs_setsecattr(zp, &vsa, 0, kcred);
 
 	if (zfsvfs->z_fuid_replay)
 		zfs_fuid_info_free(zfsvfs->z_fuid_replay);
 
 	zfsvfs->z_fuid_replay = NULL;
-	iput(ZTOI(zp));
+	zrele(zp);
 
 	return (error);
 }


### PR DESCRIPTION
Change many of the znops routines to take a znode rather
than an inode so that zfs_replay code can be largely shared
and in the future much of the znops code may be shared.

Signed-off-by: Matt Macy <mmacy@FreeBSD.org>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
