### PR TITLE
ZTS: Create xattr helpers to hide platform

### DIFF
--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -115,13 +115,17 @@ export SYSTEM_FILES_FREEBSD='chflags
     compress
     dumpon
     fsck
+    getextattr
     gpart
+    lsextattr
     md5
     mdconfig
     mkfifo
     newfs
     pw
     random
+    rmextattr
+    setextattr
     sha256
     swapctl
     sysctl

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3949,3 +3949,82 @@ function range_shuffle # begin end
 		shuf -i ${begin}-${end}
 	fi
 }
+
+#
+# Cross-platform xattr helpers
+#
+
+function get_xattr # name path
+{
+	typeset name=$1
+	typeset path=$2
+
+	case $(uname) in
+	FreeBSD)
+		getextattr -qq user "${name}" "${path}"
+		;;
+	*)
+		attr -qg "${name}" "${path}"
+		;;
+	esac
+}
+
+function set_xattr # name value path
+{
+	typeset name=$1
+	typeset value=$2
+	typeset path=$3
+
+	case $(uname) in
+	FreeBSD)
+		setextattr user "${name}" "${value}" "${path}"
+		;;
+	*)
+		attr -qs "${name}" -V "${value}" "${path}"
+		;;
+	esac
+}
+
+function set_xattr_stdin # name value
+{
+	typeset name=$1
+	typeset path=$2
+
+	case $(uname) in
+	FreeBSD)
+		setextattr -i user "${name}" "${path}"
+		;;
+	*)
+		attr -qs "${name}" "${path}"
+		;;
+	esac
+}
+
+function rm_xattr # name path
+{
+	typeset name=$1
+	typeset path=$2
+
+	case $(uname) in
+	FreeBSD)
+		rmextattr -q user "${name}" "${path}"
+		;;
+	*)
+		attr -qr "${name}" "${path}"
+		;;
+	esac
+}
+
+function ls_xattr # path
+{
+	typeset path=$1
+
+	case $(uname) in
+	FreeBSD)
+		lsextattr -qq user "${path}"
+		;;
+	*)
+		attr -ql "${path}"
+		;;
+	esac
+}

--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -517,10 +517,9 @@ function churn_files
 				attrlen="$(((RANDOM % 1000) + 1))"
 				attrvalue="$(random_string VALID_NAME_CHAR \
 				    $attrlen)"
-				attr -qr $attrname $file_name || \
+				rm_xattr $attrname $file_name || \
 				    log_fail "Failed to remove $attrname"
-				attr -qs $attrname \
-				    -V "$attrvalue" $file_name || \
+				set_xattr $attrname "$attrvalue" $file_name || \
 				    log_fail "Failed to set $attrname"
 			elif [ $value -eq 1 ]; then
 				dd if=/dev/urandom of=$file_name \
@@ -551,8 +550,8 @@ function churn_files
 					attrlen="$(((RANDOM % 1000) + 1))"
 					attrvalue="$(random_string \
 					    VALID_NAME_CHAR $attrlen)"
-					attr -qs $attrname \
-					    -V "$attrvalue" $file_name || \
+					set_xattr $attrname \
+					    "$attrvalue" $file_name || \
 					    log_fail "Failed to set $attrname"
 				done
 			fi

--- a/tests/zfs-tests/tests/functional/rsend/send_encrypted_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_encrypted_files.ksh
@@ -88,7 +88,7 @@ log_must xattrtest -f 10 -x 3 -s 32768 -r -k -p /$TESTPOOL/$TESTFS2/xattrsadir
 log_must zfs set compression=on xattr=sa $TESTPOOL/$TESTFS2
 log_must touch /$TESTPOOL/$TESTFS2/attrs
 log_must eval "python -c 'print \"a\" * 4096' | \
-	attr -s bigval /$TESTPOOL/$TESTFS2/attrs"
+	set_xattr_stdin bigval /$TESTPOOL/$TESTFS2/attrs"
 log_must zfs set compression=off xattr=on $TESTPOOL/$TESTFS2
 
 log_must zfs snapshot $TESTPOOL/$TESTFS2@snap1

--- a/tests/zfs-tests/tests/functional/rsend/send_realloc_dnode_size.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_realloc_dnode_size.ksh
@@ -93,7 +93,8 @@ log_must zfs snapshot $POOL/fs@c
 # 4. Create an empty file and add xattrs to it to exercise reclaiming a
 #    dnode that requires more than 1 slot for its bonus buffer (Zol #7433)
 log_must zfs set compression=on xattr=sa $POOL/fs
