### PR TITLE
Fix Codecov Ignore

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -22,5 +22,6 @@ comment:
   behavior: once		# update if exists; post new; skip if deleted
   require_changes: yes		# only post when coverage changes
 
-ignore:
-  - "tests/**/*"		# Don't need Tests to cover themselves
+ignore: 
+  - ""
+  - "tests2/**/*"	# Don't need Tests to cover themselves


### PR DESCRIPTION
There is a bug in the codecov yml parser.
This is a work around that passes their validation tool.
This might actually work

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

### Motivation and Context
Earlier I opened a PR to add the tests to codecov ignore.
Sadly enough that didnt work.

There seems to be a bug in codecov in the way they parse the YML.
(See:  https://community.codecov.io/t/codecov-yml-ignore-not-working/794) 
It seems their parsers adds `^` in front of the path.
This is confirmed by their validation tool

This is however does pass their validation tool and this draft is about to find out if it works.

### Description
I added a blank path, which catches the `^` that gets added in the parser.
The second path does not seem to get the `^`  added in front.

### How Has This Been Tested?
Using the Codecov validation tool.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
