### PR TITLE
ZTS: Use 4 file vdevs to simplify inuse tests

### DIFF
--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -421,7 +421,7 @@ done
 
 shift $((OPTIND-1))
 
-FILES=${FILES:-"$FILEDIR/file-vdev0 $FILEDIR/file-vdev1 $FILEDIR/file-vdev2"}
+FILES=${FILES:-"$(echo "$FILEDIR"/file-vdev{0..3})"}
 LOOPBACKS=${LOOPBACKS:-""}
 
 if [ ${#SINGLETEST[@]} -ne 0 ]; then

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,10 +27,10 @@ may be provided for your distribution.
 The pre-requisites for running the ZFS Test Suite are:
 
   * Three scratch disks
-    * Specify the disks you wish to use in the $DISKS variable, as a
-      space delimited list like this: DISKS='vdb vdc vdd'.  By default
-      the zfs-tests.sh sciprt will construct three loopback devices to
-      be used for testing: DISKS='loop0 loop1 loop2'.
+    * Specify the disks you wish to use in the $DISKS variable, as a space
+      delimited list like this: DISKS='vdb vdc vdd vde'.  By default the
+      zfs-tests.sh script will construct four loopback devices for testing:
+      DISKS='loop0 loop1 loop2 loop3'.
   * A non-root user with a full set of basic privileges and the ability
     to sudo(8) to root without a password to run the test.
   * Specify any pools you wish to preserve as a space delimited list in
@@ -127,10 +127,10 @@ with the `zfs-tests.sh` wrapper script will look something like this:
     STF_SUITE:       /usr/share/zfs/zfs-tests
     STF_PATH:        /var/tmp/constrained_path.G0Sf
     FILEDIR:         /tmp/test
-    FILES:           /tmp/test/file-vdev0 /tmp/test/file-vdev1 /tmp/test/file-vdev2
-    LOOPBACKS:       /dev/loop0 /dev/loop1 /dev/loop2 
-    DISKS:           loop0 loop1 loop2
-    NUM_DISKS:       3
+    FILES:           /tmp/test/file-vdev0 /tmp/test/file-vdev1 /tmp/test/file-vdev2 /tmp/test/file-vdev3
+    LOOPBACKS:       /dev/loop0 /dev/loop1 /dev/loop2 /dev/loop3
+    DISKS:           loop0 loop1 loop2 loop3
+    NUM_DISKS:       4
     FILESIZE:        4G
     ITERATIONS:      1
     TAGS:            functional

--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -89,8 +89,8 @@ function block_device_wait
 #
 function is_physical_device #device
 {
-	typeset device=${1#$DEV_DSKDIR}
-	device=${device#$DEV_RDSKDIR}
+	typeset device=${1#$DEV_DSKDIR/}
+	device=${device#$DEV_RDSKDIR/}
 
 	if is_linux; then
 		is_disk_device "$DEV_DSKDIR/$device" && \

--- a/tests/zfs-tests/include/default.cfg.in
+++ b/tests/zfs-tests/include/default.cfg.in
@@ -173,6 +173,7 @@ if is_linux; then
 
 	ZVOL_DEVDIR="/dev/zvol"
 	ZVOL_RDEVDIR="/dev/zvol"
+	DEV_DSKDIR="/dev"
 	DEV_RDSKDIR="/dev"
 	DEV_MPATHDIR="/dev/mapper"
 

--- a/tests/zfs-tests/tests/functional/inuse/inuse.cfg
+++ b/tests/zfs-tests/tests/functional/inuse/inuse.cfg
@@ -30,101 +30,28 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-if is_linux; then
-	export DISKSARRAY=$DISKS
-	export DISK_ARRAY_NUM=$(echo ${DISKS} | nawk '{print NF}')
-	set_device_dir
-	set_slice_prefix
-	export SLICE0=1
-	export SLICE1=2
-else
-	export SLICE_PREFIX="s"
-	export SLICE0=0
-	export SLICE1=1
-fi
-
-verify_disk_count "$DISKS" 2
 set -A disk_array $(find_disks $DISKS)
-case "${#disk_array[@]}" in
-2)
-	FS_DISK0=${disk_array[0]}
-	FS_DISK1=${disk_array[1]}
-	FS_DISK2=${disk_array[0]}
-	FS_DISK3=${disk_array[1]}
-	FS_SIDE0=${FS_DISK0}${SLICE_PREFIX}${SLICE0}
-	FS_SIDE1=${FS_DISK0}${SLICE_PREFIX}${SLICE1}
-	FS_SIDE2=${FS_DISK1}${SLICE_PREFIX}${SLICE0}
-	FS_SIDE3=${FS_DISK1}${SLICE_PREFIX}${SLICE1}
-	disk0="${DEV_DSKDIR}/$FS_SIDE0"
-	disk1="${DEV_DSKDIR}/$FS_SIDE1"
-	disk2="${DEV_DSKDIR}/$FS_SIDE2"
-	disk3="${DEV_DSKDIR}/$FS_SIDE3"
-	disktargets="$disk0 $disk2"
-	rawdisk0="${DEV_RDSKDIR}/$FS_SIDE0"
-	rawdisk1="${DEV_RDSKDIR}/$FS_SIDE1"
-	rawdisk2="${DEV_RDSKDIR}/$FS_SIDE2"
-	rawdisk3="${DEV_RDSKDIR}/$FS_SIDE3"
-	rawtargets="$rawdisk0 $rawdisk2"
-	vdisks="$FS_DISK0"
-	sdisks="$FS_DISK1"
-	vslices="$FS_SIDE0 $FS_SIDE1 $FS_SIDE2"
-	sslices="$FS_SIDE3"
-	;;
-3)
-	FS_DISK0=${disk_array[0]}
-	FS_DISK1=${disk_array[1]}
-	FS_DISK2=${disk_array[2]}
-	FS_DISK3=${disk_array[0]}
-	FS_SIDE0=${FS_DISK0}${SLICE_PREFIX}${SLICE0}
-	FS_SIDE1=${FS_DISK0}${SLICE_PREFIX}${SLICE1}
-	FS_SIDE2=${FS_DISK1}${SLICE_PREFIX}${SLICE0}
-	FS_SIDE3=${FS_DISK2}${SLICE_PREFIX}${SLICE0}
-	disk0="${DEV_DSKDIR}/$FS_SIDE0"
-	disk1="${DEV_DSKDIR}/$FS_SIDE1"
-	disk2="${DEV_DSKDIR}/$FS_SIDE2"
-	disk3="${DEV_DSKDIR}/$FS_SIDE3"
-	disktargets="$disk0 $disk2 $disk3"
-	rawdisk0="${DEV_RDSKDIR}/$FS_SIDE0"
-	rawdisk1="${DEV_RDSKDIR}/$FS_SIDE1"
-	rawdisk2="${DEV_RDSKDIR}/$FS_SIDE2"
-	rawdisk3="${DEV_RDSKDIR}/$FS_SIDE3"
-	rawtargets="$rawdisk0 $rawdisk2 $rawdisk3"
-	vdisks="$FS_DISK0 $FS_DISK1"
-	sdisks="$FS_DISK2"
-	vslices="$FS_SIDE0 $FS_SIDE2 $FS_SIDE3"
-	sslices="$FS_SIDE1"
-	;;
-*)
-	FS_DISK0=${disk_array[0]}
-	FS_DISK1=${disk_array[1]}
-	FS_DISK2=${disk_array[2]}
-	FS_DISK3=${disk_array[3]}
-	FS_SIDE0=${FS_DISK0}${SLICE_PREFIX}${SLICE0}
-	FS_SIDE1=${FS_DISK1}${SLICE_PREFIX}${SLICE0}
-	FS_SIDE2=${FS_DISK2}${SLICE_PREFIX}${SLICE0}
-	FS_SIDE3=${FS_DISK3}${SLICE_PREFIX}${SLICE0}
-	disk0="${DEV_DSKDIR}/$FS_SIDE0"
-	disk1="${DEV_DSKDIR}/$FS_SIDE1"
-	disk2="${DEV_DSKDIR}/$FS_SIDE2"
-	disk3="${DEV_DSKDIR}/$FS_SIDE3"
-	disktargets="$disk0 $disk1 $disk2 $disk3"
-	rawdisk0="${DEV_RDSKDIR}/$FS_SIDE0"
-	rawdisk1="${DEV_RDSKDIR}/$FS_SIDE1"
-	rawdisk2="${DEV_RDSKDIR}/$FS_SIDE2"
-	rawdisk3="${DEV_RDSKDIR}/$FS_SIDE3"
-	rawtargets="$rawdisk0 $rawdisk1 $rawdisk2 $rawdisk3"
-	vdisks="$FS_DISK0 $FS_DISK1 $FS_DISK2"
-	sdisks="$FS_DISK3"
-	vslices="$FS_SIDE0 $FS_SIDE1 $FS_SIDE2"
-	sslices="$FS_SIDE3"
-	;;
-esac
+FS_DISK0=${disk_array[0]}
+FS_DISK1=${disk_array[1]}
+FS_DISK2=${disk_array[2]}
+FS_DISK3=${disk_array[3]}
+disk0="${DEV_DSKDIR}/$FS_DISK0"
+disk1="${DEV_DSKDIR}/$FS_DISK1"
+disk2="${DEV_DSKDIR}/$FS_DISK2"
+disk3="${DEV_DSKDIR}/$FS_DISK3"
+disktargets="$disk0 $disk1 $disk2 $disk3"
+rawdisk0="${DEV_RDSKDIR}/$FS_DISK0"
+rawdisk1="${DEV_RDSKDIR}/$FS_DISK1"
+rawdisk2="${DEV_RDSKDIR}/$FS_DISK2"
+rawdisk3="${DEV_RDSKDIR}/$FS_DISK3"
+rawtargets="$rawdisk0 $rawdisk1 $rawdisk2 $rawdisk3"
+vdisks="$FS_DISK0 $FS_DISK1 $FS_DISK2"
+sdisks="$FS_DISK3"
 
-export FS_DISK0 FS_DISK1 FS_DISK2 FS_DISK3 SINGLE_DISK
-export FS_SIDE0 FS_SIDE1 FS_SIDE2 FS_SIDE3
+export FS_DISK0 FS_DISK1 FS_DISK2 FS_DISK3
 export disk0 disk1 disk2 disk3 disktargets
 export rawdisk0 rawdisk1 rawdisk2 rawdisk3 rawtargets
-export vdisks sdisks vslices sslices
+export vdisks sdisks
 
 export UFSMP=$TESTDIR/testinuseufsdump
 export FS_SIZE=1g

--- a/tests/zfs-tests/tests/functional/inuse/inuse_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_001_pos.ksh
@@ -60,27 +60,25 @@ log_assert "Ensure ZFS cannot use a device designated as a dump device"
 log_onexit cleanup
 
 typeset dumpdev=""
-typeset diskslice=""
 
 PREVDUMPDEV=`dumpadm | grep "Dump device" | awk '{print $3}'`
 
-log_note "Zero $FS_DISK0 and place free space in to slice 0"
+log_note "Zero $FS_DISK0"
 log_must cleanup_devices $FS_DISK0
 
-diskslice="${DEV_DSKDIR}/${FS_DISK0}${SLICE0}"
-log_note "Configuring $diskslice as dump device"
-log_must dumpadm -d $diskslice > /dev/null
+log_note "Configuring $rawdisk0 as dump device"
+log_must dumpadm -d $rawdisk0 > /dev/null
 
 log_note "Confirm that dump device has been setup"
 dumpdev=`dumpadm | grep "Dump device" | awk '{print $3}'`
 [[ -z "$dumpdev" ]] && log_untested "No dump device has been configured"
 
-[[ "$dumpdev" != "$diskslice" ]] && \
-    log_untested "Dump device has not been configured to $diskslice"
+[[ "$dumpdev" != "$rawdisk0" ]] && \
+    log_untested "Dump device has not been configured to $rawdisk0"
 
 log_note "Attempt to zpool the dump device"
 unset NOINUSE_CHECK
-log_mustnot zpool create $TESTPOOL "$diskslice"
+log_mustnot zpool create $TESTPOOL "$rawdisk0"
 log_mustnot poolexists $TESTPOOL
 
 log_pass "Unable to zpool a device in use by dumpadm"

--- a/tests/zfs-tests/tests/functional/inuse/inuse_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_003_pos.ksh
@@ -94,15 +94,6 @@ typeset restored_files="${UFSMP}/restored_files"
 typeset -i dirnum=0
 typeset -i filenum=0
 typeset cwd=""
-typeset cyl=""
-
-for num in 0 1 2; do
-	eval typeset slice=\${FS_SIDE$num}
-	disk=${slice%s*}
-	slice=${slice##*${SLICE_PREFIX}}
-	log_must set_partition $slice "$cyl" $FS_SIZE $disk
-	cyl=$(get_endslice $disk $slice)
-done
 
 log_note "Make a ufs filesystem on source $rawdisk1"
 new_fs $rawdisk1 > /dev/null 2>&1
@@ -145,7 +136,7 @@ log_mustnot zpool create $TESTPOOL1 "$disk1"
 log_mustnot poolexists $TESTPOOL1
 
 log_note "Attempt to take the source device in use by ufsdump as spare device"
-log_mustnot zpool create $TESTPOOL1 "$FS_SIDE2" spare "$disk1"
+log_mustnot zpool create $TESTPOOL1 "$FS_DISK2" spare "$disk1"
 log_mustnot poolexists $TESTPOOL1
 
 wait $PIDUFSDUMP
@@ -171,7 +162,7 @@ log_mustnot poolexists $TESTPOOL2
 
 log_note "Attempt to take the restored device in use by ufsrestore as spare" \
     "device"
-log_mustnot zpool create -f $TESTPOOL2 "$FS_SIDE2" spare "$disk1"
+log_mustnot zpool create -f $TESTPOOL2 "$FS_DISK2" spare "$disk1"
 log_mustnot poolexists $TESTPOOL2
 
 log_pass "Unable to zpool over a device in use by ufsdump or ufsrestore"

--- a/tests/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
@@ -58,7 +58,7 @@ function cleanup
 	cleanup_devices $vdisks $sdisks
 }
 
-function verify_assertion #slices
+function verify_assertion #disks
 {
 	typeset targets=$1
 
@@ -86,34 +86,7 @@ while (( i < ${#vdevs[*]} )); do
 		eval typeset disk=\${FS_DISK$num}
 		zero_partitions $disk
 	done
-	typeset cyl=""
-	for num in 0 1 2 3 ; do
-		eval typeset slice=\${FS_SIDE$num}
-		disk=${slice%${SLICE_PREFIX}*}
-		[[ -z $SLICE_PREFIX ]] && eval typeset disk=\${FS_DISK$num}
-		slice=$(echo $slice | awk '{ print substr($1,length($1),1) }')
-		log_must set_partition $slice "$cyl" $FS_SIZE $disk
-		[[ $num < 3 ]] && cyl=$(get_endslice $disk $slice)
-	done
 
-	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
-
-	create_pool $TESTPOOL1 ${vdevs[i]} $vslices spare $sslices
-	verify_assertion "$rawtargets"
-	destroy_pool $TESTPOOL1
-
-	if [[ ( $FS_DISK0 == $FS_DISK2 ) && -n ${vdevs[i]} ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
-
-	if [[ ( $FS_DISK0 == $FS_DISK3 ) && ( ${vdevs[i]} == "raidz2" ) ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
 	create_pool $TESTPOOL1 ${vdevs[i]} $vdisks spare $sdisks
 	verify_assertion "$rawtargets"
 	destroy_pool $TESTPOOL1

--- a/tests/zfs-tests/tests/functional/inuse/inuse_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_006_pos.ksh
@@ -58,7 +58,7 @@ function cleanup
 	cleanup_devices $vdisks $sdisks
 }
 
-function verify_assertion #slices
+function verify_assertion # disks
 {
 	typeset targets=$1
 
@@ -86,32 +86,6 @@ while (( i < ${#vdevs[*]} )); do
 		eval typeset disk=\${FS_DISK$num}
 		zero_partitions $disk
 	done
-
-	for num in 0 1 2 3 ; do
-		eval typeset slice=\${FS_SIDE$num}
-		disk=${slice%${SLICE_PREFIX}*}
-		slice=${slice##*${SLICE_PREFIX}}
-		log_must set_partition $slice "" $FS_SIZE $disk
-	done
-
-	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
-
-	create_pool $TESTPOOL1 ${vdevs[i]} $vslices spare $sslices
-	verify_assertion "$disktargets"
-	destroy_pool $TESTPOOL1
-
-	if [[ ( $FS_DISK0 == $FS_DISK2 ) && -n ${vdevs[i]} ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
-
-	if [[ ( $FS_DISK0 == $FS_DISK3 ) && ( ${vdevs[i]} == "raidz2" ) ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
 
 	create_pool $TESTPOOL1 ${vdevs[i]} $vdisks spare $sdisks
 	verify_assertion "$disktargets"

--- a/tests/zfs-tests/tests/functional/inuse/inuse_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_007_pos.ksh
@@ -61,7 +61,7 @@ function cleanup
 	cleanup_devices $vdisks $sdisks
 }
 
-function verify_assertion #slices
+function verify_assertion # disks
 {
 	typeset targets=$1
 
@@ -90,34 +90,6 @@ while (( i < ${#vdevs[*]} )); do
 		eval typeset disk=\${FS_DISK$num}
 		zero_partitions $disk
 	done
-
-	for num in 0 1 2 3 ; do
-		eval typeset slice=\${FS_SIDE$num}
-		disk=${slice%${SLICE_PREFIX}*}
-		slice=${slice##*${SLICE_PREFIX}}
-		log_must set_partition $slice "" $FS_SIZE $disk
-	done
-
-	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
-
-	create_pool $TESTPOOL1 ${vdevs[i]} $vslices spare $sslices
-	log_must zpool export $TESTPOOL1
-	verify_assertion "$disktargets"
-	log_must zpool import $TESTPOOL1
-	destroy_pool $TESTPOOL1
-
-	if [[ ( $FS_DISK0 == $FS_DISK2 ) && -n ${vdevs[i]} ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
-
-	if [[ ( $FS_DISK0 == $FS_DISK3 ) && ( ${vdevs[i]} == "raidz2" ) ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
 
 	create_pool $TESTPOOL1 ${vdevs[i]} $vdisks spare $sdisks
 	log_must zpool export $TESTPOOL1

--- a/tests/zfs-tests/tests/functional/inuse/inuse_008_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_008_pos.ksh
@@ -61,7 +61,7 @@ function cleanup
 	cleanup_devices $vdisks $sdisks
 }
 
-function verify_assertion #slices
+function verify_assertion # disks
 {
 	typeset targets=$1
 
@@ -89,22 +89,8 @@ for num in 0 1 2 3 ; do
 	zero_partitions $disk
 done
 
-for num in 0 1 2 3 ; do
-	eval typeset slice=\${FS_SIDE$num}
-	disk=${slice%${SLICE_PREFIX}*}
-	[[ -z $SLICE_PREFIX ]] && eval typeset disk=\${FS_DISK$num}
-	slice=$(echo $slice | awk '{ print substr($1,length($1),1) }')
-	log_must set_partition $slice "$cyl" $FS_SIZE $disk
-	[[ $num < 3 ]] && cyl=$(get_endslice $disk $slice)
-done
-
 while (( i < ${#vdevs[*]} )); do
-	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
-
-	create_pool $TESTPOOL1 ${vdevs[i]} $vslices spare $sslices
+	create_pool $TESTPOOL1 ${vdevs[i]} $vdisks spare $sdisks
 	log_must zpool export $TESTPOOL1
 	verify_assertion "$rawtargets"
 

--- a/tests/zfs-tests/tests/functional/inuse/inuse_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/inuse_009_pos.ksh
@@ -61,7 +61,7 @@ function cleanup
 	cleanup_devices $vdisks $sdisks
 }
 
-function verify_assertion #disks
+function verify_assertion # disks
 {
 	typeset targets=$1
 
@@ -86,35 +86,6 @@ while (( i < ${#vdevs[*]} )); do
 		eval typeset disk=\${FS_DISK$num}
 		zero_partitions $disk
 	done
-
-	typeset cyl=""
-	for num in 0 1 2 3 ; do
-		eval typeset slice=\${FS_SIDE$num}
-		disk=${slice%${SLICE_PREFIX}*}
-		[[ -z $SLICE_PREFIX ]] && eval typeset disk=\${FS_DISK$num}
-		slice=$(echo $slice | awk '{ print substr($1,length($1),1) }')
-		log_must set_partition $slice "$cyl" $FS_SIZE $disk
-		[[ $num < 3 ]] && cyl=$(get_endslice $disk $slice)
-	done
-
-	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
-
-	create_pool $TESTPOOL1 ${vdevs[i]} $vslices spare $sslices
-	log_must zpool export $TESTPOOL1
-	verify_assertion "$vdisks $sdisks"
-
-	if [[ ( $FS_DISK0 == $FS_DISK2 ) && -n ${vdevs[i]} ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
-
-	if [[ ( $FS_DISK0 == $FS_DISK3 ) && ( ${vdevs[i]} == "raidz2" ) ]]; then
-		(( i = i + 1 ))
-		continue
-	fi
 
 	create_pool $TESTPOOL1 ${vdevs[i]} $vdisks spare $sdisks
 	log_must zpool export $TESTPOOL1

--- a/tests/zfs-tests/tests/functional/inuse/setup.ksh
+++ b/tests/zfs-tests/tests/functional/inuse/setup.ksh
@@ -33,4 +33,6 @@
 
 verify_runnable "global"
 
+verify_disk_count "$DISKS" 4
+
 log_pass


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Many tests can avoid complex partitioning schemes by requiring 4 disks be present instead of 2 or 3. We currently only create 3 loop devices by default for testing. Bumping this to 4 will set us up to eliminate the partitioning from tests.

### Description
<!--- Describe your changes in detail -->
Create one more loop device by default in zfs-tests.sh.
As a first pass at eliminating partitioning, tackle the inuse tests:
 * Require 4 disks for the tests
 * Don't do partitioning
 * Try to adjust variable names and comments appropriately.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Many runs through ZTS on FreeBSD

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
