### PR TITLE
ZTS: Various test case fixes

### DIFF
--- a/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
+++ b/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
@@ -202,7 +202,7 @@ function create_dev_file_illumos
 	return 0
 }
 
-create_dev_file_linux
+function create_dev_file_linux
 {
 	typeset filetype=$1
 	typeset filename=$2

--- a/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
@@ -137,7 +137,7 @@ remove_disk $SDISK
 # background since the command will hang when the pool gets suspended.  The
 # command will resume and exit after we restore the missing disk later on.
 zpool scrub $TESTPOOL2 &
-sleep 1		# Give the scrub some time to run before we check if it fails
+sleep 3		# Give the scrub some time to run before we check if it fails
 
 log_must check_all $TESTPOOL2 "SUSPENDED"
 

--- a/tests/zfs-tests/tests/functional/procfs/procfs_list_basic.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/procfs_list_basic.ksh
@@ -48,7 +48,7 @@ function cleanup
 function count_snap_cmds
 {
 	typeset expected_count=$1
-	count=$(grep "command: zfs snapshot $FS@testsnapshot" | wc -l)
+	count=$(grep -E "command: (lt-)?zfs snapshot $FS@testsnapshot" | wc -l)
 	log_must eval "[[ $count -eq $expected_count ]]"
 }
 


### PR DESCRIPTION
### Motivation and Context

Resolve recently observed ZTS failures.  It's still unclear why they failures
were not caught by the `zts-report.py` script, but they were caught by the [known-issues](http://build.zfsonlinux.org/known-issues.html) page.

### Description

* devices_001_pos and devices_002_neg - Failing after FreeBSD ZTS
  merged due to missing 'function' keyword for create_dev_file_linux.

* pool_state - Occasionally fails due to an insufficient delay
  before checking 'zpool status'.  Increasing the delay from 1 to 3
  seconds resolved the issue in local testing.

* procfs_list_basic - Fails when run in-tree because the logged
  command is actually 'lt-zfs'.  Updated the regex accordingly.

### How Has This Been Tested?

Locally ran the updated tests cases and verified they are now passing:

```sh
$ ./scripts/zfs-tests.sh -T devices,procfs
Test (Linux): tests/functional/devices/setup (run as root) [00:00] [PASS]
Test (Linux): tests/functional/devices/devices_001_pos (run as root) [00:00] [PASS]
Test (Linux): tests/functional/devices/devices_002_neg (run as root) [00:00] [PASS]
Test (Linux): tests/functional/devices/devices_003_pos (run as root) [00:00] [PASS]
Test (Linux): tests/functional/devices/cleanup (run as root) [00:00] [PASS]
Test (Linux): tests/functional/procfs/setup (run as root) [00:01] [PASS]
Test (Linux): tests/functional/procfs/procfs_list_basic (run as root) [00:06] [PASS]
Test (Linux): tests/functional/procfs/procfs_list_concurrent_readers (run as root) [00:07] [PASS]
Test (Linux): tests/functional/procfs/procfs_list_stale_read (run as root) [00:04] [PASS]
Test (Linux): tests/functional/procfs/pool_state (run as root) [00:14] [PASS]
Test (Linux): tests/functional/procfs/cleanup (run as root) [00:01] [PASS]

Results Summary
PASS      11
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
