### PR TITLE
ZTS: Remove some path workarounds for FreeBSD

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_004_pos.ksh
@@ -40,12 +40,12 @@ function cleanup
 	for DISK in $DISKS; do
 		zpool labelclear -f $DEV_RDSKDIR/$DISK
 	done
-	if is_freebsd ; then
+	if is_freebsd; then
 		log_must sysctl kern.geom.debugflags=$saved_debugflags
 	fi
 }
 
-if is_freebsd ; then
+if is_freebsd; then
 	# FreeBSD won't allow writing to an in-use device without this set
 	saved_debugflags=$(sysctl -n kern.geom.debugflags)
 	log_must sysctl kern.geom.debugflags=16
@@ -54,32 +54,21 @@ fi
 verify_runnable "global"
 verify_disk_count "$DISKS" 2
 set -A DISK $DISKS
-if is_freebsd ; then
-	WHOLE_DISK=/dev/${DISK[0]}
-else
-	WHOLE_DISK=${DISK[0]}
-fi
 
 default_mirror_setup_noexit $DISKS
 DEVS=$(get_pool_devices ${TESTPOOL} ${DEV_RDSKDIR})
 [[ -n $DEVS ]] && set -A DISK $DEVS
 
-log_must zpool offline $TESTPOOL ${WHOLE_DISK}
+log_must zpool offline $TESTPOOL ${DISK[0]}
 log_must dd if=/dev/urandom of=$TESTDIR/testfile bs=1K count=2
 log_must zpool export $TESTPOOL
 
 log_must dd if=$DEV_RDSKDIR/${DISK[0]} of=$DEV_RDSKDIR/${DISK[1]} bs=1K count=256 conv=notrunc
 
-if is_freebsd; then
-	DISK1="/dev/${DISK[1]}"
-else
-	DISK1="${DISK[1]}"
-fi
-
-ubs=$(zdb -lu ${DISK1} | grep -e LABEL -e Uberblock -e 'labels = ')
+ubs=$(zdb -lu ${DISK[1]} | grep -e LABEL -e Uberblock -e 'labels = ')
 log_note "vdev 1: ubs $ubs"
 
-ub_dump_counts=$(zdb -lu ${DISK1} | \
+ub_dump_counts=$(zdb -lu ${DISK[1]} | \
 	awk '	/LABEL/	{label=$NF; blocks[label]=0};
 		/Uberblock/ {blocks[label]++};
 		END {print blocks[0],blocks[1],blocks[2],blocks[3]}')


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These are no longer needed after fixing device name matching for whole disks in libzutil on FreeBSD.

### Description
<!--- Describe your changes in detail -->
Remove special cases that prepend /dev to device names in zdb_004_pos.ksh

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Many ZTS runs on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
