### PR TITLE
ZTS: Move more tests out of common.run

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -290,7 +290,7 @@ tags = ['functional', 'cli_root', 'zpool']
 tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
     'zpool_add_004_pos', 'zpool_add_006_pos', 'zpool_add_007_neg',
     'zpool_add_008_neg', 'zpool_add_009_neg', 'zpool_add_010_pos',
-    'add-o_ashift', 'add_prop_ashift', 'add_nested_replacing_spare']
+    'add-o_ashift', 'add_prop_ashift']
 tags = ['functional', 'cli_root', 'zpool_add']
 
 [tests/functional/cli_root/zpool_attach]
@@ -328,11 +328,6 @@ tags = ['functional', 'cli_root', 'zpool_destroy']
 [tests/functional/cli_root/zpool_detach]
 tests = ['zpool_detach_001_neg']
 tags = ['functional', 'cli_root', 'zpool_detach']
-
-[tests/functional/cli_root/zpool_expand]
-tests = ['zpool_expand_001_pos', 'zpool_expand_002_pos',
-    'zpool_expand_003_neg', 'zpool_expand_004_pos', 'zpool_expand_005_pos']
-tags = ['functional', 'cli_root', 'zpool_expand']
 
 [tests/functional/cli_root/zpool_export]
 tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
@@ -408,12 +403,6 @@ tags = ['functional', 'cli_root', 'zpool_online']
 tests = ['zpool_remove_001_neg', 'zpool_remove_002_pos',
     'zpool_remove_003_pos']
 tags = ['functional', 'cli_root', 'zpool_remove']
-
-[tests/functional/cli_root/zpool_reopen]
-tests = ['zpool_reopen_001_pos', 'zpool_reopen_002_pos',
-    'zpool_reopen_003_pos', 'zpool_reopen_004_pos', 'zpool_reopen_005_pos',
-    'zpool_reopen_006_neg', 'zpool_reopen_007_pos']
-tags = ['functional', 'cli_root', 'zpool_reopen']
 
 [tests/functional/cli_root/zpool_replace]
 tests = ['zpool_replace_001_neg', 'replace-o_ashift', 'replace_prop_ashift']
@@ -551,12 +540,6 @@ tags = ['functional', 'delegate']
 tests = ['exec_001_pos', 'exec_002_neg']
 tags = ['functional', 'exec']
 
-[tests/functional/fault]
-tests = ['auto_offline_001_pos', 'auto_online_001_pos', 'auto_replace_001_pos',
-    'auto_spare_001_pos', 'auto_spare_002_pos', 'auto_spare_multiple',
-    'auto_spare_shared', 'decrypt_fault', 'decompress_fault']
-tags = ['functional', 'fault']
-
 [tests/functional/features/async_destroy]
 tests = ['async_destroy_001_pos']
 tags = ['functional', 'features', 'async_destroy']
@@ -627,15 +610,8 @@ tags = ['functional', 'migration']
 tests = ['mmap_write_001_pos', 'mmap_read_001_pos']
 tags = ['functional', 'mmap']
 
-[tests/functional/mmp]
-tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
-    'mmp_active_import', 'mmp_inactive_import', 'mmp_exported_import',
-    'mmp_write_uberblocks', 'mmp_reset_interval', 'multihost_history',
-    'mmp_on_zdb', 'mmp_write_distribution', 'mmp_hostid']
-tags = ['functional', 'mmp']
-
 [tests/functional/mount]
-tests = ['umount_001', 'umount_unlinked_drain', 'umountall_001']
+tests = ['umount_001', 'umountall_001']
 tags = ['functional', 'mount']
 
 [tests/functional/mv_files]
@@ -888,8 +864,7 @@ tests = ['zvol_misc_002_pos', 'zvol_misc_hierarchy', 'zvol_misc_rename_inuse',
 tags = ['functional', 'zvol', 'zvol_misc']
 
 [tests/functional/zvol/zvol_swap]
-tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',
-    'zvol_swap_004_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos']
+tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_004_pos']
 tags = ['functional', 'zvol', 'zvol_swap']
 
 [tests/functional/libzfs]

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -55,10 +55,25 @@ tests = ['zfeature_set_unsupported', 'zfs_get_unsupported',
     'zpool_set_unsupported']
 tags = ['functional', 'cli_root', 'zfs_sysfs']
 
+[tests/functional/cli_root/zpool_add:Linux]
+tests = ['add_nested_replacing_spare']
+tags = ['functional', 'cli_root', 'zpool_add']
+
 [tests/functional/cli_root/zpool_events:Linux]
 tests = ['zpool_events_clear', 'zpool_events_cliargs', 'zpool_events_follow',
     'zpool_events_poolname', 'zpool_events_errors']
 tags = ['functional', 'cli_root', 'zpool_events']
+
+[tests/functional/cli_root/zpool_expand:Linux]
+tests = ['zpool_expand_001_pos', 'zpool_expand_002_pos',
+    'zpool_expand_003_neg', 'zpool_expand_004_pos', 'zpool_expand_005_pos']
+tags = ['functional', 'cli_root', 'zpool_expand']
+
+[tests/functional/cli_root/zpool_reopen:Linux]
+tests = ['zpool_reopen_001_pos', 'zpool_reopen_002_pos',
+    'zpool_reopen_003_pos', 'zpool_reopen_004_pos', 'zpool_reopen_005_pos',
+    'zpool_reopen_006_neg', 'zpool_reopen_007_pos']
+tags = ['functional', 'cli_root', 'zpool_reopen']
 
 [tests/functional/compression:Linux]
 tests = ['compress_004_pos']
