### PR TITLE
zfs-load-key.sh: ${ZFS} is not the zfs binary

### DIFF
--- a/contrib/dracut/90zfs/zfs-load-key.sh.in
+++ b/contrib/dracut/90zfs/zfs-load-key.sh.in
@@ -38,7 +38,7 @@ if [ "$(zpool list -H -o feature@encryption $(echo "${BOOTFS}" | awk -F\/ '{prin
     # if the root dataset has encryption enabled
     ENCRYPTIONROOT=$(zfs get -H -o value encryptionroot "${BOOTFS}")
     # where the key is stored (in a file or loaded via prompt)
-    KEYLOCATION=$(${ZFS} get -H -o value keylocation "${ENCRYPTIONROOT}")
+    KEYLOCATION=$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")
     if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
         KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
         # continue only if the key needs to be loaded


### PR DESCRIPTION

### Motivation and Context
This change fixes the zfs-load-key.sh dracut script so that `zfs get` can retrieve the key location.

### Description
I think this line, committed yesterday, broke booting with zfs encryption passwords

https://github.com/zfsonlinux/zfs/pull/9764/files#diff-df72a4107f2673aa772b7d7acc9923f5R41

### How Has This Been Tested?
Tested locally by rebuilding and booting my initramfs with this change applied ontop of today's master branch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
