### PR TITLE
ZTS: Use the correct spelling of 'jailed' in tests

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs/zfs_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs/zfs_001_neg.ksh
@@ -57,7 +57,7 @@ set -A args  "" "create" "create -s" "create -V" "create -s -V" \
     "set compressratio=" "set mounted=" "set origin=" "set quota=" \
     "set reservation=" "set volsize=" " set volblocksize=" "set recordsize=" \
     "set mountpoint=" "set devices=" "set exec=" "set setuid=" "set readonly=" \
-    "set zoned=" "set snapdir=" "set aclmode=" "set aclinherit=" \
+    "set snapdir=" "set aclmode=" "set aclinherit=" \
     "set quota=blah" "set reservation=blah" "set atime=blah" "set checksum=blah" \
     "set compression=blah" \
     "upgrade blah" "mount blah" "mount -o" \
@@ -65,6 +65,11 @@ set -A args  "" "create" "create -s" "create -V" "create -s -V" \
     "share" "unshare" "send" "send -i" "receive" "receive -d" "receive -vnF" \
     "recv" "recv -d" "recv -vnF" "allow" "unallow" \
     "blah blah" "-%" "--" "--?" "-*" "-="
+if is_freebsd; then
+	args+=("set jailed=")
+else
+	args+=("set zoned=")
+fi
 
 log_assert "Badly-formed zfs sub-command should return an error."
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/properties.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/properties.kshlib
@@ -61,9 +61,13 @@ set -A FS_ONLY_PROP "quota=536870912" \
                     "devices=off" \
                     "exec=off" \
                     "setuid=off" \
-                    "zoned=on" \
                     "snapdir=visible" \
 		    "canmount=off" \
 		    "version=1"
+if is_freebsd; then
+	FS_ONLY_PROP+=("jailed=on")
+else
+	FS_ONLY_PROP+=("zoned=on")
+fi
 
 set -A VOL_ONLY_PROP "volblocksize=16384" "volsize=536870912"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_008_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_create/zfs_create_008_neg.ksh
@@ -74,7 +74,6 @@ set -A args "ab" "-?" "-cV" "-Vc" "-c -V" "c" "V" "--c" "-e" "-s" \
     "-o readonly=ON" "-o reADOnly=off" "-o rdonly=OFF" "-o rdonly=aaa" \
     "-o readonly=ON -V $VOLSIZE" "-o reADOnly=off -V $VOLSIZE" \
     "-o rdonly=OFF -V $VOLSIZE" "-o rdonly=aaa -V $VOLSIZE" \
-    "-o zoned=ON" "-o ZoNed=off" "-o zoned=aaa" \
     "-o snapdIR=hidden" "-o snapdir=VISible" "-o snapdir=aaa" \
     "-o aclmode=DIScard" "-o aclmODE=groupmask" "-o aclmode=aaa" \
     "-o aclinherit=deny" "-o aclinHerit=secure" "-o aclinherit=aaa" \
@@ -88,6 +87,11 @@ set -A args "ab" "-?" "-cV" "-Vc" "-c -V" "c" "V" "--c" "-e" "-s" \
     "-o compressratio=1.00x" "-o compressratio=1.00x -V $VOLSIZE" \
     "-o version=0" "-o version=1.234" "-o version=10K" "-o version=-1" \
     "-o version=aaa" "-o version=999"
+if is_freebsd; then
+	args+=("-o jailed=ON" "-o JaiLed=off" "-o jailed=aaa")
+else
+	args+=("-o zoned=ON" "-o ZoNed=off" "-o zoned=aaa")
+fi
 
 log_assert "'zfs create' should return an error with badly-formed parameters."
 

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_inherit/zfs_inherit_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_inherit/zfs_inherit_002_neg.ksh
@@ -56,8 +56,13 @@ log_onexit cleanup
 
 set -A badopts "r" "R" "-R" "-rR" "-a" "-" "-?" "-1" "-2" "-v" "-n"
 set -A props "recordsize" "mountpoint" "sharenfs" "checksum" "compression" \
-    "atime" "devices" "exec" "setuid" "readonly" "zoned" "snapdir" "aclmode" \
+    "atime" "devices" "exec" "setuid" "readonly" "snapdir" "aclmode" \
     "aclinherit" "xattr" "copies"
