### PR TITLE
ZTS: devices_001_pos and devices_002_neg

### DIFF
--- a/tests/zfs-tests/tests/functional/devices/devices_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/devices/devices_002_neg.ksh
@@ -42,7 +42,7 @@
 # 1. Create pool and file system.
 # 2. Set devices=off on this file system.
 # 3. Separately create block device file and character file.
-# 4. Separately read from those two device files.
+# 4. Separately read and write from those two device files.
 # 5. Check the return value, and make sure it failed.
 #
 
@@ -55,12 +55,16 @@ log_onexit cleanup
 log_must zfs set devices=off $TESTPOOL/$TESTFS
 
 #
-# Separately create block device file and character device file, then try to
-# open them and make sure it failed.
+# Create block device file backed by a ZFS volume.
+# Verify it cannot be opened, written, and read.
 #
-create_dev_file b $TESTDIR/$TESTFILE1
-log_mustnot dd if=$TESTDIR/$TESTFILE1 of=$TESTDIR/$TESTFILE1.out count=1
+create_dev_file b $TESTDIR/$TESTFILE1 $ZVOL_DEVDIR/$TESTPOOL/$TESTVOL
+log_mustnot dd if=/dev/urandom of=$TESTDIR/$TESTFILE1 count=1 bs=128k
+log_mustnot dd if=$TESTDIR/$TESTFILE1 of=/dev/null count=1 bs=128k
+
+# Create character device file backed by /dev/null
+# Verify it cannot be opened and written.
 create_dev_file c $TESTDIR/$TESTFILE2
-log_mustnot dd if=$TESTDIR/$TESTFILE2 of=$TESTDIR/$TESTFILE2.out count=1
+log_mustnot dd if=/dev/urandom of=$TESTDIR/$TESTFILE2 count=1 bs=128k
 
 log_pass "Setting devices=off on file system and testing it pass."

--- a/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
+++ b/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
@@ -36,192 +36,70 @@
 #
 # $1 device file type
 # $2 file name
+# $3 device path (used for 'b' device type)
 #
 function create_dev_file
 {
 	typeset filetype=$1
 	typeset filename=$2
-
-	case $(uname) in
-	FreeBSD)
-		create_dev_file_freebsd "$filetype" "$filename"
-		;;
-	Linux)
-		create_dev_file_linux "$filetype" "$filename"
-		;;
-	*)
-		create_dev_file_illumos "$filetype" "$filename"
-		;;
-	esac
-
-	return 0
-}
-
-function create_dev_file_freebsd
-{
-	typeset filetype=$1
-	typeset filename=$2
+	typeset devstr=$3
 
 	case $filetype in
 	b)
-		devtype=$(df -T / | grep -v "Type" | awk '{print $2}')
-		case $devtype in
-		zfs)
-			rootpool=$(df / | grep -v "Filesystem" | \
-				awk '{print $2}')
-			rootpool=${rootpool#\(}
-			rootpool=${rootpool%%/*}
-
-			devstr=$(get_disklist $rootpool)
-			devstr=$(echo "$devstr" | \
-				awk '{print $1}')
-			[[ -z $devstr ]] && \
-				log_fail "Can not get block device file."
-			devstr=/dev/${devstr}
-			;;
-		ufs)
-		#
-		# Get the existing block device file in current system.
-		# And bring out the first one.
-		#
-			devstr=$(df -t ufs | \
-				grep "^/dev/" | \
-				head -n 1 | \
-				awk '{print $1}')
-			devstr=$(echo "$devstr" | \
-				awk '{print $1}')
-			[[ -z $devstr ]] && \
-				log_fail "Can not get block device file."
+		case $(uname) in
+		Linux)
+			#
+			# stat(1) --format=FORMAT tokens
+			# %t - major device type in hex
+			# %T - minor device type in hex
+			#
+			major=$(stat --dereference --format="%t" "$devstr")
+			minor=$(stat --dereference --format="%T" "$devstr")
+			log_must mknod $filename b "0x${major}" "0x${minor}"
 			;;
 		*)
-			log_unsupported "Unsupported fstype " \
-				"for / ($devtype)," \
-				"only ufs|zfs is supported."
+			#
+			# Get the device file information. i.e:
+			# $devstr:      block special (28/768)
+			#
+			devstr=$(file $devstr)
+			major=${devstr##*\(}
+			major=${major%%/*}
+			minor=${devstr##*/}
+			minor=${minor%\)}
+			log_must mknod $filename b $major $minor
 			;;
 		esac
-
-		#
-		# Get the device file information. i.e:
-		# /dev/c0t0d0s0:      block special (28/768)
-		#
-		devstr=$(file $devstr)
-
-		#
-		# Bring out major and minor number.
-		#
-		major=${devstr##*\(}
-		major=${major%%/*}
-		minor=${devstr##*/}
-		minor=${minor%\)}
-
-		log_must mknod $filename b $major $minor
 		;;
 	c)
 		#
-		# Create device file '/dev/null'
+		# Create device file '/dev/null', $devstr is unused.
 		#
