### PR TITLE
ZTS: Don't use lsblk on FreeBSD

### DIFF
--- a/tests/zfs-tests/tests/functional/refreserv/refreserv_multi_raidz.ksh
+++ b/tests/zfs-tests/tests/functional/refreserv/refreserv_multi_raidz.ksh
@@ -61,7 +61,11 @@ poolexists "$TESTPOOL" && log_must_busy zpool destroy "$TESTPOOL"
 # that small test disks may fill before creating small volumes.  However,
 # testing 512b and 1K blocks on ashift=9 pools is an ok approximation for
 # testing the problems that arise from 4K and 8K blocks on ashift=12 pools.
-bps=$(lsblk -nrdo min-io /dev/${alldisks[0]})
+if is_freebsd; then
+	bps=$(diskinfo -v ${alldisks[0]} | awk '/sectorsize/ { print $1 }')
+elif is_linux; then
+	bps=$(lsblk -nrdo min-io /dev/${alldisks[0]})
+fi
 case "$bps" in
 512)
 	allshifts=(9 10 17)

--- a/tests/zfs-tests/tests/functional/refreserv/refreserv_raidz.ksh
+++ b/tests/zfs-tests/tests/functional/refreserv/refreserv_raidz.ksh
@@ -63,7 +63,11 @@ poolexists "$TESTPOOL" && log_must_busy zpool destroy "$TESTPOOL"
 # that small test disks may fill before creating small volumes.  However,
 # testing 512b and 1K blocks on ashift=9 pools is an ok approximation for
 # testing the problems that arise from 4K and 8K blocks on ashift=12 pools.
-bps=$(lsblk -nrdo min-io /dev/${alldisks[0]})
+if is_freebsd; then
+	bps=$(diskinfo -v ${alldisks[0]} | awk '/sectorsize/ { print $1 }')
+elif is_linux; then
+	bps=$(lsblk -nrdo min-io /dev/${alldisks[0]})
+fi
 log_must test "$bps" -eq 512 -o "$bps" -eq 4096
 case "$bps" in
 512)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The refreserv raidz tests use lsblk to find the sector size of a disk.
FreeBSD doesn't have lsblk.

### Description
<!--- Describe your changes in detail -->
Use diskinfo -v to get sector size on FreeBSD.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
The tests are passing on FreeBSD now.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
