### PR TITLE
Add ARC support for dbuf_read_cached

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -157,8 +157,11 @@ typedef enum arc_flags
 	ARC_FLAG_COMPRESS_3		= 1 << 27,
 	ARC_FLAG_COMPRESS_4		= 1 << 28,
 	ARC_FLAG_COMPRESS_5		= 1 << 29,
-	ARC_FLAG_COMPRESS_6		= 1 << 30
-
+	ARC_FLAG_COMPRESS_6		= 1 << 30,
+	/**
+	 * cache lookup only
+	 */
+	ARC_FLAG_CACHED_ONLY		= 1 << 31
 } arc_flags_t;
 
 typedef enum arc_buf_flags {
@@ -259,6 +262,7 @@ arc_buf_t *arc_loan_raw_buf(spa_t *spa, uint64_t dsobj, boolean_t byteorder,
     enum zio_compress compression_type);
 void arc_return_buf(arc_buf_t *buf, void *tag);
 void arc_loan_inuse_buf(arc_buf_t *buf, void *tag);
+void arc_transfer_cache_state(arc_buf_t *from, arc_buf_t *to);
 void arc_buf_destroy(arc_buf_t *buf, void *tag);
 void arc_buf_info(arc_buf_t *buf, arc_buf_info_t *abi, int state_index);
 uint64_t arc_buf_size(arc_buf_t *buf);
@@ -268,6 +272,7 @@ void arc_release(arc_buf_t *buf, void *tag);
 int arc_released(arc_buf_t *buf);
 void arc_buf_sigsegv(int sig, siginfo_t *si, void *unused);
 void arc_buf_freeze(arc_buf_t *buf);
+boolean_t arc_buf_frozen(arc_buf_t *buf);
 void arc_buf_thaw(arc_buf_t *buf);
 #ifdef ZFS_DEBUG
 int arc_referenced(arc_buf_t *buf);

--- a/include/sys/dmu_traverse.h
+++ b/include/sys/dmu_traverse.h
@@ -62,14 +62,14 @@ typedef int (blkptr_cb_t)(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 #define	TRAVERSE_VISIT_NO_CHILDREN	-1
 
 int traverse_dataset(struct dsl_dataset *ds,
-    uint64_t txg_start, int flags, blkptr_cb_t func, void *arg);
+    uint64_t txg_start, arc_flags_t flags, blkptr_cb_t func, void *arg);
 int traverse_dataset_resume(struct dsl_dataset *ds, uint64_t txg_start,
-    zbookmark_phys_t *resume, int flags, blkptr_cb_t func, void *arg);
+    zbookmark_phys_t *resume, arc_flags_t flags, blkptr_cb_t func, void *arg);
 int traverse_dataset_destroyed(spa_t *spa, blkptr_t *blkptr,
-    uint64_t txg_start, zbookmark_phys_t *resume, int flags,
+    uint64_t txg_start, zbookmark_phys_t *resume, arc_flags_t flags,
     blkptr_cb_t func, void *arg);
 int traverse_pool(spa_t *spa,
-    uint64_t txg_start, int flags, blkptr_cb_t func, void *arg);
+    uint64_t txg_start, arc_flags_t flags, blkptr_cb_t func, void *arg);
 
 /*
  * Note that this calculation cannot overflow with the current maximum indirect

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1400,12 +1400,10 @@ dbuf_read_impl(dmu_buf_impl_t *db, zio_t *zio, uint32_t flags,
 {
 	dnode_t *dn;
 	zbookmark_phys_t zb;
-	uint32_t aflags = ARC_FLAG_NOWAIT;
-	int err, zio_flags;
-	boolean_t bonus_read;
+	arc_flags_t aflags = ARC_FLAG_NOWAIT;
+	int err, zio_flags = 0;
 
 	err = zio_flags = 0;
-	bonus_read = B_FALSE;
 	DB_DNODE_ENTER(db);
 	dn = DB_DNODE(db);
 	ASSERT(!zfs_refcount_is_zero(&db->db_holds));

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -292,7 +292,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 	}
 
 	if (BP_GET_LEVEL(bp) > 0) {
-		uint32_t flags = ARC_FLAG_WAIT;
+		arc_flags_t flags = ARC_FLAG_WAIT;
 		int32_t i;
 		int32_t epb = BP_GET_LSIZE(bp) >> SPA_BLKPTRSHIFT;
 		zbookmark_phys_t *czb;
@@ -328,7 +328,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		kmem_free(czb, sizeof (zbookmark_phys_t));
 
 	} else if (BP_GET_TYPE(bp) == DMU_OT_DNODE) {
-		uint32_t flags = ARC_FLAG_WAIT;
+		arc_flags_t flags = ARC_FLAG_WAIT;
 		uint32_t zio_flags = ZIO_FLAG_CANFAIL;
 		int32_t i;
 		int32_t epb = BP_GET_LSIZE(bp) >> DNODE_SHIFT;
@@ -587,7 +587,7 @@ traverse_prefetch_thread(void *arg)
  */
 static int
 traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
