### PR TITLE
entity_namecheck: doc comment: include space as allowed character

### DIFF
--- a/module/zcommon/zfs_namecheck.c
+++ b/module/zcommon/zfs_namecheck.c
@@ -171,7 +171,7 @@ dataset_nestcheck(const char *path)
  * Where each component is made up of alphanumeric characters plus the following
  * characters:
  *
- *	[-_.:%]
+ *	[-_.: %]
  *
  * We allow '%' here as we use that character internally to create unique
  * names for temporary clones (for online recv).


### PR DESCRIPTION
The helper function valid_char already allows it but
the doc comment was out of date.

### How Has This Been Tested?
- `make checkstyle`

### Types of changes
- ~~Bug fix (non-breaking change which fixes an issue)~~
- ~~New feature (non-breaking change which adds functionality)~~
- ~~Performance enhancement (non-breaking change which improves efficiency)~~
- ~~Code cleanup (non-breaking change which makes code smaller or more readable)~~
- ~~Breaking change (fix or feature that would cause existing functionality to change)~~
- [x] Documentation (a change to man pages or other documentation)


### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
