### PR TITLE
ZTS: Make DVA pattern in zdb tests more robust

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_checksum.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_checksum.ksh
@@ -53,7 +53,7 @@ log_note "file $init_data has object number $obj"
 
 output=$(zdb -ddddddbbbbbb $TESTPOOL/$TESTFS $obj 2> /dev/null \
     |grep -m 1 "L0 DVA" |head -n1)
-dva=$(sed -Ene 's/^.+DVA\[0\]=<(.+)>.*$/\1/p' <<< "$output")
+dva=$(sed -Ene 's/^.+DVA\[0\]=<([^>]+)>.*$/\1/p' <<< "$output")
 log_note "block 0 of $init_data has a DVA of $dva"
 cksum_expected=$(sed -Ene 's/^.+ cksum=([a-z0-9:]+)$/\1/p' <<< "$output")
 log_note "expecting cksum $cksum_expected"

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_decompress.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_decompress.ksh
@@ -74,7 +74,7 @@ log_note "file $init_data has object number $obj"
 
 output=$(zdb -ddddddbbbbbb $TESTPOOL/$TESTFS $obj 2> /dev/null \
     |grep -m 1 "L0 DVA" |head -n1)
-dva=$(sed -Ene 's/^.+DVA\[0\]=<(.+)>.*$/\1/p' <<< "$output")
+dva=$(sed -Ene 's/^.+DVA\[0\]=<([^>]+)>.*$/\1/p' <<< "$output")
 log_note "block 0 of $init_data has a DVA of $dva"
 
 # use the length reported by zdb -ddddddbbbbbb


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current pattern will capture incorrectly when there are multiple DVA copies on the same line of zdb output:
```
$ export output="0 L1 DVA[0]=<0:40109600:2000> DVA[1]=<0:50000800:2000> [L1 ZFS plain file]"
$ echo $output | sed -Ene 's/^.+DVA\[0\]=<(.+)>.*/\1/p'
0:40109600:2000> DVA[1]=<0:50000800:2000
```
I don't think we have actually had an issue with this in existing tests, but it is worthwhile to have a good example for future tests to base on.

### Description
<!--- Describe your changes in detail -->
Ensure the capture ends at the first DVA in case there are multiple DVAs on the same line by only capturing up to the first '>' character.
```
$ echo $output | sed -Ene 's/^.+DVA\[0\]=<([^>]+)>.*$/\1/p'
0:40109600:2000
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Tested on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
