### PR TITLE
ZTS: Eliminate partitioning from zpool_remove

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_remove/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_remove/setup.ksh
@@ -34,10 +34,4 @@
 
 verify_runnable "global"
 
-if ! is_physical_device $DISKS ; then
-	log_unsupported "This directory cannot be run on raw files."
-fi
-
-partition_disk $SIZE $DISK 6
-
 log_pass

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove.cfg
@@ -28,29 +28,4 @@
 # Copyright (c) 2012 by Delphix. All rights reserved.
 #
 
-export DISK=${DISKS%% *}
-export SIZE="200m"
-export DISK_ARRAY_NUM=$(echo ${DISKS} | nawk '{print NF}')
-export DISKSARRAY=$DISKS
-
-if is_linux; then
-	set_device_dir
-	set_slice_prefix
-	export SLICE0=1
-	export SLICE1=2
-	export SLICE2=3
-	export SLICE3=4
-	export SLICE4=5
-	export SLICE5=6
-	export SLICE6=7
-	export SLICE7=8
-else
-	export SLICE0=0
-	export SLICE1=1
-	export SLICE2=2
-	export SLICE3=3
-	export SLICE4=4
-	export SLICE5=5
-	export SLICE6=6
-	export SLICE7=7
-fi
+echo $DISKS | read DISK0 DISK1 DISK2

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove_001_neg.ksh
@@ -42,14 +42,13 @@
 # 3. Verify that the remove failed.
 #
 
-typeset disk=${DISK}
-typeset vdev_devs="${disk}${SLICE_PREFIX}${SLICE0}"
-typeset mirror_devs="${disk}${SLICE_PREFIX}${SLICE0} ${disk}${SLICE_PREFIX}${SLICE1}"
+typeset vdev_devs="${DISK0}"
+typeset mirror_devs="${DISK0} ${DISK1}"
 typeset raidz_devs=${mirror_devs}
 typeset raidz1_devs=${mirror_devs}
-typeset raidz2_devs="${mirror_devs} ${disk}${SLICE_PREFIX}${SLICE3}"
-typeset spare_devs1="${disk}${SLICE_PREFIX}${SLICE0}"
-typeset spare_devs2="${disk}${SLICE_PREFIX}${SLICE1}"
+typeset raidz2_devs="${mirror_devs} ${DISK2}"
+typeset spare_devs1="${DISK0}"
+typeset spare_devs2="${DISK1}"
 
 function check_remove
 {

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove_002_pos.ksh
@@ -50,10 +50,9 @@ function cleanup
 }
 
 log_onexit cleanup
-typeset disk=${DISK}
 
-typeset spare_devs1="${disk}${SLICE_PREFIX}${SLICE0}"
-typeset spare_devs2="${disk}${SLICE_PREFIX}${SLICE1}"
+typeset spare_devs1="${DISK0}"
+typeset spare_devs2="${DISK1}"
 
 log_assert "zpool remove can only remove inactive hotspare device from pool"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_remove/zpool_remove_003_pos.ksh
@@ -54,17 +54,15 @@ function cleanup
 log_onexit cleanup
 typeset disk=${DISK}
 
-typeset spare_devs1="${disk}${SLICE_PREFIX}${SLICE0}"
-typeset spare_devs2="${disk}${SLICE_PREFIX}${SLICE1}"
-typeset spare_devs3="${disk}${SLICE_PREFIX}${SLICE3}"
-typeset spare_devs4="${disk}${SLICE_PREFIX}${SLICE4}"
+typeset spare_devs1="${DISK0}"
+typeset spare_devs2="${DISK1}"
+typeset spare_devs3="${DISK2}"
 
 log_assert "zpool remove can remove hotspare device which state go though" \
 	" active to inactive in pool"
 
 log_note "Check spare device which state go through active to inactive"
-log_must zpool create $TESTPOOL $spare_devs1 $spare_devs2 spare \
-                 $spare_devs3 $spare_devs4
+log_must zpool create $TESTPOOL $spare_devs1 $spare_devs2 spare $spare_devs3
 log_must zpool replace $TESTPOOL $spare_devs2 $spare_devs3
 log_mustnot zpool remove $TESTPOOL $spare_devs3
 log_must zpool detach $TESTPOOL $spare_devs3


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These tests do not need to use partitions.

### Description
<!--- Describe your changes in detail -->
Get rid of the partitioning and just use the disks directly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Tested on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
