### PR TITLE
libspl: declare aok extern in header

### DIFF
--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -34,7 +34,7 @@
 #include <stdarg.h>
 
 #ifndef _KERNEL
-int aok;
+extern int aok;
 #endif
 
 static inline int

--- a/lib/libspl/zone.c
+++ b/lib/libspl/zone.c
@@ -27,6 +27,8 @@
 #include <string.h>
 #include <errno.h>
 
+int aok = 0;
+
 zoneid_t
 getzoneid()
 {

--- a/tests/zfs-tests/tests/functional/checksum/edonr_test.c
+++ b/tests/zfs-tests/tests/functional/checksum/edonr_test.c
@@ -40,6 +40,8 @@
 #include <sys/time.h>
 #include <sys/stdtypes.h>
 
+int aok = 0;
+
 /*
  * Test messages from:
  * http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA_All.pdf


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
`aok` is declared and defined in `assert.h`. This causes anyone who ends up including libspl's `assert.h` to pick up a definition of `aok`, resulting in a situation like:

```
/usr/bin/ld: src/aggregate.o and src/growlight.o: warning: multiple common of `aok'
/usr/bin/ld: src/crypt.o and src/growlight.o: warning: multiple common of `aok'
/usr/bin/ld: src/nvme.o and src/growlight.o: warning: multiple common of `aok'
/usr/bin/ld: src/stats.o and src/growlight.o: warning: multiple common of `aok'
```

Maybe this is intended, so that independent files can set their assert settings up independently, but I don't see any kind of use like that within ZoL (and would be questionable IMHO in any case). Instead, I create a single definition in `zone.c`.

### Description


### How Has This Been Tested?
Recompiled and reinstalled ZoL on my Debian Unstable machine, and reboooted. All zpools were discovered and filesystems mounted. I then ran `make check` in a checkout, and it succeeded.

```
[schwarzgerat](0) $ zpool --version
zfs-0.8.0-1
zfs-kmod-0.8.0-1
[schwarzgerat](0) $ 
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
