### PR TITLE
ZTS: Misc test fixes for FreeBSD

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_rollback/zfs_rollback_common.kshlib
@@ -116,7 +116,7 @@ function setup_snap_env
 
 			if datasetnonexists $snap; then
 				log_must cp /etc/passwd $fname
-				if is_linux; then
+				if is_linux || is_freebsd; then
 					log_must sync
 				else
 					#

--- a/tests/zfs-tests/tests/functional/cli_root/zpool/zpool_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool/zpool_003_pos.ksh
@@ -42,9 +42,17 @@
 # 3. Verify it run successfully.
 #
 
+function cleanup
+{
+	if is_freebsd && [ -n "$old_corefile" ]; then
+		sysctl kern.corefile=$old_corefile
+	fi
+}
+
 verify_runnable "both"
 
 log_assert "Debugging features of zpool should succeed."
+log_onexit cleanup
 
 log_must zpool -? > /dev/null 2>&1
 
@@ -67,7 +75,8 @@ if is_linux; then
 	export ASAN_OPTIONS="abort_on_error=1:disable_coredump=0"
 elif is_freebsd; then
 	ulimit -c unlimited
-	log_must sysctl kern.corefile=$corepath/core.zpool
+	old_corefile=$(sysctl -n kern.corefile)
+	log_must sysctl kern.corefile=core
 	export ASAN_OPTIONS="abort_on_error=1:disable_coredump=0"
 fi
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_012_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_012_neg.ksh
@@ -52,7 +52,9 @@ function cleanup
 	fi
 }
 
