### PR TITLE
Remove limit on number of async zio_frees of non-dedup blocks

### DIFF
--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -138,6 +138,7 @@ typedef struct dsl_scan {
 
 	/* per txg statistics */
 	uint64_t scn_visited_this_txg;	/* total bps visited this txg */
+	uint64_t scn_dedup_frees_this_txg;	/* dedup bps freed this txg */
 	uint64_t scn_holes_this_txg;
 	uint64_t scn_lt_min_this_txg;
 	uint64_t scn_gt_max_this_txg;

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1642,6 +1642,17 @@ Default value: \fB1\fR.
 .RS 12n
 Maximum number of blocks freed in a single txg.
 .sp
+Default value: \fBULONG_MAX\fR (unlimited).
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_max_async_dedup_frees\fR (ulong)
+.ad
+.RS 12n
+Maximum number of dedup blocks freed in a single txg.
+.sp
 Default value: \fB100,000\fR.
 .RE
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The module parameter zfs_async_block_max_blocks limits the number of
blocks that can be freed by the background freeing of filesystems and
snapshots (from "zfs destroy"), in one TXG.  This is useful when freeing
dedup blocks, becuase each zio_free() of a dedup block can require an
i/o to read the relevant part of the dedup table (DDT), and will also
dirty that block.

zfs_async_block_max_blocks is set to 100,000 by default.  For the more
typical case where dedup is not used, this can have a negative
performance impact on the rate of background freeing (from "zfs
destroy").  For example, with recordsize=8k, and TXG's syncing once
every 5 seconds, we can free only 160MB of data per second, which may be
much less than the rate we can write data.


### Description
<!--- Describe your changes in detail -->
This change increases zfs_async_block_max_blocks to be unlimited by
default.  To address the dedup freeing issue, a new tunable is
introduced, zfs_max_async_dedup_frees, which limits the number of
zio_free()'s of dedup blocks done by background destroys, per txg.  The
default is 100,000 free's (same as the old zfs_async_block_max_blocks
default).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Without this change, deleting a filesystem with lots of blocks (non-dedup in this case, but behavior is the same for dedup):

```
1581569878   dsl_scan.c:3366:dsl_process_async_destroys(): freed 100000 blocks in 487ms from free_bpobj/bptree txg 22103; err=85
1581569879   dsl_scan.c:3366:dsl_process_async_destroys(): freed 100000 blocks in 359ms from free_bpobj/bptree txg 22104; err=85
1581569880   dsl_scan.c:3366:dsl_process_async_destroys(): freed 100000 blocks in 535ms from free_bpobj/bptree txg 22105; err=85
...
(takes ~20 txg's and 14 seconds to free 2,000,000 blocks - system is otherwise idle)
```

With this change, deleting a filesystem with lots of dedup blocks (same behavior as without this change):
```
1581540878   dsl_scan.c:3375:dsl_process_async_destroys(): freed 100097 blocks in 3565ms from free_bpobj/bptree txg 16765; err=85
1581540967   bptree.c:233:bptree_iterate(): bptree index 0: traversing from min_txg=1 bookmark -1/2/0/1833840
1581540970   dsl_scan.c:3375:dsl_process_async_destroys(): freed 100098 blocks in 2934ms from free_bpobj/bptree txg 16766; err=85
1581541056   bptree.c:233:bptree_iterate(): bptree index 0: traversing from min_txg=1 bookmark -1/2/0/1933840
...
(takes ~10,000 seconds to free 2,000,000 blocks)
(note that the long time between calls to dsl_process_async_destroys() is spent writing the DDT changes)
```

With this change, deleting a filesystem without dedup:
```
1581549877   dsl_scan.c:3375:dsl_process_async_destroys(): freed 187576 blocks in 1001ms from free_bpobj/bptree txg 18353; err=85
1581549885   dsl_scan.c:3375:dsl_process_async_destroys(): freed 1137010 blocks in 6000ms from free_bpobj/bptree txg 18354; err=85
1581549889   dsl_scan.c:3375:dsl_process_async_destroys(): freed 725435 blocks in 4204ms from free_bpobj/bptree txg 18355; err=0
(takes 3 txg's and 12 seconds to free 2,000,000 blocks)
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
