### PR TITLE
Fix dbufstats.cache_levels_* kstat names

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -846,6 +846,17 @@ retry:
 	dbuf_cache_evict_thread = thread_create(NULL, 0, dbuf_evict_thread,
 	    NULL, 0, &p0, TS_RUN, minclsyspri);
 
+	/* Initialize numbered names for the cache levels kstats. */
+	for (i = 0; i < DN_MAX_LEVELS; i++) {
+		snprintf(dbuf_stats.cache_levels[i].name,
+		    KSTAT_STRLEN, "cache_level_%d", i);
+		dbuf_stats.cache_levels[i].data_type =
+		    KSTAT_DATA_UINT64;
+		snprintf(dbuf_stats.cache_levels_bytes[i].name,
+		    KSTAT_STRLEN, "cache_level_%d_bytes", i);
+		dbuf_stats.cache_levels_bytes[i].data_type =
+		    KSTAT_DATA_UINT64;
+	}
 	dbuf_ksp = kstat_create("zfs", 0, "dbufstats", "misc",
 	    KSTAT_TYPE_NAMED, sizeof (dbuf_stats) / sizeof (kstat_named_t),
 	    KSTAT_FLAG_VIRTUAL);
@@ -853,17 +864,6 @@ retry:
 		dbuf_ksp->ks_data = &dbuf_stats;
 		dbuf_ksp->ks_update = dbuf_kstat_update;
 		kstat_install(dbuf_ksp);
-
-		for (i = 0; i < DN_MAX_LEVELS; i++) {
-			snprintf(dbuf_stats.cache_levels[i].name,
-			    KSTAT_STRLEN, "cache_level_%d", i);
-			dbuf_stats.cache_levels[i].data_type =
-			    KSTAT_DATA_UINT64;
-			snprintf(dbuf_stats.cache_levels_bytes[i].name,
-			    KSTAT_STRLEN, "cache_level_%d_bytes", i);
-			dbuf_stats.cache_levels_bytes[i].data_type =
-			    KSTAT_DATA_UINT64;
-		}
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prior to this change the names for dbufstats.cache_levels_* kstats are statically initialized to literally "cache_levels_N" and "cache_levels_bytes_N" for all elements of each of the arrays, and then properly numbered after the dbuf kstats have been created and installed.

On FreeBSD the kstat names need to be set before they are installed. We were seeing the following warnings from the kernel when loading the module:
```
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
sysctl_warn_reuse: can't re-use a leaf (kstat.zfs.misc.dbufstats.cache_levels_bytes_N)!
```

### Description
<!--- Describe your changes in detail -->
Move the loop that sets the numbered names for the cache_levels_* kstats to before the kstats are created and installed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
After loading the module with this change on FreeBSD, the warnings about reused names no longer appear.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