-log_must eval "python -c 'print \"a\" * 512' | attr -s bigval /$POOL/fs/attrs"
+log_must eval "python -c 'print \"a\" * 512' |
+    set_xattr_stdin bigval /$POOL/fs/attrs"
 log_must zfs snapshot $POOL/fs@d
 
 # 5. Generate initial and incremental streams

--- a/tests/zfs-tests/tests/functional/rsend/send_spill_block.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_spill_block.ksh
@@ -59,7 +59,7 @@ for i in {1..40}; do
 
 	log_must mkfile 16384 $file
 	for j in {1..20}; do
-		log_must attr -qs "testattr$j" -V "$attrvalue" $file
+		log_must set_xattr "testattr$j" "$attrvalue" $file
 	done
 done
 
@@ -103,7 +103,7 @@ log_must truncate -s 1073741824 /$POOL/fs/file15
 log_must truncate -s 50 /$POOL/fs/file16
 
 for i in {11..20}; do
-	log_must attr -qr testattr1 /$POOL/fs/file$i
+	log_must rm_xattr testattr1 /$POOL/fs/file$i
 done
 
 #
@@ -125,7 +125,7 @@ log_must truncate -s 50 /$POOL/fs/file26
 
 for i in {21..30}; do
 	for j in {1..20}; do
-		log_must attr -qr testattr$j /$POOL/fs/file$i
+		log_must rm_xattr testattr$j /$POOL/fs/file$i
 	done
 done
 
@@ -134,8 +134,8 @@ done
 #
 for i in {31..40}; do
 	file="/$POOL/fs/file$i"
-	log_must attr -qr testattr$(((RANDOM % 20) + 1)) $file
-	log_must attr -qs testattr$(((RANDOM % 20) + 1)) -V "$attrvalue" $file
+	log_must rm_xattr testattr$(((RANDOM % 20) + 1)) $file
+	log_must set_xattr testattr$(((RANDOM % 20) + 1)) "$attrvalue" $file
 done
 
 # Calculate the expected recursive checksum for the source.

--- a/tests/zfs-tests/tests/functional/slog/slog_replay_fs_001.ksh
+++ b/tests/zfs-tests/tests/functional/slog/slog_replay_fs_001.ksh
@@ -151,23 +151,13 @@ log_must dd if=/dev/zero of=/$TESTPOOL/$TESTFS/holes.3 bs=128k count=2 \
 # TX_MKXATTR
 log_must mkdir /$TESTPOOL/$TESTFS/xattr.dir
 log_must touch /$TESTPOOL/$TESTFS/xattr.file
-if is_freebsd; then
-	log_must setextattr -q user fileattr HelloWorld /$TESTPOOL/$TESTFS/xattr.dir
-	log_must setextattr -q user tmpattr HelloWorld /$TESTPOOL/$TESTFS/xattr.dir
-	log_must rmextattr -q user fileattr /$TESTPOOL/$TESTFS/xattr.dir
+log_must set_xattr fileattr HelloWorld /$TESTPOOL/$TESTFS/xattr.dir
+log_must set_xattr tmpattr HelloWorld /$TESTPOOL/$TESTFS/xattr.dir
+log_must rm_xattr fileattr /$TESTPOOL/$TESTFS/xattr.dir
 
-	log_must setextattr -q user fileattr HelloWorld /$TESTPOOL/$TESTFS/xattr.file
-	log_must setextattr -q user tmpattr HelloWorld /$TESTPOOL/$TESTFS/xattr.file
-	log_must rmextattr -q user tmpattr /$TESTPOOL/$TESTFS/xattr.file
-elif is_linux; then
-	log_must attr -qs fileattr -V HelloWorld /$TESTPOOL/$TESTFS/xattr.dir
-	log_must attr -qs tmpattr -V HelloWorld /$TESTPOOL/$TESTFS/xattr.dir
-	log_must attr -qr tmpattr /$TESTPOOL/$TESTFS/xattr.dir
-
-	log_must attr -qs fileattr -V HelloWorld /$TESTPOOL/$TESTFS/xattr.file
-	log_must attr -qs tmpattr -V HelloWorld /$TESTPOOL/$TESTFS/xattr.file
-	log_must attr -qr tmpattr /$TESTPOOL/$TESTFS/xattr.file
-fi
+log_must set_xattr fileattr HelloWorld /$TESTPOOL/$TESTFS/xattr.file
+log_must set_xattr tmpattr HelloWorld /$TESTPOOL/$TESTFS/xattr.file
+log_must rm_xattr tmpattr /$TESTPOOL/$TESTFS/xattr.file
 
 # TX_WRITE, TX_LINK, TX_REMOVE
 # Make sure TX_REMOVE won't affect TX_WRITE if file is not destroyed
