### PR TITLE
ZTS: Replace /var/tmp with $TEST_BASE_DIR

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_dev_removal.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_dev_removal.ksh
@@ -37,10 +37,10 @@ function cleanup
 
 log_onexit cleanup
 
-VIRTUAL_DISK1=/var/tmp/disk1
-VIRTUAL_DISK2=/var/tmp/disk2
-log_must mkfile $(($MINVDEVSIZE * 8)) $VIRTUAL_DISK1
-log_must mkfile $(($MINVDEVSIZE * 16)) $VIRTUAL_DISK2
+VIRTUAL_DISK1=$TEST_BASE_DIR/disk1
+VIRTUAL_DISK2=$TEST_BASE_DIR/disk2
+log_must truncate -s $(($MINVDEVSIZE * 8)) $VIRTUAL_DISK1
+log_must truncate -s $(($MINVDEVSIZE * 16)) $VIRTUAL_DISK2
 
 log_must zpool create $TESTPOOL2 $VIRTUAL_DISK1
 log_must poolexists $TESTPOOL2

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_dev_removal_condense.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_dev_removal_condense.ksh
@@ -48,10 +48,10 @@ log_onexit cleanup
 ORIGINAL_MAX=$(get_tunable $LIVELIST_MAX_ENTRIES)
 set_tunable64 $LIVELIST_MAX_ENTRIES 20
 
-VIRTUAL_DISK1=/var/tmp/disk1
-VIRTUAL_DISK2=/var/tmp/disk2
-log_must mkfile $(($MINVDEVSIZE * 8)) $VIRTUAL_DISK1
-log_must mkfile $(($MINVDEVSIZE * 16)) $VIRTUAL_DISK2
+VIRTUAL_DISK1=$TEST_BASE_DIR/disk1
+VIRTUAL_DISK2=$TEST_BASE_DIR/disk2
+log_must truncate -s $(($MINVDEVSIZE * 8)) $VIRTUAL_DISK1
+log_must truncate -s $(($MINVDEVSIZE * 16)) $VIRTUAL_DISK2
 
 log_must zpool create $TESTPOOL2 $VIRTUAL_DISK1
 log_must poolexists $TESTPOOL2

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_001_pos.ksh
@@ -75,7 +75,7 @@ log_onexit cleanup
 init_snap=$TESTPOOL/$TESTFS@init_snap
 inc_snap=$TESTPOOL/$TESTFS@inc_snap
 full_bkup=$TEST_BASE_DIR/fullbkup.$$
-inc_bkup=/var/tmp/incbkup.$$
+inc_bkup=$TEST_BASE_DIR/incbkup.$$
 init_data=$TESTDIR/$TESTFILE1
 inc_data=$TESTDIR/$TESTFILE2
 orig_sum=""

--- a/tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_user/zfs_list/zfs_list_007_pos.ksh
@@ -57,9 +57,8 @@ function cleanup
 log_onexit cleanup
 log_assert "'zfs list -d <n>' should get expected output."
 
-mntpnt=/var/tmp
-DEPTH_OUTPUT="$mntpnt/depth_output"
-EXPECT_OUTPUT="$mntpnt/expect_output"
+DEPTH_OUTPUT="$TEST_BASE_DIR/depth_output"
+EXPECT_OUTPUT="$TEST_BASE_DIR/expect_output"
 typeset -i old_val=0
 typeset -i j=0
 typeset -i fs=0


### PR DESCRIPTION
### Motivation and Context

Keep the ZTS test files restricted to the requested target directory.
Assuming `/var/tmp` always has a large amount of free space can
lead to CI failures.  This is particularly true in the CI where the root
filesystem, and hense /var/tmp is not particularly large.

### Description

Remove a few hardcoded instances of /var/tmp.  This should use
the $TEST_BASE_DIR in order to allow the ZTS to be optionally
run in an alternate directory using `zfs-tests.sh -d <path>`.

### How Has This Been Tested?

Locally reran the modified test cases to verify they work as intended.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
