### PR TITLE
dsl_bookmark_create_check: fix NULL pointer deref if dbca_errors == NULL

### DIFF
--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -167,6 +167,9 @@ static int
 dsl_bookmark_create_check(void *arg, dmu_tx_t *tx)
 {
 	dsl_bookmark_create_arg_t *dbca = arg;
+	ASSERT3P(dbca, !=, NULL);
+	ASSERT3P(dbca->dbca_bmarks, !=, NULL);
+
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	int rv = 0;
 
@@ -187,9 +190,10 @@ dsl_bookmark_create_check(void *arg, dmu_tx_t *tx)
 			dsl_dataset_rele(snapds, FTAG);
 		}
 		if (error != 0) {
-			fnvlist_add_int32(dbca->dbca_errors,
-			    nvpair_name(pair), error);
 			rv = error;
+			if (dbca->dbca_errors != NULL)
+				fnvlist_add_int32(dbca->dbca_errors,
+				    nvpair_name(pair), error);
 		}
 	}
 


### PR DESCRIPTION
Disovered in prepartion of zcp support for creating bookmarks.

### How Has This Been Tested?
- [x] manual testing
- [x] as part of the tests in #9571 , the PR for which this patch was written originally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~~New feature (non-breaking change which adds functionality)~~
- ~~Performance enhancement (non-breaking change which improves efficiency)~~
- ~~Code cleanup (non-breaking change which makes code smaller or more readable)~~
- ~~Breaking change (fix or feature that would cause existing functionality to change)~~
- ~~Documentation (a change to man pages or other documentation)~~


### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
