### PR TITLE
fix zstreamdump -C

### DIFF
--- a/cmd/zstreamdump/zstreamdump.c
+++ b/cmd/zstreamdump/zstreamdump.c
@@ -117,7 +117,8 @@ read_hdr(dmu_replay_record_t *drr, zio_cksum_t *cksum)
 	    sizeof (zio_cksum_t), cksum);
 	if (r == 0)
 		return (0);
-	if (!ZIO_CHECKSUM_IS_ZERO(&drr->drr_u.drr_checksum.drr_checksum) &&
+	if (do_cksum &&
+	    !ZIO_CHECKSUM_IS_ZERO(&drr->drr_u.drr_checksum.drr_checksum) &&
 	    !ZIO_CHECKSUM_EQUAL(saved_cksum,
 	    drr->drr_u.drr_checksum.drr_checksum)) {
 		fprintf(stderr, "invalid checksum\n");


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
zstreamdump -C always fails.  It is not calculating the checksums, but
it's still trying to verify that the (non-calculated) checksum matches
the one stored in the send stream.

```
sudo zfs send rpool/ROOT/delphix.90dy59N/home@a | zstreamdump -C
BEGIN record
	hdrtype = 1
	features = 4
	magic = 2f5bacbac
	creation_time = 5e43118e
	type = 2
	flags = 0xc
	toguid = 6aa4b2b137ccdfee
	fromguid = 0
	toname = rpool/ROOT/delphix.90dy59N/home@a
invalid checksum
Incorrect checksum in record header.
Expected checksum = 0/0/0/0
SUMMARY:
	Total DRR_BEGIN records = 1 (0 bytes)
	Total DRR_END records = 0 (0 bytes)
	Total DRR_OBJECT records = 0 (0 bytes)
	Total DRR_FREEOBJECTS records = 0 (0 bytes)
	Total DRR_WRITE records = 0 (0 bytes)
	Total DRR_WRITE_BYREF records = 0 (0 bytes)
	Total DRR_WRITE_EMBEDDED records = 0 (0 bytes)
	Total DRR_FREE records = 0 (0 bytes)
	Total DRR_SPILL records = 0 (0 bytes)
	Total records = 1
	Total payload size = 0 (0x0)
	Total header overhead = 312 (0x138)
	Total stream length = 624 (0x270)
```
### Description
<!--- Describe your changes in detail -->
This change makes zstreamdump -C not verify checksums.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
manual testing of zstreamdump.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
