### PR TITLE
Use -Werror to check if the compiler supports specific options

### DIFF
--- a/config/always-compiler-options.m4
+++ b/config/always-compiler-options.m4
@@ -22,7 +22,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_CC_ASAN], [
 	AS_IF([ test "$enable_asan" = "yes" ], [
 		AC_MSG_CHECKING([whether $CC supports -fsanitize=address])
 		saved_cflags="$CFLAGS"
-		CFLAGS="$CFLAGS -fsanitize=address"
+		CFLAGS="$CFLAGS -Werror -fsanitize=address"
 		AC_LINK_IFELSE([
 			AC_LANG_SOURCE([[ int main() { return 0; } ]])
 		], [
@@ -52,7 +52,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_CC_FRAME_LARGER_THAN], [
 	AC_MSG_CHECKING([whether $CC supports -Wframe-larger-than=<size>])
 
 	saved_flags="$CFLAGS"
-	CFLAGS="$CFLAGS -Wframe-larger-than=4096"
+	CFLAGS="$CFLAGS -Werror -Wframe-larger-than=4096"
 
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])], [
 		FRAME_LARGER_THAN="-Wframe-larger-than=4096"
@@ -73,7 +73,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_CC_NO_FORMAT_TRUNCATION], [
 	AC_MSG_CHECKING([whether $CC supports -Wno-format-truncation])
 
 	saved_flags="$CFLAGS"
-	CFLAGS="$CFLAGS -Wno-format-truncation"
+	CFLAGS="$CFLAGS -Werror -Wno-format-truncation"
 
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])], [
 		NO_FORMAT_TRUNCATION=-Wno-format-truncation
@@ -100,7 +100,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_CC_NO_BOOL_COMPARE], [
 	AC_MSG_CHECKING([whether $CC supports -Wno-bool-compare])
 
 	saved_flags="$CFLAGS"
-	CFLAGS="$CFLAGS -Wbool-compare"
+	CFLAGS="$CFLAGS -Werror -Wbool-compare"
 
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])], [
 		NO_BOOL_COMPARE=-Wno-bool-compare
@@ -126,7 +126,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_CC_NO_UNUSED_BUT_SET_VARIABLE], [
 	AC_MSG_CHECKING([whether $CC supports -Wno-unused-but-set-variable])
 
 	saved_flags="$CFLAGS"
-	CFLAGS="$CFLAGS -Wunused-but-set-variable"
+	CFLAGS="$CFLAGS -Werror -Wunused-but-set-variable"
 
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])], [
 		NO_UNUSED_BUT_SET_VARIABLE=-Wno-unused-but-set-variable
@@ -147,7 +147,7 @@ AC_DEFUN([ZFS_AC_CONFIG_ALWAYS_CC_NO_OMIT_FRAME_POINTER], [
 	AC_MSG_CHECKING([whether $CC supports -fno-omit-frame-pointer])
 
 	saved_flags="$CFLAGS"
-	CFLAGS="$CFLAGS -fno-omit-frame-pointer"
+	CFLAGS="$CFLAGS -Werror -fno-omit-frame-pointer"
 
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])], [
 		NO_OMIT_FRAME_POINTER=-fno-omit-frame-pointer


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Be default, clang treats unknown warning option as warning.
We need to use -Werror to make it an error.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/zfsonlinux/zfs/issues/9926
With this patch, `configure` can generate working `zfs_config.h` when using clang to build kernel.

### Description
<!--- Describe your changes in detail -->
Be default, clang treats unknown warning option as warning.
We need to use -Werror to make it an error.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Tested in Gentoo Linux using Linux 5.5 and clang 9.0.1
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
