### PR TITLE
Make zpool.d/iostat work on FreeBSD

### DIFF
--- a/cmd/zpool/zpool.d/iostat
+++ b/cmd/zpool/zpool.d/iostat
@@ -17,14 +17,14 @@ fi
 
 if [ "$script" = "iostat-1s" ] ; then
 	# Do a single one-second sample
-	extra="1 1"
+	interval=1
 	# Don't show summary stats
-	y="-y"
+	brief="yes"
 elif [ "$script" = "iostat-10s" ] ; then
 	# Do a single ten-second sample
-	extra="10 1"
+	interval=10
 	# Don't show summary stats
-	y="-y"
+	brief="yes"
 fi
 
 if [ -f "$VDEV_UPATH" ] ; then
@@ -32,7 +32,19 @@ if [ -f "$VDEV_UPATH" ] ; then
 	exit
 fi
 
-out=$(eval "iostat $y -k -x $VDEV_UPATH $extra")
+if [ "$(uname)" = "FreeBSD" ]; then
+	out=$(iostat -dKx \
+		${interval:+"-w $interval"} \
+		${interval:+"-c 1"} \
+		"$VDEV_UPATH" | tail -n 2)
+else
+	out=$(iostat -kx \
+		${brief:+"-y"} \
+		${interval:+"$interval"} \
+		${interval:+"1"} \
+		"$VDEV_UPATH" | awk NF | tail -n 2)
+fi
+
 
 # Sample output (we want the last two lines):
 #
@@ -46,16 +58,16 @@ out=$(eval "iostat $y -k -x $VDEV_UPATH $extra")
 #
 
 # Get the column names
-cols=$(echo "$out" | grep Device)
+cols=$(echo "$out" | head -n 1)
 
 # Get the values and tab separate them to make them cut-able.
-vals="$(echo "$out" | grep -A1 Device | tail -n 1 | sed -r 's/[[:blank:]]+/\t/g')"
+vals=$(echo "$out" | tail -n 1 | sed -r 's/[[:blank:]]+/\t/g')
 
 i=0
 for col in $cols ; do
 	i=$((i+1))
 	# Skip the first column since it's just the device name
-	if [ "$col" = "Device:" ] ; then
+	if [ $i -eq 1 ]; then
 		continue
 	fi
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are slight differences in the iostat commands between FreeBSD and Linux.

### Description
<!--- Describe your changes in detail -->
Use the appropriate flags on FreeBSD. Simplify the output manipulation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
We've been running this through ZTS on FreeBSD for a while, and Linux was manually tested at some point.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
