### PR TITLE
Add compression benchmark to ZFS

### DIFF
--- a/tests/benchmarks/.gitignore
+++ b/tests/benchmarks/.gitignore
@@ -1,0 +1,5 @@
+enwik9.zip
+enwik9
+*test_results_*
+CUSTOM.TEST
+bbb_sunflower_native_60fps_stereo_abl.mp4

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,0 +1,42 @@
+## Current available Benchmarks:
+
+| Benchmark  | File | Description |
+| ------------- | ------------- | ------------- |
+| **Compression Benchmark**  | compression-bench.sh  | _Generates repeatable compression results_ |
+
+	
+	
+	
+---
+	
+	
+	
+## Compression Benchmark
+Crude Standardised ZFS compression test, with repeatable results in mind
+
+### Important notes
+- Make sure you do not have zfs installed already via other means such as OS packages etc.
+- This assumes a clean install with unzip, wget and git installed
+- The enwik9 and mpeg4 datasets get downloaded just once, don't worry about the time it takes
+- This script makes sure the build/test environment is as prestine as possible before and after running
+- This script uses a ramdisk as source and (pool) destination for writes tests to asure clean and unbottlenecked results
+
+### How Use
+
+1. Build ZFS on Linux and install all dependancies as described here: https://github.com/zfsonlinux/zfs/wiki/Building-ZFS#installing-dependencies
+2. Make sure you cd'ed into the `benchmarks` directory
+3. run: sudo ./compression-bench.sh with one of the **options**
+
+### options
+
+**Compression Tests**
+- **-b** A basic test of only the following algorithms: off lz4 zle lzjb gzip zstd
+- **-f** A full test of all compression algorithms available for ZFS
+- **-c** A Custom test with only the argument algorithm
+- **-t** Select a different compression test file. Options: `enwik9` and `mpeg4`
+- **-p** Enter a different prefix for the test results
+
+**Other**
+- **-h** Displays a help page, which includes a reference to the different commands
+
+When finished you'll have a .txt file in the benchmarks directory, containing the test results

