### PR TITLE
Add an .editorconfig; document git whitespace settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{c,h}]
+tab_width = 8
+indent_style = tab

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -137,8 +137,8 @@ changes easier to review and approve which speeds up the merging process.
 * Try to keep pull requests simple. Simple code with comments is much easier
 to review and approve.
 * All proposed changes must be approved by a ZFS on Linux organization member.
-* If you have an idea you'd like to discuss or which requires additional testing, consider opening it as a draft pull request. 
-Once everything is in good shape and the details have been worked out you can remove its draft status. 
+* If you have an idea you'd like to discuss or which requires additional testing, consider opening it as a draft pull request.
+Once everything is in good shape and the details have been worked out you can remove its draft status.
 Any required reviews can then be finalized and the pull request merged.
 
 #### Tests and Benchmarks
@@ -176,6 +176,16 @@ to verify ZFS is behaving as intended.
 We currently use [C  Style  and  Coding  Standards  for
 SunOS](http://www.cis.upenn.edu/%7Elee/06cse480/data/cstyle.ms.pdf) as our
 coding convention.
+
+This repository has an `.editorconfig` file. If your editor [supports
+editorconfig](https://editorconfig.org/#download), it will
+automatically respect most of this project's whitespace preferences.
+
+Additionally, Git can help warn on whitespace problems as well:
+
+```
+git config --local core.whitespace trailing-space,space-before-tab,indent-with-non-tab,-tab-in-indent
+```
 
 ### Commit Message Formats
 #### New Changes
@@ -315,4 +325,3 @@ but may be used in any situation where there are co-authors.
 The email address used here should be the same as on the GitHub profile of said user.
 If said user does not have their email address public, please use the following instead:
 `Co-authored-by: Name <[username]@users.noreply.github.com>`
-


### PR DESCRIPTION
### Motivation and Context

Most of the projects I work on don't use tabs, and while authoring my
first patch I had to wrestle with my editor to not introduce
whitespace editors.

### Description

The `.editorconfig` file is supported by a large number of editors
out of the box, and many more with plugins.

### How Has This Been Tested?

As a first-time contributor, I can't say for certain these settings
are totally correct, but thus far git and my editor are satisfied
enough.

I considered adding `git config --local format.signOff true` but
wanted to respect the warning:

    format.signOff
        A boolean value which lets you enable the -s/--signoff
        option of format-patch by default.  Note: Adding the
        Signed-off-by: line to a patch should be a conscious act and
        means that you certify you have the rights to submit this
        work under the same open source license. Please see the
        SubmittingPatches document for further discussion.

Requires-builders: none

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