@@ -211,13 +201,8 @@ log_note "Verify current block usage:"
 log_must zdb -bcv $TESTPOOL
 
 log_note "Verify copy of xattrs:"
-if is_freebsd; then
-	log_must lsextattr -s /$TESTPOOL/$TESTFS/xattr.dir
-	log_must lsextattr -s /$TESTPOOL/$TESTFS/xattr.file
-elif is_linux; then
-	log_must attr -l /$TESTPOOL/$TESTFS/xattr.dir
-	log_must attr -l /$TESTPOOL/$TESTFS/xattr.file
-fi
+log_must ls_xattr /$TESTPOOL/$TESTFS/xattr.dir
+log_must ls_xattr /$TESTPOOL/$TESTFS/xattr.file
 
 log_note "Verify working set diff:"
 log_must diff -r /$TESTPOOL/$TESTFS $TESTDIR/copy

--- a/tests/zfs-tests/tests/functional/xattr/xattr_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_003_neg.ksh
@@ -58,14 +58,14 @@ create_xattr $TESTDIR/myfile.$$ passwd /etc/passwd
 log_must chmod 000 $TESTDIR/myfile.$$
 if is_linux; then
 	user_run $ZFS_USER eval \
-	    "attr -q -g passwd $TESTDIR/myfile.$$ >/tmp/passwd.$$"
+	    "get_xattr passwd $TESTDIR/myfile.$$ >/tmp/passwd.$$"
 	log_mustnot diff /etc/passwd /tmp/passwd.$$
 	log_must rm /tmp/passwd.$$
 
 	user_run $ZFS_USER eval \
-	    "attr -q -s passwd $TESTDIR/myfile.$$ </etc/group"
+	    "set_xattr_stdin passwd $TESTDIR/myfile.$$ </etc/group"
 	log_must chmod 644 $TESTDIR/myfile.$$
-	attr -q -g passwd $TESTDIR/myfile.$$ >/tmp/passwd.$$
+	get_xattr passwd $TESTDIR/myfile.$$ >/tmp/passwd.$$
 	log_must diff /etc/passwd /tmp/passwd.$$
 	log_must rm /tmp/passwd.$$
 else

--- a/tests/zfs-tests/tests/functional/xattr/xattr_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_004_pos.ksh
@@ -74,9 +74,9 @@ if is_linux; then
 	log_must touch /tmp/tmpfs-file.$$
 	echo "TEST XATTR" >/tmp/xattr1
 	echo "1234567890" >/tmp/xattr2
-	log_must attr -q -s xattr1 \
+	log_must set_xattr_stdin xattr1 \
 	    /tmp/$NEWFS_DEFAULT_FS.$$/$NEWFS_DEFAULT_FS-file.$$ </tmp/xattr1
-	log_must attr -q -s xattr2 /tmp/tmpfs-file.$$ </tmp/xattr2
+	log_must set_xattr_stdin xattr2 /tmp/tmpfs-file.$$ </tmp/xattr2
 
 	# copy those files to ZFS
 	log_must cp -a /tmp/$NEWFS_DEFAULT_FS.$$/$NEWFS_DEFAULT_FS-file.$$ \
@@ -84,11 +84,11 @@ if is_linux; then
 	log_must cp -a /tmp/tmpfs-file.$$ $TESTDIR
 
 	# ensure the xattr information has been copied correctly
-	log_must eval "attr -q -g xattr1 $TESTDIR/$NEWFS_DEFAULT_FS-file.$$ \
+	log_must eval "get_xattr xattr1 $TESTDIR/$NEWFS_DEFAULT_FS-file.$$ \
 	    >/tmp/xattr1.$$"
 
 	log_must diff /tmp/xattr1.$$ /tmp/xattr1
-	log_must eval "attr -q -g xattr2 $TESTDIR/tmpfs-file.$$ >/tmp/xattr2.$$"
+	log_must eval "get_xattr xattr2 $TESTDIR/tmpfs-file.$$ >/tmp/xattr2.$$"
 	log_must diff /tmp/xattr2.$$ /tmp/xattr2
 	log_must rm /tmp/xattr1 /tmp/xattr1.$$ /tmp/xattr2 /tmp/xattr2.$$
 

--- a/tests/zfs-tests/tests/functional/xattr/xattr_007_neg.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_007_neg.ksh
@@ -52,7 +52,6 @@ function cleanup {
 	log_must rm $TEST_BASE_DIR/output.$$
 	[[ -e $TEST_BASE_DIR/expected_output.$$ ]]  && log_must rm  \
 	$TEST_BASE_DIR/expected_output.$$
-
 }
 
 log_assert "create/write xattr on a snapshot fails"