-		log_must mknod $filename c 13 2
-		;;
-	*)
-		log_fail "'$filetype' is wrong."
-		;;
-	esac
-
-	return 0
-}
-
-function create_dev_file_illumos
-{
-	typeset filetype=$1
-	typeset filename=$2
-
-	case $filetype in
-	b)
-		devtype=$(df -n / | awk '{print $3}')
-		case $devtype in
-		zfs)
-			rootpool=$(df / | \
-				awk '{print $2}')
-			rootpool=${rootpool#\(}
-			rootpool=${rootpool%%/*}
-
-			devstr=$(get_disklist $rootpool)
-			devstr=$(echo "$devstr" | \
-				awk '{print $1}')
-			[[ -z $devstr ]] && \
-				log_fail "Can not get block device file."
-			devstr=$DEV_DSKDIR/${devstr}
+		case $(uname) in
+		Linux)
+			#
+			# stat(1) --format=FORMAT tokens
+			# %t - major device type in hex
+			# %T - minor device type in hex
+			#
+			major=$(stat --format="%t" /dev/null)
+			minor=$(stat --format="%T" /dev/null)
+			log_must mknod $filename c "0x${major}" "0x${minor}"
 			;;
-		ufs)
-		#
-		# Get the existing block device file in current system.
-		# And bring out the first one.
-		#
-			devstr=$(df-lhF ufs | \
-				grep "^${DEV_DSKDIR}" | \
-				awk '{print $1}')
-			devstr=$(echo "$devstr" | \
-				awk '{print $1}')
-			[[ -z $devstr ]] && \
-				log_fail "Can not get block device file."
+		FreeBSD)
+			#
+			# Create device file '/dev/null'
+			#
+			major=13
+			minor=2
+			log_must mknod $filename b $major $minor
 			;;
 		*)
-			log_unsupported "Unsupported fstype " \
-				"for / ($devtype)," \
-				"only ufs|zfs is supported."
+			major=$(getmajor mm)
+			minor=2
+			log_must mknod $filename b $major $minor
 			;;
 		esac
-
-		#
-		# Get the device file information. i.e:
-		# $DEV_DSKDIR/c0t0d0s0:      block special (28/768)
-		#
-		devstr=$(file $devstr)
-
-		#
-		# Bring out major and minor number.
-		#
-		major=${devstr##*\(}
-		major=${major%%/*}
-		minor=${devstr##*/}
-		minor=${minor%\)}
-
-		log_must mknod $filename b $major $minor
-		;;
-	c)
-		#
-		# Create device file '/dev/null'
-		#
-		log_must mknod $filename c $(getmajor mm) 2
-		;;
-	*)
-		log_fail "'$filetype' is wrong."
-		;;
-	esac
-
-	return 0
-}
-
-function create_dev_file_linux
-{
-	typeset filetype=$1
-	typeset filename=$2
-
-	case $filetype in
-	b)
-		major=$(awk '/[hsv]d/ { print $1; exit }' \
-		    /proc/partitions)
-		minor=$(awk '/[hsv]d/ { print $2; exit }' \
-		    /proc/partitions)
-		log_must mknod $filename b $major $minor
-		;;
-	c)
-		#
-		# Create device file '/dev/null'
-		#
-		major=$(stat -c %t /dev/null)
-		minor=$(stat -c %T /dev/null)
-		log_must mknod $filename c $major $minor
 		;;
 	*)
 		log_fail "'$filetype' is wrong."
@@ -236,6 +114,6 @@ function cleanup
 	log_must zfs set devices=on $TESTPOOL/$TESTFS
 	log_must rm -f $TESTDIR/$TESTFILE1
 	log_must rm -f $TESTDIR/$TESTFILE2
-	log_must rm -f $TESTDIR/$TESTFILE1.out
-	log_must rm -f $TESTDIR/$TESTFILE2.out
+	log_must rm -f $TESTDIR/$TESTFILE1.out1
+	log_must rm -f $TESTDIR/$TESTFILE1.out2
 }

--- a/tests/zfs-tests/tests/functional/devices/setup.ksh
+++ b/tests/zfs-tests/tests/functional/devices/setup.ksh
@@ -32,4 +32,4 @@
 . $STF_SUITE/include/libtest.shlib
 
 DISK=${DISKS%% *}
-default_setup $DISK
+default_volume_setup $DISK


### PR DESCRIPTION
### Motivation and Context

The way the `devices_001_pos` and `devices_002_neg` tests were
original written and then ported has resulted ZTS failures when running
in environment with only NVMe  devices.  Update the test case so they
no longer need to grub around in the /dev/ directory to determine the
major and minor numbers to be used.

### Description

Update the `devices_001_pos` and `devices_002_neg` test cases such that the
special block device file created is backed by a ZFS volume.  Specifying
a specific device allows the major and minor numbers to be easily
determined.  Furthermore, this avoids the potentially dangerous behavior
of opening the first block device we happen to find under `/dev/`.

### How Has This Been Tested?

Manually tested in the problematic environment as configured by the CI.
For this initial PR I've restricted the ZTS tags run to those I've observed
fail in the CI without this change.  Assuming the CI confirms all is will
I'll resubmit this for a full ZTS run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
