### PR TITLE
redaction: memory leak fix + error message improvements

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -3746,8 +3746,13 @@ zfs_do_redact(int argc, char **argv)
 		    "specified\n"));
 		break;
 	case EINVAL:
-		(void) fprintf(stderr, gettext("redaction snapshot must be "
-		    "descendent of snapshot being redacted\n"));
+		if (strchr(bookname, '#') != NULL)
+			(void) fprintf(stderr, gettext(
+			    "redaction bookmark name must not contain '#'\n"));
+		else
+			(void) fprintf(stderr, gettext(
+			    "redaction snapshot must be descendent of "
+			    "snapshot being redacted\n"));
 		break;
 	case EALREADY:
 		(void) fprintf(stderr, gettext("attempted to redact redacted "
@@ -3756,6 +3761,10 @@ zfs_do_redact(int argc, char **argv)
 	case ENOTSUP:
 		(void) fprintf(stderr, gettext("redaction bookmarks feature "
 		    "not enabled\n"));
+		break;
+	case EXDEV:
+		(void) fprintf(stderr, gettext("potentially invalid redaction "
+		    "snapshot; full dataset names required\n"));
 		break;
 	default:
 		(void) fprintf(stderr, gettext("internal error: %s\n"),

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -4403,6 +4403,12 @@ zfs_do_send(int argc, char **argv)
 				    "do a redacted send to a filesystem.\n"));
 				return (1);
 			}
+			if (strchr(redactbook, '#') != NULL) {
+				(void) fprintf(stderr, gettext("Error: "
+				    "redaction bookmark argument must "
+				    "not contain '#'\n"));
+				return (1);
+			}
 		}
 
 		zhp = zfs_open(g_zfs, argv[0], ZFS_TYPE_DATASET);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -2342,12 +2342,6 @@ dmu_send_impl(struct dmu_send_params *dspp)
 		return (err);
 	}
 
-	from_arg = kmem_zalloc(sizeof (*from_arg), KM_SLEEP);
-	to_arg = kmem_zalloc(sizeof (*to_arg), KM_SLEEP);
-	rlt_arg = kmem_zalloc(sizeof (*rlt_arg), KM_SLEEP);
-	smt_arg = kmem_zalloc(sizeof (*smt_arg), KM_SLEEP);
-	spt_arg = kmem_zalloc(sizeof (*spt_arg), KM_SLEEP);
-
 	/*
 	 * If we're doing a redacted send, hold the bookmark's redaction list.
 	 */
@@ -2381,6 +2375,12 @@ dmu_send_impl(struct dmu_send_params *dspp)
 	}
 
 	dsl_dataset_long_hold(to_ds, FTAG);
+
+	from_arg = kmem_zalloc(sizeof (*from_arg), KM_SLEEP);
+	to_arg = kmem_zalloc(sizeof (*to_arg), KM_SLEEP);
+	rlt_arg = kmem_zalloc(sizeof (*rlt_arg), KM_SLEEP);
+	smt_arg = kmem_zalloc(sizeof (*smt_arg), KM_SLEEP);
+	spt_arg = kmem_zalloc(sizeof (*spt_arg), KM_SLEEP);
 
 	drr = create_begin_record(dspp, os, featureflags);
 	dssp = setup_send_progress(dspp);

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_negative.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_negative.ksh
@@ -77,4 +77,12 @@ log_mustnot zfs redact $recvfs@snap book5 $clone3@snap
 # Nor may a redacted dataset appear in the redaction list.
 log_mustnot zfs redact testpool2/recvfs@snap2 book7 testpool2/recvfs@snap
 
+# Error messages for common usage errors
+log_mustnot_expect "not contain '#'"    zfs redact $sendfs@snap1 \#book $sendfs@snap2
+log_mustnot_expect "not contain '#'"    zfs redact $sendfs@snap1 $sendfs#book $sendfs@snap2
+log_mustnot_expect "full dataset names" zfs redact $sendfs@snap1 book @snap2
+log_mustnot_expect "full dataset names" zfs redact $sendfs@snap1 book @snap2
+log_mustnot_expect "full dataset names" zfs redact $sendfs@snap1 \#book @snap2
+log_mustnot_expect "descendent of snapshot" zfs redact $sendfs@snap2 book $sendfs@snap1
+
 log_pass "Verify that redacted send correctly detects invalid arguments."

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_negative.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_negative.ksh
@@ -77,6 +77,10 @@ log_mustnot zfs redact $recvfs@snap book5 $clone3@snap
 # Nor may a redacted dataset appear in the redaction list.
 log_mustnot zfs redact testpool2/recvfs@snap2 book7 testpool2/recvfs@snap
 
+# Non-redaction bookmark cannot be sent and produces invalid argument error
+log_must zfs bookmark "$sendfs@snap1" "$sendfs#book8"
+log_must eval "zfs send --redact book8 -i $sendfs@snap1 $sendfs@snap2 2>&1 | head -n 100 | grep 'internal error: Invalid argument'"
+
 # Error messages for common usage errors
 log_mustnot_expect "not contain '#'"    zfs redact $sendfs@snap1 \#book $sendfs@snap2
 log_mustnot_expect "not contain '#'"    zfs redact $sendfs@snap1 $sendfs#book $sendfs@snap2


### PR DESCRIPTION
### Motivation and Context

I encountered these bugs in the redaction feature code while working on #9571 

### Description

I think the commit messages are fairly self-explanatory. It's mostly about the (I think not too unreasonable but wrong) assumption that the redaction bookmark would be referred to with a leading `#`.

* dmu_send: redacted: fix memory leak on invalid redaction/from bookmark
* cmd/zfs: redact: better error message for common usage errors
* cmd/zfs: send: meaningful error message for incorrect redaction bookmark

The last two may be squashed together, the first one should stay independent.

### How Has This Been Tested?

* Manual tests
* the tests added to ZTS
* probably some tests in #9571 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~~New feature (non-breaking change which adds functionality)~~
- ~~Performance enhancement (non-breaking change which improves efficiency)~~
- ~~Code cleanup (non-breaking change which makes code smaller or more readable)~~
- ~~Breaking change (fix or feature that would cause existing functionality to change)~~
- ~~Documentation (a change to man pages or other documentation)~~

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
