### PR TITLE
initramfs: setup keymapping and video for prompts

### DIFF
--- a/contrib/initramfs/conf-hooks.d/zfs
+++ b/contrib/initramfs/conf-hooks.d/zfs
@@ -1,2 +1,9 @@
 # Force the inclusion of Busybox in the initramfs.
 BUSYBOX=y
+
+# Setup the keyboard mapping so passphrases can be entered correctly.
+KEYMAP=y
+
+# Require the plymouth script to guarantee working video for the passphrase
+# prompting.
+FRAMEBUFFER=y


### PR DESCRIPTION
# Motivation and Context
From Steve Langasek <steve.langasek@canonical.com>:
> The poorly-named 'FRAMEBUFFER' option in initramfs-tools controls
> whether the console_setup and plymouth scripts are included and used
> in the initramfs. These are required for any initramfs which will be
> prompting for user input: console_setup because without it the user's
> configured keymap will not be set up, and plymouth because you are
> not guaranteed to have working video output in the initramfs without
> it (e.g. some nvidia+UEFI configurations with the default GRUB
> behavior).

> The zfs initramfs script may need to prompt the user for passphrases
> for encrypted zfs datasets, and we don't know definitively whether
> this is the case or not at the time the initramfs is constructed (and
> it's difficult to dynamically populate initramfs config variables
> anyway), therefore the zfs-initramfs package should just set
> FRAMEBUFFER=yes in a conf snippet the same way that the
> cryptsetup-initramfs package does
> (/usr/share/initramfs-tools/conf-hooks.d/cryptsetup).

https://bugs.launchpad.net/ubuntu/+source/zfs-linux/+bug/1856408

### Description
This sets the `KEYMAP` and `FRAMEBUFFER` variables to `y` in the initramfs script, just like cryptsetup does.

### How Has This Been Tested?
I tested this on an Ubuntu 18.04 system with an encrypted root.

I ran `update-initramfs -c -k all`. It complained that I did not have console-setup installed, saying, `setupcon is missing. Please install the 'console-setup' package.`

I tested with and without console-setup installed. This did not break anything. I was not experiencing any problem to start with, though, so I cannot confirm it fixes the issue. However, the analysis above seems correct to me, and in any case, we are just matching cryptsetup.

I also added "`quiet splash`" back to the kernel command line and tested that. That also worked.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
