### PR TITLE
ZTS: Fix pool_state cleanup

### DIFF
--- a/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/pool_state.ksh
@@ -105,8 +105,10 @@ check_all $TESTPOOL "ONLINE"
 
 # Fault one of the disks, and check that pool is degraded
 DISK1=$(echo "$DISKS" | awk '{print $2}')
-zpool offline -tf $TESTPOOL $DISK1
+log_must zpool offline -tf $TESTPOOL $DISK1
 check_all $TESTPOOL "DEGRADED"
+log_must zpool online $TESTPOOL $DISK1
+log_must zpool clear $TESTPOOL
 
 # Create a new pool out of a scsi_debug disk
 TESTPOOL2=testpool2

--- a/tests/zfs-tests/tests/functional/procfs/setup.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/setup.ksh
@@ -27,4 +27,3 @@
 . $STF_SUITE/include/libtest.shlib
 
 default_mirror_setup $DISKS
-log_pass


### PR DESCRIPTION
### Motivation and Context

When running the ZTS tests in a different order it was observed that
`pool_state.ksh` does not wipe one of the vdev labels which can result
in the next test group failing when `-f` isn't used with `zpool create`.
In this case, several `refreserv` test cases failed incorrectly.

### Description

The externally faulted vdev should be brought back online and have
its errors cleared before the pool is destroyed.  Failure to do so
will leave a vdev with a valid active label.  This vdev may then
not be used to create a new pool without the -f flag potentially
leading to subsequent test failures.

Additionally remove an unreachable log_pass from setup.ksh.

### How Has This Been Tested?

Without this PR running only the `procfs,refreserv` test groups:

```
$ ./scripts/zfs-tests.sh -T procfs,refreserv
Test (Linux): /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/procfs/setup (run as root) [00:01] [PASS]
Test (Linux): /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/procfs/procfs_list_basic (run as root) [00:10] [PASS]
...
Tests with result of PASS that are unexpected:

Tests with results other than PASS that are unexpected:
    FAIL refreserv/refreserv_multi_raidz (expected PASS)
    FAIL refreserv/refreserv_raidz (expected PASS)
```

With this PR:

```
$ ./scripts/zfs-tests.sh -T procfs,refreserv
Test (Linux): /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/procfs/setup (run as root) [00:01] [PASS]
Test (Linux): /home/behlendo/src/git/zfs/tests/zfs-tests/tests/functional/procfs/procfs_list_basic (run as root) [00:06] [PASS]
...
Tests with result of PASS that are unexpected:

Tests with results other than PASS that are unexpected:
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).