+if is_freebsd; then
+	props+=("jailed")
+else
+	props+=("zoned")
+fi
 set -A illprops "recordsiz" "mountpont" "sharen" "compres" "atme" "blah"
 
 log_must zfs snapshot $TESTPOOL/$TESTFS@$TESTSNAP

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/ro_props_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/ro_props_001_pos.ksh
@@ -55,7 +55,12 @@ typeset ro_props="type used creation referenced refer compressratio \
 	mounted origin"
 typeset snap_ro_props="volsize recordsize recsize quota reservation reserv mountpoint \
 	sharenfs checksum compression compress atime devices exec readonly rdonly \
-	setuid zoned"
+	setuid"
+if is_freebsd; then
+	snap_ro_props+=" jailed"
+else
+	snap_ro_props+=" zoned"
+fi
 
 zfs upgrade -v > /dev/null 2>&1
 if [[ $? -eq 0 ]]; then

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_001_neg.ksh
@@ -45,7 +45,12 @@
 verify_runnable "both"
 
 set -A props "" "mountpoint" "checksum" "compression" "atime" "readonly" \
-	"setuid" "zoned" "canmount"
+	"setuid" "canmount"
+if is_freebsd; then
+	props+=("jailed")
+else
+	props+=("zoned")
+fi
 
 set -A values "" "mountpoint" "checksum" "compression" "atime" "readonly" \
 	"setuid" "zoned" "0" "-?" "-on" "--on" "*" "?" "Legacy" "NONE" "oN" \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/zfs_set_002_neg.ksh
@@ -47,8 +47,13 @@ log_assert "'zfs set' fails with invalid arguments"
 
 set -A editable_props "quota" "reservation" "reserv" "volsize" "recordsize" "recsize" \
 		"mountpoint" "checksum" "compression" "compress" "atime" \
-		"devices" "exec" "setuid" "readonly" "zoned" "snapdir" "aclmode" \
+		"devices" "exec" "setuid" "readonly" "snapdir" "aclmode" \
 		"aclinherit" "canmount" "xattr" "copies" "version"
+if is_freebsd; then
+	editable_props+=("jailed")
+else
+	editable_props+=("zoned")
+fi
 
 for ds in $TESTPOOL $TESTPOOL/$TESTFS $TESTPOOL/$TESTVOL \
 	$TESTPOOL/$TESTFS@$TESTSNAP; do

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_007_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_snapshot/zfs_snapshot_007_neg.ksh
@@ -74,7 +74,12 @@ typeset ro_props="type used available avail creation referenced refer compressra
 	mounted origin"
 typeset snap_ro_props="volsize recordsize recsize quota reservation reserv mountpoint \
 	sharenfs checksum compression compress atime devices exec readonly rdonly \
-	setuid zoned"
+	setuid"
+if is_freebsd; then
+	snap_ro_props+=" jailed"
+else
+	snap_ro_props+=" zoned"
+fi
 
 zfs upgrade -v > /dev/null 2>&1
 if [[ $? -eq 0 ]]; then

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_021_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_021_pos.ksh
@@ -70,8 +70,12 @@ set -A RW_FS_PROP "quota=536870912" \
 		  "snapdir=visible" \
 		  "acltype=posixacl" \
 		  "aclinherit=discard" \
