### PR TITLE
Move Codecov Ignores to LCOV

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -22,5 +22,4 @@ comment:
   behavior: once		# update if exists; post new; skip if deleted
   require_changes: yes		# only post when coverage changes
 
-ignore:
-  - "tests/**/*"		# Don't need Tests to cover themselves
+# ignore: Please place any ignores in config/ax_code_coverage.m4 instead

--- a/config/ax_code_coverage.m4
+++ b/config/ax_code_coverage.m4
@@ -142,7 +142,7 @@ AC_DEFUN([AX_CODE_COVERAGE],[
 ']
 		[CODE_COVERAGE_RULES_CAPTURE='
 	$(code_coverage_v_lcov_cap)$(LCOV) $(code_coverage_quiet) $(addprefix --directory ,$(CODE_COVERAGE_DIRECTORY)) --capture --output-file "$(CODE_COVERAGE_OUTPUT_FILE).tmp" --test-name "$(call code_coverage_sanitize,$(PACKAGE_NAME)-$(PACKAGE_VERSION))" --no-checksum --compat-libtool $(CODE_COVERAGE_LCOV_SHOPTS) $(CODE_COVERAGE_LCOV_OPTIONS)
-	$(code_coverage_v_lcov_ign)$(LCOV) $(code_coverage_quiet) $(addprefix --directory ,$(CODE_COVERAGE_DIRECTORY)) --remove "$(CODE_COVERAGE_OUTPUT_FILE).tmp" "/tmp/*" $(CODE_COVERAGE_IGNORE_PATTERN) --output-file "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_LCOV_SHOPTS) $(CODE_COVERAGE_LCOV_RMOPTS)
+	$(code_coverage_v_lcov_ign)$(LCOV) $(code_coverage_quiet) $(addprefix --directory ,$(CODE_COVERAGE_DIRECTORY)) --remove "$(CODE_COVERAGE_OUTPUT_FILE).tmp" $(CODE_COVERAGE_IGNORE_PATTERN) --output-file "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_LCOV_SHOPTS) $(CODE_COVERAGE_LCOV_RMOPTS)
 	-@rm -f $(CODE_COVERAGE_OUTPUT_FILE).tmp
 	$(code_coverage_v_genhtml)LANG=C $(GENHTML) $(code_coverage_quiet) $(addprefix --prefix ,$(CODE_COVERAGE_DIRECTORY)) --output-directory "$(CODE_COVERAGE_OUTPUT_DIRECTORY)" --title "$(PACKAGE_NAME)-$(PACKAGE_VERSION) Code Coverage" --legend --show-details "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_GENHTML_OPTIONS)
 	@echo "file://$(abs_builddir)/$(CODE_COVERAGE_OUTPUT_DIRECTORY)/index.html"
@@ -219,7 +219,10 @@ CODE_COVERAGE_GENHTML_OPTIONS_DEFAULT ?=\
 $(if $(CODE_COVERAGE_BRANCH_COVERAGE),\
 --rc genhtml_branch_coverage=$(CODE_COVERAGE_BRANCH_COVERAGE))
 CODE_COVERAGE_GENHTML_OPTIONS ?= $(CODE_COVERAGE_GENHTML_OPTIONS_DEFAULT)
-CODE_COVERAGE_IGNORE_PATTERN ?=
+
+# Add any folders you want to ignore here
+# Ignore tmp and tests themselves
+CODE_COVERAGE_IGNORE_PATTERN ?= "/tmp/*" "*/tests/*"  
 
 GITIGNOREFILES ?=
 GITIGNOREFILES += $(CODE_COVERAGE_OUTPUT_FILE) $(CODE_COVERAGE_OUTPUT_DIRECTORY)


### PR DESCRIPTION
TL:DR
- Removes broken codecov ignore
- Places ignore section ax_code_coverage
- Forwards users from codecov to LCOV for ignores

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>


### Motivation and Context
After many hours trying to figure out why we/I couldn't get codecov ignore working I have finally solved the problem.

The issue with codecov ignore came out to be two fold:
1. There is a bug in codecov, which prevents ignore from working, there have been about 3-5 reports about it from last months.
2. Codecov support is rather unsupportive for some reason, resorting to smokescreening and ignoring all reports of this bug.

This leads to my conclusion:
If we want to ignore folders, we beter not rely on codecov to do it for us.

### Description
This PR ignores folders, by removing them from the report before they  are send to codecov. As this is actually opensource and maintainable by OpenZFS/ZoL, I expect this to keep be a more sustainable long-term solution and this would even survive changing codecov-report-provider.

Before you ask: Why the wildcard prefix?
- The path thats actually ignored in the report, is the full path:
`Removing /var/lib/buildbot/slaves/zfs/Ubuntu_17_04_x86_64_Coverage__TEST_/build/zfs/tests/zfs-tests/cmd/file_check/file_check.c`
Not:
`tests/zfs-tests/cmd/file_check/file_check.c`

It's a bit of an oddity or bug with lcov, but it does not lead to sideeffects on the ZFS codebase.

Before you ask: Do we really need an ignore at all?
It would be cleaner to ignore tests covering themselves, but yes that wouldn't in itself warrant a change. However some PR's in the future might rely on externally maintained libraries that are not covered by our tests completely, an ignore would be essential to keep codecoverage reports representing actual coverage of zfs. (an example of which is/could be ZSTD)

### How Has This Been Tested?
Currently it's a draft. As soon as I get all tests to pass, i'll note it down and open it up for review.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
