### PR TITLE
Add zdb -n option to specify object range to dump

### DIFF
--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -26,6 +26,7 @@
 .Op Fl AbcdDFGhikLMPsvXY
 .Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl I Ar inflight I/Os
+.Op Fl n Ar start Ns Op : Ns Ar end
 .Oo Fl o Ar var Ns = Ns Ar value Oc Ns ...
 .Op Fl t Ar txg
 .Op Fl U Ar cache
@@ -134,8 +135,10 @@ size, and object count.
 .Pp
 If specified multiple times provides greater and greater verbosity.
 .Pp
-If object IDs are specified, display information about those specific objects
-only.
+If individual object IDs are specified as command line arguments
+following the dataset name, or if a range of object IDs is specified with the
+.Fl n
+option, display information about those specific objects only.
 .It Fl D
 Display deduplication statistics, including the deduplication ratio
 .Pq Sy dedup ,
@@ -227,6 +230,18 @@ must be relative to the root of
 This option can be combined with
 .Fl v
 for increasing verbosity.
+.It Fl n Ar start Ns Op : Ns Ar end
+When combined the
+.Fl d
+option, dump dataset objects with identifiers between
+.Ar start
+and
+.Ar end Ns ,
+inclusive. If
+.Ar end
+is not specified, dump all dataset objects with identifiers greater than
+or equal to
+.Ar start Ns .
 .It Xo
 .Fl R Ar poolname vdev Ns \&: Ns Ar offset Ns \&: Ns Ar [<lsize>/]<psize> Ns Op : Ns Ar flags
 .Xc


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

Allow a range of object identifiers to dump with -d. This may
be useful when dumping a large dataset and you want to break
it up into multiple phases, or resume where a previous scan
left off. Syntax: zdb -d -n <start>[:<end>].

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This feature provides a way to specify a range of object identifiers
for zdb to dump. This may be useful when dumping a large dataset.
If a zdb dataset dump is interrupted, this option could be used to
resume where the previous dump left off.

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Tested manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