-		  "canmount=off" \
-		  "zoned=on"
+		  "canmount=off"
+if is_freebsd; then
+	RW_FS_PROP+=("jailed=on")
+else
+	RW_FS_PROP+=("zoned=on")
+fi
 
 typeset -i i=0
 while (( $i < ${#RW_FS_PROP[*]} )); do

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_023_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_023_neg.ksh
@@ -63,7 +63,6 @@ set -A args "QuOta=none" "quota=non" "quota=abcd" "quota=0" "quota=" \
     "deviCes=on" "devices=OFF" "devices=aaa" \
     "exec=ON" "EXec=off" "exec=aaa" \
     "readonly=ON" "reADOnly=off" "rdonly=OFF" "rdonly=aaa" \
-    "zoned=ON" "ZoNed=off" "zoned=aaa" \
     "snapdIR=hidden" "snapdir=VISible" "snapdir=aaa" \
     "acltype=DIScard" "acltYPE=groupmask" "acltype=aaa" \
     "aclinherit=deny" "aclinHerit=secure" "aclinherit=aaa" \
@@ -72,6 +71,11 @@ set -A args "QuOta=none" "quota=non" "quota=abcd" "quota=0" "quota=" \
     "referenced=10K" "compressratio=1.00x" \
     "version=0" "version=1.234" "version=10K" "version=-1" \
     "version=aaa" "version=999"
+if is_freebsd; then
+	args+=("jailed=ON" "JaiLed=off" "jailed=aaa")
+else
+	args+=("zoned=ON" "ZoNed=off" "zoned=aaa")
+fi
 
 log_assert "'zpool create -O' should return an error with badly formed parameters."
 

--- a/tests/zfs-tests/tests/functional/delegate/zfs_allow_010_pos.ksh
+++ b/tests/zfs-tests/tests/functional/delegate/zfs_allow_010_pos.ksh
@@ -93,7 +93,7 @@ elif is_freebsd; then
 #		Permission	Filesystem	Volume
 #
 # Removed for FreeBSD
-# - zoned	- zones are not supported
+# - zoned	- spelled "jailed"
 # - sharenfs	- sharing requires superuser privileges
 # - share	- sharing requires superuser privileges
 # - xattr	- Not supported on FreeBSD
@@ -125,6 +125,7 @@ set -A perms	create		true		false	\
 		clone		true		true	\
 		rename		true		true	\
 		promote		true		true	\
+		jailed		true		false	\
 		receive		true		false   \
 		destroy		true		true
 

--- a/tests/zfs-tests/tests/functional/delegate/zfs_allow_012_neg.ksh
+++ b/tests/zfs-tests/tests/functional/delegate/zfs_allow_012_neg.ksh
@@ -66,7 +66,7 @@ set -A perms	create snapshot mount send allow quota reservation \
 		recordsize mountpoint checksum compression canmount atime \
 		devices exec volsize setuid readonly snapdir userprop \
 		aclmode aclinherit rollback clone rename promote dnodesize \
-		zoned receive destroy
+		jailed receive destroy
 else
 set -A perms	create snapshot mount send allow quota reservation \
 		recordsize mountpoint checksum compression canmount atime \

--- a/tests/zfs-tests/tests/functional/history/history_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_002_pos.ksh
@@ -105,7 +105,7 @@ props=(
 	exec		on		exec		off
 	setuid		on		setuid		off
 	readonly	on		readonly	off
-	zoned		on		zoned		off
+	jailed		on		jailed		off
 	snapdir		hidden		snapdir		visible
 	aclinherit	discard		aclinherit	noallow
 	aclinherit	secure		aclinherit	passthrough

--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -217,15 +217,21 @@ function cmp_ds_prop
 {
 	typeset dtst1=$1
 	typeset dtst2=$2
-
-	for item in "type" "origin" "volblocksize" "acltype" "dnodesize" \
+	typeset -a props=("type" "origin" "volblocksize" "acltype" "dnodesize" \
 	    "atime" "canmount" "checksum" "compression" "copies" "devices" \
 	    "exec" "quota" "readonly" "recordsize" "reservation" "setuid" \
-	    "snapdir" "version" "volsize" "xattr" "zoned" "mountpoint";
+	    "snapdir" "version" "volsize" "xattr" "mountpoint");
+	if is_freebsd; then
+		props+=("jailed")
+	else
+		props+=("zoned")
+	fi
+
+	for prop in $props;
 	do
-		zfs get -H -o property,value,source $item $dtst1 >> \
+		zfs get -H -o property,value,source $prop $dtst1 >> \
 		    $BACKDIR/dtst1
-		zfs get -H -o property,value,source $item $dtst2 >> \
+		zfs get -H -o property,value,source $prop $dtst2 >> \
 		    $BACKDIR/dtst2
 	done
 


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FreeBSD has jails, not zones, so the 'zoned' property is spelled 'jailed' on FreeBSD.

### Description
<!--- Describe your changes in detail -->
Make sure the correct property name is used when testing on FreeBSD.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Many runs of ZTS on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
