### PR TITLE
ZTS: Fix incorrect is_physical_device usage

### DIFF
--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -260,7 +260,7 @@ function get_device_dir #device
 {
 	typeset device=$1
 
-	if ! is_freebsd && ! $(is_physical_device $device) ; then
+	if ! is_freebsd && ! is_physical_device $device; then
 		if [[ $device != "/" ]]; then
 			device=${device%/*}
 		fi

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/setup.ksh
@@ -34,7 +34,7 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $DISKS) ; then
+if ! is_physical_device $DISKS; then
 	log_unsupported "This directory cannot be run on raw files."
 fi
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/setup.ksh
@@ -34,7 +34,7 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $DISKS) ; then
+if ! is_physical_device $DISKS; then
 	log_unsupported "This directory cannot be run on raw files."
 fi
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh
@@ -61,7 +61,7 @@ function cleanup
 
 set -A datasets "$TESTPOOL" "$TESTPOOL2"
 
-if ! $(is_physical_device $DISKS) ; then
+if ! is_physical_device $DISKS; then
 	log_unsupported "This case cannot be run on raw files."
 fi
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/setup.ksh
@@ -30,7 +30,7 @@
 
 DISK=${DISKS%% *}
 
-if ! $(is_physical_device $DISK) ; then
+if ! is_physical_device $DISK; then
 	log_unsupported "Only partitionable physical disks can be used"
 fi
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/setup.ksh
@@ -35,7 +35,7 @@
 verify_runnable "global"
 verify_disk_count "$DISKS" 2
 
-if ! $(is_physical_device $ZFS_DISK1) ; then
+if ! is_physical_device $ZFS_DISK1; then
 	log_unsupported "Only partitionable physical disks can be used"
 fi
 

--- a/tests/zfs-tests/tests/functional/write_dirs/setup.ksh
+++ b/tests/zfs-tests/tests/functional/write_dirs/setup.ksh
@@ -34,7 +34,7 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $DISKS) ; then
+if ! is_physical_device $DISKS; then
 	log_unsupported "This directory cannot be run on raw files."
 fi
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_001_neg.ksh
@@ -45,7 +45,7 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $DISKS) ; then
+if ! is_physical_device $DISKS; then
 	log_unsupported "This directory cannot be run on raw files."
 fi
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
@@ -46,7 +46,7 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $DISKS) ; then
+if ! is_physical_device $DISKS; then
 	log_unsupported "This directory cannot be run on raw files."
 fi
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_004_pos.ksh
@@ -45,7 +45,7 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $DISKS) ; then
+if ! is_physical_device $DISKS; then
 	log_unsupported "This directory cannot be run on raw files."
 fi
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_005_neg.ksh
@@ -45,7 +45,7 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $DISKS) ; then
+if ! is_physical_device $DISKS; then
 	log_unsupported "This directory cannot be run on raw files."
 fi
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_006_pos.ksh
@@ -45,7 +45,7 @@
 
 verify_runnable "global"
 
-if ! $(is_physical_device $DISKS) ; then
+if ! is_physical_device $DISKS; then
 	log_unsupported "This directory cannot be run on raw files."
 fi
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `is_physical_device` check function isn't meant to be used with command substitution.

### Description
<!--- Describe your changes in detail -->
Invoke the check directly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
A few runs of ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
