### PR TITLE
ZTS: Use wc -c instead of --bytes for portability

### DIFF
--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_size.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_size.ksh
@@ -45,7 +45,7 @@ log_must zfs snapshot $clone@snap
 log_must zfs redact $sendfs@snap book $clone@snap
 log_must eval "zfs send -nvP --redact book $sendfs@snap | \
     grep '^size' | awk '{print \$2}' >$size"
-log_must eval "zfs send --redact book $sendfs@snap | wc --bytes \
+log_must eval "zfs send --redact book $sendfs@snap | wc -c \
     >$size2"
 bytes1=$(cat $size | tr -d '[[:space:]]')
 bytes2=$(cat $size2 | tr -d '[[:space:]]')
@@ -55,7 +55,7 @@ bytes2=$(cat $size2 | tr -d '[[:space:]]')
 log_must zfs snapshot $sendfs@snap2
 log_must eval "zfs send -nvP -i $sendfs#book $sendfs@snap2 | \
     grep '^size' | awk '{print \$2}' >$size"
-log_must eval "zfs send -i $sendfs#book $sendfs@snap2 | wc --bytes >$size2"
+log_must eval "zfs send -i $sendfs#book $sendfs@snap2 | wc -c >$size2"
 bytes1=$(cat $size | tr -d '[[:space:]]')
 bytes2=$(cat $size2 | tr -d '[[:space:]]')
 [[ "$bytes1" -eq "$bytes2" ]] || \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FreeBSD does not have the long opts for wc.

### Description
<!--- Describe your changes in detail -->
Use wc -c instead of --bytes for portability.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
We'll see if anything surprising happens.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
