### PR TITLE
In initramfs, do not prompt if keylocation is "file"

### DIFF
--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -37,15 +37,22 @@ fi
 if [ "$(zpool list -H -o feature@encryption $(echo "${BOOTFS}" | awk -F\/ '{print $1}'))" = 'active' ]; then
     # if the root dataset has encryption enabled
     ENCRYPTIONROOT=$(zfs get -H -o value encryptionroot "${BOOTFS}")
+    # where the key is stored (in a file or loaded via prompt)
+    KEYLOCATION=$(${ZFS} get -H -o value keylocation "${ENCRYPTIONROOT}")
     if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
         KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
         # continue only if the key needs to be loaded
         [ "$KEYSTATUS" = "unavailable" ] || exit 0
-        # decrypt them
-        TRY_COUNT=5
-        while [ $TRY_COUNT -gt 0 ]; do
-            systemd-ask-password "Encrypted ZFS password for ${BOOTFS}" --no-tty | zfs load-key "${ENCRYPTIONROOT}" && break
-            TRY_COUNT=$((TRY_COUNT - 1))
-        done
+        # if key is stored in a file, do not prompt
+        if ! [ "${KEYLOCATION}" = "prompt" ]; then
+            zfs load-key "${ENCRYPTIONROOT}"
+        else
+            # decrypt them
+            TRY_COUNT=5
+            while [ $TRY_COUNT -gt 0 ]; do
+                systemd-ask-password "Encrypted ZFS password for ${BOOTFS}" --no-tty | zfs load-key "${ENCRYPTIONROOT}" && break
+                TRY_COUNT=$((TRY_COUNT - 1))
+            done
+        fi
     fi
 fi

--- a/contrib/initramfs/scripts/zfs.in
+++ b/contrib/initramfs/scripts/zfs.in
@@ -411,6 +411,7 @@ decrypt_fs()
 
 		# Determine dataset that holds key for root dataset
 		ENCRYPTIONROOT="$(get_fs_value "${fs}" encryptionroot)"
+		KEYLOCATION="$(get_fs_value "${ENCRYPTIONROOT}" keylocation)"
 
 		# If root dataset is encrypted...
 		if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
@@ -418,8 +419,13 @@ decrypt_fs()
 			# Continue only if the key needs to be loaded
 			[ "$KEYSTATUS" = "unavailable" ] || return 0
 			TRY_COUNT=3
+
+			# If key is stored in a file, do not prompt
+			if ! [ "${KEYLOCATION}" = "prompt" ]; then
+				$ZFS load-key "${ENCRYPTIONROOT}"
+
 			# Prompt with plymouth, if active
-			if [ -e /bin/plymouth ] && /bin/plymouth --ping 2>/dev/null; then
+			elif [ -e /bin/plymouth ] && /bin/plymouth --ping 2>/dev/null; then
 				while [ $TRY_COUNT -gt 0 ]; do
 					plymouth ask-for-password --prompt "Encrypted ZFS password for ${ENCRYPTIONROOT}" | \
 						$ZFS load-key "${ENCRYPTIONROOT}" && break


### PR DESCRIPTION
If the encryption key is stored in a file, the initramfs should not
prompt for the password. This scenario is possible if the initramfs is
stored on a removable media that is only inserted when booting

### Motivation and Context
I placed my /boot partition on flash drive that is only inserted at boot time (I have a home server that normally does not have a monitor attached). The initramfs is built with the key file in the location specified by the `keylocation` property, so there is no need for the prompt at boot time.

### Description
This is a small change to the initramfs-tools script that loads the zfs filesystem. I made the corresponding change to the dracut script as well.

### How Has This Been Tested?
I edited the initramfs-tools script for my system, rebuilt the initramfs, and booted successfully. I don't have a system that builds the initramfs using dracut, so that change wasn't tested directly. It's the same logic as the initramfs, however.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
