### PR TITLE
ZTS: Don't use edonr on FreeBSD

### DIFF
--- a/tests/zfs-tests/include/properties.shlib
+++ b/tests/zfs-tests/include/properties.shlib
@@ -13,9 +13,14 @@
 # Copyright (c) 2012, 2016, Delphix. All rights reserved.
 #
 
+. $STF_SUITE/include/libtest.shlib
+
 typeset -a compress_prop_vals=('off' 'lzjb' 'lz4' 'gzip' 'zle')
 typeset -a checksum_prop_vals=('on' 'off' 'fletcher2' 'fletcher4' 'sha256'
-    'noparity' 'sha512' 'skein' 'edonr')
+    'noparity' 'sha512' 'skein')
+if ! is_freebsd; then
+	checksum_prop_vals+=('edonr')
+fi
 typeset -a recsize_prop_vals=('512' '1024' '2048' '4096' '8192' '16384'
     '32768' '65536' '131072' '262144' '524288' '1048576')
 typeset -a canmount_prop_vals=('on' 'off' 'noauto')

--- a/tests/zfs-tests/tests/functional/checksum/default.cfg
+++ b/tests/zfs-tests/tests/functional/checksum/default.cfg
@@ -28,4 +28,9 @@
 # Copyright (c) 2013 by Delphix. All rights reserved.
 #
 
-set -A CHECKSUM_TYPES "fletcher2" "fletcher4" "sha256" "sha512" "skein" "edonr"
+. $STF_SUITE/include/libtest.shlib
+
+set -A CHECKSUM_TYPES "fletcher2" "fletcher4" "sha256" "sha512" "skein"
+if ! is_freebsd; then
+	CHECKSUM_TYPES+=("edonr")
+fi

--- a/tests/zfs-tests/tests/functional/checksum/filetest_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/checksum/filetest_001_pos.ksh
@@ -75,11 +75,6 @@ firstvdev=${array[0]}
 typeset -i i=1
 while [[ $i -lt ${#CHECKSUM_TYPES[*]} ]]; do
 	type=${CHECKSUM_TYPES[i]}
-	# edonr not supported on FreeBSD
-	if is_freebsd && [[ "$type" == "edonr" ]] ; then
-		(( i = i + 1 ))
-		continue
-	fi
 	log_must zfs set checksum=$type $TESTPOOL
 	log_must file_write -o overwrite -f $TESTDIR/test_$type \
 	    -b $WRITESZ -c 5 -d R
@@ -101,11 +96,6 @@ log_assert "Test corrupting the files and seeing checksum errors"
 typeset -i j=1
 while [[ $j -lt ${#CHECKSUM_TYPES[*]} ]]; do
 	type=${CHECKSUM_TYPES[$j]}
-	# edonr not supported on FreeBSD
-	if is_freebsd && [[ "$type" == "edonr" ]] ; then
-		(( j = j + 1 ))
-		continue
-	fi
 	log_must zfs set checksum=$type $TESTPOOL
 	log_must file_write -o overwrite -f $TESTDIR/test_$type \
 	    -b $WRITESZ -c 5 -d R

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -71,7 +71,6 @@ typeset -a properties=(
     "feature@large_blocks"
     "feature@sha512"
     "feature@skein"
-    "feature@edonr"
     "feature@device_removal"
     "feature@obsolete_counts"
     "feature@zpool_checkpoint"
@@ -93,5 +92,11 @@ if is_linux || is_freebsd; then
 	    "feature@resilver_defer"
 	    "feature@bookmark_v2"
 	    "feature@livelist"
+	)
+fi
+
+if ! is_freebsd; then
+	properties+=(
+	    "feature@edonr"
 	)
 fi

--- a/tests/zfs-tests/tests/functional/removal/removal_nopwrite.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_nopwrite.ksh
@@ -29,7 +29,7 @@ BLOCKSIZE=8192
 origin="$TESTPOOL/$TESTFS"
 
 log_must zfs set compress=on $origin
-log_must zfs set checksum=edonr $origin
+log_must zfs set checksum=skein $origin
 
 log_must zfs set recordsize=8k $origin
 dd if=/dev/urandom of=$TESTDIR/file_8k bs=1024k count=$MEGS oflag=sync \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FreeBSD doesn't support feature@edonr.

### Description
<!--- Describe your changes in detail -->
Don't include edonr in the list of compression algorithms when testing on FreeBSD.
Use a different algo in removal_nowrite. It didn't seem to be important that edonr was chosen there.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Passed full ZTS

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
