### PR TITLE
libzfs: add zfs_mount_at() function

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -788,6 +788,7 @@ extern boolean_t zfs_bookmark_exists(const char *path);
 extern boolean_t is_mounted(libzfs_handle_t *, const char *special, char **);
 extern boolean_t zfs_is_mounted(zfs_handle_t *, char **);
 extern int zfs_mount(zfs_handle_t *, const char *, int);
+extern int zfs_mount_at(zfs_handle_t *, const char *, int, const char *);
 extern int zfs_unmount(zfs_handle_t *, const char *, int);
 extern int zfs_unmountall(zfs_handle_t *, int);
 


### PR DESCRIPTION

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

`zfs_mount_at` will be used by FreeBSD's libbe to transition away from directly using `zmount`.

### Description

This adds the capability for libzfs consumers to mount a dataset at an arbitrary mountpoint without resorting to digging deeper into libzfs internals to use hidden OS-specific mounting interfaces, and to do so without modifying dataset/pool properties to achieve the desired effect.

### How Has This Been Tested?

Replaced libbe's zmount() with zfs_mount_at() in our local zfs; diff is similar enough that I wouldn't anticipate any issues in the transition here.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

I'm not entirely sure where one would find libzfs documentation, given the nature of it. Also unsure of where one would add tests for it, but given that this just pulls the 'grab mountpoint 'part out into zfs_mount() and doesn't functionally change much- I guess the test coverage doesn't drop all that much.