### PR TITLE
Fix cppcheck 1.82 warnings

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -5102,7 +5102,6 @@ parse_fs_perm(fs_perm_t *fsperm, nvlist_t *nvl)
 		zfs_deleg_who_type_t perm_type = name[0];
 		char perm_locality = name[1];
 		const char *perm_name = name + 3;
-		boolean_t is_set = B_TRUE;
 		who_perm_t *who_perm = NULL;
 
 		assert('$' == name[2]);
@@ -5132,57 +5131,56 @@ parse_fs_perm(fs_perm_t *fsperm, nvlist_t *nvl)
 			assert(!"unhandled zfs_deleg_who_type_t");
 		}
 
-		if (is_set) {
-			who_perm_node_t *found_node = NULL;
-			who_perm_node_t *node = safe_malloc(
-			    sizeof (who_perm_node_t));
-			who_perm = &node->who_perm;
-			uu_avl_index_t idx = 0;
+		who_perm_node_t *found_node = NULL;
+		who_perm_node_t *node = safe_malloc(
+		    sizeof (who_perm_node_t));
+		who_perm = &node->who_perm;
+		uu_avl_index_t idx = 0;
 
-			uu_avl_node_init(node, &node->who_avl_node, avl_pool);
-			who_perm_init(who_perm, fsperm, perm_type, perm_name);
+		uu_avl_node_init(node, &node->who_avl_node, avl_pool);
+		who_perm_init(who_perm, fsperm, perm_type, perm_name);
 
-			if ((found_node = uu_avl_find(avl, node, NULL, &idx))
-			    == NULL) {
-				if (avl == fsperm->fsp_uge_avl) {
-					uid_t rid = 0;
-					struct passwd *p = NULL;
-					struct group *g = NULL;
-					const char *nice_name = NULL;
+		if ((found_node = uu_avl_find(avl, node, NULL, &idx))
+		    == NULL) {
+			if (avl == fsperm->fsp_uge_avl) {
+				uid_t rid = 0;
+				struct passwd *p = NULL;
+				struct group *g = NULL;
+				const char *nice_name = NULL;
 
-					switch (perm_type) {
-					case ZFS_DELEG_USER_SETS:
-					case ZFS_DELEG_USER:
-						rid = atoi(perm_name);
-						p = getpwuid(rid);
-						if (p)
-							nice_name = p->pw_name;
-						break;
-					case ZFS_DELEG_GROUP_SETS:
-					case ZFS_DELEG_GROUP:
-						rid = atoi(perm_name);
-						g = getgrgid(rid);
-						if (g)
-							nice_name = g->gr_name;
-						break;
+				switch (perm_type) {
+				case ZFS_DELEG_USER_SETS:
+				case ZFS_DELEG_USER:
+					rid = atoi(perm_name);
+					p = getpwuid(rid);
+					if (p)
+						nice_name = p->pw_name;
+					break;
+				case ZFS_DELEG_GROUP_SETS:
+				case ZFS_DELEG_GROUP:
+					rid = atoi(perm_name);
+					g = getgrgid(rid);
+					if (g)
+						nice_name = g->gr_name;
+					break;
 
-					default:
-						break;
-					}
-
-					if (nice_name != NULL)
-						(void) strlcpy(
-						    node->who_perm.who_ug_name,
-						    nice_name, 256);
+				default:
+					break;
 				}
 
-				uu_avl_insert(avl, node, idx);
-			} else {
-				node = found_node;
-				who_perm = &node->who_perm;
+				if (nice_name != NULL)
+					(void) strlcpy(
+					    node->who_perm.who_ug_name,
+					    nice_name, 256);
 			}
+
+			uu_avl_insert(avl, node, idx);
+		} else {
+			node = found_node;
+			who_perm = &node->who_perm;
 		}
-		VERIFY3P(who_perm, !=, NULL);
+
+		assert(who_perm != NULL);
 		(void) parse_who_perm(who_perm, nvl2, perm_locality);
 	}
 

--- a/module/icp/algs/modes/ccm.c
+++ b/module/icp/algs/modes/ccm.c
@@ -885,15 +885,13 @@ ccm_init_ctx(ccm_ctx_t *ccm_ctx, char *param, int kmflag,
 
 		ccm_ctx->ccm_flags |= CCM_MODE;
 	} else {
-		rv = CRYPTO_MECHANISM_PARAM_INVALID;
-		goto out;
+		return (CRYPTO_MECHANISM_PARAM_INVALID);
 	}
 
 	if (ccm_init(ccm_ctx, ccm_param->nonce, ccm_param->ulNonceSize,
 	    ccm_param->authData, ccm_param->ulAuthDataSize, block_size,
 	    encrypt_block, xor_block) != 0) {
-		rv = CRYPTO_MECHANISM_PARAM_INVALID;
-		goto out;
+		return (CRYPTO_MECHANISM_PARAM_INVALID);
 	}
 	if (!is_encrypt_init) {
 		/* allocate buffer for storing decrypted plaintext */
@@ -903,7 +901,6 @@ ccm_init_ctx(ccm_ctx_t *ccm_ctx, char *param, int kmflag,
 			rv = CRYPTO_HOST_MEMORY;
 		}
 	}
-out:
 	return (rv);
 }
 

--- a/module/icp/algs/modes/gcm.c
+++ b/module/icp/algs/modes/gcm.c
@@ -557,8 +557,7 @@ gcm_init_ctx(gcm_ctx_t *gcm_ctx, char *param, size_t block_size,
 		rv = CRYPTO_SUCCESS;
 		gcm_ctx->gcm_flags |= GCM_MODE;
 	} else {
-		rv = CRYPTO_MECHANISM_PARAM_INVALID;
-		goto out;
+		return (CRYPTO_MECHANISM_PARAM_INVALID);
 	}
 
 	if (gcm_init(gcm_ctx, gcm_param->pIv, gcm_param->ulIvLen,
@@ -566,7 +565,7 @@ gcm_init_ctx(gcm_ctx_t *gcm_ctx, char *param, size_t block_size,
 	    encrypt_block, copy_block, xor_block) != 0) {
 		rv = CRYPTO_MECHANISM_PARAM_INVALID;
 	}
-out:
+
 	return (rv);
 }
 
@@ -592,8 +591,7 @@ gmac_init_ctx(gcm_ctx_t *gcm_ctx, char *param, size_t block_size,
 		rv = CRYPTO_SUCCESS;
 		gcm_ctx->gcm_flags |= GMAC_MODE;
 	} else {
-		rv = CRYPTO_MECHANISM_PARAM_INVALID;
-		goto out;
+		return (CRYPTO_MECHANISM_PARAM_INVALID);
 	}
 
 	if (gcm_init(gcm_ctx, gmac_param->pIv, AES_GMAC_IV_LEN,
@@ -601,7 +599,7 @@ gmac_init_ctx(gcm_ctx_t *gcm_ctx, char *param, size_t block_size,
 	    encrypt_block, copy_block, xor_block) != 0) {
 		rv = CRYPTO_MECHANISM_PARAM_INVALID;
 	}
-out:
+
 	return (rv);
 }
 

--- a/module/lua/ldebug.c
+++ b/module/lua/ldebug.c
@@ -324,6 +324,7 @@ static void kname (Proto *p, int pc, int c, const char **name) {
   if (ISK(c)) {  /* is 'c' a constant? */
     TValue *kvalue = &p->k[INDEXK(c)];
     if (ttisstring(kvalue)) {  /* literal constant? */
+      // cppcheck-suppress autoVariables
       *name = svalue(kvalue);  /* it is its own name */
       return;
     }

--- a/module/lua/ldo.c
+++ b/module/lua/ldo.c
@@ -176,6 +176,7 @@ int luaD_rawrunprotected (lua_State *L, Pfunc f, void *ud) {
   struct lua_longjmp lj;
   lj.status = LUA_OK;
   lj.previous = L->errorJmp;  /* chain new error handler */
+  // cppcheck-suppress autoVariables
   L->errorJmp = &lj;
   LUAI_TRY(L, &lj,
     (*f)(L, ud);

--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -2559,7 +2559,7 @@ nvlist_common(nvlist_t *nvl, char *buf, size_t *buflen, int encoding,
 #else
 	int host_endian = 0;
 #endif	/* _LITTLE_ENDIAN */
-	nvs_header_t *nvh = (void *)buf;
+	nvs_header_t *nvh;
 
 	if (buflen == NULL || nvl == NULL ||
 	    (nvs.nvs_priv = (nvpriv_t *)(uintptr_t)nvl->nvl_priv) == NULL)
@@ -2578,6 +2578,7 @@ nvlist_common(nvlist_t *nvl, char *buf, size_t *buflen, int encoding,
 		if (buf == NULL || *buflen < sizeof (nvs_header_t))
 			return (EINVAL);
 
+		nvh = (void *)buf;
 		nvh->nvh_encoding = encoding;
 		nvh->nvh_endian = nvl_endian = host_endian;
 		nvh->nvh_reserved1 = 0;
@@ -2589,6 +2590,7 @@ nvlist_common(nvlist_t *nvl, char *buf, size_t *buflen, int encoding,
 			return (EINVAL);
 
 		/* get method of encoding from first byte */
+		nvh = (void *)buf;
 		encoding = nvh->nvh_encoding;
 		nvl_endian = nvh->nvh_endian;
 		break;

--- a/module/os/linux/spl/spl-generic.c
+++ b/module/os/linux/spl/spl-generic.c
@@ -275,7 +275,9 @@ int64_t
 __divdi3(int64_t u, int64_t v)
 {
 	int64_t q, t;
+	// cppcheck-suppress shiftTooManyBitsSigned
 	q = __udivdi3(abs64(u), abs64(v));
+	// cppcheck-suppress shiftTooManyBitsSigned
 	t = (u ^ v) >> 63;	// If u, v have different
 	return ((q ^ t) - t);	// signs, negate q.
 }

--- a/module/os/linux/spl/spl-generic.c
+++ b/module/os/linux/spl/spl-generic.c
@@ -697,7 +697,7 @@ static void __init
 spl_random_init(void)
 {
 	uint64_t s[2];
-	int i;
+	int i = 0;
 
 	get_random_bytes(s, sizeof (s));
 

--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -344,7 +344,7 @@ static spl_kmem_slab_t *
 spl_slab_alloc(spl_kmem_cache_t *skc, int flags)
 {
 	spl_kmem_slab_t *sks;
-	spl_kmem_obj_t *sko, *n;
+	spl_kmem_obj_t *sko;
 	void *base, *obj;
 	uint32_t obj_size, offslab_size = 0;
 	int i,  rc = 0;
@@ -388,6 +388,7 @@ spl_slab_alloc(spl_kmem_cache_t *skc, int flags)
 
 out:
 	if (rc) {
+		spl_kmem_obj_t *n = NULL;
 		if (skc->skc_flags & KMC_OFFSLAB)
 			list_for_each_entry_safe(sko,
 			    n, &sks->sks_free_list, sko_list) {
@@ -437,8 +438,8 @@ spl_slab_free(spl_kmem_slab_t *sks,
 static void
 spl_slab_reclaim(spl_kmem_cache_t *skc)
 {
-	spl_kmem_slab_t *sks, *m;
-	spl_kmem_obj_t *sko, *n;
+	spl_kmem_slab_t *sks = NULL, *m = NULL;
+	spl_kmem_obj_t *sko = NULL, *n = NULL;
 	LIST_HEAD(sks_list);
 	LIST_HEAD(sko_list);
 	uint32_t size = 0;
@@ -834,7 +835,7 @@ spl_magazine_free(spl_kmem_magazine_t *skm)
 static int
 spl_magazine_create(spl_kmem_cache_t *skc)
 {
-	int i;
+	int i = 0;
 
 	if (skc->skc_flags & KMC_NOMAGAZINE)
 		return (0);
@@ -865,7 +866,7 @@ static void
 spl_magazine_destroy(spl_kmem_cache_t *skc)
 {
 	spl_kmem_magazine_t *skm;
-	int i;
+	int i = 0;
 
 	if (skc->skc_flags & KMC_NOMAGAZINE)
 		return;
@@ -1644,7 +1645,7 @@ static spl_shrinker_t
 __spl_kmem_cache_generic_shrinker(struct shrinker *shrink,
     struct shrink_control *sc)
 {
-	spl_kmem_cache_t *skc;
+	spl_kmem_cache_t *skc = NULL;
 	int alloc = 0;
 
 	/*

--- a/module/os/linux/spl/spl-kmem.c
+++ b/module/os/linux/spl/spl-kmem.c
@@ -376,7 +376,7 @@ kmem_del_init(spinlock_t *lock, struct hlist_head *table,
     int bits, const void *addr)
 {
 	struct hlist_head *head;
-	struct hlist_node *node;
+	struct hlist_node *node = NULL;
 	struct kmem_debug *p;
 	unsigned long flags;
 
@@ -573,7 +573,7 @@ static void
 spl_kmem_fini_tracking(struct list_head *list, spinlock_t *lock)
 {
 	unsigned long flags;
-	kmem_debug_t *kd;
+	kmem_debug_t *kd = NULL;
 	char str[17];
 
 	spin_lock_irqsave(lock, flags);

--- a/module/os/linux/spl/spl-kstat.c
+++ b/module/os/linux/spl/spl-kstat.c
@@ -431,7 +431,7 @@ static struct seq_operations kstat_seq_ops = {
 static kstat_module_t *
 kstat_find_module(char *name)
 {
-	kstat_module_t *module;
+	kstat_module_t *module = NULL;
 
 	list_for_each_entry(module, &kstat_module_list, ksm_module_list) {
 		if (strncmp(name, module->ksm_name, KSTAT_STRLEN) == 0)
@@ -624,7 +624,7 @@ static int
 kstat_detect_collision(kstat_proc_entry_t *kpep)
 {
 	kstat_module_t *module;
-	kstat_proc_entry_t *tmp;
+	kstat_proc_entry_t *tmp = NULL;
 	char *parent;
 	char *cp;
 
@@ -659,7 +659,7 @@ kstat_proc_entry_install(kstat_proc_entry_t *kpep, mode_t mode,
     const struct file_operations *file_ops, void *data)
 {
 	kstat_module_t *module;
-	kstat_proc_entry_t *tmp;
+	kstat_proc_entry_t *tmp = NULL;
 
 	ASSERT(kpep);
 

--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -144,7 +144,7 @@ proc_doslab(struct ctl_table *table, int write,
 	int rc = 0;
 	unsigned long min = 0, max = ~0, val = 0, mask;
 	spl_ctl_table dummy = *table;
-	spl_kmem_cache_t *skc;
+	spl_kmem_cache_t *skc = NULL;
 
 	dummy.data = &val;
 	dummy.proc_handler = &proc_dointvec;
@@ -249,7 +249,7 @@ static int
 taskq_seq_show_impl(struct seq_file *f, void *p, boolean_t allflag)
 {
 	taskq_t *tq = p;
-	taskq_thread_t *tqt;
+	taskq_thread_t *tqt = NULL;
 	spl_wait_queue_entry_t *wq;
 	struct task_struct *tsk;
 	taskq_ent_t *tqe;

--- a/module/os/linux/spl/spl-taskq.c
+++ b/module/os/linux/spl/spl-taskq.c
@@ -83,7 +83,7 @@ task_km_flags(uint_t flags)
 static int
 taskq_find_by_name(const char *name)
 {
-	struct list_head *tql;
+	struct list_head *tql = NULL;
 	taskq_t *tq;
 
 	list_for_each_prev(tql, &tq_list) {
@@ -212,7 +212,7 @@ task_expire_impl(taskq_ent_t *t)
 {
 	taskq_ent_t *w;
 	taskq_t *tq = t->tqent_taskq;
-	struct list_head *l;
+	struct list_head *l = NULL;
 	unsigned long flags;
 
 	spin_lock_irqsave_nested(&tq->tq_lock, flags, tq->tq_lock_class);
@@ -301,7 +301,7 @@ static void
 taskq_insert_in_order(taskq_t *tq, taskq_thread_t *tqt)
 {
 	taskq_thread_t *w;
-	struct list_head *l;
+	struct list_head *l = NULL;
 
 	ASSERT(tq);
 	ASSERT(tqt);
@@ -324,7 +324,7 @@ taskq_insert_in_order(taskq_t *tq, taskq_thread_t *tqt)
 static taskq_ent_t *
 taskq_find_list(taskq_t *tq, struct list_head *lh, taskqid_t id)
 {
-	struct list_head *l;
+	struct list_head *l = NULL;
 	taskq_ent_t *t;
 
 	list_for_each(l, lh) {
@@ -350,7 +350,7 @@ static taskq_ent_t *
 taskq_find(taskq_t *tq, taskqid_t id)
 {
 	taskq_thread_t *tqt;
-	struct list_head *l;
+	struct list_head *l = NULL;
 	taskq_ent_t *t;
 
 	t = taskq_find_list(tq, &tq->tq_delay_list, id);
@@ -1209,7 +1209,7 @@ param_set_taskq_kick(const char *val, struct kernel_param *kp)
 #endif
 {
 	int ret;
-	taskq_t *tq;
+	taskq_t *tq = NULL;
 	taskq_ent_t *t;
 	unsigned long flags;
 

--- a/module/os/linux/spl/spl-tsd.c
+++ b/module/os/linux/spl/spl-tsd.c
@@ -98,7 +98,7 @@ static tsd_hash_table_t *tsd_hash_table = NULL;
 static tsd_hash_entry_t *
 tsd_hash_search(tsd_hash_table_t *table, uint_t key, pid_t pid)
 {
-	struct hlist_node *node;
+	struct hlist_node *node = NULL;
 	tsd_hash_entry_t *entry;
 	tsd_hash_bin_t *bin;
 	ulong_t hash;

--- a/module/os/linux/spl/spl-vmem.c
+++ b/module/os/linux/spl/spl-vmem.c
@@ -50,7 +50,7 @@ EXPORT_SYMBOL(zio_arena);
 size_t
 vmem_size(vmem_t *vmp, int typemask)
 {
-	spl_kmem_cache_t *skc;
+	spl_kmem_cache_t *skc = NULL;
 	size_t alloc = VMEM_FLOOR_SIZE;
 
 	if ((typemask & VMEM_ALLOC) && (typemask & VMEM_FREE))

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1559,6 +1559,7 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 	dnode_slots_rele(dnc, idx, slots);
 
 	DNODE_VERIFY(dn);
+	ASSERT3P(dnp, !=, NULL);
 	ASSERT3P(dn->dn_dbuf, ==, db);
 	ASSERT3U(dn->dn_object, ==, object);
 	dbuf_rele(db, FTAG);


### PR DESCRIPTION
### Motivation and Context

Resolve new warnings and errors reported by cppcheck 1.82.
This enables us to update the version of cppcheck used by the
CI and is generally needed to keep the `make cppcheck` target
useful with the latest tool chain.

### Description

None of the reported warnings or errors fixed were cause for
concern, but fixing them does improve the overall code quality.
Each patch in this stack addresses a specific class of issue and
is described by its commit message.

84a615f0a28 cppcheck: (warning) Possible null pointer dereference: nvh
161704bc68f cppcheck: (error) Address of local auto-variable assigned
3511eb8fb10 cppcheck: (error) Null pointer dereference: who_perm
dd35210f4f4 cppcheck: (warning) Possible null pointer dereference: dnp
0f02a61d4c0 cppcheck: (error) Memory leak: vtoc
d4fb6f16069 cppcheck: (error) Shifting signed 64-bit value by 63 bits
dbd873af613 cppcheck: (error) Uninitialized variable
1bad16537d4 cppcheck: (error) Uninitialized variable

### How Has This Been Tested?

All of the following pass cleanly when testing on Ubuntu 18.04
using the distribution provided version of cppcheck 1.82.  Prior
to this change `make cppcheck` would report multiple warnings.

```
make -s
make cppcheck
make checkstyle
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