@@ -79,7 +94,10 @@ tests = ['events_001_pos', 'events_002_pos', 'zed_rc_filter']
 tags = ['functional', 'events']
 
 [tests/functional/fault:Linux]
-tests = ['auto_spare_ashift', 'scrub_after_resilver', 'zpool_status_-s']
+tests = ['auto_offline_001_pos', 'auto_online_001_pos', 'auto_replace_001_pos',
+    'auto_spare_001_pos', 'auto_spare_002_pos', 'auto_spare_multiple',
+    'auto_spare_ashift', 'auto_spare_shared', 'decrypt_fault',
+    'decompress_fault', 'scrub_after_resilver', 'zpool_status_-s']
 tags = ['functional', 'fault']
 
 [tests/functional/features/large_dnode:Linux]
@@ -93,6 +111,17 @@ tags = ['functional', 'io']
 [tests/functional/mmap:Linux]
 tests = ['mmap_libaio_001_pos']
 tags = ['functional', 'mmap']
+
+[tests/functional/mmp:Linux]
+tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
+    'mmp_active_import', 'mmp_inactive_import', 'mmp_exported_import',
+    'mmp_write_uberblocks', 'mmp_reset_interval', 'multihost_history',
+    'mmp_on_zdb', 'mmp_write_distribution', 'mmp_hostid']
+tags = ['functional', 'mmp']
+
+[tests/functional/mount:Linux]
+tests = ['umount_unlinked_drain']
+tags = ['functional', 'mount']
 
 [tests/functional/procfs:Linux]
 tests = ['procfs_list_basic', 'procfs_list_concurrent_readers',

--- a/tests/runfiles/sunos.run
+++ b/tests/runfiles/sunos.run
@@ -41,3 +41,7 @@ tags = ['functional', 'xattr']
 tests = ['zvol_misc_001_neg', 'zvol_misc_003_neg', 'zvol_misc_004_pos',
     'zvol_misc_005_neg', 'zvol_misc_006_pos']
 tags = ['functional', 'zvol', 'zvol_misc']
+
+[tests/functional/zvol/zvol_swap:illumos]
+tests = ['zvol_swap_003_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos']
+tags = ['functional', 'zvol', 'zvol_swap']

--- a/tests/test-runner/bin/zts-report.py
+++ b/tests/test-runner/bin/zts-report.py
@@ -162,9 +162,6 @@ known = {
     'rootpool/setup': ['SKIP', na_reason],
     'rsend/rsend_008_pos': ['SKIP', '6066'],
     'vdev_zaps/vdev_zaps_007_pos': ['FAIL', known_reason],
-    'zvol/zvol_swap/zvol_swap_003_pos': ['SKIP', na_reason],
-    'zvol/zvol_swap/zvol_swap_005_pos': ['SKIP', na_reason],
-    'zvol/zvol_swap/zvol_swap_006_pos': ['SKIP', na_reason],
 }
 
 #

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_002_pos.ksh
@@ -56,6 +56,8 @@ function cleanup
 
 log_assert "Using a zvol as swap space, fill /var/tmp to 80%."
 
+log_onexit cleanup
+
 vol=$TESTPOOL/$TESTVOL
 swapdev=${ZVOL_DEVDIR}/$vol
 log_must swap_setup $swapdev

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_003_pos.ksh
@@ -46,10 +46,6 @@
 
 verify_runnable "global"
 
-if is_linux || is_freebsd; then
-	log_unsupported "Modifies global non-ZFS system config"
-fi
-
 function cleanup
 {
 	[[ -f $TESTDIR/$TESTFILE ]] && log_must rm -f $TESTDIR/$TESTFILE

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_005_pos.ksh
@@ -44,10 +44,6 @@
 
 verify_runnable "global"
 
-if is_linux || is_freebsd; then
-	log_unsupported "swaplow + swaplen unsupported Linux/FreeBSD options"
-fi
-
 assertion="Verify the sum of swaplow and swaplen is less or equal to volsize"
 log_assert $assertion
 

--- a/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_006_pos.ksh
@@ -45,10 +45,6 @@
 
 verify_runnable "global"
 
-if is_linux || is_freebsd; then
-	log_unsupported "swaplow + swaplen unsupported Linux/FreeBSD options"
-fi
-
 function cleanup
 {
 	typeset -i i=0


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These tests won't run on all platforms as currently implemented:
 * add_nested_replacing_spare (needs zed)
 * fault (needs zed)
 * mmp (needs multihost_history)
 * umount_unlinked_drain (needs procfs)
 * zpool_expand (needs udev events and zed)
 * zpool_reopen (needs scsi_debug)
 * zvol_swap_003_pos (needs to modify vfstab)
 * zvol_swap_00[56]_pos (needs swaphigh/swaplen)

### Description
<!--- Describe your changes in detail -->
Move the zvol_swap_* tests to sunos.run, the rest to linux.run.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
ZTS on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
