### PR TITLE
Unify target_cpu handling

### DIFF
--- a/config/always-arch.m4
+++ b/config/always-arch.m4
@@ -1,22 +1,41 @@
 dnl #
-dnl # Set the target arch for libspl atomic implementation and the icp
+dnl # Set the target cpu architecture.  This allows the
+dnl # following syntax to be used in a Makefile.am.
+dnl #
+dnl # ifeq ($(TARGET_CPU),x86_64)
+dnl # ...
+dnl # endif
+dnl #
+dnl # if TARGET_CPU_POWERPC
+dnl # ...
+dnl # else
+dnl # ...
+dnl # endif
 dnl #
 AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_ARCH], [
-	AC_MSG_CHECKING(for target asm dir)
-	TARGET_ARCH=`echo ${target_cpu} | sed -e s/i.86/i386/`
-
-	case $TARGET_ARCH in
-	i386|x86_64)
-		TARGET_ASM_DIR=asm-${TARGET_ARCH}
+	case $target_cpu in
+	i?86)
+		TARGET_CPU=i386
 		;;
-	*)
-		TARGET_ASM_DIR=asm-generic
+	x86_64)
+		TARGET_CPU=x86_64
+		;;
+	powerpc*)
+		TARGET_CPU=powerpc
+		;;
+	aarch64*)
+		TARGET_CPU=aarch64
+		;;
+	sparc64)
+		TARGET_CPU=sparc64
 		;;
 	esac
 
-	AC_SUBST([TARGET_ASM_DIR])
-	AM_CONDITIONAL([TARGET_ASM_X86_64], test $TARGET_ASM_DIR = asm-x86_64)
-	AM_CONDITIONAL([TARGET_ASM_I386], test $TARGET_ASM_DIR = asm-i386)
-	AM_CONDITIONAL([TARGET_ASM_GENERIC], test $TARGET_ASM_DIR = asm-generic)
-	AC_MSG_RESULT([$TARGET_ASM_DIR])
+	AC_SUBST(TARGET_CPU)
+
+	AM_CONDITIONAL([TARGET_CPU_I386], test $TARGET_CPU = i386)
+	AM_CONDITIONAL([TARGET_CPU_X86_64], test $TARGET_CPU = x86_64)
+	AM_CONDITIONAL([TARGET_CPU_POWERPC], test $TARGET_CPU = powerpc)
+	AM_CONDITIONAL([TARGET_CPU_AARCH64], test $TARGET_CPU = aarch64)
+	AM_CONDITIONAL([TARGET_CPU_SPARC64], test $TARGET_CPU = sparc64)
 ])

--- a/lib/libicp/Makefile.am
+++ b/lib/libicp/Makefile.am
@@ -9,7 +9,7 @@ AM_CFLAGS += $(FRAME_LARGER_THAN)
 
 noinst_LTLIBRARIES = libicp.la
 
-if TARGET_ASM_X86_64
+if TARGET_CPU_X86_64
 ASM_SOURCES_C = asm-x86_64/aes/aeskey.c
 ASM_SOURCES_AS = \
 	asm-x86_64/aes/aes_amd64.S \
@@ -18,21 +18,10 @@ ASM_SOURCES_AS = \
 	asm-x86_64/sha1/sha1-x86_64.S \
 	asm-x86_64/sha2/sha256_impl.S \
 	asm-x86_64/sha2/sha512_impl.S
-endif
-
-if TARGET_ASM_I386
+else
 ASM_SOURCES_C =
 ASM_SOURCES_AS =
 endif
-
-if TARGET_ASM_GENERIC
-ASM_SOURCES_C =
-ASM_SOURCES_AS =
-endif
-
-USER_C =
-
-USER_ASM =
 
 KERNEL_C = \
 	spi/kcf_spi.c \
@@ -78,8 +67,6 @@ KERNEL_C = \
 KERNEL_ASM = $(ASM_SOURCES_AS)
 
 nodist_libicp_la_SOURCES = \
-	$(USER_C) \
-	$(USER_ASM) \
 	$(KERNEL_C) \
 	$(KERNEL_ASM)
 

--- a/lib/libspl/Makefile.am
+++ b/lib/libspl/Makefile.am
@@ -1,10 +1,20 @@
 include $(top_srcdir)/config/Rules.am
 
+if TARGET_CPU_I386
+TARGET_CPU_DIR = asm-i386
+else
+if TARGET_CPU_X86_64
+TARGET_CPU_DIR = asm-x86_64
+else
+TARGET_CPU_DIR = asm-generic
+endif
+endif
+
 VPATH = \
 	$(top_srcdir)/lib/libspl \
-	$(top_srcdir)/lib/libspl/$(TARGET_ASM_DIR)
+	$(top_srcdir)/lib/libspl/$(TARGET_CPU_DIR)
 
-SUBDIRS = include $(TARGET_ASM_DIR)
+SUBDIRS = include $(TARGET_CPU_DIR)
 DIST_SUBDIRS = include asm-generic asm-i386 asm-x86_64
 
 AM_CFLAGS += $(LIBTIRPC_CFLAGS)

--- a/lib/libspl/asm-generic/.gitignore
+++ b/lib/libspl/asm-generic/.gitignore
@@ -1,0 +1,1 @@
+/atomic.S

