### PR TITLE
Fix zfs-mount-generator escaping

### DIFF
--- a/etc/systemd/system-generators/zfs-mount-generator.in
+++ b/etc/systemd/system-generators/zfs-mount-generator.in
@@ -156,7 +156,7 @@ ExecStop=@sbindir@/zfs unload-key '${dataset}'"   > "${dest_norm}/${keyloadunit}
   fi
 
   # Escape the mountpoint per systemd policy.
-  mountfile="$(systemd-escape "${p_mountpoint#?}").mount"
+  mountfile="$(systemd-escape --path --suffix=mount "${p_mountpoint}")"
 
   # Parse options
   # see lib/libzfs/libzfs_mount.c:zfs_add_options


### PR DESCRIPTION
### Motivation and Context
This fixes the name of the mount unit for the root filesystem. I discovered these pre-existing issues in review/testing of #9649.

In practice, the root filesystem is mounted by the initrd anyway, so this is moot in practice (which is why this wasn't noticed), but we should be correct nonetheless.

### Description

The correct name for the mount unit for / is "-.mount", not ".mount".

### How Has This Been Tested?
I used some print statements and some diffing. This is a nice test case, if it works on your particular system:
```
rm -rf /tmp/before
mkdir /tmp/before
sudo /lib/systemd/system-generators/zfs-mount-generator /tmp/before /tmp/before /tmp/before

rm -rf /tmp/after
mkdir /tmp/after
sudo /lib/systemd/system-generators/zfs-mount-generator /tmp/after /tmp/after /tmp/after

diff -urN /tmp/before /tmp/after
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
