### PR TITLE
Enable zpool events tunables and tests on FreeBSD

### DIFF
--- a/include/os/linux/kernel/linux/mod_compat.h
+++ b/include/os/linux/kernel/linux/mod_compat.h
@@ -70,6 +70,7 @@ enum scope_prefix_types {
 	zfs_vdev,
 	zfs_vdev_cache,
 	zfs_vdev_mirror,
+	zfs_zevent,
 	zfs_zio,
 	zfs_zil,
 	spa

--- a/module/zfs/fm.c
+++ b/module/zfs/fm.c
@@ -1607,9 +1607,7 @@ fm_erpt_dropped_increment(void)
 {
 	atomic_inc_64(&ratelimit_dropped);
 }
-#endif
 
-#ifdef _KERNEL
 void
 fm_init(void)
 {
@@ -1664,14 +1662,13 @@ fm_fini(void)
 		fm_ksp = NULL;
 	}
 }
-
-module_param(zfs_zevent_len_max, int, 0644);
-MODULE_PARM_DESC(zfs_zevent_len_max, "Max event queue length");
-
-module_param(zfs_zevent_cols, int, 0644);
-MODULE_PARM_DESC(zfs_zevent_cols, "Max event column width");
-
-module_param(zfs_zevent_console, int, 0644);
-MODULE_PARM_DESC(zfs_zevent_console, "Log events to the console");
-
 #endif /* _KERNEL */
+
+ZFS_MODULE_PARAM(zfs_zevent, zfs_zevent_, len_max, INT, ZMOD_RW,
+	"Max event queue length");
+
+ZFS_MODULE_PARAM(zfs_zevent, zfs_zevent_, cols, INT, ZMOD_RW,
+	"Max event column width");
+
+ZFS_MODULE_PARAM(zfs_zevent, zfs_zevent_, console, INT, ZMOD_RW,
+	"Log events to the console");

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -333,6 +333,11 @@ tags = ['functional', 'cli_root', 'zpool_destroy']
 tests = ['zpool_detach_001_neg']
 tags = ['functional', 'cli_root', 'zpool_detach']
 
+[tests/functional/cli_root/zpool_events]
+tests = ['zpool_events_clear', 'zpool_events_cliargs', 'zpool_events_follow',
+    'zpool_events_poolname', 'zpool_events_errors']
+tags = ['functional', 'cli_root', 'zpool_events']
+
 [tests/functional/cli_root/zpool_export]
 tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
     'zpool_export_003_neg', 'zpool_export_004_pos']

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -59,11 +59,6 @@ tags = ['functional', 'cli_root', 'zfs_sysfs']
 tests = ['add_nested_replacing_spare']
 tags = ['functional', 'cli_root', 'zpool_add']
 
-[tests/functional/cli_root/zpool_events:Linux]
-tests = ['zpool_events_clear', 'zpool_events_cliargs', 'zpool_events_follow',
-    'zpool_events_poolname', 'zpool_events_errors']
-tags = ['functional', 'cli_root', 'zpool_events']
-
 [tests/functional/cli_root/zpool_expand:Linux]
 tests = ['zpool_expand_001_pos', 'zpool_expand_002_pos',
     'zpool_expand_003_neg', 'zpool_expand_004_pos', 'zpool_expand_005_pos']

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -73,7 +73,7 @@ VDEV_VALIDATE_SKIP		vdev.validate_skip		vdev_validate_skip
 VOL_INHIBIT_DEV			UNSUPPORTED			zvol_inhibit_dev
 VOL_MODE			vol.mode			zvol_volmode
 VOL_RECURSIVE			vol.recursive			UNSUPPORTED
-ZEVENT_LEN_MAX			UNSUPPORTED			zfs_zevent_len_max
+ZEVENT_LEN_MAX			zevent.len_max			zfs_zevent_len_max
 ZIO_SLOW_IO_MS			zio.slow_io_ms			zio_slow_io_ms
 %%%%
 while read name FreeBSD Linux; do

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_clear.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_clear.ksh
@@ -43,14 +43,14 @@ for i in `seq 1 $EVENTS_NUM`; do
 done
 # wait a bit to allow the kernel module to process new events
 zpool_events_settle
-EVENTS_NUM="$(zpool events -H | wc -l)"
+EVENTS_NUM=$(zpool events -H | wc -l | xargs)
 
 # 3. Verify 'zpool events -c' successfully clear new events
-CLEAR_OUTPUT="$(zpool events -c)"
+CLEAR_OUTPUT=$(zpool events -c)
 if [[ "$CLEAR_OUTPUT" != "cleared $EVENTS_NUM events" ]]; then
 	log_fail "Failed to clear $EVENTS_NUM events: $CLEAR_OUTPUT"
 fi
-EVENTS_NUM="$(zpool events -H | wc -l)"
+EVENTS_NUM=$(zpool events -H | wc -l)
 if [[ $EVENTS_NUM -ne 0 ]];  then
 	log_fail "Unexpected events number: $EVENTS_NUM != 0"
 fi

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_errors.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_errors.ksh
@@ -129,11 +129,11 @@ function do_test
 		fi
 	fi
 
-	if [ "$val" == "0" ] || [ "$events" == "" ] ; then
+	if [ -z "$val" -o $val -eq 0 -o -z "$events" -o $events -eq 0 ] ; then
 		log_fail "Didn't see any errors or events ($val/$events)"
 	fi
 
-	if [ "$val" != "$events" ] ; then
+	if [ $val -ne $events ] ; then
 		log_fail "$val $POOLTYPE $str errors != $events events"
 	else
 		log_note "$val $POOLTYPE $str errors == $events events"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_follow.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_follow.ksh
@@ -56,8 +56,8 @@ done
 zpool_events_settle
 
 # 4. Verify 'zpool events -f' successfully recorded these new events
-EVENTS_LOG="$(cat $EVENTS_FILE | wc -l)"
-if [[ "$EVENTS_LOG" != "$EVENTS_NUM" ]]; then
+EVENTS_LOG=$(cat $EVENTS_FILE | wc -l)
+if [[ $EVENTS_LOG -ne $EVENTS_NUM ]]; then
 	log_fail "Unexpected number of events: $EVENTS_LOG != $EVENTS_NUM"
 fi
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have have made the necessary changes in our FreeBSD module code to expose zevents through both devd and the zpool events ioctl. Now the tunables can be exposed and zpool events tests can be enabled on both Linux and FreeBSD.

### Description
<!--- Describe your changes in detail -->
A few minor tweaks to the tests were needed to accomodate the way wc formats output on FreeBSD.

zed remains to be ported at a later time.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
zpool_events tests pass on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
