### PR TITLE
Fix ZPOOL_VDEV_NAME_PATH option description

### DIFF
--- a/man/man8/zpool.8
+++ b/man/man8/zpool.8
@@ -497,7 +497,7 @@ Cause
 .Nm zpool
 subcommands to output full vdev path names by default.  This
 behavior is identical to the
-.Nm zpool status -p
+.Nm zpool status -P
 command line option.
 .El
 .Bl -tag -width "ZFS_VDEV_DEVID_OPT_OUT"


### PR DESCRIPTION
### Motivation and Context

Update the zpool.8 man page to list the correct option.

### Description

The corresponding zpool status option is -P and not -p.  Update
this description to reference the correct option.

### How Has This Been Tested?

Proofread.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