--- a/tests/benchmarks/compression-bench.sh
+++ b/tests/benchmarks/compression-bench.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+#Automated ZFS compressiontest
+now=$(date +%s)
+
+MODE="NONE"
+GZIP="gzip gzip-1 gzip-2 gzip-3 gzip-4 gzip-5 gzip-6 gzip-7 gzip-8 gzip-9"
+
+TYPE="WIKIPEDIA"
+TESTRESULTS="test_results_$now.txt"
+
+if [ $# -eq 0 ]
+then
+        echo "Missing options!"
+        echo "(run $0 -h for help)"
+        echo ""
+        exit 0
+fi
+
+while getopts "p:t:ribfhc:" OPTION; do
+        case $OPTION in
+		p)	
+			TESTRESULTS="$OPTARG-$TESTRESULTS"
+			echo "Results file of the test is called: ./$TESTRESULTS"
+			
+			;;
+		t)	
+			TYPE="$OPTARG"
+			case $TYPE in
+				[wW])	
+					echo "Selected highly compressible Wikipedia file"
+					TYPE="WIKIPEDIA"
+					;;
+				[mM])
+					echo "Selected nearly uncompressible MPEG4 file"
+					TYPE="MPEG4"
+					;;
+				[cC])
+					echo "Selected custom file named CUSTOM.TEST"
+					TYPE="CUSTOM"
+					;;
+				*)	
+					echo "Unknown Selection of Testtype. Using default"
+				       	TYPE="WIKIPEDIA"
+					;;	
+			esac
+			;;
+                b)
+                        MODE="BASIC"
+                        ALGO="off lz4 zle lzjb gzip"
+                        echo "Selected BASIC compression test"
+                        ;;
+                f)
+                        MODE="FULL"
+                        ALGO="off lz4 zle lzjb $GZIP"
+                        echo "Selected FULL compression test"
+                        echo "This might take a while..."
+                        ;;
+                c)
+                        MODE="CUSTOM"
+                        ALGO="$OPTARG"
+                        echo "Selected custom compression test using the following algorithms:"
+                        echo "$ALGO"
+                        ;;
+                h)
+                        echo "Usage:"
+                        echo "$0 -h "
+                        echo "$0 -b "
+                        echo "$0 -f "
+						echo "$0 -c "
+                        echo ""
+                        echo "   -b    to execute a basic compression test containing: off lz4 zle lzjb gzip zstd"
+                        echo "   -f    to execute a full compression test containing all currently available ZFS compression algorithms"
+						echo "   -c    to execute the entered list of following compression types: "
+						echo "         off lz4 zle lzjb $GZIP"
+                        echo ""
+						echo "   -p to enter a prefix to the test_result files"
+						echo "   -t to select the type of test:"
+						echo "      w for highly compressible wikipedia file"
+						echo "      m for nearly uncompressible mpeg4 file"
+						echo "      c for custom file onder script root named CUSTOM.TEST"
+                        echo "   -h     help (this output)"
+                        echo "ALL these values are mutually exclusive"
+                        exit 0
+                        ;;
+
+        esac
+done
+
+if [  $MODE = "FULL" -o $MODE = "BASIC" -o $MODE = "CUSTOM" ]
+then
+        echo "destroy testpool and unmount ramdisk of previous broken/canceled tests"
+        test -f ../../cmd/zpool/zpool && sudo ./zfs/cmd/zpool/zpool destroy testpool 2>&1 >/dev/null
+        sudo umount -l /mnt/ramdisk >/dev/null 2>&1
+
+        echo "creating ramdisk"
+        sudo mkdir /mnt/ramdisk
+        sudo mount -t tmpfs -o size=2400m tmpfs /mnt/ramdisk
+
+        echo "creating virtial pool drive"
+        truncate -s 1200m /mnt/ramdisk/pooldisk.img
+
+        echo "creating zfs testpool/fs1"
+        sudo ../../cmd/zpool/zpool create testpool -f -o ashift=12  /mnt/ramdisk/pooldisk.img
+        sudo ../../cmd/zfs/zfs create testpool/fs1
+        sudo ../../cmd/zfs/zfs set recordsize=1M  testpool/fs1 
+
+	# Downloading and may be uncompressing file 
+	FILENAME=""
+	case "$TYPE" in 
+
+		WIKIPEDIA)	
+        	echo "downloading and extracting enwik9 testset"
+        	sudo wget -nc http://mattmahoney.net/dc/enwik9.zip
+        	sudo unzip -n enwik9.zip
+			FILENAME="enwik9"
+			;;
+		MPEG4)
+			echo "downloading a MPEG4 testfile"
+			sudo wget -nc http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_stereo_abl.mp4
+			FILENAME="bbb_sunflower_native_60fps_stereo_abl.mp4"
+			;;
+		CUSTOM)
+			if [ -f "CUSTOM.TEST" ]
+			then
+				echo "CUSTOM.TEST found."
+			else
+				echo "CUSTOM.TEST not found."
+				exit 1
+			fi
+			FILENAME="CUSTOM.TEST"
+			;;
+		*)	
+			echo "ERROR: $TYPE is not unknown"
+			exit 1
+			;;
+	esac
+
+    echo "copying $FILENAME to ramdisk, truncating it after 1000M"
+	sudo dd if=$FILENAME of=/mnt/ramdisk/$FILENAME bs=1M count=1000 status=none
+    cd /mnt/ramdisk/
+    chksum=`sha256sum $FILENAME`
+    cd -
+    echo "" >> "./$TESTRESULTS"
+    echo "Test with $FILENAME file" >> "./$TESTRESULTS"
+	grep "^model name" /proc/cpuinfo |sort -u >> "./$TESTRESULTS"
+	grep "^flags" /proc/cpuinfo |sort -u >>  "./$TESTRESULTS"
+	echo "" >> "./$TESTRESULTS"
+	
+    echo "starting compression test suite"
+        for comp in $ALGO
+        do
+            echo "running compression test for $comp"
+            ../../cmd/zfs/zfs set compression=$comp testpool/fs1
+            echo “Compression results for $comp” >> "./$TESTRESULTS"
+            dd if=/mnt/ramdisk/$FILENAME of=/testpool/fs1/$FILENAME bs=4M  2>> "./$TESTRESULTS"
+            ../../cmd/zfs/zfs get compressratio testpool/fs1 >> "./$TESTRESULTS"
+            echo "" >> "./$TESTRESULTS"
+            echo “Decompression results for $comp” >> "./$TESTRESULTS"
+            dd if=/testpool/fs1/$FILENAME of=/dev/null bs=4M  2>> "./$TESTRESULTS"
+            echo ""  >> "./$TESTRESULTS"
+            echo "verifying testhash"
+            cd /testpool/fs1/
+            chkresult=`echo "$chksum" | sha256sum --check`
+            sudo rm $FILENAME
+            cd -
+            echo "hashcheck result: $chkresult" >> "./$TESTRESULTS"
+            echo "" >> "./$TESTRESULTS"
+            echo "----" >> "./$TESTRESULTS"
+            echo "" >> "./$TESTRESULTS"
+        done
+
+        echo "compression test finished"
+        echo "destroying pool and unmounting ramdisk"
+        sudo ../../cmd/zpool/zpool destroy testpool
+        sudo umount -l /mnt/ramdisk
+
+        echo "Done. results writen to test_results_$now.txt "
+fi


### PR DESCRIPTION
- Add compression benchmark script to ZFS
- Create a location to but benchmarks
- Document it

Co-authored-by: Daniel Andersen <dan-and@users.noreply.github.com>
Signed-off-by: Daniel Andersen <dan-and@users.noreply.github.com>
Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During the work on ZSTD we came to realise there is no easy-reachable standardised way to make a benchmark of a compression algorithm in such a way that at least the compression results (ratio) is repeatable accoss runs and platforms.

### Description
<!--- Describe your changes in detail -->
Research showed a good way to get benchmark results are the enwik suit of testfiles, which are basically a highly compressable plain-text export of wikipedia. This script uses a 1GB file (enwik9) to lower the margin of error.

To test if said results are in fact correct, I got the suggestion to use checksums which is included. @dan-and also added uncompressable testing and some code cleaning to ensure proper functioning.

Why include this with zfs?
- It's good to have a standardised test if people have issues about compression performance. As long as said test has ben thoroughly tested. Due to our many test and benchmark runs for ZSTD we can be very sure this test functions very well. As it even brought interesting behavorial differences between zstd and other algorithms to light (https://github.com/zfsonlinux/zfs/pull/9735#issuecomment-567692612)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Manually, running it and crossreferencing values.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X] All new and existing tests passed.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