-if is_linux; then
+if is_freebsd; then
+	typeset swap_disks=$(swapinfo -l | grep "/dev" | awk '{print $1}')
+elif is_linux; then
 	typeset swap_disks=`swapon -s | grep "/dev" | awk '{print $1}'`
 else
 	typeset swap_disks=`swap -l | grep "c[0-9].*d[0-9].*s[0-9]" | \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
@@ -83,7 +83,12 @@ log_must zfs create -V 100m $vol_name
 block_device_wait
 swap_setup ${ZVOL_DEVDIR}/$vol_name
 
-for opt in "-n" "" "-f"; do
+if is_freebsd; then
+	typeset -a opts=("" "-f")
+else
+	typeset -a opts=("-n" "" "-f")
+fi
+for opt in "${opts[@]}"; do
 	log_mustnot zpool create $opt $TESTPOOL1 ${ZVOL_DEVDIR}/${vol_name}
 done
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_trim/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_trim/setup.ksh
@@ -23,15 +23,21 @@
 
 verify_runnable "global"
 
-DISK1=${DISKS%% *}
+if is_freebsd; then
+	log_unsupported "FreeBSD has no hole punching mechanism for the time being."
+	diskinfo -v $DISKS | grep -qE 'No.*# TRIM/UNMAP support' &&
+	    log_unsupported "DISKS do not support discard (TRIM/UNMAP)"
+else
+	DISK1=${DISKS%% *}
 
-typeset -i max_discard=0
-if is_disk_device $DEV_RDSKDIR/$DISK1; then
-	max_discard=$(lsblk -Dbn $DEV_RDSKDIR/$DISK1 | awk '{ print $4; exit }')
-fi
+	typeset -i max_discard=0
+	if is_disk_device $DEV_RDSKDIR/$DISK1; then
+		max_discard=$(lsblk -Dbn $DEV_RDSKDIR/$DISK1 | awk '{ print $4; exit }')
+	fi
 
-if test $max_discard -eq 0; then
-	log_unsupported "DISKS do not support discard (TRIM/UNMAP)"
+	if test $max_discard -eq 0; then
+		log_unsupported "DISKS do not support discard (TRIM/UNMAP)"
+	fi
 fi
 
 log_pass

--- a/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_capacity.ksh
+++ b/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_capacity.ksh
@@ -46,7 +46,7 @@
 function test_cleanup
 {
 	poolexists $NESTEDPOOL && destroy_pool $NESTEDPOOL
-	log_must set_tunable32 SPA_ASIZE_INFLATION 24
+	set_tunable32 SPA_ASIZE_INFLATION 24
 	cleanup_test_pool
 }
 

--- a/tests/zfs-tests/tests/functional/rsend/rsend_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_012_pos.ksh
@@ -26,7 +26,6 @@
 # Use is subject to license terms.
 #
 
-#
 . $STF_SUITE/include/properties.shlib
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
 

--- a/tests/zfs-tests/tests/functional/rsend/send_realloc_encrypted_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_realloc_encrypted_files.ksh
@@ -16,8 +16,8 @@
 # Use is subject to license terms.
 #
 
-. $STF_SUITE/include/properties.shlib
 . $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/properties.shlib
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
 
 #
@@ -67,9 +67,14 @@ log_must eval "zfs recv $POOL/newfs < $BACKDIR/fs@snap${last_snap}"
 # Set atime=off to prevent the recursive_cksum from modifying newfs.
 log_must zfs set atime=off $POOL/newfs
 
-# Due to reduced performance on debug kernels use fewer files by default.
 if is_kmemleak; then
+	# Use fewer files and passes on debug kernels
+	# to avoid timeout due to reduced performance.
 	nr_files=100
+	passes=2
+elif is_freebsd; then
+	# Use fewer files and passes on FreeBSD to avoid timeout.
+	nr_files=500
 	passes=2
 else
 	nr_files=1000

--- a/tests/zfs-tests/tests/functional/rsend/send_realloc_files.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_realloc_files.ksh
@@ -59,9 +59,14 @@ log_must eval "zfs recv $POOL/newfs < $BACKDIR/fs@snap${last_snap}"
 # Set atime=off to prevent the recursive_cksum from modifying newfs.
 log_must zfs set atime=off $POOL/newfs
 
-# Due to reduced performance on debug kernels use fewer files by default.
 if is_kmemleak; then
+	# Use fewer files and passes on debug kernels
+	# to avoid timeout due to reduced performance.
 	nr_files=100
+	passes=2
+elif is_freebsd; then
+	# Use fewer passes and files on FreeBSD to avoid timeout.
+	nr_files=500
 	passes=2
 else
 	nr_files=1000

--- a/tests/zfs-tests/tests/functional/trim/setup.ksh
+++ b/tests/zfs-tests/tests/functional/trim/setup.ksh
@@ -24,6 +24,7 @@
 verify_runnable "global"
 
 if is_freebsd; then
+	log_unsupported "FreeBSD has no hole punching mechanism for the time being."
 	diskinfo -v $DISKS | grep -qE 'No.*# TRIM/UNMAP support' &&
 	    log_unsupported "DISKS do not support discard (TRIM/UNMAP)"
 else

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_common.kshlib
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_common.kshlib
@@ -131,7 +131,7 @@ function verify_partition # device
 		log_fail "$device is not a block device"
 	fi
 	# create a small dummy partition
-	set_partition 0 1 1m $device
+	set_partition 0 "" 1m $device
 	# verify we can access the partition on the device
 	devname="$(readlink -f "$device")"
 	if is_linux || is_freebsd; then

--- a/tests/zfs-tests/tests/perf/perf.shlib
+++ b/tests/zfs-tests/tests/perf/perf.shlib
@@ -383,14 +383,18 @@ function get_directory
 
 function get_min_arc_size
 {
-	if is_linux; then
-		typeset -l min_arc_size=`awk '$1 == "c_min" { print $3 }' \
-		    /proc/spl/kstat/zfs/arcstats`
-	else
-		typeset -l min_arc_size=$(dtrace -qn 'BEGIN {
+	typeset -l min_arc_size
+
+	if is_freebsd; then
+		min_arc_size=$(sysctl -n kstat.zfs.misc.arcstats.c_min)
+	elif is_illumos; then
+		min_arc_size=$(dtrace -qn 'BEGIN {
 		    printf("%u\n", `arc_stats.arcstat_c_min.value.ui64);
 		    exit(0);
 		}')
