### PR TITLE
ZTS: Fix zdb_display_block on FreeBSD

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_display_block.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_display_block.ksh
@@ -111,7 +111,7 @@ offset=$(echo "$dva" |awk '{split($0,array,":")} END{print array[2]}')
 output=$(export ZDB_NO_ZLE=\"true\";\
     zdb -R $TESTPOOL $vdev:$offset:$l1_read_size:id 2> /dev/null)
 block_cnt=$(echo "$output" | grep 'L0' | wc -l)
-if [ "$block_cnt" != "$write_count" ]; then
+if [ $block_cnt -ne $write_count ]; then
 	log_fail "zdb -R :id (indirect block display) failed"
 fi
 
@@ -121,7 +121,7 @@ log_note "Reading from DVA $vdev:$offset:$l1_read_size"
 output=$(export ZDB_NO_ZLE=\"true\";\
     zdb -R $TESTPOOL $vdev:$offset:$l1_read_size:id 2> /dev/null)
 block_cnt=$(echo "$output" | grep 'L0' | wc -l)
-if [ "$block_cnt" != "$write_count" ]; then
+if [ $block_cnt -ne $write_count ]; then
         log_fail "zdb -R 0.0:offset:length:id (indirect block display) failed"
 fi
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Missed this in the review, but wc output on FreeBSD is indented, so string comparisons mismatch when comparing to an unindented number.

### Description
<!--- Describe your changes in detail -->
Compare counts as integers instead of strings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I ran the test on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
