### PR TITLE
ZTS: Enable zpool_create_008_pos.ksh

### DIFF
--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -191,7 +191,6 @@ maybe = {
     'cli_root/zfs_snapshot/zfs_snapshot_002_neg': ['FAIL', known_reason],
     'cli_root/zfs_unshare/setup': ['SKIP', share_reason],
     'cli_root/zpool_add/zpool_add_004_pos': ['FAIL', known_reason],
-    'cli_root/zpool_create/zpool_create_008_pos': ['FAIL', known_reason],
     'cli_root/zpool_destroy/zpool_destroy_001_pos': ['SKIP', '6145'],
     'cli_root/zpool_import/import_rewind_device_replaced':
         ['FAIL', rewind_reason],

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_008_pos.ksh
@@ -44,18 +44,6 @@
 
 verify_runnable "global"
 
-if is_linux; then
-	# Versions of libblkid older than 2.27.0 will not always detect member
-	# devices of a pool, therefore skip this test case for old versions.
-	currentver="$(blkid -v | tr ',' ' ' | awk '/libblkid/ { print $6 }')"
-	requiredver="2.27.0"
-
-	if [ "$(printf "$requiredver\n$currentver" | sort -V | head -n1)" ==  \
-	    "$currentver" ] && [ "$currentver" != "$requiredver" ]; then
-		log_unsupported "libblkid ($currentver) may not detect pools"
-	fi
-fi
-
 function cleanup
 {
 	if [[ $exported_pool == true ]]; then
@@ -153,6 +141,8 @@ fi
 log_must zpool create -f $TESTPOOL $disk
 destroy_pool $TESTPOOL
 log_must partition_disk $SIZE $disk 6
+block_device_wait
+
 create_pool $TESTPOOL ${disk}${SLICE_PREFIX}${SLICE0} \
 	${disk}${SLICE_PREFIX}${SLICE1}
 log_must zpool export $TESTPOOL


### PR DESCRIPTION
### Motivation and Context

Follow up from #9828.  This test was skipped on CentOS 7
which is no longer required.

### Description

Remove the blkid version check from zpool_create_008_pos.ksh
so the test case will not be skipped.
    
All versions of blkid tested by the CI are either new enough
to not suffer from this issue, or have been patched as is
the case with CentOS 7 (libblkid-2.23.2-61).
    
Additionally, add a block_device_wait after device partitioning
to ensure the expected partitions will exist.

### How Has This Been Tested?

Locally running the entire test group on a CentOS 7 system
many times and verifying it always passed.

A comment was added to the PR to request multiple runs
of the zpool_create test group for additional verification.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
