### PR TITLE
ZTS: Add helper for disk device check

### DIFF
--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -93,11 +93,19 @@ function is_physical_device #device
 	device=${device#$DEV_RDSKDIR}
 
 	if is_linux; then
-		[[ -b "$DEV_DSKDIR/$device" ]] && \
+		is_disk_device "$DEV_DSKDIR/$device" && \
 		[[ -f /sys/module/loop/parameters/max_part ]]
 		return $?
 	elif is_freebsd; then
-		echo $device | grep -q -e '^a?da[0-9]*$' -e '^md[0-9]*$' > /dev/null 2>&1
+		is_disk_device "$DEV_DSKDIR/$device" && \
+		echo $device | grep -q \
+			-e '^a?da[0-9]+$' \
+			-e '^md[0-9]+$' \
+			-e '^mfid[0-9]+$' \
+			-e '^nda[0-9]+$' \
+			-e '^nvd[0-9]+$' \
+			-e '^vtbd[0-9]+$' \
+			> /dev/null 2>&1
 		return $?
 	else
 		echo $device | egrep "^c[0-F]+([td][0-F]+)+$" > /dev/null 2>&1
@@ -162,9 +170,24 @@ function is_mpath_device #disk
 			return $?
 		fi
 	elif is_freebsd; then
-		test -b $DEV_MPATHDIR/$disk
+		is_disk_device $DEV_MPATHDIR/$disk
 	else
 		false
+	fi
+}
+
+#
+# Check if the given path is the appropriate sort of device special node.
+#
+function is_disk_device #path
+{
+	typeset path=$1
+
+	if is_freebsd; then
+		# FreeBSD doesn't have block devices, only character devices.
+		test -c $path
+	else
+		test -b $path
 	fi
 }
 
