### PR TITLE
ZTS: Test case failures

### DIFF
--- a/tests/zfs-tests/cmd/btree_test/.gitignore
+++ b/tests/zfs-tests/cmd/btree_test/.gitignore
@@ -1,0 +1,1 @@
+/btree_test

--- a/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/features/large_dnode/large_dnode_008_pos.ksh
@@ -39,7 +39,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TEST_FS && log_must zfs destroy $TEST_FS
+	datasetexists $TEST_FS && destroy_dataset $TEST_FS
 }
 
 function verify_dnode_packing
@@ -71,6 +71,7 @@ for ((i=0; i < 100; i++)); do
 done
 
 log_must wait
+sync_pool $TESTPOOL
 
 verify_dnode_packing
 

--- a/tests/zfs-tests/tests/functional/refreserv/refreserv_raidz.ksh
+++ b/tests/zfs-tests/tests/functional/refreserv/refreserv_raidz.ksh
@@ -121,6 +121,7 @@ for parity in 1 2 3; do
 			log_must test "$deltapct" -le $maxpct
 
 			log_must_busy zfs destroy "$vol"
+			block_device_wait
 		done
 
 		log_must_busy zpool destroy "$TESTPOOL"


### PR DESCRIPTION
### Motivation and Context

Resolve several ZTS failures now being regularly observed by the CI
after changing the test instance type.  

### Description

* ~devices/devices_001_pos, devices/devices_002_neg - When only NVMe
  block devices exist no valid major/minor are found.  Update the
  create_dev_file_linux function to handle this case.~

* large_dnode_008_pos - Force a pool sync before invoking zdb to
  ensure the updated dnode blocks have been persistented to disk.

* refreserv_raidz - Wait for the /dev/zvol links to be both created
  and removed, this is important because the same device volume
  names are being used repeatedly.

* btree_test - Add missing .gitignore file for btree_test binary.

### How Has This Been Tested?

Locally verified using the ZTS.  Pending full CI results to confirm
these changes do resolve the issues in the CI environment.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
