### PR TITLE
Fix QAT allocation failure return value

### DIFF
--- a/module/os/linux/zfs/qat_compress.c
+++ b/module/os/linux/zfs/qat_compress.c
@@ -248,7 +248,7 @@ qat_compress_impl(qat_compress_dir_t dir, char *src, int src_len,
 	Cpa8U *buffer_meta_dst = NULL;
 	Cpa32U buffer_meta_size = 0;
 	CpaDcRqResults dc_results;
-	CpaStatus status = CPA_STATUS_SUCCESS;
+	CpaStatus status = CPA_STATUS_FAIL;
 	Cpa32U hdr_sz = 0;
 	Cpa32U compressed_sz;
 	Cpa32U num_src_buf = (src_len >> PAGE_SHIFT) + 2;
@@ -277,16 +277,19 @@ qat_compress_impl(qat_compress_dir_t dir, char *src, int src_len,
 	Cpa32U dst_buffer_list_mem_size = sizeof (CpaBufferList) +
 	    ((num_dst_buf + num_add_buf) * sizeof (CpaFlatBuffer));
 
-	if (QAT_PHYS_CONTIG_ALLOC(&in_pages,
-	    num_src_buf * sizeof (struct page *)) != CPA_STATUS_SUCCESS)
+	status = QAT_PHYS_CONTIG_ALLOC(&in_pages,
+	    num_src_buf * sizeof (struct page *));
+	if (status != CPA_STATUS_SUCCESS)
 		goto fail;
 
-	if (QAT_PHYS_CONTIG_ALLOC(&out_pages,
-	    num_dst_buf * sizeof (struct page *)) != CPA_STATUS_SUCCESS)
+	status = QAT_PHYS_CONTIG_ALLOC(&out_pages,
+	    num_dst_buf * sizeof (struct page *));
+	if (status != CPA_STATUS_SUCCESS)
 		goto fail;
 
-	if (QAT_PHYS_CONTIG_ALLOC(&add_pages,
-	    num_add_buf * sizeof (struct page *)) != CPA_STATUS_SUCCESS)
+	status = QAT_PHYS_CONTIG_ALLOC(&add_pages,
+	    num_add_buf * sizeof (struct page *));
+	if (status != CPA_STATUS_SUCCESS)
 		goto fail;
 
 	i = (Cpa32U)atomic_inc_32_nv(&inst_num) % num_inst;
@@ -295,19 +298,19 @@ qat_compress_impl(qat_compress_dir_t dir, char *src, int src_len,
 
 	cpaDcBufferListGetMetaSize(dc_inst_handle, num_src_buf,
 	    &buffer_meta_size);
-	if (QAT_PHYS_CONTIG_ALLOC(&buffer_meta_src, buffer_meta_size) !=
-	    CPA_STATUS_SUCCESS)
+	status = QAT_PHYS_CONTIG_ALLOC(&buffer_meta_src, buffer_meta_size);
+	if (status != CPA_STATUS_SUCCESS)
 		goto fail;
 
 	cpaDcBufferListGetMetaSize(dc_inst_handle, num_dst_buf + num_add_buf,
 	    &buffer_meta_size);
-	if (QAT_PHYS_CONTIG_ALLOC(&buffer_meta_dst, buffer_meta_size) !=
-	    CPA_STATUS_SUCCESS)
+	status = QAT_PHYS_CONTIG_ALLOC(&buffer_meta_dst, buffer_meta_size);
+	if (status != CPA_STATUS_SUCCESS)
 		goto fail;
 
 	/* build source buffer list */
-	if (QAT_PHYS_CONTIG_ALLOC(&buf_list_src, src_buffer_list_mem_size) !=
-	    CPA_STATUS_SUCCESS)
+	status = QAT_PHYS_CONTIG_ALLOC(&buf_list_src, src_buffer_list_mem_size);
+	if (status != CPA_STATUS_SUCCESS)
 		goto fail;
 
 	flat_buf_src = (CpaFlatBuffer *)(buf_list_src + 1);
@@ -315,8 +318,8 @@ qat_compress_impl(qat_compress_dir_t dir, char *src, int src_len,
 	buf_list_src->pBuffers = flat_buf_src; /* always point to first one */
 
 	/* build destination buffer list */
-	if (QAT_PHYS_CONTIG_ALLOC(&buf_list_dst, dst_buffer_list_mem_size) !=
-	    CPA_STATUS_SUCCESS)
+	status = QAT_PHYS_CONTIG_ALLOC(&buf_list_dst, dst_buffer_list_mem_size);
+	if (status != CPA_STATUS_SUCCESS)
 		goto fail;
 
 	flat_buf_dst = (CpaFlatBuffer *)(buf_list_dst + 1);


### PR DESCRIPTION
### Motivation and Context

Issue #9784 

### Description

When qat_compress() fails to allocate the required contigeous memory
it mistakenly returns success.  This prevents the fallback software
compression from taking over and (un)compressing the block.

Resolve the issue by correctly setting the local 'status' variable
on all exit paths.  Furthermore, initialize it to CPA_STATUS_FAIL
to ensure qat_compress() always fails safe to guard against any
similar bugs in the future.

### How Has This Been Tested?

Visually inspected.  Unfortunately, I don't currently have access to
a qat accelerator to verify the fix.

@wli5 @cfzhu would it be possible for you to review and test this.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
