### PR TITLE
Fix zfs-functions packaging bug

### DIFF
--- a/contrib/initramfs/Makefile.am
+++ b/contrib/initramfs/Makefile.am
@@ -6,16 +6,14 @@ initrd_SCRIPTS = \
 SUBDIRS = hooks scripts
 
 EXTRA_DIST = \
-	$(top_srcdir)/etc/init.d/zfs \
-	$(top_srcdir)/etc/init.d/zfs-functions \
+	$(top_srcdir)/etc/init.d/zfs.in \
+	$(top_srcdir)/etc/init.d/zfs-functions.in \
 	$(top_srcdir)/contrib/initramfs/conf.d/zfs \
 	$(top_srcdir)/contrib/initramfs/conf-hooks.d/zfs \
 	$(top_srcdir)/contrib/initramfs/README.initramfs.markdown
 
-$(top_srcdir)/etc/init.d/zfs $(top_srcdir)/etc/init.d/zfs-functions:
-	$(MAKE) -C $(top_srcdir)/etc/init.d zfs zfs-functions
 
-install-initrdSCRIPTS: $(EXTRA_DIST)
+install-initrdSCRIPTS: $(EXTRA_DIST) $(top_srcdir)/etc/init.d/zfs $(top_srcdir)/etc/init.d/zfs-functions
 	for d in conf.d conf-hooks.d scripts/local-top; do \
 		$(MKDIR_P) $(DESTDIR)$(initrddir)/$$d; \
 		cp $(top_srcdir)/contrib/initramfs/$$d/zfs \

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,2 +1,2 @@
-SUBDIRS = zfs sudoers.d $(ZFS_INIT_SYSTEMD) $(ZFS_INIT_SYSV) $(ZFS_MODULE_LOAD)
+SUBDIRS = init.d zfs sudoers.d $(ZFS_INIT_SYSTEMD) $(ZFS_INIT_SYSV) $(ZFS_MODULE_LOAD)
 DIST_SUBDIRS = init.d zfs systemd modules-load.d sudoers.d

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -450,6 +450,9 @@ systemctl --system daemon-reload >/dev/null || true
 %{_presetdir}/*
 %{_modulesloaddir}/*
 %{_systemdgeneratordir}/*
+
+# We're using systemd, so don't include the init.d scripts that get built
+%exclude %{_sysconfdir}/init.d/*
 %else
 %config(noreplace) %{_sysconfdir}/init.d/*
 %endif


### PR DESCRIPTION
### Motivation and Context
Fixes: #9443

### Description
This fixes a bug where the generated `zfs-functions` was being included along with original `zfs-functions.in` in the make dist tarball.  This caused an unfortunate series of events during build/packaging that resulted in the RPM-installed `/etc/zfs/zfs-functions` listing the paths as:
```
ZFS="/usr/local/sbin/zfs"
ZED="/usr/local/sbin/zed"
ZPOOL="/usr/local/sbin/zpool"
```
When they should have been:
```
ZFS="/sbin/zfs"
ZED="/sbin/zed"
ZPOOL="/sbin/zpool"
```
This affects init.d (non-systemd) distros like CentOS 6.
### How Has This Been Tested?
Manually tested on Centos 6 against the `zfs-0.8-release` branch, since `master` no longer supports Centos 6.  Verified that /etc/zfs/zfs-functions in the zfs rpm had the right paths.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
