### PR TITLE
ZTS: Fix a few defaults

### DIFF
--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -89,8 +89,8 @@ function block_device_wait
 #
 function is_physical_device #device
 {
-	typeset device=${1#$DEV_DSKDIR}
-	device=${device#$DEV_RDSKDIR}
+	typeset device=${1#$DEV_DSKDIR/}
+	device=${device#$DEV_RDSKDIR/}
 
 	if is_linux; then
 		is_disk_device "$DEV_DSKDIR/$device" && \
@@ -216,9 +216,6 @@ function set_slice_prefix
 			fi
 			(( i = i + 1))
 		done
-	elif is_freebsd; then
-		export SLICE_PREFIX="p"
-		return 0
 	fi
 }
 

--- a/tests/zfs-tests/include/default.cfg.in
+++ b/tests/zfs-tests/include/default.cfg.in
@@ -173,6 +173,7 @@ if is_linux; then
 
 	ZVOL_DEVDIR="/dev/zvol"
 	ZVOL_RDEVDIR="/dev/zvol"
+	DEV_DSKDIR="/dev"
 	DEV_RDSKDIR="/dev"
 	DEV_MPATHDIR="/dev/mapper"
 
@@ -182,8 +183,8 @@ if is_linux; then
 	VDEVID_CONF="$ZEDLET_DIR/vdev_id.conf"
 	VDEVID_CONF_ETC="/etc/zfs/vdev_id.conf"
 
-
 	NEWFS_DEFAULT_FS="ext2"
+	SLICE_PREFIX=""
 elif is_freebsd; then
 	unpack_opts="xv"
 	pack_opts="cf"
@@ -198,6 +199,7 @@ elif is_freebsd; then
 	DEV_MPATHDIR="/dev/multipath"
 
 	NEWFS_DEFAULT_FS="ufs"
+	SLICE_PREFIX="p"
 else
 	unpack_opts="xv"
 	pack_opts="cf"
@@ -211,8 +213,9 @@ else
 	DEV_RDSKDIR="/dev/rdsk"
 
 	NEWFS_DEFAULT_FS="ufs"
+	SLICE_PREFIX="s"
 fi
 export unpack_opts pack_opts verbose unpack_preserve pack_preserve \
        ZVOL_DEVDIR ZVOL_RDEVDIR DEV_DSKDIR DEV_RDSKDIR DEV_MPATHDIR \
        ZEDLET_DIR ZED_LOG ZED_DEBUG_LOG VDEVID_CONF VDEVID_CONF_ETC \
-       NEWFS_DEFAULT_FS
+       NEWFS_DEFAULT_FS SLICE_PREFIX

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -912,14 +912,15 @@ function set_partition
 	typeset -i slicenum=$1
 	typeset start=$2
 	typeset size=$3
-	typeset disk=$4
+	typeset disk=${4#$DEV_DSKDIR/}
+	disk=${disk#$DEV_RDSKDIR/}
 
 	case "$(uname)" in
 	Linux)
 		if [[ -z $size || -z $disk ]]; then
 			log_fail "The size or disk name is unspecified."
 		fi
-		[[ -n $DEV_DSKDIR ]] && disk=$DEV_DSKDIR/$disk
+		disk=$DEV_DSKDIR/$disk
 		typeset size_mb=${size%%[mMgG]}
 
 		size_mb=${size_mb%%[mMgG][bB]}
@@ -967,7 +968,7 @@ function set_partition
 		if [[ -z $size || -z $disk ]]; then
 			log_fail "The size or disk name is unspecified."
 		fi
-		[[ -n $DEV_DSKDIR ]] && disk=$DEV_DSKDIR/$disk
+		disk=$DEV_DSKDIR/$disk
 
 		if [[ $slicenum -eq 0 ]] || ! gpart show $disk >/dev/null 2>&1; then
 			gpart destroy -F $disk >/dev/null 2>&1

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.cfg
@@ -73,8 +73,6 @@ if is_linux || is_freebsd; then
 	export SLICE5=6
 	export SLICE6=7
 else
-	export DEV_DSKDIR="/dev"
-	export SLICE_PREFIX="s"
 	export SLICE0=0
 	export SLICE1=1
 	export SLICE3=3

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create.cfg
@@ -78,7 +78,6 @@ if is_linux; then
 		delete_partitions
 	fi
 else
-	export SLICE_PREFIX="s"
 	export SLICE0=0
 	export SLICE1=1
 	export SLICE2=2

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
@@ -38,7 +38,6 @@ if is_linux; then
 	export SLICE0=1
 	export SLICE1=2
 else
-	export SLICE_PREFIX="s"
 	export SLICE0=0
 	export SLICE1=1
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove.cfg
@@ -45,7 +45,6 @@ if is_linux; then
 	export SLICE6=7
 	export SLICE7=8
 else
-	export SLICE_PREFIX="s"
 	export SLICE0=0
 	export SLICE1=1
 	export SLICE2=2

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_reopen/zpool_reopen.cfg
@@ -40,6 +40,4 @@ if is_linux; then
 	devs_id[1]=$(get_persistent_disk_name $DISK2)
 	devs_id[2]=$(get_persistent_disk_name $DISK3)
 	export devs_id
-else
-	DEV_DSKDIR="/dev"
 fi

--- a/tests/zfs-tests/tests/functional/fault/fault.cfg
+++ b/tests/zfs-tests/tests/functional/fault/fault.cfg
@@ -47,8 +47,6 @@ if is_linux; then
 	devs_id[1]=$(get_persistent_disk_name $DISK2)
 	devs_id[2]=$(get_persistent_disk_name $DISK3)
 	export devs_id
-else
-	DEV_DSKDIR="/dev"
 fi
 
 export VDEV_FILES="$TEST_BASE_DIR/file-1 $TEST_BASE_DIR/file-2 \

--- a/tests/zfs-tests/tests/functional/inuse/inuse.cfg
+++ b/tests/zfs-tests/tests/functional/inuse/inuse.cfg
@@ -38,7 +38,6 @@ if is_linux; then
 	export SLICE0=1
 	export SLICE1=2
 else
-	export SLICE_PREFIX="s"
 	export SLICE0=0
 	export SLICE1=1
 fi

--- a/tests/zfs-tests/tests/functional/migration/migration.cfg
+++ b/tests/zfs-tests/tests/functional/migration/migration.cfg
@@ -60,7 +60,6 @@ case "${#disk_array[*]}" in
 			log_fail "$ZFS_DISK not supported for partitioning."
 		fi
 	else
-		export DEV_DSKDIR="/dev"
 		ZFSSIDE_DISK=${SINGLE_DISK}s0
 		NONZFSSIDE_DISK=${SINGLE_DISK}s1
 	fi
@@ -93,7 +92,6 @@ case "${#disk_array[*]}" in
 			log_fail "$NONZFS_DISK not supported for partitioning."
 		fi
 	else
-		export DEV_DSKDIR="/dev"
 		ZFSSIDE_DISK=${ZFS_DISK}s0
 		NONZFSSIDE_DISK=${NONZFS_DISK}s0
 	fi

--- a/tests/zfs-tests/tests/functional/write_dirs/write_dirs.cfg
+++ b/tests/zfs-tests/tests/functional/write_dirs/write_dirs.cfg
@@ -41,7 +41,5 @@ if is_linux; then
 	set_device_dir
 	export SLICE=1
 else
-	DEV_DSKDIR="/dev"
-	export SLICE_PREFIX="s"
 	export SLICE=0
 fi

--- a/tests/zfs-tests/tests/functional/zvol/zvol_ENOSPC/zvol_ENOSPC.cfg
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_ENOSPC/zvol_ENOSPC.cfg
@@ -32,17 +32,10 @@
 
 verify_runnable "global"
 
-#export SIZE="1gb"
 export DISK_ARRAY_NUM=$(echo ${DISKS} | nawk '{print NF}')
 export DISKSARRAY=$DISKS
-
 
 if is_linux; then
 	set_slice_prefix
 	set_device_dir
-#	export SLICE=1
-else
-	DEV_DSKDIR="/dev"
-	export SLICE_PREFIX="s"
-#	export SLICE=0
 fi

--- a/tests/zfs-tests/tests/functional/zvol/zvol_cli/zvol_cli.cfg
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_cli/zvol_cli.cfg
@@ -35,11 +35,7 @@ verify_runnable "global"
 export DISK_ARRAY_NUM=$(echo ${DISKS} | nawk '{print NF}')
 export DISKSARRAY=$DISKS
 
-
 if is_linux; then
 	set_slice_prefix
 	set_device_dir
-else
-	DEV_DSKDIR="/dev"
-	export SLICE_PREFIX="s"
 fi


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While troubleshooting some test failures after changes to partitioning I discovered Linux was missing a default value for DEV_DSKDIR, and instead it was being set in various places throughout the tests. Other platforms have a default set for DEV_DSKDIR, only on Linux is it missing.

Similarly SLICE_PREFIX seems like a good candidate for including in the defaults. It was being set in various places throughout the code. Moving to one definition in the defaults.cfg file ensures it is always available and simplifies tests.

### Description
<!--- Describe your changes in detail -->
* Set DEV_DSKDIR=/dev on Linux in defaults.cfg
* Remove other random places it is being set (except in blkdev set_device_dir)
* Fix the fallout
* Consolidate SLICE_PREFIX variable into defaults.cfg

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Pending full ZTS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
