### PR TITLE
Prefer org.openzfs for features and properties

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -591,8 +591,8 @@ typedef struct zpool_load_policy {
 
 /*
  * The following are configuration names used in the nvlist describing a pool's
- * configuration.  New on-disk names should be prefixed with "<reverse-DNS>:"
- * (e.g. "org.open-zfs:") to avoid conflicting names being developed
+ * configuration.  New on-disk names should be prefixed with "<reversed-DNS>:"
+ * (e.g. "org.openzfs:") to avoid conflicting names being developed
  * independently.
  */
 #define	ZPOOL_CONFIG_VERSION		"version"

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -39,7 +39,7 @@ this set may include unsupported features.
 .sp
 .LP
 Every feature has a GUID of the form \fIcom.example:feature_name\fR. The
-reverse DNS name ensures that the feature's GUID is unique across all ZFS
+reversed DNS name ensures that the feature's GUID is unique across all ZFS
 implementations. When unsupported features are encountered on a pool they will
 be identified by their GUIDs. Refer to the documentation for the ZFS
 implementation that created the pool for information about those features.

--- a/module/zcommon/zfeature_common.c
+++ b/module/zcommon/zfeature_common.c
@@ -259,6 +259,19 @@ zfeature_register(spa_feature_t fid, const char *guid, const char *name,
 	feature->fi_zfs_mod_supported = zfs_mod_supported_feature(guid);
 }
 
+/*
+ * Every feature has a GUID of the form com.example:feature_name.  The
+ * reversed DNS name ensures that the feature's GUID is unique across all ZFS
+ * implementations.  This allows companies to independently develop and
+ * release features.  Examples include org.delphix and org.datto.  Previously,
+ * features developed on one implementation have used that implementation's
+ * domain name (e.g. org.illumos and org.zfsonlinux).  Use of the org.openzfs
+ * domain name is recommended for new features which are developed by the
+ * OpenZFS community and its platforms.  This domain may optionally be used by
+ * companies developing features for initial release through an OpenZFS
+ * implementation.  Use of the org.openzfs domain requires reserving the
+ * feature name in advance with the OpenZFS project.
+ */
 void
 zpool_feature_init(void)
 {
@@ -548,12 +561,10 @@ zpool_feature_init(void)
 	    ZFEATURE_TYPE_BOOLEAN, project_quota_deps);
 	}
 
-	{
 	zfeature_register(SPA_FEATURE_ALLOCATION_CLASSES,
 	    "org.zfsonlinux:allocation_classes", "allocation_classes",
 	    "Support for separate allocation classes.",
 	    ZFEATURE_FLAG_READONLY_COMPAT, ZFEATURE_TYPE_BOOLEAN, NULL);
-	}
 
 	zfeature_register(SPA_FEATURE_RESILVER_DEFER,
 	    "com.datto:resilver_defer", "resilver_defer",

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send-b.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send-b.ksh
@@ -52,8 +52,8 @@ log_must zfs snapshot "$SENDFS@s1"
 log_must zfs bookmark "$SENDFS@s1" "$SENDFS#bm"
 log_must zfs snapshot "$SENDFS@s2"
 log_must zfs set "compression=gzip" $SENDFS
-log_must zfs set "org.zfsonlinux:prop=val" $SENDFS
-log_must zfs set "org.zfsonlinux:snapprop=val" "$SENDFS@s1"
+log_must zfs set "org.openzfs:prop=val" $SENDFS
+log_must zfs set "org.openzfs:snapprop=val" "$SENDFS@s1"
 
 # 2. Verify command line options interact with '-b' correctly
 typeset opts=("" "p" "Rp" "cew" "nv" "D" "DLPRcenpvw")
@@ -78,21 +78,21 @@ for opt in ${opts[@]}; do
 	# NOTE: override "received" values and set some new properties as well
 	log_must zfs set "compression=lz4" $BACKUP
 	log_must zfs set "exec=off" $BACKUP
-	log_must zfs set "org.zfsonlinux:prop=newval" $BACKUP
-	log_must zfs set "org.zfsonlinux:newprop=newval" $BACKUP
-	log_must zfs set "org.zfsonlinux:snapprop=newval" "$BACKUP@s1"
-	log_must zfs set "org.zfsonlinux:newsnapprop=newval" "$BACKUP@s1"
+	log_must zfs set "org.openzfs:prop=newval" $BACKUP
+	log_must zfs set "org.openzfs:newprop=newval" $BACKUP
+	log_must zfs set "org.openzfs:snapprop=newval" "$BACKUP@s1"
+	log_must zfs set "org.openzfs:newsnapprop=newval" "$BACKUP@s1"
 
 	# 5. Restore the "backup" dataset to a new destination
 	log_must eval "zfs send -b$opt $BACKUP@s1 | zfs recv $RESTORE"
 
 	# 6. Verify only original (received) properties are sent from "backup"
 	log_must eval "check_prop_source $RESTORE compression gzip received"
-	log_must eval "check_prop_source $RESTORE org.zfsonlinux:prop val received"
-	log_must eval "check_prop_source $RESTORE@s1 org.zfsonlinux:snapprop val received"
+	log_must eval "check_prop_source $RESTORE org.openzfs:prop val received"
+	log_must eval "check_prop_source $RESTORE@s1 org.openzfs:snapprop val received"
 	log_must eval "check_prop_source $RESTORE exec on default"
-	log_must eval "check_prop_missing $RESTORE org.zfsonlinux:newprop"
-	log_must eval "check_prop_missing $RESTORE@s1 org.zfsonlinux:newsnapprop"
+	log_must eval "check_prop_missing $RESTORE org.openzfs:newprop"
+	log_must eval "check_prop_missing $RESTORE@s1 org.openzfs:newsnapprop"
 
 	# cleanup
 	log_must zfs destroy -r $BACKUP


### PR DESCRIPTION
### Motivation and Context
Moving forward, we wish to use `org.openzfs` (no dash) rather than `org.open-zfs` or `org.zfsonlinux` for feature GUIDs and property names.

We want to avoid the dash for property names, as it is easier to type without the dash. Then, we might as well be consistent in feature names. The website's "main" name is still open-zfs.org and openzfs.org is a redirect, though I have proposed swapping those around. (This situation occurred because openzfs.org was not originally available.)

The ZFS-on-Linux branding is being minimized (though not completely eliminated), so it makes sense to discourage that in these contexts too.

### Description
I changed as many existing instances as possible to use the new naming style.

The existing feature GUIDs cannot be changed. I added comments to each in `man/man5/zpool-features.5` and `module/zcommon/zfeature_common.c` to try to alert people who are looking at those as a precedent. I'm open to other ideas here.

### How Has This Been Tested?
I looked at `zpool-features.5` with `man` to make sure the comments were not visible.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