@@ -70,12 +69,12 @@ log_must zfs snapshot $TESTPOOL/$TESTFS@snap
 
 # we shouldn't be able to alter the first file's xattr
 if is_linux; then
-	log_mustnot eval "attr -s cp $TESTDIR/.zfs/snapshot/snap/myfile.$$ \
+	log_mustnot eval "set_xattr_stdin cp $TESTDIR/.zfs/snapshot/snap/myfile.$$ \
 	     </etc/passwd  > $TEST_BASE_DIR/output.$$  2>&1"
 	log_must grep  -i  Read-only  $TEST_BASE_DIR/output.$$
-	log_must eval "attr -q -l $TESTDIR/.zfs/snapshot/snap/myfile2.$$ \
+	log_must eval "ls_xattr $TESTDIR/.zfs/snapshot/snap/myfile2.$$ \
 	    > $TEST_BASE_DIR/output.$$  2>&1"
-	log_must eval "attr -q -l $TESTDIR/myfile2.$$ > $TEST_BASE_DIR/expected_output.$$"
+	log_must eval "ls_xattr $TESTDIR/myfile2.$$ > $TEST_BASE_DIR/expected_output.$$"
 else
 	log_mustnot eval " runat $TESTDIR/.zfs/snapshot/snap/myfile.$$ \
 	    cp /etc/passwd .  > $TEST_BASE_DIR/output.$$  2>&1"

--- a/tests/zfs-tests/tests/functional/xattr/xattr_011_pos.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_011_pos.ksh
@@ -102,7 +102,7 @@ if is_linux; then
 
 	# without the right flag, there should be no xattr
 	log_must cp $TESTDIR/myfile.$$ $TESTDIR/myfile2.$$
-	log_mustnot attr -q -g passwd $TESTDIR/myfile2.$$
+	log_mustnot get_xattr passwd $TESTDIR/myfile2.$$
 	log_must rm $TESTDIR/myfile2.$$
 else
 	log_must cp -@ $TESTDIR/myfile.$$ $TESTDIR/myfile2.$$
@@ -187,7 +187,7 @@ if is_linux; then
 
 	# we should have no xattr here
 	log_must tar --no-xattrs -xf xattr.tar
-	log_mustnot attr -q -g passwd $TESTDIR/tar.$$
+	log_mustnot get_xattr passwd $TESTDIR/tar.$$
 	log_must rm $TESTDIR/tar.$$
 
 	# we should have an xattr here
@@ -197,12 +197,12 @@ if is_linux; then
 
 	# we should have no xattr here
 	log_must tar --no-xattrs -xf $TESTDIR/noxattr.tar
-	log_mustnot attr -q -g passwd $TESTDIR/tar.$$
+	log_mustnot get_xattr passwd $TESTDIR/tar.$$
 	log_must rm $TESTDIR/tar.$$
 
 	# we should have no xattr here
 	log_must tar --xattrs -xf $TESTDIR/noxattr.tar
-	log_mustnot attr -q -g passwd $TESTDIR/tar.$$
+	log_mustnot get_xattr passwd $TESTDIR/tar.$$
 	log_must rm $TESTDIR/tar.$$ $TESTDIR/noxattr.tar $TESTDIR/xattr.tar
 else
 	log_must touch $TESTDIR/tar.$$

--- a/tests/zfs-tests/tests/functional/xattr/xattr_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_013_pos.ksh
@@ -66,13 +66,13 @@ log_must zfs mount -o noxattr $TESTPOOL/$TESTFS
 
 # check that we can't perform xattr operations
 if is_linux; then
-	log_mustnot attr -q -g passwd $TESTDIR/myfile.$$
-	log_mustnot attr -q -r passwd $TESTDIR/myfile.$$
-	log_mustnot attr -q -s passwd $TESTDIR/myfile.$$ </etc/passwd
+	log_mustnot get_xattr passwd $TESTDIR/myfile.$$
+	log_mustnot rm_xattr passwd $TESTDIR/myfile.$$
+	log_mustnot set_xattr_stdin passwd $TESTDIR/myfile.$$ </etc/passwd
 
 	log_must touch $TESTDIR/new.$$
-	log_mustnot attr -q -s passwd $TESTDIR/new.$$ </etc/passwd
-	log_mustnot attr -q -r passwd $TESTDIR/new.$$
+	log_mustnot set_xattr_stdin passwd $TESTDIR/new.$$ </etc/passwd
+	log_mustnot rm_xattr passwd $TESTDIR/new.$$
 else
 	log_mustnot eval "runat $TESTDIR/myfile.$$ cat passwd > /dev/null 2>&1"
 	log_mustnot eval "runat $TESTDIR/myfile.$$ rm passwd > /dev/null 2>&1"
