### PR TITLE
Add notice that forcefully unmount is not supported on Linux.

### DIFF
--- a/man/man8/zfs-mount.8
+++ b/man/man8/zfs-mount.8
@@ -30,7 +30,7 @@
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd June 30, 2019
+.Dd February 16, 2019
 .Dt ZFS-MOUNT 8
 .Os Linux
 .Sh NAME
@@ -117,6 +117,7 @@ Unmount all available ZFS file systems.
 Invoked automatically as part of the shutdown process.
 .It Fl f
 Forcefully unmount the file system, even if it is currently in use.
+This option is not supported on Linux.
 .It Fl u
 Unload keys for any encryption roots unmounted by this command.
 .It Ar filesystem Ns | Ns Ar mountpoint

--- a/man/man8/zpool-export.8
+++ b/man/man8/zpool-export.8
@@ -27,7 +27,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd August 9, 2019
+.Dd February 16, 2020
 .Dt ZPOOL-EXPORT 8
 .Os Linux
 .Sh NAME
@@ -72,6 +72,7 @@ Exports all pools imported on the system.
 Forcefully unmount all datasets, using the
 .Nm unmount Fl f
 command.
+This option is not supported on Linux.
 .Pp
 This command will forcefully export the pool even if it has a shared spare that
 is currently being used.


### PR DESCRIPTION
#9700 # Motivation and Context
Add notice that forcefully unmount is not supported on Linux.
As discussed: https://github.com/zfsonlinux/zfs/pull/9904#discussion_r377405614

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