+	elif is_linux; then
+		min_arc_size=`awk '$1 == "c_min" { print $3 }' \
+		    /proc/spl/kstat/zfs/arcstats`
 	fi
 
 	[[ $? -eq 0 ]] || log_fail "get_min_arc_size failed"
@@ -400,14 +404,18 @@ function get_min_arc_size
 
 function get_max_arc_size
 {
-	if is_linux; then
-		typeset -l max_arc_size=`awk '$1 == "c_max" { print $3 }' \
-		    /proc/spl/kstat/zfs/arcstats`
-	else
-		typeset -l max_arc_size=$(dtrace -qn 'BEGIN {
+	typeset -l max_arc_size
+
+	if is_freebsd; then
+		max_arc_size=$(sysctl -n kstat.zfs.misc.arcstats.c_max)
+	elif is_illumos; then
+		max_arc_size=$(dtrace -qn 'BEGIN {
 		    printf("%u\n", `arc_stats.arcstat_c_max.value.ui64);
 		    exit(0);
 		}')
+	elif is_linux; then
+		max_arc_size=`awk '$1 == "c_max" { print $3 }' \
+		    /proc/spl/kstat/zfs/arcstats`
 	fi
 
 	[[ $? -eq 0 ]] || log_fail "get_max_arc_size failed"
@@ -419,16 +427,16 @@ function get_max_dbuf_cache_size
 {
 	typeset -l max_dbuf_cache_size
 
-	if is_linux; then
-		max_dbuf_cache_size=$(get_tunable DBUF_CACHE_MAX_BYTES)
-	else
+	if is_illumos; then
 		max_dbuf_cache_size=$(dtrace -qn 'BEGIN {
 		    printf("%u\n", `dbuf_cache_max_bytes);
 		    exit(0);
 		}')
-
-		[[ $? -eq 0 ]] || log_fail "get_max_dbuf_cache_size failed"
+	else
+		max_dbuf_cache_size=$(get_tunable DBUF_CACHE_MAX_BYTES)
 	fi
+
+	[[ $? -eq 0 ]] || log_fail "get_max_dbuf_cache_size failed"
 
 	echo $max_dbuf_cache_size
 }
@@ -531,14 +539,7 @@ function pool_to_lun_list
 	typeset ctd ctds devname lun
 	typeset lun_list=':'
 
-	if is_linux; then
-		ctds=$(zpool list -HLv $pool | \
-		    awk '/sd[a-z]*|loop[0-9]*|dm-[0-9]*/ {print $1}')
-
-		for ctd in $ctds; do
-			lun_list="$lun_list$ctd:"
-		done
-	else
+	if is_illumos; then
 		ctds=$(zpool list -v $pool |
 		    awk '/c[0-9]*t[0-9a-fA-F]*d[0-9]*/ {print $1}')
 
@@ -550,7 +551,18 @@ function pool_to_lun_list
 		# number to the list for comparison with dev_statname.
 		lun=$(sed 's/"//g' /etc/path_to_inst | grep \
 		    $devname | awk '{print $3$2}')
-		un_list="$lun_list$lun:"
+		lun_list="$lun_list$lun:"
+		done
+	elif is_freebsd; then
+		lun_list+=$(zpool list -HLv $pool | \
+		    awk '/a?da[0-9]+|md[0-9]+|mfid[0-9]+|nda[0-9]+|nvd[0-9]+|vtbd[0-9]+/
+		         { printf "%s:", $1 }')
+	elif is_linux; then
+		ctds=$(zpool list -HLv $pool | \
+		    awk '/sd[a-z]*|loop[0-9]*|dm-[0-9]*/ {print $1}')
+
+		for ctd in $ctds; do
+			lun_list="$lun_list$ctd:"
 		done
 	fi
 	echo $lun_list


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Several test scripts follow a pattern `if is_linux; then linux things; else illumos things; fi` where the illumos things do not make sense for FreeBSD.

### Description
<!--- Describe your changes in detail -->
Add missing logic for FreeBSD to a few test scripts.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
These changes have been running through our CI on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
