### PR TITLE
ZTS: Move privilege tests to sunos.run

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -668,10 +668,6 @@ tags = ['functional', 'pool_names']
 tests = ['poolversion_001_pos', 'poolversion_002_pos']
 tags = ['functional', 'poolversion']
 
-[tests/functional/privilege]
-tests = ['privilege_001_pos', 'privilege_002_pos']
-tags = ['functional', 'privilege']
-
 [tests/functional/pyzfs]
 tests = ['pyzfs_unittest']
 pre =

--- a/tests/runfiles/sunos.run
+++ b/tests/runfiles/sunos.run
@@ -33,6 +33,10 @@ tags = ['functional', 'cli_root', 'zpool_add']
 tests = ['zpool_create_016_pos']
 tags = ['functional', 'cli_root', 'zpool_create']
 
+[tests/functional/privilege]
+tests = ['privilege_001_pos', 'privilege_002_pos']
+tags = ['functional', 'privilege']
+
 [tests/functional/xattr:illumos]
 tests = ['xattr_008_pos', 'xattr_009_neg', 'xattr_010_neg']
 tags = ['functional', 'xattr']

--- a/tests/zfs-tests/tests/functional/privilege/setup.ksh
+++ b/tests/zfs-tests/tests/functional/privilege/setup.ksh
@@ -31,10 +31,6 @@
 
 . $STF_SUITE/include/libtest.shlib
 
-if is_linux || is_freebsd; then
-	log_unsupported "Requires pfexec command"
-fi
-
 ZFS_USER=zfsrbac
 USES_NIS=false
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These tests are unspported on FreeBSD and Linux for lack of pfexec.

### Description
<!--- Describe your changes in detail -->
Move the privilege tests to sunos.run and remove the platform checks.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
The tests were not run on FreeBSD ;)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
