### PR TITLE
ZTS: Eliminate partitioning from zpool_destroy

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy.cfg
@@ -28,18 +28,10 @@
 # Copyright (c) 2012 by Delphix. All rights reserved.
 #
 
-export DISK=${DISKS%% *}
 export DISK_ARRAY_NUM=$(echo ${DISKS} | nawk '{print NF}')
 export DISKSARRAY=$DISKS
+echo $DISKS | read DISK0 DISK1
 
 if is_linux; then
 	set_device_dir
-	set_slice_prefix
-	export SLICE0=1
-	export SLICE1=2
-else
-	export SLICE0=0
-	export SLICE1=1
-
 fi
-export SLICE_SIZE=500m

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_001_pos.ksh
@@ -56,26 +56,24 @@ function cleanup
 		poolexists $pool && destroy_pool $pool
 	done
 
-	zero_partitions $DISK
+	[ -n "$recursive" ] && set_tunable64 VOL_RECURSIVE $recursive
 }
 
 set -A datasets "$TESTPOOL" "$TESTPOOL2"
-
-if ! is_physical_device $DISKS; then
-	log_unsupported "This case cannot be run on raw files."
-fi
 
 log_assert "'zpool destroy <pool>' can destroy a specified pool."
 
 log_onexit cleanup
 
-partition_disk $SLICE_SIZE $DISK 2
-
-create_pool "$TESTPOOL" "${DISK}${SLICE_PREFIX}${SLICE0}"
-create_pool "$TESTPOOL1" "${DISK}${SLICE_PREFIX}${SLICE1}"
+create_pool $TESTPOOL $DISK0
+create_pool $TESTPOOL1 $DISK1
 log_must zfs create -s -V $VOLSIZE $TESTPOOL1/$TESTVOL
 block_device_wait
-create_pool "$TESTPOOL2" "${ZVOL_DEVDIR}/$TESTPOOL1/$TESTVOL"
+if is_freebsd; then
+	typeset recursive=$(get_tunable VOL_RECURSIVE)
+	log_must set_tunable64 VOL_RECURSIVE 1
+fi
+create_pool $TESTPOOL2 $ZVOL_DEVDIR/$TESTPOOL1/$TESTVOL
 
 typeset -i i=0
 while (( i < ${#datasets[*]} )); do

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
@@ -73,9 +73,7 @@ log_assert "'zpool destroy -f <pool>' can forcely destroy the specified pool"
 
 log_onexit cleanup
 
-typeset cwd=""
-
-create_pool "$TESTPOOL" "$DISK"
+create_pool $TESTPOOL $DISK0
 log_must zfs create $TESTPOOL/$TESTFS
 log_must mkdir -p $TESTDIR
 log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
@@ -90,7 +88,6 @@ while (( $i < ${#datasets[*]} )); do
 	((i = i + 1))
 done
 
-cwd=$PWD
 log_note "'zpool destroy' without '-f' will fail " \
 	"while pool is busy."
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The zpool destroy tests partition a single disk to create two pools.

### Description
<!--- Describe your changes in detail -->
This can be done using two disks and no partitioning instead.
And temporarily allow vol recursion for FreeBSD while in here.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
The tests are passing on FreeBSD.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