@@ -241,7 +264,7 @@ function get_device_dir #device
 		if [[ $device != "/" ]]; then
 			device=${device%/*}
 		fi
-		if [[ -b "$DEV_DSKDIR/$device" ]]; then
+		if is_disk_device "$DEV_DSKDIR/$device"; then
 			device="$DEV_DSKDIR"
 		fi
 		echo $device

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2380,12 +2380,11 @@ EOF
 # each case. limit the number to max_finddisksnum
 	count=0
 	for disk in $unused_candidates; do
-		if [ -b $DEV_DSKDIR/${disk}s0 ]; then
-		if [ $count -lt $max_finddisksnum ]; then
+		if is_disk_device $DEV_DSKDIR/${disk}s0 && \
+		    [ $count -lt $max_finddisksnum ]; then
 			unused="$unused $disk"
 			# do not impose limit if $@ is provided
 			[[ -z $@ ]] && ((count = count + 1))
-		fi
 		fi
 	done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/setup.ksh
@@ -26,7 +26,7 @@ verify_runnable "global"
 DISK1=${DISKS%% *}
 
 typeset -i max_discard=0
-if [[ -b $DEV_RDSKDIR/$DISK1 ]]; then
+if is_disk_device $DEV_RDSKDIR/$DISK1; then
 	max_discard=$(lsblk -Dbn $DEV_RDSKDIR/$DISK1 | awk '{ print $4; exit }')
 fi
 

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_mounts.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_mounts.ksh
@@ -76,23 +76,23 @@ log_must diff <(echo ${contents//$recv_mnt/}) \
 log_must zfs redact $sendvol@snap book2 $clonevol@snap
 log_must eval "zfs send --redact book2 $sendvol@snap >$stream"
 log_must eval "zfs receive $recvvol <$stream"
-[[ -b $recv_vol_file ]] && log_fail "Volume device file should not exist."
+is_disk_device $recv_vol_file && log_fail "Volume device file should not exist."
 log_must set_tunable32 zfs_allow_redacted_dataset_mount 1
 log_must zpool export $POOL2
 log_must zpool import $POOL2
 udevadm settle
 
 # The device file isn't guaranteed to show up right away.
-if [[ ! -b $recv_vol_file ]]; then
+if ! is_disk_device $recv_vol_file; then
 	udevadm settle
 	for t in 10 5 3 2 1; do
 		log_note "Polling $t seconds for device file."
 		udevadm settle
 		sleep $t
-		[[ -b $recv_vol_file ]] && break
+		is_disk_device $recv_vol_file && break
 	done
 fi
-[[ -b $recv_vol_file ]] || log_fail "Volume device file should exist."
+is_disk_device $recv_vol_file || log_fail "Volume device file should exist."
 
 log_must dd if=/dev/urandom of=$send_mnt/dir1/contents1 bs=512 count=2
 log_must rm $send_mnt/dir1/dir2/empty

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_volume.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_volume.ksh
@@ -44,13 +44,13 @@ sleep 10
 log_must zpool export $POOL
 log_must zpool import $POOL
 udevadm settle
-if [[ ! -b $send_file ]]; then
+if ! is_disk_device $send_file; then
 	udevadm settle
 	for t in 10 5 3 2 1; do
 		log_note "Polling $t seconds for device file."
 		udevadm settle
 		sleep $t
-		[[ -b $send_file ]] && break
+		is_disk_device $send_file && break
 	done
 fi
 log_must dd if=/dev/urandom of=$send_file bs=8k count=64
@@ -66,13 +66,13 @@ sleep 10
 log_must zpool export $POOL2
 log_must zpool import $POOL2
 udevadm settle
-if [[ ! -b $recv_file ]]; then
+if ! is_disk_device $recv_file; then
 	udevadm settle
 	for t in 10 5 3 2 1; do
 		log_note "Polling $t seconds for device file."
 		udevadm settle
 		sleep $t
-		[[ -b $recv_file ]] && break
+		is_disk_device $recv_file && break
 	done
 fi
 log_must dd if=$send_file of=$tmpdir/send.dd bs=8k count=64
@@ -89,13 +89,13 @@ sleep 10
 log_must zpool export $POOL2
 log_must zpool import $POOL2
 udevadm settle
-if  [[ ! -b $recv_file ]]; then
+if ! is_disk_device $recv_file; then
 	udevadm settle
 	for t in 10 5 3 2 1; do
 		log_note "Polling $t seconds for device file."
 		udevadm settle
 		sleep $t
-		[[ -b $recv_file ]] && break
+		is_disk_device $recv_file && break
 	done
 fi
 log_must dd if=$send_file of=$tmpdir/send.dd bs=8k count=32 skip=32

--- a/tests/zfs-tests/tests/functional/trim/setup.ksh
+++ b/tests/zfs-tests/tests/functional/trim/setup.ksh
@@ -30,7 +30,7 @@ else
 	DISK1=${DISKS%% *}
 
 	typeset -i max_discard=0
-	if [[ -b $DEV_RDSKDIR/$DISK1 ]]; then
+	if is_disk_device $DEV_RDSKDIR/$DISK1; then
 		max_discard=$(lsblk -Dbn $DEV_RDSKDIR/$DISK1 | awk '{ print $4; exit }')
 	fi
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_common.kshlib
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_common.kshlib
@@ -80,7 +80,7 @@ function blockdev_exists # device
 	# that can affect device nodes
 	for i in {1..3}; do
 		udev_wait
-		[[ -b "$device" ]] && return 0
+		is_disk_device "$device" && return 0
 	done
 	log_fail "$device does not exist as a block device"
 }
@@ -127,17 +127,17 @@ function verify_partition # device
 {
 	typeset device="$1"
 
-	if [[ ! -b "$device" ]]; then
+	if ! is_disk_device "$device"; then
 		log_fail "$device is not a block device"
 	fi
 	# create a small dummy partition
 	set_partition 0 1 1m $device
 	# verify we can access the partition on the device
 	devname="$(readlink -f "$device")"
-	if is_linux; then
-		[[ -b "$devname""p1" ]]
+	if is_linux || is_freebsd; then
+		is_disk_device "$devname""p1"
 	else
-		[[ -b "$devname""s0" ]]
+		is_disk_device "$devname""s0"
 	fi
 	return $?
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FreeBSD has no block cache layer for devices, so disks are character special devices rather than block special devices.

### Description
<!--- Describe your changes in detail -->
Replace `test -b` and equivalents with `is_disk_device`, which will use the correct test for each platform.
Also added more device names to match in is_physical_device.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Passed ZTS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
