### PR TITLE
Fix const-correctness in raidz math

### DIFF
--- a/module/zfs/vdev_raidz_math_impl.h
+++ b/module/zfs/vdev_raidz_math_impl.h
@@ -391,7 +391,7 @@ raidz_gen_pq_add(void **c, const void *dc, const size_t csize,
 {
 	v_t *p = (v_t *)c[0];
 	v_t *q = (v_t *)c[1];
-	const v_t *d = (v_t *)dc;
+	const v_t *d = (const v_t *)dc;
 	const v_t * const dend = d + (dsize / sizeof (v_t));
 	const v_t * const qend = q + (csize / sizeof (v_t));
 
@@ -462,7 +462,7 @@ raidz_gen_pqr_add(void **c, const void *dc, const size_t csize,
 	v_t *p = (v_t *)c[0];
 	v_t *q = (v_t *)c[1];
 	v_t *r = (v_t *)c[CODE_R];
-	const v_t *d = (v_t *)dc;
+	const v_t *d = (const v_t *)dc;
 	const v_t * const dend = d + (dsize / sizeof (v_t));
 	const v_t * const qend = q + (csize / sizeof (v_t));
 
@@ -629,7 +629,7 @@ raidz_syn_q_abd(void **xc, const void *dc, const size_t xsize,
     const size_t dsize)
 {
 	v_t *x = (v_t *)xc[TARGET_X];
-	const v_t *d = (v_t *)dc;
+	const v_t *d = (const v_t *)dc;
 	const v_t * const dend = d + (dsize / sizeof (v_t));
 	const v_t * const xend = x + (xsize / sizeof (v_t));
 
@@ -720,7 +720,7 @@ raidz_syn_r_abd(void **xc, const void *dc, const size_t tsize,
     const size_t dsize)
 {
 	v_t *x = (v_t *)xc[TARGET_X];
-	const v_t *d = (v_t *)dc;
+	const v_t *d = (const v_t *)dc;
 	const v_t * const dend = d + (dsize / sizeof (v_t));
 	const v_t * const xend = x + (tsize / sizeof (v_t));
 
@@ -813,7 +813,7 @@ raidz_syn_pq_abd(void **tc, const void *dc, const size_t tsize,
 {
 	v_t *x = (v_t *)tc[TARGET_X];
 	v_t *y = (v_t *)tc[TARGET_Y];
-	const v_t *d = (v_t *)dc;
+	const v_t *d = (const v_t *)dc;
 	const v_t * const dend = d + (dsize / sizeof (v_t));
 	const v_t * const yend = y + (tsize / sizeof (v_t));
 
@@ -971,7 +971,7 @@ raidz_syn_pr_abd(void **c, const void *dc, const size_t tsize,
 {
 	v_t *x = (v_t *)c[TARGET_X];
 	v_t *y = (v_t *)c[TARGET_Y];
-	const v_t *d = (v_t *)dc;
+	const v_t *d = (const v_t *)dc;
 	const v_t * const dend = d + (dsize / sizeof (v_t));
 	const v_t * const yend = y + (tsize / sizeof (v_t));
 
@@ -1130,7 +1130,7 @@ raidz_syn_qr_abd(void **c, const void *dc, const size_t tsize,
 	v_t *x = (v_t *)c[TARGET_X];
 	v_t *y = (v_t *)c[TARGET_Y];
 	const v_t * const xend = x + (tsize / sizeof (v_t));
-	const v_t *d = (v_t *)dc;
+	const v_t *d = (const v_t *)dc;
 	const v_t * const dend = d + (dsize / sizeof (v_t));
 
 	SYN_QR_DEFINE();
@@ -1295,7 +1295,7 @@ raidz_syn_pqr_abd(void **c, const void *dc, const size_t tsize,
 	v_t *y = (v_t *)c[TARGET_Y];
 	v_t *z = (v_t *)c[TARGET_Z];
 	const v_t * const yend = y + (tsize / sizeof (v_t));
-	const v_t *d = (v_t *)dc;
+	const v_t *d = (const v_t *)dc;
 	const v_t * const dend = d + (dsize / sizeof (v_t));
 
 	SYN_PQR_DEFINE();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Clang warns (errors) that "cast from 'const void *' to 'struct v *' drops const qualifier."

### Description
<!--- Describe your changes in detail -->
The cast values are being assigned to const variables. Add const qualifiers to the casts.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Passed CI

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
