### PR TITLE
ZTS: Cleanup partition tables

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -132,6 +132,7 @@ export SYSTEM_FILES_LINUX='attr
     blockdev
     chattr
     cksum
+    dmidecode
     exportfs
     fallocate
     fdisk

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2301,10 +2301,11 @@ function cleanup_devices #vdevs
 {
 	typeset pool="foopool$$"
 
-	if poolexists $pool ; then
-		destroy_pool $pool
-	fi
+	for vdev in $@; do
+		zero_partitions $vdev
+	done
 
+	poolexists $pool && destroy_pool $pool
 	create_pool $pool $@
 	destroy_pool $pool
 

--- a/tests/zfs-tests/tests/functional/inuse/inuse_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_008_pos.ksh
@@ -107,7 +107,6 @@ while (( i < ${#vdevs[*]} )); do
 	create_pool $TESTPOOL1 ${vdevs[i]} $vslices spare $sslices
 	log_must zpool export $TESTPOOL1
 	verify_assertion "$rawtargets"
-	cleanup_devices $vslices $sslices
 
 	(( i = i + 1 ))
 done


### PR DESCRIPTION
### Motivation and Context

The updated version of libblkid (version 2.34-4) used in Fedora 31
results in `zpool import` failures when running the ZTS because a
pool cannot be found.  This is due to stale partition tables left on
the loopback devices during cleanup, which results in `blkid`
misidentifying which devices contain pool members.

### Description

The cleanup_devices function should remove any partitions created
on the device and force the partition table to be reread.  This
is needed to ensure that blkid has an up to date version of what
devices and partitions are used by zfs.

### How Has This Been Tested?

Locally ran the section of the ZTS where test failures were observed.
Submitting to the CI for a full test run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