--- a/module/icp/Makefile.in
+++ b/module/icp/Makefile.in
@@ -3,26 +3,6 @@ obj = @abs_builddir@
 
 MODULE := icp
 
-TARGET_ASM_DIR = @TARGET_ASM_DIR@
-
-ifeq ($(TARGET_ASM_DIR), asm-x86_64)
-ASM_SOURCES := asm-x86_64/aes/aeskey.o
-ASM_SOURCES += asm-x86_64/aes/aes_amd64.o
-ASM_SOURCES += asm-x86_64/aes/aes_aesni.o
-ASM_SOURCES += asm-x86_64/modes/gcm_pclmulqdq.o
-ASM_SOURCES += asm-x86_64/sha1/sha1-x86_64.o
-ASM_SOURCES += asm-x86_64/sha2/sha256_impl.o
-ASM_SOURCES += asm-x86_64/sha2/sha512_impl.o
-endif
-
-ifeq ($(TARGET_ASM_DIR), asm-i386)
-ASM_SOURCES :=
-endif
-
-ifeq ($(TARGET_ASM_DIR), asm-generic)
-ASM_SOURCES :=
-endif
-
 obj-$(CONFIG_ZFS) := $(MODULE).o
 
 asflags-y := -I$(src)/include
@@ -66,7 +46,14 @@ $(MODULE)-objs += algs/sha1/sha1.o
 $(MODULE)-objs += algs/skein/skein.o
 $(MODULE)-objs += algs/skein/skein_block.o
 $(MODULE)-objs += algs/skein/skein_iv.o
-$(MODULE)-objs += $(ASM_SOURCES)
+
+$(MODULE)-$(CONFIG_X86_64) += asm-x86_64/aes/aeskey.o
+$(MODULE)-$(CONFIG_X86_64) += asm-x86_64/aes/aes_amd64.o
+$(MODULE)-$(CONFIG_X86_64) += asm-x86_64/aes/aes_aesni.o
+$(MODULE)-$(CONFIG_X86_64) += asm-x86_64/modes/gcm_pclmulqdq.o
+$(MODULE)-$(CONFIG_X86_64) += asm-x86_64/sha1/sha1-x86_64.o
+$(MODULE)-$(CONFIG_X86_64) += asm-x86_64/sha2/sha256_impl.o
+$(MODULE)-$(CONFIG_X86_64) += asm-x86_64/sha2/sha512_impl.o
 
 $(MODULE)-$(CONFIG_X86) += algs/modes/gcm_pclmulqdq.o
 $(MODULE)-$(CONFIG_X86) += algs/aes/aes_impl_aesni.o

--- a/module/os/linux/zfs/Makefile.in
+++ b/module/os/linux/zfs/Makefile.in
@@ -3,9 +3,7 @@
 #
 
 # Suppress unused-value warnings in sparc64 architecture headers
-ifeq ($(target_cpu),sparc64)
-ccflags-y += -Wno-unused-value
-endif
+ccflags-$(CONFIG_SPARC64) += -Wno-unused-value
 
 ccflags-y += -I@abs_top_srcdir@/module/os/linux/zfs
 

--- a/module/zcommon/Makefile.in
+++ b/module/zcommon/Makefile.in
@@ -9,9 +9,7 @@ obj-$(CONFIG_ZFS) := $(MODULE).o
 ccflags-y := $(ZFS_MODULE_CFLAGS) $(ZFS_MODULE_CPPFLAGS)
 
 # Suppress unused-value warnings in sparc64 architecture headers
-ifeq ($(target_cpu),sparc64)
-ccflags-y += -Wno-unused-value
-endif
+ccflags-$(CONFIG_SPARC64) += -Wno-unused-value
 
 $(MODULE)-objs += zfeature_common.o
 $(MODULE)-objs += zfs_comutil.o

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -8,13 +8,11 @@ obj-$(CONFIG_ZFS) := $(MODULE).o
 
 ccflags-y := $(ZFS_MODULE_CFLAGS) $(ZFS_MODULE_CPPFLAGS)
 
-# Suppress unused-value warnings in sparc64 architecture headers
-ifeq ($(target_cpu),sparc64)
-ccflags-y += -Wno-unused-value
-endif
-
 # Suppress unused but set variable warnings often due to ASSERTs
 ccflags-y += $(NO_UNUSED_BUT_SET_VARIABLE)
+
+# Suppress unused-value warnings in sparc64 architecture headers
+ccflags-$(CONFIG_SPARC64) += -Wno-unused-value
 
 $(MODULE)-objs += aggsum.o
 $(MODULE)-objs += arc.o


### PR DESCRIPTION
### Motivation and Context

Resolve some technical dept which makes detecting the target
architecture for conditional Makefiles overly difficult.

### Description

Over the years several slightly different approaches were used
in the Makefiles to determine the target architecture.  This
change updates both the build system and Makefile to handle
this in a consistent fashion.

TARGET_CPU is set to i386, x86_64, powerpc, aarch6 or sparc64
and made available in the Makefiles to be used as appropriate.

### How Has This Been Tested?

Test built on x86_64 and ppc64.  Pending CI build testing for arm,
aarch64, ppc, and i386.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
