### PR TITLE
Fix static data to link with -fno-common.

### DIFF
--- a/cmd/zfs/zfs_util.h
+++ b/cmd/zfs/zfs_util.h
@@ -33,7 +33,7 @@ extern "C" {
 
 void * safe_malloc(size_t size);
 void nomem(void);
-libzfs_handle_t *g_zfs;
+extern libzfs_handle_t *g_zfs;
 
 #ifdef	__cplusplus
 }

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -76,6 +76,8 @@
 
 #include "statcommon.h"
 
+libzfs_handle_t *g_zfs;
+
 static int zpool_do_create(int, char **);
 static int zpool_do_destroy(int, char **);
 

--- a/cmd/zpool/zpool_util.h
+++ b/cmd/zpool/zpool_util.h
@@ -79,7 +79,7 @@ void pool_list_free(zpool_list_t *);
 int pool_list_count(zpool_list_t *);
 void pool_list_remove(zpool_list_t *, zpool_handle_t *);
 
-libzfs_handle_t *g_zfs;
+extern libzfs_handle_t *g_zfs;
 
 
 typedef	struct vdev_cmd_data

--- a/lib/libshare/smb.c
+++ b/lib/libshare/smb.c
@@ -65,6 +65,8 @@ static boolean_t smb_available(void);
 
 static sa_fstype_t *smb_fstype;
 
+smb_share_t *smb_shares;
+
 /*
  * Retrieve the list of SMB shares.
  */

--- a/lib/libshare/smb.h
+++ b/lib/libshare/smb.h
@@ -44,6 +44,6 @@ typedef struct smb_share_s {
 	struct smb_share_s *next;
 } smb_share_t;
 
-smb_share_t *smb_shares;
+extern smb_share_t *smb_shares;
 
 void libshare_smb_init(void);


### PR DESCRIPTION
-fno-common is the new default in GCC 10, replacing -fcommon in GCC <= 9, so static data must only be allocated once.

Signed-off-by: Romain Dolbeau <romain.dolbeau@european-processor-initiative.eu>

### Motivation and Context
GCC 10 will change the default from -fcommon to -fno-common (<https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html>), preventing the linking of any variables with multiple definitions.

This remove multiple definitions of variables, allowing compilation with GCC 10 (or older GCC using -fno-common).

### Description
Remove multiple definitions: variables are defined in a single .c file, and .h only contains 'extern' declarations.

### How Has This Been Tested?
It compiles and allow using a pool on RISC-V a x86-64.

### Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [X ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [X ] I have run the ZFS Test Suite with this change applied.
- [X ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