@@ -95,7 +95,7 @@ verify_xattr $TESTDIR/myfile.$$ passwd /etc/passwd
 # there should be no xattr on the file we created while the fs was mounted
 # -o noxattr
 if is_linux; then
-	log_mustnot attr -q -g passwd $TESTDIR/new.$$
+	log_mustnot get_xattr passwd $TESTDIR/new.$$
 else
 	log_mustnot eval "runat $TESTDIR/new.$$ cat passwd > /dev/null 2>&1"
 fi

--- a/tests/zfs-tests/tests/functional/xattr/xattr_common.kshlib
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_common.kshlib
@@ -40,8 +40,8 @@ function create_xattr { # filename xattr_name xattr_contents
 	typeset XATTR_CONTENTS=$3
 
 	if is_linux; then
-		log_mustnot attr -q -g $XATTR_NAME $FILE
-		log_must attr -q -s $XATTR_NAME $FILE < $XATTR_CONTENTS
+		log_mustnot get_xattr $XATTR_NAME $FILE
+		log_must set_xattr_stdin $XATTR_NAME $FILE < $XATTR_CONTENTS
 	else
 		# read any empty xattr on that file
 		log_must runat $FILE ls
@@ -60,8 +60,8 @@ function compare_xattrs { # filename1 filename2 xattr_name
 	typeset XATTR_NAME=$3
 
 	if is_linux; then
-		attr -q -g $XATTR_NAME $FILE1 > $TEST_BASE_DIR/file1.$$
-		attr -q -g $XATTR_NAME $FILE2 > $TEST_BASE_DIR/file2.$$
+		get_xattr $XATTR_NAME $FILE1 > $TEST_BASE_DIR/file1.$$
+		get_xattr $XATTR_NAME $FILE2 > $TEST_BASE_DIR/file2.$$
 	else
 		runat $FILE1 cat $XATTR_NAME > $TEST_BASE_DIR/file1.$$
 		runat $FILE2 cat $XATTR_NAME > $TEST_BASE_DIR/file2.$$
@@ -79,7 +79,7 @@ function verify_xattr { # filename xattr_name xattr_contents
 	# read the xattr, writing it to a temp file
 	if is_linux; then
 		log_must eval \
-		    "attr -q -g $XATTR_NAME $FILE > $TEST_BASE_DIR/$XATTR_NAME.$$"
+		    "get_xattr $XATTR_NAME $FILE > $TEST_BASE_DIR/$XATTR_NAME.$$"
 	else
 		log_must eval \
 		    "runat $FILE cat $XATTR_NAME > $TEST_BASE_DIR/$XATTR_NAME.$$ 2>&1"
@@ -95,8 +95,8 @@ function delete_xattr { # filename xattr_name
 
         # delete the xattr
         if is_linux; then
-		log_must attr -r $XATTR_NAME $FILE
-		log_mustnot attr -q -g $XATTR_NAME $FILE
+		log_must rm_xattr $XATTR_NAME $FILE
+		log_mustnot get_xattr $XATTR_NAME $FILE
 	else
 	        log_must runat $FILE rm $XATTR_NAME
 	        log_mustnot eval "runat $FILE ls $XATTR_NAME > /dev/null 2>&1"
@@ -109,9 +109,9 @@ function verify_write_xattr { # filename xattr_name
         typeset XATTR_NAME=$2
 
 	if is_linux; then
-                log_must attr -q -s $XATTR_NAME $FILE < /etc/passwd
+                log_must set_xattr_stdin $XATTR_NAME $FILE < /etc/passwd
 		log_must eval \
-		    "attr -q -g $XATTR_NAME $FILE > $TEST_BASE_DIR/$XATTR_NAME.$$"
+		    "get_xattr $XATTR_NAME $FILE > $TEST_BASE_DIR/$XATTR_NAME.$$"
 	else
 	        log_must eval "runat $FILE dd if=/etc/passwd of=$XATTR_NAME"
 	        log_must eval \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Linux and FreeBSD have different utilities for manipulating extended attributes on files.

### Description
<!--- Describe your changes in detail -->
Create wrapper functions for the xattr manipulation with the appropriate implementations for FreeBSD and Linux.
Update tests to use the new wrappers.

This does not generally aim to enable all xattr tests for FreeBSD yet, but it is a necessary step in that direction.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Ran ZTS on FreeBSD, Linux run pending.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