-    uint64_t txg_start, zbookmark_phys_t *resume, int flags,
+    uint64_t txg_start, zbookmark_phys_t *resume, arc_flags_t flags,
     blkptr_cb_t func, void *arg)
 {
 	traverse_data_t *td;
@@ -636,6 +636,7 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 		uint32_t flags = ARC_FLAG_WAIT;
 		objset_phys_t *osp;
 		arc_buf_t *buf;
+		arc_flags_t aflags = flags;
 		ASSERT(!BP_IS_REDACTED(rootbp));
 
 		if ((td->td_flags & TRAVERSE_NO_DECRYPT) &&
@@ -643,7 +644,7 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 			zio_flags |= ZIO_FLAG_RAW;
 
 		err = arc_read(NULL, td->td_spa, rootbp, arc_getbuf_func,
-		    &buf, ZIO_PRIORITY_ASYNC_READ, zio_flags, &flags, czb);
+		    &buf, ZIO_PRIORITY_ASYNC_READ, zio_flags, &aflags, czb);
 		if (err != 0) {
 			/*
 			 * If both TRAVERSE_HARD and TRAVERSE_PRE are set,
@@ -691,7 +692,7 @@ out:
 int
 traverse_dataset_resume(dsl_dataset_t *ds, uint64_t txg_start,
     zbookmark_phys_t *resume,
-    int flags, blkptr_cb_t func, void *arg)
+    arc_flags_t flags, blkptr_cb_t func, void *arg)
 {
 	return (traverse_impl(ds->ds_dir->dd_pool->dp_spa, ds, ds->ds_object,
 	    &dsl_dataset_phys(ds)->ds_bp, txg_start, resume, flags, func, arg));
@@ -699,14 +700,14 @@ traverse_dataset_resume(dsl_dataset_t *ds, uint64_t txg_start,
 
 int
 traverse_dataset(dsl_dataset_t *ds, uint64_t txg_start,
-    int flags, blkptr_cb_t func, void *arg)
+   arc_flags_t flags, blkptr_cb_t func, void *arg)
 {
 	return (traverse_dataset_resume(ds, txg_start, NULL, flags, func, arg));
 }
 
 int
 traverse_dataset_destroyed(spa_t *spa, blkptr_t *blkptr,
-    uint64_t txg_start, zbookmark_phys_t *resume, int flags,
+    uint64_t txg_start, zbookmark_phys_t *resume, arc_flags_t flags,
     blkptr_cb_t func, void *arg)
 {
 	return (traverse_impl(spa, NULL, ZB_DESTROYED_OBJSET,
@@ -717,7 +718,7 @@ traverse_dataset_destroyed(spa_t *spa, blkptr_t *blkptr,
  * NB: pool must not be changing on-disk (eg, from zdb or sync context).
  */
 int
-traverse_pool(spa_t *spa, uint64_t txg_start, int flags,
+traverse_pool(spa_t *spa, uint64_t txg_start, arc_flags_t flags,
     blkptr_cb_t func, void *arg)
 {
 	int err;

--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -85,7 +85,7 @@ my $verbose = $opts{'v'};
 my $ignore_hdr_comment = $opts{'C'};
 my $check_posix_types = $opts{'P'};
 
-my $doxygen_comments = 0;
+my $doxygen_comments = 1;
 my $splint_comments = 0;
 
 if (defined($opts{'o'})) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->    
Handle ARC_FLAG_CACHED_ONLY used by dbuf_read_cached. On a dirty fault if a dirty won't fill the buffer we see if the previous version is in the ARC.

This is a dependency for COW fault avoidance work.

Additionally, allow doxygen style comments.
    
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
