### PR TITLE
ZTS: Clean up properties.shlib a bit

### DIFF
--- a/tests/zfs-tests/include/properties.shlib
+++ b/tests/zfs-tests/include/properties.shlib
@@ -34,47 +34,54 @@ typeset -a vol_props=('compress' 'checksum' 'copies' 'logbias' 'primarycache'
     'secondarycache' 'redundant_metadata' 'sync')
 
 #
-# Given the property array passed in, return 'num_props' elements to the
-# user, excluding any elements below 'start.' This allows us to exclude
-# 'off' and 'on' which can be either unwanted, or a duplicate of another
-# property respectively.
+# Given the 'prop' passed in, return 'num_vals' elements of the corresponding
+# values array to the user, excluding any elements below 'first.' This allows
+# us to exclude 'off' and 'on' which can be either unwanted, or a duplicate of
+# another property respectively.
 #
-function get_rand_prop
+function get_rand_prop_vals
 {
-	typeset prop_array=($(eval echo \${$1[@]}))
-	typeset -i num_props=$2
-	typeset -i start=$3
+	typeset prop=$1
+	typeset -i num_vals=$2
+	typeset -i first=$3
+
+	[[ -z $prop || -z $num_vals || -z $first ]] && \
+	    log_fail "get_rand_prop_vals: bad arguments"
+
 	typeset retstr=""
 
-	[[ -z $prop_array || -z $num_props || -z $start ]] && \
-	    log_fail "get_rand_prop: bad arguments"
+	typeset prop_vals_var=${prop}_prop_vals
+	typeset -a prop_vals=($(eval echo \${${prop_vals_var}[@]}))
 
-	typeset prop_max=$((${#prop_array[@]} - 1))
+	[[ -z $prop_vals ]] && \
+	    log_fail "get_rand_prop_vals: bad prop $prop"
+
+	typeset -i last=$((${#prop_vals[@]} - 1))
 	typeset -i i
-	for i in $(range_shuffle $start $prop_max | head -n $num_props); do
-		retstr="${prop_array[$i]} $retstr"
+	for i in $(range_shuffle $first $last | head -n $num_vals); do
+		retstr="${prop_vals[$i]} $retstr"
 	done
 	echo $retstr
 }
 
 function get_rand_checksum
 {
-	get_rand_prop checksum_prop_vals $1 2
+	get_rand_prop_vals checksum $1 2
 }
 
 function get_rand_checksum_any
 {
-	get_rand_prop checksum_prop_vals $1 0
+	get_rand_prop_vals checksum $1 0
 }
 
 function get_rand_recsize
 {
-	get_rand_prop recsize_prop_vals $1 0
+	get_rand_prop_vals recsize $1 0
 }
 
 function get_rand_large_recsize
 {
-	get_rand_prop recsize_prop_vals $1 9
+	get_rand_prop_vals recsize $1 9
 }
 
 #
@@ -137,7 +144,7 @@ function randomize_ds_props
 	fi
 
 	for prop in $proplist; do
-		typeset val=$(get_rand_prop "${prop}_prop_vals" 1 0)
+		typeset val=$(get_rand_prop_vals $prop 1 0)
 		log_must zfs set $prop=$val $ds
 	done
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We encountered an issue in ZTS on FreeBSD where we were attempting to set an empty value for a property sometimes.
In debugging this issue, I attempted to consolidate the complexity of properties.shlib a bit to make easier to follow, which coincidentally seems to have made the issue go away.

### Description
<!--- Describe your changes in detail -->
* Change the interface of `get_rand_prop` from taking the name of a prop vals array to instead take the name of a prop.
* Rename `get_rand_prop` to `get_rand_prop_vals` so it is clear you are getting random values for the given property, not getting a random property.
* Add what amounts to type annotations (`typeset -i`) for a few variables in `get_rand_prop_vals`.
* Rename some variables in `get_rand_prop_vals` for clarity.
* Adjust comment to reflect changes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
This has been run through dozens of passes of ZTS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
