### PR TITLE
ZTS: Eliminate partitioning in zpool_import setup

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/cleanup.ksh
@@ -47,20 +47,4 @@ for dir in "$TESTDIR" "$TESTDIR1" "$DEVICE_DIR" ; do
 		log_must rm -rf $dir
 done
 
-DISK=${DISKS%% *}
-if is_mpath_device $DISK; then
-	delete_partitions
-fi
-# recreate and destroy a zpool over the disks to restore the partitions to
-# normal
-case $DISK_COUNT in
-0|1)
-	log_note "No disk devices to restore"
-	;;
-*)
-	log_must cleanup_devices $ZFS_DISK1
-	log_must cleanup_devices $ZFS_DISK2
-	;;
-esac
-
 log_pass

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/setup.ksh
@@ -33,32 +33,8 @@
 . $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.cfg
 
 verify_runnable "global"
-verify_disk_count "$DISKS" 2
 
-if ! is_physical_device $ZFS_DISK1; then
-	log_unsupported "Only partitionable physical disks can be used"
-fi
-
-DISK=${DISKS%% *}
-
-for dev in $ZFS_DISK1 $ZFS_DISK2 ; do
-	log_must cleanup_devices $dev
-done
-
-typeset -i i=0
-while (( i <= $GROUP_NUM )); do
-	if is_illumos; then
-		if (( i == 2 )); then
-			(( i = i + 1 ))
-			continue
-		fi
-	fi
-	log_must set_partition $i "$cyl" $SLICE_SIZE $ZFS_DISK1
-	cyl=$(get_endslice $ZFS_DISK1 $i)
-	(( i = i + 1 ))
-done
-
-create_pool "$TESTPOOL" "$ZFSSIDE_DISK1"
+create_pool "$TESTPOOL" "$DISK"
 
 if [[ -d $TESTDIR ]]; then
 	rm -rf $TESTDIR  || log_unresolved Could not remove $TESTDIR

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.cfg
@@ -30,100 +30,11 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-export DISKSARRAY=$DISKS
-export DISK_ARRAY_NUM=$(echo ${DISKS} | nawk '{print NF}')
-typeset -a disk_array=($(find_disks $DISKS))
-case "${#disk_array[*]}" in
-0)
-	#
-	# on stf_configure, disk_freelist returns empty.
-	#
-	DISK_COUNT=0
-	;;
-1)
-	# We need to repartition the single disk to two slices.
-	if is_linux; then
-	        set_device_dir
-	        set_slice_prefix
-		PRIMARY_SLICE=1
-		DISK_COUNT=1
-		ZFS_DISK1=${disk_array[0]}
-		ZFS_DISK2=${disk_array[0]}
-		if is_mpath_device $ZFS_DISK1; then
-			export DEV_DSKDIR=$DEV_MPATHDIR
-		else
-			export DEV_DSKDIR=$DEV_RDSKDIR
-		fi
-		if ( is_mpath_device $ZFS_DISK1 ) && [[ -z $(echo $ZFS_DISK1 | awk 'substr($1,18,1)\
-                    ~ /^[[:digit:]]+$/') ]] || ( is_real_device $ZFS_DISK1 ); then
-			ZFSSIDE_DISK1=${ZFS_DISK1}1
-		elif ( is_mpath_device $ZFS_DISK1 || is_loop_device $ZFS_DISK1 ); then
-			ZFSSIDE_DISK1=${ZFS_DISK1}p1
-		else
-			log_fail "$ZFS_DISK1 not supported for partitioning."
-		fi
-	elif is_freebsd; then
-		SLICE_PREFIX="p"
-		PRIMARY_SLICE=1
-		DISK_COUNT=1
-		ZFS_DISK1=${disk_array[0]}
-		ZFS_DISK2=${disk_array[0]}
-		ZFSSIDE_DISK1=${ZFS_DISK1}p1
-	else
-		export DEV_DSKDIR="/dev"
-		PRIMARY_SLICE=2
-		DISK_COUNT=1
-		ZFS_DISK1=${disk_array[0]}
-		ZFSSIDE_DISK1=${ZFS_DISK1}s0
-		ZFS_DISK2=${disk_array[0]}
-	fi
-	;;
-*)
-	# We need to repartition the single disk to two slices.
-	if is_linux; then
-	        set_device_dir
-	        set_slice_prefix
-		PRIMARY_SLICE=1
-		DISK_COUNT=2
-		ZFS_DISK1=${disk_array[0]}
-		if is_mpath_device $ZFS_DISK1; then
-			export DEV_DSKDIR=$DEV_MPATHDIR
-		else
-			export DEV_DSKDIR=$DEV_RDSKDIR
-		fi
-		if ( is_mpath_device $ZFS_DISK1 ) && [[ -z $(echo $ZFS_DISK1 | awk 'substr($1,18,1)\
-		    ~ /^[[:digit:]]+$/') ]] || ( is_real_device $ZFS_DISK1 ); then
-			ZFSSIDE_DISK1=${ZFS_DISK1}1
-		elif ( is_mpath_device $ZFS_DISK1 || is_loop_device $ZFS_DISK1 ); then
-			ZFSSIDE_DISK1=${ZFS_DISK1}p1
-		else
-			log_fail "$ZFS_DISK1 not supported for partitioning."
-		fi
-		ZFS_DISK2=${disk_array[1]}
-	elif is_freebsd; then
-		SLICE_PREFIX="p"
-		PRIMARY_SLICE=1
-		DISK_COUNT=2
-		ZFS_DISK1=${disk_array[0]}
-		ZFSSIDE_DISK1=${ZFS_DISK1}p1
-	else
-		export DEV_DSKDIR="/dev"
-		PRIMARY_SLICE=2
-		DISK_COUNT=2
-		ZFS_DISK1=${disk_array[0]}
-		ZFSSIDE_DISK1=${ZFS_DISK1}s0
-		ZFS_DISK2=${disk_array[1]}
-	fi
-	;;
-esac
-
-export DISK_COUNT ZFS_DISK1 ZFSSIDE_DISK1 ZFS_DISK2
-
+export DISK=${DISKS%% *}
 export FS_SIZE="$((($MINVDEVSIZE / (1024 * 1024)) * 32))m"
 export FILE_SIZE="$((MINVDEVSIZE))"
 export SLICE_SIZE="$((($MINVDEVSIZE / (1024 * 1024)) * 2))m"
 export MAX_NUM=5
-export GROUP_NUM=3
 export DEVICE_DIR=$TEST_BASE_DIR/dev_import-test
 export BACKUP_DEVICE_DIR=$TEST_BASE_DIR/bakdev_import-test
 export DEVICE_FILE=disk
@@ -136,6 +47,7 @@ export CPATHBKP2=$TEST_BASE_DIR/cachefile.$$.bkp2
 export MD5FILE=$TEST_BASE_DIR/md5sums.$$
 export MD5FILE2=$TEST_BASE_DIR/md5sums.$$.2
 
+export GROUP_NUM=3
 typeset -i num=0
 while (( num < $GROUP_NUM )); do
 	DEVICE_FILES="$DEVICE_FILES ${DEVICE_DIR}/${DEVICE_FILE}$num"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There doesn't seem to be a need for this complexity.

### Description
<!--- Describe your changes in detail -->
The tests only use one disk, so use only one disk for the setup.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I ran `./scripts/zfs-tests.sh -vxT zpool_import` on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
