### PR TITLE
ZTS: zfs_program_json

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json.ksh
@@ -91,14 +91,28 @@ typeset -a pos_cmds_out=(
         }
     }
 }")
+
+#
+# N.B. json.tool is needed to guarantee consistent ordering of fields,
+# sed is needed to trim trailing space in CentOS 6's json.tool output
+#
+# As of Python 3.5 the behavior of json.tool changed to keep the order
+# the same as the input and the --sort-keys option was added.  Detect when
+# --sort-keys is supported and apply the option to ensure the expected order.
+#
+if python -m json.tool --sort-keys <<< "{}"; then
+	JSON_TOOL_CMD="python -m json.tool --sort-keys"
+else
+	JSON_TOOL_CMD="python -m json.tool"
+fi
+
 typeset -i cnt=0
 typeset cmd
 for cmd in ${pos_cmds[@]}; do
 	log_must zfs program $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1
 	log_must zfs program -j $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1
-	# json.tool is needed to guarantee consistent ordering of fields
-	# sed is needed to trim trailing space in CentOS 6's json.tool output
-	OUTPUT=$(zfs program -j $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1 | python -m json.tool | sed 's/[[:space:]]*$//')
+	OUTPUT=$(zfs program -j $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1 |
+	    $JSON_TOOL_CMD | sed 's/[[:space:]]*$//')
 	if [ "$OUTPUT" != "${pos_cmds_out[$cnt]}" ]; then
 		log_note "Got     :$OUTPUT"
 		log_note "Expected:${pos_cmds_out[$cnt]}"


### PR DESCRIPTION
### Motivation and Context

The `zfs_program_json` test case consistently fails on Fedora 31
because the `python` command defaults to Python 3.7.5 and the
default behavior of `json.tool` was changed in Python 3.5.

### Description

As of Python 3.5 the default behavior of json.tool was changed to
preserve the input order rather than lexical order.  The test case
expects the output to be sorted so apply the --sort-keys option
to the json.tool command when using Python 3.5 and the option is
supported.

https://docs.python.org/3/library/json.html#module-json.tool

### How Has This Been Tested?

Manually on Fedora 31 with Python 3.7.5.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
